### PR TITLE
chore(ui-scripts): fix TypeScript type definition build for files that use newer syntax

### DIFF
--- a/packages/ui-scripts/lib/generate-types.js
+++ b/packages/ui-scripts/lib/generate-types.js
@@ -28,9 +28,23 @@ const globby = require('globby')
 
 async function run() {
   const paths = await globby(['**/src/*/index.js'])
-  const tsDefinitions = paths.map((filePath) =>
-    react2dts.generateFromFile(null, filePath)
-  )
+  // ui-babel-preset defines its own babel plugins too
+  // we should use the list from there if we dont move to typeScript
+  const babelPlugins = [
+    'optionalChaining',
+    'nullishCoalescingOperator',
+    'dfgdfg'
+  ]
+  const tsDefinitions = paths.map((filePath) => {
+    try {
+      react2dts.generateFromFile(null, filePath, {
+        babylonPlugins: babelPlugins
+      })
+    } catch (e) {
+      console.error(`Error compiling typeScript definitions for "${filePath}"`)
+      throw e
+    }
+  })
 
   try {
     await fs.mkdir('./types')

--- a/packages/ui-scripts/lib/generate-types.js
+++ b/packages/ui-scripts/lib/generate-types.js
@@ -30,11 +30,7 @@ async function run() {
   const paths = await globby(['**/src/*/index.js'])
   // ui-babel-preset defines its own babel plugins too
   // we should use the list from there if we dont move to typeScript
-  const babelPlugins = [
-    'optionalChaining',
-    'nullishCoalescingOperator',
-    'dfgdfg'
-  ]
+  const babelPlugins = ['optionalChaining', 'nullishCoalescingOperator']
   const tsDefinitions = paths.map((filePath) => {
     try {
       react2dts.generateFromFile(null, filePath, {


### PR DESCRIPTION
Closes: INSTUI-2813

some files are using newer JS features (e.g. `?.` ) and the TypeScript definition generation script
needed to be updated to handle this.

Also add better error handling, it was not outputting which file caused the failure