### PR TITLE
Spinner title attribute deprecated, update example

### DIFF
--- a/packages/ui-overlays/src/Overlay/README.md
+++ b/packages/ui-overlays/src/Overlay/README.md
@@ -40,7 +40,7 @@ class Example extends React.Component {
             onClick={() => { this.setState({ open: false })}}
             elementRef={this.handleMaskRef}
           >
-            <Spinner title="Loading" size="large" margin="0 0 0 medium" />
+            <Spinner renderTitle="Loading" size="large" margin="0 0 0 medium" />
           </Mask>
         </Overlay>
       </div>


### PR DESCRIPTION
renderTitle it the newer attribute and should be used instead as the title attribute is being removed in 7.0.0.