### PR TITLE
refactor(emotion): make theme variables listed on docs page again

### DIFF
--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -192,24 +192,18 @@ export default generateComponentTheme
 
 You need to create a `styles.js` file next to the `theme.js`. (Don't forget the copyright block!)\
 Write and export a `function` named `generateStyle`.\
-Import the `generateComponentTheme` from `theme.js` and use it in `generateStyle`, passing the theme and themeOverride parameters.\
 You need to use the content of the `styles.css` and convert it to css-in-js. Use the passed component props and state where needed.\
 [Emotion's Object Styles documentation](https://emotion.sh/docs/object-styles)
 
 ```js
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   // optional mappings can be provided based on - for example - props
   const colorStyles = {
     primary: {
@@ -244,8 +238,8 @@ export default generateStyle
 
 #### 3. Make changes in the component.
 
-Import the style generator (`generateStyle`) from `styles.js`, `{ withStyle, jsx, css }` from `@instructure/emotion`, and add the `/** @jsx jsx */` annotation on top.\
-Replace `@themeable` with `@withStyle(generateStyle)`, passing the style generator.\
+Import the style generator (`generateStyle`) from `styles.js`, the component theme generator (`generateComponentTheme`) from `theme.js`, `{ withStyle, jsx }` from `@instructure/emotion`, and add the `/** @jsx jsx */` annotation on top.\
+Replace `@themeable` with `@withStyle(generateStyle, generateComponentTheme)`, passing the style and theme generators.\
 In the `componentDidMount` and `componentDidUpdate` methods, call the `makeStyles` method (available on this.props) to generate the styles object, passing the state (or any other object needed).\
 In the `render` method, use emotion's `css={this.props.styles.componentName}` syntax to add styles.\
 
@@ -253,11 +247,12 @@ In the `render` method, use emotion's `css={this.props.styles.componentName}` sy
 /** @jsx jsx */
 import { Component } from 'react'
 // other imports
-import { withStyle, jsx, css } from '@instructure/emotion'
+import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class MyComponent extends Component {
   // ...
   // rest

--- a/packages/ui-alerts/src/Alert/index.js
+++ b/packages/ui-alerts/src/Alert/index.js
@@ -45,13 +45,14 @@ import { uid } from '@instructure/uid'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Alert extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-alerts/src/Alert/styles.js
+++ b/packages/ui-alerts/src/Alert/styles.js
@@ -22,18 +22,15 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props) => {
+const generateStyle = (componentTheme, props) => {
   const { variant } = props
-  const componentTheme = generateComponentTheme(theme, themeOverride)
 
   const variantStyles = {
     error: {

--- a/packages/ui-avatar/src/Avatar/index.js
+++ b/packages/ui-avatar/src/Avatar/index.js
@@ -32,6 +32,7 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -39,7 +40,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Avatar extends Component {
   static propTypes = {

--- a/packages/ui-avatar/src/Avatar/styles.js
+++ b/packages/ui-avatar/src/Avatar/styles.js
@@ -22,24 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (
-  theme,
-  themeOverride,
-  { size, shape, src },
-  { loaded }
-) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, { size, shape, src }, { loaded }) => {
   const sizeStyles = {
     auto: {
       fontSize: 'inherit',

--- a/packages/ui-badge/src/Badge/index.js
+++ b/packages/ui-badge/src/Badge/index.js
@@ -35,7 +35,8 @@ import { testable } from '@instructure/ui-testable'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -43,7 +44,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Badge extends Component {
   static propTypes = {

--- a/packages/ui-badge/src/Badge/styles.js
+++ b/packages/ui-badge/src/Badge/styles.js
@@ -23,7 +23,6 @@
  */
 
 import { keyframes } from '@instructure/emotion'
-import generateComponentTheme from './theme'
 
 // keyframes have to be outside of 'generateStyle',
 // since it is causing problems in style recalculation
@@ -35,15 +34,12 @@ const pulseAnimation = keyframes`
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { type, variant, placement, standalone, pulse } = props
 
   const top = placement.indexOf('top') > -1

--- a/packages/ui-billboard/src/Billboard/index.js
+++ b/packages/ui-billboard/src/Billboard/index.js
@@ -38,13 +38,14 @@ import {
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Billboard extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-billboard/src/Billboard/styles.js
+++ b/packages/ui-billboard/src/Billboard/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { size, href, onClick, disabled, hero, heading } = props
 
   const clickable = href || onClick

--- a/packages/ui-breadcrumb/src/Breadcrumb/index.js
+++ b/packages/ui-breadcrumb/src/Breadcrumb/index.js
@@ -36,6 +36,7 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { BreadcrumbLink } from './BreadcrumbLink'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -43,7 +44,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Breadcrumb extends Component {
   static propTypes = {

--- a/packages/ui-breadcrumb/src/Breadcrumb/styles.js
+++ b/packages/ui-breadcrumb/src/Breadcrumb/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { size } = props
 
   const crumbSizeVariants = {

--- a/packages/ui-byline/src/Byline/index.js
+++ b/packages/ui-byline/src/Byline/index.js
@@ -33,13 +33,14 @@ import { View } from '@instructure/ui-view'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Byline extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-byline/src/Byline/styles.js
+++ b/packages/ui-byline/src/Byline/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { alignContent, size } = props
 
   const alignContentVariants = {

--- a/packages/ui-docs-client/src/Document/index.js
+++ b/packages/ui-docs-client/src/Document/index.js
@@ -29,7 +29,7 @@ import { Link } from '@instructure/ui-link'
 import { View } from '@instructure/ui-view'
 import { Tabs } from '@instructure/ui-tabs'
 import { CodeEditor } from '@instructure/ui-code-editor'
-import { themeable } from '@instructure/ui-themeable'
+import { ThemeRegistry, themeable } from '@instructure/ui-themeable'
 
 import { Description } from '../Description'
 import { Properties } from '../Properties'
@@ -84,13 +84,17 @@ class Document extends Component {
 
   renderTheme(doc) {
     const { themeKey } = this.props
-    const { generateTheme } = doc
-    const theme = typeof generateTheme === 'function' && generateTheme(themeKey)
+    const { generateComponentTheme } = doc.resource
+
+    const themeVariables = ThemeRegistry.getRegisteredTheme(themeKey).variables
+    const theme =
+      typeof generateComponentTheme === 'function' &&
+      generateComponentTheme(themeVariables)
 
     return theme && Object.keys(theme).length > 0 ? (
       <View margin="x-large 0" display="block">
         <Heading level="h2" as="h3" id={`${doc.id}Theme`} margin="0 0 small 0">
-          Theme Variables
+          Default Theme Variables
         </Heading>
         <ComponentTheme theme={theme} />
       </View>

--- a/packages/ui-flex/src/Flex/Item/styles.js
+++ b/packages/ui-flex/src/Flex/Item/styles.js
@@ -24,13 +24,12 @@
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
+const generateStyle = (componentTheme, props, state) => {
   const { grow, shouldGrow, shrink, shouldShrink, align, size } = props
 
   const alignSelfValues = {

--- a/packages/ui-flex/src/Flex/index.js
+++ b/packages/ui-flex/src/Flex/index.js
@@ -40,6 +40,7 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { Item } from './Item'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -47,7 +48,7 @@ category: components
 ---
 @module Flex
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @deprecated('8.0.0', {
   inline: 'display',
   wrapItems: 'wrap',

--- a/packages/ui-flex/src/Flex/styles.js
+++ b/packages/ui-flex/src/Flex/styles.js
@@ -22,12 +22,9 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {string} props.justifyItems
  * @param  {string} props.direction
@@ -36,9 +33,7 @@ import generateComponentTheme from './theme'
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { justifyItems, wrap, wrapItems, direction } = props
 
   // align-items css prop

--- a/packages/ui-form-field/src/FormFieldGroup/index.js
+++ b/packages/ui-form-field/src/FormFieldGroup/index.js
@@ -33,14 +33,15 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { FormFieldLayout } from '../FormFieldLayout'
 import { FormPropTypes } from '../FormPropTypes'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class FormFieldGroup extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldGroup/styles.js
+++ b/packages/ui-form-field/src/FormFieldGroup/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { disabled } = props
   const { invalid } = state
 

--- a/packages/ui-form-field/src/FormFieldLabel/index.js
+++ b/packages/ui-form-field/src/FormFieldLabel/index.js
@@ -29,7 +29,8 @@ import PropTypes from 'prop-types'
 import { omitProps, getElementType } from '@instructure/ui-react-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -47,7 +48,7 @@ example: true
 ```
 
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class FormFieldLabel extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldLabel/styles.js
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.js
@@ -23,19 +23,15 @@
  */
 
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
-import generateComponentTheme from './theme'
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { children } = props
 
   const hasContent = hasVisibleChildren(children)

--- a/packages/ui-form-field/src/FormFieldLayout/index.js
+++ b/packages/ui-form-field/src/FormFieldLayout/index.js
@@ -43,14 +43,14 @@ import { FormFieldLabel } from '../FormFieldLabel'
 import { FormFieldMessages } from '../FormFieldMessages'
 import { FormPropTypes } from '../FormPropTypes'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
 
 /**
 ---
 parent: FormField
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle)
 class FormFieldLayout extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldLayout/styles.js
+++ b/packages/ui-form-field/src/FormFieldLayout/styles.js
@@ -24,13 +24,12 @@
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
+const generateStyle = (componentTheme, props, state) => {
   const { inline } = props
 
   return {

--- a/packages/ui-form-field/src/FormFieldMessage/index.js
+++ b/packages/ui-form-field/src/FormFieldMessage/index.js
@@ -30,7 +30,8 @@ import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -47,7 +48,7 @@ example: true
 <FormFieldMessage variant="error">Invalid value</FormFieldMessage>
 ```
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class FormFieldMessage extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldMessage/styles.js
+++ b/packages/ui-form-field/src/FormFieldMessage/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { variant } = props
 
   const variants = {

--- a/packages/ui-form-field/src/FormFieldMessages/index.js
+++ b/packages/ui-form-field/src/FormFieldMessages/index.js
@@ -33,7 +33,8 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { FormPropTypes } from '../FormPropTypes'
 import { FormFieldMessage } from '../FormFieldMessage'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -53,7 +54,7 @@ example: true
 ]} />
 ```
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class FormFieldMessages extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldMessages/styles.js
+++ b/packages/ui-form-field/src/FormFieldMessages/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     formFieldMessages: {
       label: 'formFieldMessages',

--- a/packages/ui-grid/src/Grid/index.js
+++ b/packages/ui-grid/src/Grid/index.js
@@ -41,13 +41,14 @@ import { GridCol } from '../GridCol'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Grid extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-grid/src/Grid/styles.js
+++ b/packages/ui-grid/src/Grid/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { startAt, visualDebug } = props
 
   const getStartAtVariants = (breakpoint) =>

--- a/packages/ui-grid/src/GridCol/index.js
+++ b/packages/ui-grid/src/GridCol/index.js
@@ -31,6 +31,7 @@ import { omitProps } from '@instructure/ui-react-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 // TODO: get numcols from theme config
 const COL_WIDTHS = ['auto', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -41,7 +42,7 @@ parent: Grid
 id: Grid.Col
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class GridCol extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-grid/src/GridCol/styles.js
+++ b/packages/ui-grid/src/GridCol/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const {
     vAlign,
     textAlign,

--- a/packages/ui-grid/src/GridRow/index.js
+++ b/packages/ui-grid/src/GridRow/index.js
@@ -40,6 +40,7 @@ import { GridCol } from '../GridCol'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -47,7 +48,7 @@ parent: Grid
 id: Grid.Row
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class GridRow extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-grid/src/GridRow/styles.js
+++ b/packages/ui-grid/src/GridRow/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const {
     hAlign,
     vAlign,

--- a/packages/ui-heading/src/Heading/index.js
+++ b/packages/ui-heading/src/Heading/index.js
@@ -33,13 +33,14 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Heading extends Component {
   componentDidMount() {

--- a/packages/ui-heading/src/Heading/styles.js
+++ b/packages/ui-heading/src/Heading/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, { level, color, border, as }) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, { level, color, border, as }) => {
   const levelStyles = {
     h1: {
       fontFamily: componentTheme.h1FontFamily,

--- a/packages/ui-img/src/Img/index.js
+++ b/packages/ui-img/src/Img/index.js
@@ -32,13 +32,14 @@ import { supportsObjectFit } from '@instructure/ui-dom-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Img extends Component {
   componentDidMount() {
     this.props.makeStyles(this.state)

--- a/packages/ui-img/src/Img/styles.js
+++ b/packages/ui-img/src/Img/styles.js
@@ -22,19 +22,15 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (
-  theme,
-  themeOverride,
-  {
+const generateStyle = (componentTheme, props) => {
+  const {
     overlay,
     withBlur,
     withGrayscale,
@@ -42,9 +38,7 @@ const generateStyle = (
     src,
     supportsObjectFit,
     constrain
-  }
-) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+  } = props
 
   const overlayStyle = overlay
     ? {

--- a/packages/ui-link/src/Link/index.js
+++ b/packages/ui-link/src/Link/index.js
@@ -43,13 +43,14 @@ import { testable } from '@instructure/ui-testable'
 
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @deprecated('8.0.0', {
   linkRef: 'elementRef',
   variant: 'color'

--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const { isWithinText, renderIcon, iconPlacement, variant, color } = props
   const { containsTruncateText, hasVisibleChildren, elementType } = state
   const inverseStyle = variant === 'inverse' || color === 'link-inverse'

--- a/packages/ui-list/src/InlineList/InlineListItem/index.js
+++ b/packages/ui-list/src/InlineList/InlineListItem/index.js
@@ -33,6 +33,7 @@ import { passthroughProps } from '@instructure/ui-react-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -40,7 +41,7 @@ parent: InlineList
 id: InlineList.Item
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class InlineListItem extends Component {
   static propTypes = {

--- a/packages/ui-list/src/InlineList/InlineListItem/styles.js
+++ b/packages/ui-list/src/InlineList/InlineListItem/styles.js
@@ -22,22 +22,18 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 import { error } from '@instructure/console/macro'
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {String} props.delimiter
  * @param  {String} props.spacing
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { size, delimiter, spacing } = props
 
   const withDelimiter = delimiter !== 'none'

--- a/packages/ui-list/src/List/ListItem/index.js
+++ b/packages/ui-list/src/List/ListItem/index.js
@@ -34,6 +34,7 @@ import { passthroughProps } from '@instructure/ui-react-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -41,7 +42,7 @@ parent: List
 id: List.Item
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ListItem extends Component {
   static propTypes = {

--- a/packages/ui-list/src/List/ListItem/styles.js
+++ b/packages/ui-list/src/List/ListItem/styles.js
@@ -22,22 +22,18 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 import { error } from '@instructure/console/macro'
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {String} props.delimiter
  * @param  {String} props.spacing
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { size, delimiter, spacing } = props
 
   const withDelimiter = delimiter !== 'none'

--- a/packages/ui-list/src/List/index.js
+++ b/packages/ui-list/src/List/index.js
@@ -37,13 +37,14 @@ import { ListItem } from './ListItem'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class List extends Component {
   static propTypes = {

--- a/packages/ui-list/src/List/styles.js
+++ b/packages/ui-list/src/List/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { isUnstyled, as } = props
 
   const ordered = as === 'ol'

--- a/packages/ui-metric/src/Metric/index.js
+++ b/packages/ui-metric/src/Metric/index.js
@@ -30,13 +30,14 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { callRenderProp, passthroughProps } from '@instructure/ui-react-utils'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Metric extends Component {
   static propTypes = {

--- a/packages/ui-metric/src/Metric/styles.js
+++ b/packages/ui-metric/src/Metric/styles.js
@@ -22,18 +22,15 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props) => {
+const generateStyle = (componentTheme, props) => {
   const { textAlign } = props
-  const componentTheme = generateComponentTheme(theme, themeOverride)
 
   return {
     metric: {

--- a/packages/ui-metric/src/MetricGroup/index.js
+++ b/packages/ui-metric/src/MetricGroup/index.js
@@ -31,13 +31,14 @@ import { passthroughProps, safeCloneElement } from '@instructure/ui-react-utils'
 import { Metric } from '../Metric'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class MetricGroup extends Component {
   static propTypes = {

--- a/packages/ui-metric/src/MetricGroup/styles.js
+++ b/packages/ui-metric/src/MetricGroup/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme) => {
   return {
     metricGroup: {
       label: 'metricGroup',

--- a/packages/ui-navigation/src/Navigation/NavigationItem/index.js
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/index.js
@@ -32,6 +32,7 @@ import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -39,7 +40,7 @@ parent: Navigation
 id: Navigation.Item
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class NavigationItem extends Component {
   static propTypes = {

--- a/packages/ui-navigation/src/Navigation/NavigationItem/styles.js
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/styles.js
@@ -22,18 +22,15 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
+const generateStyle = (componentTheme, props, state) => {
   const { selected } = props
-  const componentTheme = generateComponentTheme(theme, themeOverride)
 
   return {
     navigationItem: {

--- a/packages/ui-navigation/src/Navigation/index.js
+++ b/packages/ui-navigation/src/Navigation/index.js
@@ -38,6 +38,7 @@ import { withStyle, jsx } from '@instructure/emotion'
 import { NavigationItem } from './NavigationItem'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 const navMinimized = ({ minimized }) => ({ minimized: !minimized })
 
@@ -46,7 +47,7 @@ const navMinimized = ({ minimized }) => ({ minimized: !minimized })
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Navigation extends Component {
   static propTypes = {

--- a/packages/ui-navigation/src/Navigation/styles.js
+++ b/packages/ui-navigation/src/Navigation/styles.js
@@ -22,18 +22,16 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} themeOverride User provided overrides of the default theme mapping.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
+const generateStyle = (componentTheme, props, state) => {
   const { minimized } = state
-  const componentTheme = generateComponentTheme(theme, themeOverride)
 
   return {
     navigation: {

--- a/packages/ui-pages/src/Pages/index.js
+++ b/packages/ui-pages/src/Pages/index.js
@@ -38,13 +38,14 @@ import { Page } from './Page'
 
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Pages extends Component {
   static propTypes = {
     children: Children.oneOf([Page]),

--- a/packages/ui-pages/src/Pages/styles.js
+++ b/packages/ui-pages/src/Pages/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     pages: {
       fontSize: componentTheme.fontSize,

--- a/packages/ui-pill/src/Pill/index.js
+++ b/packages/ui-pill/src/Pill/index.js
@@ -36,13 +36,14 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Pill extends Component {
   static propTypes = {

--- a/packages/ui-pill/src/Pill/styles.js
+++ b/packages/ui-pill/src/Pill/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { color } = props
 
   const pillColorVariants = {

--- a/packages/ui-position/src/Position/index.js
+++ b/packages/ui-position/src/Position/index.js
@@ -46,6 +46,7 @@ import { Portal } from '@instructure/ui-portal'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import { calculateElementPosition } from '../calculateElementPosition'
 import { PositionPropTypes } from '../PositionPropTypes'
@@ -55,7 +56,7 @@ import { PositionPropTypes } from '../PositionPropTypes'
 category: components/utilities
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Position extends Component {
   static locatorAttribute = 'data-position'

--- a/packages/ui-position/src/Position/styles.js
+++ b/packages/ui-position/src/Position/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     zIndex: componentTheme.zIndex
   }

--- a/packages/ui-rating/src/Rating/styles.js
+++ b/packages/ui-rating/src/Rating/styles.js
@@ -24,13 +24,12 @@
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
+const generateStyle = (componentTheme, props, state) => {
   return {
     rating: {
       label: 'rating',

--- a/packages/ui-rating/src/RatingIcon/index.js
+++ b/packages/ui-rating/src/RatingIcon/index.js
@@ -32,13 +32,14 @@ import { Transition } from '@instructure/ui-motion'
 
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 parent: Rating
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class RatingIcon extends Component {
   static propTypes = {
     animationDelay: PropTypes.number,

--- a/packages/ui-rating/src/RatingIcon/styles.js
+++ b/packages/ui-rating/src/RatingIcon/styles.js
@@ -22,17 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const { size } = props
 
   const sizeVariants = {

--- a/packages/ui-spinner/src/Spinner/index.js
+++ b/packages/ui-spinner/src/Spinner/index.js
@@ -39,13 +39,14 @@ import { error } from '@instructure/console/macro'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @deprecated('8.0.0', { title: 'renderTitle' })
 @testable()
 class Spinner extends Component {

--- a/packages/ui-spinner/src/Spinner/styles.js
+++ b/packages/ui-spinner/src/Spinner/styles.js
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 import { keyframes } from '@instructure/emotion'
 
 // keyframes have to be outside of 'generateStyle',
@@ -49,15 +48,12 @@ const morph = keyframes`
 
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { size, variant } = props
 
   const spinnerSizes = {

--- a/packages/ui-svg-images/src/InlineSVG/index.js
+++ b/packages/ui-svg-images/src/InlineSVG/index.js
@@ -33,13 +33,14 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components/utilities
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class InlineSVG extends Component {
   static propTypes = {

--- a/packages/ui-svg-images/src/InlineSVG/styles.js
+++ b/packages/ui-svg-images/src/InlineSVG/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { inline, color } = props
 
   const colorVariants = {

--- a/packages/ui-svg-images/src/SVGIcon/index.js
+++ b/packages/ui-svg-images/src/SVGIcon/index.js
@@ -33,13 +33,14 @@ import { InlineSVG } from '../InlineSVG'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components/utilities
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class SVGIcon extends Component {
   static propTypes = {

--- a/packages/ui-svg-images/src/SVGIcon/styles.js
+++ b/packages/ui-svg-images/src/SVGIcon/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { rotate, size, bidirectional } = props
 
   const rotateVariants = {

--- a/packages/ui-table/src/Table/Body/index.js
+++ b/packages/ui-table/src/Table/Body/index.js
@@ -35,7 +35,8 @@ import { Children as ChildrenPropTypes } from '@instructure/ui-prop-types'
 import { View } from '@instructure/ui-view'
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 import { Row } from '../Row'
 
 /**
@@ -44,7 +45,7 @@ parent: Table
 id: Table.Body
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class Body extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Body/styles.js
+++ b/packages/ui-table/src/Table/Body/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     body: {
       label: 'body',

--- a/packages/ui-table/src/Table/Cell/index.js
+++ b/packages/ui-table/src/Table/Cell/index.js
@@ -31,7 +31,8 @@ import { View } from '@instructure/ui-view'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -39,7 +40,7 @@ parent: Table
 id: Table.Cell
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class Cell extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Cell/styles.js
+++ b/packages/ui-table/src/Table/Cell/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { textAlign } = props
 
   return {

--- a/packages/ui-table/src/Table/ColHeader/index.js
+++ b/packages/ui-table/src/Table/ColHeader/index.js
@@ -34,7 +34,8 @@ import {
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -42,7 +43,7 @@ parent: Table
 id: Table.ColHeader
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class ColHeader extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/ColHeader/styles.js
+++ b/packages/ui-table/src/Table/ColHeader/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { onRequestSort, textAlign } = props
 
   const headerStyle = {

--- a/packages/ui-table/src/Table/Head/index.js
+++ b/packages/ui-table/src/Table/Head/index.js
@@ -39,7 +39,8 @@ import { warn } from '@instructure/console'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import { Row } from '../Row'
 import { ColHeader } from '../ColHeader'
@@ -50,7 +51,7 @@ parent: Table
 id: Table.Head
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class Head extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Head/styles.js
+++ b/packages/ui-table/src/Table/Head/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     head: {
       label: 'head',

--- a/packages/ui-table/src/Table/Row/index.js
+++ b/packages/ui-table/src/Table/Row/index.js
@@ -36,7 +36,8 @@ import { View } from '@instructure/ui-view'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import { ColHeader } from '../ColHeader'
 import { RowHeader } from '../RowHeader'
@@ -48,7 +49,7 @@ parent: Table
 id: Table.Row
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class Row extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Row/styles.js
+++ b/packages/ui-table/src/Table/Row/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { hover, isStacked } = props
 
   return {

--- a/packages/ui-table/src/Table/RowHeader/index.js
+++ b/packages/ui-table/src/Table/RowHeader/index.js
@@ -31,7 +31,8 @@ import { View } from '@instructure/ui-view'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -39,7 +40,7 @@ parent: Table
 id: Table.RowHeader
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class RowHeader extends Component {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/RowHeader/styles.js
+++ b/packages/ui-table/src/Table/RowHeader/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { textAlign } = props
 
   return {

--- a/packages/ui-table/src/Table/index.js
+++ b/packages/ui-table/src/Table/index.js
@@ -38,7 +38,8 @@ import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
-import generateStyles from './styles'
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import { Head } from './Head'
 import { Body } from './Body'
@@ -52,7 +53,7 @@ import { Cell } from './Cell'
 category: components
 ---
 **/
-@withStyle(generateStyles)
+@withStyle(generateStyle, generateComponentTheme)
 class Table extends Component {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-table/src/Table/styles.js
+++ b/packages/ui-table/src/Table/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { layout } = props
 
   return {

--- a/packages/ui-tag/src/Tag/index.js
+++ b/packages/ui-tag/src/Tag/index.js
@@ -34,6 +34,7 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -41,7 +42,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Tag extends Component {
   static propTypes = {

--- a/packages/ui-tag/src/Tag/styles.js
+++ b/packages/ui-tag/src/Tag/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   const { variant, size, dismissible, onClick, disabled } = props
 
   const isButton = !!onClick

--- a/packages/ui-text-area/src/TextArea/index.js
+++ b/packages/ui-text-area/src/TextArea/index.js
@@ -41,13 +41,14 @@ import { px } from '@instructure/ui-utils'
 import { testable } from '@instructure/ui-testable'
 import { omitProps, pickProps } from '@instructure/ui-react-utils'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class TextArea extends Component {
   static propTypes = {

--- a/packages/ui-text-area/src/TextArea/styles.js
+++ b/packages/ui-text-area/src/TextArea/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const { disabled, size } = props
 
   const fontSizeVariants = {

--- a/packages/ui-text-input/src/TextInput/index.js
+++ b/packages/ui-text-input/src/TextInput/index.js
@@ -37,9 +37,10 @@ import { isActiveElement } from '@instructure/ui-dom-utils'
 import { FormField, FormPropTypes } from '@instructure/ui-form-field'
 import { Flex } from '@instructure/ui-flex'
 import { uid } from '@instructure/uid'
+import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
-import { testable } from '@instructure/ui-testable'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -47,7 +48,7 @@ category: components
 tags: form, field
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @deprecated('8.0.0', {
   label: 'renderLabel',
   required: 'isRequired',

--- a/packages/ui-text-input/src/TextInput/styles.js
+++ b/packages/ui-text-input/src/TextInput/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const { size, textAlign, as } = props
   const { disabled, invalid, focused } = state
 

--- a/packages/ui-text/src/Text/index.js
+++ b/packages/ui-text/src/Text/index.js
@@ -30,13 +30,14 @@ import { passthroughProps, getElementType } from '@instructure/ui-react-utils'
 
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class Text extends Component {
   static propTypes = {
     /**

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const {
     size,
     wrap,

--- a/packages/ui-themeable/src/ThemeRegistry.js
+++ b/packages/ui-themeable/src/ThemeRegistry.js
@@ -459,7 +459,8 @@ const ThemeRegistry = {
   registerComponentTheme,
   registerTheme,
   mountComponentStyles,
-  flushComponentStyles
+  flushComponentStyles,
+  getRegisteredTheme
 }
 
 export default ThemeRegistry
@@ -474,5 +475,6 @@ export {
   registerComponentTheme,
   registerTheme,
   mountComponentStyles,
-  flushComponentStyles
+  flushComponentStyles,
+  getRegisteredTheme
 }

--- a/packages/ui-tooltip/src/Tooltip/index.js
+++ b/packages/ui-tooltip/src/Tooltip/index.js
@@ -41,13 +41,14 @@ import { element } from '@instructure/ui-prop-types'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Tooltip extends Component {
   static propTypes = {

--- a/packages/ui-tooltip/src/Tooltip/styles.js
+++ b/packages/ui-tooltip/src/Tooltip/styles.js
@@ -22,19 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
-
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme, props, state) => {
   return {
     tooltip: {
       label: 'tooltip',

--- a/packages/ui-tray/src/Tray/index.js
+++ b/packages/ui-tray/src/Tray/index.js
@@ -37,12 +37,13 @@ import { mirrorHorizontalPlacement } from '@instructure/ui-position'
 import { Transition } from '@instructure/ui-motion'
 import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 /**
 ---
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 @bidirectional()
 class Tray extends Component {

--- a/packages/ui-tray/src/Tray/styles.js
+++ b/packages/ui-tray/src/Tray/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, state) => {
-  // get the theme variables object for the component
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, state) => {
   const { border, shadow, size, placement } = props
 
   const borderStyle = {

--- a/packages/ui-truncate-text/src/TruncateText/index.js
+++ b/packages/ui-truncate-text/src/TruncateText/index.js
@@ -37,6 +37,7 @@ import { testable } from '@instructure/ui-testable'
 import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import truncate from './utils/truncate'
 
@@ -45,7 +46,7 @@ import truncate from './utils/truncate'
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 @hack(['shouldTruncateWhenInvisible'])
 class TruncateText extends Component {

--- a/packages/ui-truncate-text/src/TruncateText/styles.js
+++ b/packages/ui-truncate-text/src/TruncateText/styles.js
@@ -22,18 +22,14 @@
  * SOFTWARE.
  */
 
-import generateComponentTheme from './theme'
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
-
+const generateStyle = (componentTheme) => {
   return {
     truncateText: {
       label: 'truncateText',

--- a/packages/ui-view/src/ContextView/index.js
+++ b/packages/ui-view/src/ContextView/index.js
@@ -32,6 +32,7 @@ import { omitProps } from '@instructure/ui-react-utils'
 
 import { View } from '../View'
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -39,7 +40,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 class ContextView extends Component {
   static propTypes = {
     /**

--- a/packages/ui-view/src/ContextView/styles.js
+++ b/packages/ui-view/src/ContextView/styles.js
@@ -24,8 +24,6 @@
 
 import { mirrorPlacement } from '@instructure/ui-position'
 
-import generateComponentTheme from './theme'
-
 const getPlacementStyle = (placement, theme) => {
   if (
     ['end-center', 'end-top', 'end-bottom', 'center-end', 'end'].includes(
@@ -224,11 +222,17 @@ const getArrowPlacementVariant = (placement, background, theme) => {
   }
 }
 
-const generateStyle = (theme, themeOverride, props, extraArgs) => {
+/**
+ * Generates the style object from the theme and provided additional information
+ * @param  {Object} componentTheme The theme variable object.
+ * @param  {Object} props the props of the component, the style is applied to
+ * @param  {Object} state the state of the component, the style is applied to
+ * @return {Object} The final style object, which will be used in the component
+ */
+const generateStyle = (componentTheme, props, state) => {
   const { placement, background } = props
   const transformedPlacement = placement.replace(' ', '-')
 
-  const componentTheme = generateComponentTheme(theme, themeOverride)
   const arrowBaseStyles = {
     content: '""',
     height: '0',

--- a/packages/ui-view/src/View/index.js
+++ b/packages/ui-view/src/View/index.js
@@ -41,6 +41,7 @@ import {
 } from '@instructure/ui-react-utils'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 /**
 ---
@@ -48,7 +49,7 @@ category: components
 ---
 @module View
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, generateComponentTheme)
 @bidirectional()
 class View extends Component {
   static propTypes = {

--- a/packages/ui-view/src/View/styles.js
+++ b/packages/ui-view/src/View/styles.js
@@ -29,7 +29,6 @@ import {
 } from '@instructure/ui-themeable'
 import { pickProps } from '@instructure/ui-react-utils'
 import { error } from '@instructure/console/macro'
-import generateComponentTheme from './theme'
 
 const getBorderStyle = ({ borderRadius, borderWidth, dir, theme }) => {
   const isRtlDirection = dir === DIRECTION.rtl
@@ -315,16 +314,15 @@ const getFocusStyles = (props, componentTheme) => {
     }
   }
 }
+
 /**
  * Generates the style object from the theme and provided additional information
- * @param  {Object} theme The actual theme object.
- * @param  {Object} themeOverride User provided overrides of the default theme mapping.
+ * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
  * @param  {Object} extraArgs
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (theme, themeOverride, props, extraArgs = {}) => {
-  const componentTheme = generateComponentTheme(theme, themeOverride)
+const generateStyle = (componentTheme, props, extraArgs = {}) => {
   const {
     borderRadius,
     borderWidth,


### PR DESCRIPTION
Closes: INSTUI-2823

Refactored componentTheme handling: the theme generator is now imported in `index.js` instead of
`styles.js`, and passed to and handled in `withStyle` decorator.
In the `withStyle` decorator we
expose the theme generator so we can use it in the docs client to generate the theme variables on
the component's page.
TEST PLAN:
The `Default Theme Variables` block appears on the docs page of migrated components.