### PR TITLE
build(ci): Add TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# Even though we run everything inside docker,
+# Travis requires us to pick a language else it will pick Ruby by default.
+# Let's choose a lightweight base image then we provide our own build tools.
+# Note: `language: generic` was failing in OSX so in that case you can use language: c
+language: generic
+
+# https://docs.travis-ci.com/user/reference/trusty/#Docker
+dist: trusty
+services:
+  - docker
+
+before_install:
+  - docker --version
+  - docker-compose --version
+
+script:
+  - travis_retry ./docker/test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [npm]: https://img.shields.io/npm/v/instructure-ui.svg
 [npm-url]: https://npmjs.com/package/instructure-ui
 
+[build-status]: https://travis-ci.org/instructure/instructure-ui.svg?branch=master
+[build-status-url]: https://travis-ci.org/instructure/instructure-ui "Travis CI"
+
 <div style="text-align: center; margin-bottom: 10rem; padding-bottom: 3rem;">
   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 300px;" viewBox="0 0 400 400">
       <path class="strokeColor" d="M204.59,355.17h-.94v-2.86h.94Zm0-6.61h-.94v-3.75h.94Zm0-7.5h-.94V337.3h.94Zm0-7.5h-.94V329.8h.94Zm0-7.5h-.94V322.3h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94v-3.75h.94Zm0-7.5h-.94V112.2h.94Zm0-7.5h-.94V104.7h.94Zm0-7.5h-.94V97.2h.94Zm0-7.5h-.94V89.69h.94Zm0-7.5h-.94V82.19h.94Zm0-7.5h-.94V74.69h.94Zm0-7.5h-.94V67.18h.94Z"/>
@@ -49,6 +52,7 @@
 </div>
 
 [![npm][npm]][npm-url]
+[![build-status][build-status]][build-status-url]
 
 ### Installation
 


### PR DESCRIPTION
Before merging this PR please enable Travis integration:

1. Open https://travis-ci.org/profile/instructure
2. Slick Sync (if necessary)
3. Slide-enable `instructure-ui`

The image badge will be broken until this is merged into master and run for the first time.
I tested it in my fork and looks good: [![build-status][build-status]][build-status-url]

[build-status]: https://travis-ci.org/elgalu/instructure-ui.svg?branch=add-travis-ci
[build-status-url]: https://travis-ci.org/elgalu/instructure-ui "Travis CI"
