### PR TITLE
fix(ui-a11y-utils): don't hide elements with aria-live

### DIFF
--- a/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.js
+++ b/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.js
@@ -75,10 +75,13 @@ class ScreenReaderFocusRegion {
 
   hideNodes (nodes) {
     nodes.forEach((node) => {
+      const ariaLive = typeof node.getAttribute === 'function' && node.getAttribute('aria-live')?.toLowerCase()
       if (
         node &&
         node.nodeType === 1 &&
         node.tagName.toLowerCase() !== 'script' &&
+        ariaLive !== 'assertive' &&
+        ariaLive !== 'polite' &&
         this._parents.indexOf(node) === -1 &&
         this._nodes.indexOf(node) === -1 &&
         this._liveRegion.indexOf(node) === -1 &&

--- a/packages/ui-a11y-utils/src/__tests__/ScreenReaderFocusRegion.test.js
+++ b/packages/ui-a11y-utils/src/__tests__/ScreenReaderFocusRegion.test.js
@@ -204,6 +204,24 @@ describe('ScreenReaderFocusRegion', async () => {
     })
   })
 
+  it('should not apply aria-hidden to elements that have aria-live attributes', async () => {
+    const subject = await mount(
+      <div data-test-main role="main" aria-label="test app">
+        <div data-test-live aria-live="assertive"></div>
+        <div data-test-regular></div>
+        <div data-test-content></div>
+      </div>
+    )
+    const main = within(subject.getDOMNode())
+    const content = (await main.find('[data-test-content]')).getDOMNode()
+    const screenReaderFocusRegion = new ScreenReaderFocusRegion(content)
+    screenReaderFocusRegion.activate()
+
+    const liveRegion = (await main.find('[data-test-live]')).getDOMNode()
+    const regularRegion = (await main.find('[data-test-regular]')).getDOMNode()
+    expect(liveRegion.getAttribute('aria-hidden')).to.not.exist()
+    expect(regularRegion.getAttribute('aria-hidden')).to.exist()
+  })
 
   it('should hide the body element of any iframes present on the page', async () => {
     const subject = await mount(


### PR DESCRIPTION
ScreenReaderFocusRegion hides a bunch of nodes when modals, trays,
etc open so the SR can focus on their content. We shouldn't hide
elements with aria-live=[assertive|polite] since these tags instruct
the SR to read a message ASAP.

fixes INSTUI-2700
refs LS-1532

Test plan:
 - Go to Canvas Dashboard
 - Click the hamburger menu button on one of the courses
 - Open dev tools and inspect the page
 - #flash_screenreader_holder should NOT be aria-hidden