### PR TITLE
feat(ui-docs-plugin): display the faulty YAML that caused a parsing error

### DIFF
--- a/packages/ui-docs-plugin/src/utils/parseDoc.js
+++ b/packages/ui-docs-plugin/src/utils/parseDoc.js
@@ -46,8 +46,15 @@ module.exports = function (resourcePath, source, errorHandler) {
     doc = getCodeDoc(source, errorHandler)
   }
 
+  let frontMatter
+  try {
+    frontMatter = getFrontMatter(doc.description)
+  } catch (e) {
+    throw `Failed to parse YAML "${doc.description}" \nexception is \n${e}`
+  }
+
   return {
     ...doc,
-    ...getFrontMatter(doc.description)
+    ...frontMatter
   }
 }


### PR DESCRIPTION
when running the documentation app with `yarn dev` and a source code file had a malformed YAML it caused a generic build error message. This commit prints the wrong YAML string to the console when it causes the build to fail.