### PR TITLE
don't force all locales to be included in bundles

### DIFF
--- a/lib/util/time.js
+++ b/lib/util/time.js
@@ -1,5 +1,4 @@
 import moment from 'moment' // eslint-disable-line import/no-extraneous-dependencies
-import 'moment/min/locales' // eslint-disable-line import/no-extraneous-dependencies
 import 'moment-timezone/builds/moment-timezone-with-data'
 
 function checkParams (locale, timezone) {


### PR DESCRIPTION
I think we can remove this line because if you do `moment().locale('es')` and it has not loaded the spanish locale it will automatically load it for you on demand. because in the quizzes repos, we build a locale-specific build, we already set up a webpack contextReplacementPlugin to tell moment when it gets to that location in it's code (https://github.com/moment/moment/blob/develop/moment.js#L1830) that it will only ever have to load the specific locale we are building for. eg: Gauge's webpack.config looks like this `webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, RegExp(`^./${process.env.BUILD_LOCALE || 'en'}$`))`.  But by explicitly loading 'moment/min/locales' here, even if you already have the local you care about loaded, and even if you have set up that webpack contextReplacementPlugin that you have to use to tell moment to only load the locale(s) you care about, it still forces you download all of them.