### PR TITLE
feat(ui-tree-browser): add showFulltext option

### DIFF
--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7",
     "@instructure/ui-elements": "^5.49.0",
     "@instructure/ui-icons": "^5.49.0",
+    "@instructure/ui-overlays": "^5.49.0",
     "@instructure/ui-prop-types": "^5.49.0",
     "@instructure/ui-testable": "^5.49.0",
     "@instructure/ui-themeable": "^5.49.0",

--- a/packages/ui-tree-browser/src/components/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/components/TreeBrowser/README.md
@@ -32,6 +32,7 @@ example: true
   }}
   defaultExpanded={[1, 3]}
   rootId={1}
+  showFulltext
 />
 ```
 

--- a/packages/ui-tree-browser/src/components/TreeBrowser/TreeButton/__tests__/TreeButton.test.js
+++ b/packages/ui-tree-browser/src/components/TreeBrowser/TreeButton/__tests__/TreeButton.test.js
@@ -28,6 +28,7 @@ import TreeButton from '../index'
 import styles from '../styles.css'
 
 const TreeButtonLocator = locator(TreeButton.selector)
+import TooltipLocator from '@instructure/ui-overlays/lib/components/Tooltip/locator'
 
 describe('<TreeButton />', async () => {
   it('should render', async () => {
@@ -155,6 +156,38 @@ describe('<TreeButton />', async () => {
         { expectEmpty: true }
       )).to.not.exist()
       expect(await TreeButtonLocator.find('img')).to.exist()
+    })
+  })
+
+  describe('fulltext', async () => {
+    const wideSpaceStyle = {
+      width: '1000px'
+    }
+
+    const narrowSpaceStyle = {
+      width: '10px'
+    }
+
+    const buttonName = "Exampleeof a tree button"
+
+    it('should render the tree button with a tooltip if the content inside the tree button has been truncated', async () => {
+      await mount(<div style={narrowSpaceStyle}>
+        <TreeButton id="1" type="item" name={buttonName} showFulltext></TreeButton>
+      </div>
+      )
+
+      const tooltipLocator = await TooltipLocator.find()
+      expect(tooltipLocator).to.exist()
+    })
+
+    it('should not the render tree button with a tooltip if the content inside the tree button has not been truncated', async () => {
+      await mount(<div style={wideSpaceStyle}>
+        <TreeButton id="1" type="item" name={buttonName} showFulltext></TreeButton>
+      </div>
+      )
+
+      const tooltipLocator = await TooltipLocator.find({ expectEmpty: true })
+      expect(tooltipLocator).to.not.exist()
     })
   })
 })

--- a/packages/ui-tree-browser/src/components/TreeBrowser/TreeCollection/index.js
+++ b/packages/ui-tree-browser/src/components/TreeBrowser/TreeCollection/index.js
@@ -65,7 +65,8 @@ export default class TreeCollection extends Component {
     onKeyDown: PropTypes.func,
     numChildren: PropTypes.number,
     level: PropTypes.number,
-    position: PropTypes.number
+    position: PropTypes.number,
+    showFulltext: PropTypes.bool
   }
 
   static defaultProps = {
@@ -218,7 +219,8 @@ export default class TreeCollection extends Component {
       descriptor: this.props.descriptor,
       size: this.props.size,
       variant: this.props.variant,
-      itemIcon: this.props.itemIcon
+      itemIcon: this.props.itemIcon,
+      showFulltext: this.props.showFulltext
     }
   }
 

--- a/packages/ui-tree-browser/src/components/TreeBrowser/index.js
+++ b/packages/ui-tree-browser/src/components/TreeBrowser/index.js
@@ -93,9 +93,13 @@ export default class TreeBrowser extends Component {
     onCollectionToggle: PropTypes.func,
     onItemClick: PropTypes.func,
     /**
-    * An optional label to assist visually impaired users
-    */
-    treeLabel: PropTypes.string
+     * An optional label to assist visually impaired users
+     */
+    treeLabel: PropTypes.string,
+    /**
+     * whether or not to display text and descriptors in full text on hover.
+     */
+    showFulltext: PropTypes.bool
   }
 
   static defaultProps = {
@@ -112,7 +116,8 @@ export default class TreeBrowser extends Component {
     onCollectionToggle: function (collection) {},
     rootId: undefined,
     expanded: undefined,
-    treeLabel: undefined
+    treeLabel: undefined,
+    showFulltext: false
   }
 
   constructor (props) {


### PR DESCRIPTION
Re: #22 -- I'm working on a project using the ui-tree-browser where it's possible to have very long titles.

This will: add the ability to show a tooltip when hovering over a TreeButton that has been truncated.

<img width="357" alt="Screen Shot 2019-03-27 at 10 47 48 AM" src="https://user-images.githubusercontent.com/5502587/55099916-db2ffc80-507d-11e9-8c0c-44676abb8a5a.png">
