### PR TITLE
Fixes for createSuper being undefined.

### DIFF
--- a/packages/ui-testable/package.json
+++ b/packages/ui-testable/package.json
@@ -26,6 +26,7 @@
     "prop-types": "^15.6.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.9.2",
     "@instructure/ui-decorator": "^6.26.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
If the project ui-testable is used in isn’t pulling in a newish version of table then you can end up getting an error of:

Module not found: Error: Can't resolve '@babel/runtime/helpers/esm/createSuper' 

This makes this module explicitly depend on a newer version of @babel/runtime so that this can’t happen.

Fixes #94