### PR TITLE
Generate cache busting files by default.

### DIFF
--- a/packages/template-app/template/webpack.config.js.ejs
+++ b/packages/template-app/template/webpack.config.js.ejs
@@ -33,7 +33,7 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: outputPath,
-    filename: '[name].js'
+    filename: '[name].[contenthash].js'
   },
   devServer: {
     contentBase: outputPath,


### PR DESCRIPTION
By default the files generated by the webpack configuration will be cached by browsers and when a new version of the application is deployed the changes won’t be detected. This adds a cache busting content hash to the filename to avoid this.