### PR TITLE
allow <optgroup>s inside <Select>s

### DIFF
--- a/packages/ui-core/src/components/Select/index.js
+++ b/packages/ui-core/src/components/Select/index.js
@@ -27,7 +27,7 @@ class Select extends Component {
     /**
     * Children must be option tags.
     */
-    children: CustomPropTypes.Children.oneOf(['option']),
+    children: CustomPropTypes.Children.oneOf(['option', 'optgroup']),
     label: PropTypes.node.isRequired,
     disabled: PropTypes.bool,
     /**


### PR DESCRIPTION
is there a reason we can't also allow optgroups inside selects? if you want me to make a gerrit commit I can do that too but this was just quicker to ask the question