### PR TITLE
INSTUI-2828 - test: temporarily disable tests for unmigrated components

### DIFF
--- a/packages/ui-a11y-content/src/AccessibleContent/__tests__/AccessibleContent.test.js
+++ b/packages/ui-a11y-content/src/AccessibleContent/__tests__/AccessibleContent.test.js
@@ -26,7 +26,7 @@ import React from 'react'
 import { expect, mount, within } from '@instructure/ui-test-utils'
 import { AccessibleContent } from '../index'
 
-describe('<AccessibleContent />', async () => {
+xdescribe('<AccessibleContent />', async () => {
   it('should render screen reader content', async () => {
     const subject = await mount(
       <AccessibleContent alt="Screen Reader Content">

--- a/packages/ui-a11y-content/src/PresentationContent/__tests__/PresentationContent.test.js
+++ b/packages/ui-a11y-content/src/PresentationContent/__tests__/PresentationContent.test.js
@@ -33,7 +33,7 @@ import {
 
 import { PresentationContent } from '../index'
 
-describe('<PresentationContent />', async () => {
+xdescribe('<PresentationContent />', async () => {
   it('should render children with an aria-hidden attribute', async () => {
     await mount(<PresentationContent>Hello World</PresentationContent>)
 

--- a/packages/ui-a11y-content/src/ScreenReaderContent/__tests__/ScreenReaderContent.test.js
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/__tests__/ScreenReaderContent.test.js
@@ -26,7 +26,7 @@ import React from 'react'
 import { expect, mount } from '@instructure/ui-test-utils'
 import { ScreenReaderContent } from '../index'
 
-describe('<ScreenReaderContent />', async () => {
+xdescribe('<ScreenReaderContent />', async () => {
   it('should render the specified tag when `as` prop is set', async () => {
     const subject = await mount(<ScreenReaderContent as="div" />)
     expect(subject.getDOMNode()).to.have.tagName('div')

--- a/packages/ui-calendar/src/Calendar/Day/__tests__/Day.test.js
+++ b/packages/ui-calendar/src/Calendar/Day/__tests__/Day.test.js
@@ -35,7 +35,7 @@ import { Day } from '../index'
 import { DayLocator } from '../DayLocator'
 import DayExamples from '../__examples__/Day.examples'
 
-describe('Day', async () => {
+xdescribe('Day', async () => {
   beforeEach(async () => {
     stub(console, 'warn') // suppress experimental warnings
   })

--- a/packages/ui-calendar/src/Calendar/Day/__tests__/theme.test.js
+++ b/packages/ui-calendar/src/Calendar/Day/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { Day } from '../index'
 
-describe('Day.theme', () => {
+xdescribe('Day.theme', () => {
   describe('with the default theme', () => {
     const variables = Day.generateTheme()
 

--- a/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.js
+++ b/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.js
@@ -34,7 +34,7 @@ import { Calendar } from '../index'
 import { CalendarLocator } from '../CalendarLocator'
 import CalendarExamples from '../__examples__/Calendar.examples'
 
-describe('<Calendar />', async () => {
+xdescribe('<Calendar />', async () => {
   beforeEach(async () => {
     stub(console, 'warn') // suppress experimental warnings
   })

--- a/packages/ui-calendar/src/Calendar/__tests__/theme.test.js
+++ b/packages/ui-calendar/src/Calendar/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { Calendar } from '../index'
 
-describe('Calendar.theme', () => {
+xdescribe('Calendar.theme', () => {
   describe('with the default theme', () => {
     const variables = Calendar.generateTheme()
 

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/__tests__/CheckboxFacade.test.js
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/__tests__/CheckboxFacade.test.js
@@ -27,7 +27,7 @@ import { expect, mount, within } from '@instructure/ui-test-utils'
 
 import { CheckboxFacade } from '../index'
 
-describe('<CheckboxFacade />', async () => {
+xdescribe('<CheckboxFacade />', async () => {
   it('should render', async () => {
     const subject = await mount(<CheckboxFacade>label text</CheckboxFacade>)
     const checkboxFacade = within(subject.getDOMNode())

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/__tests__/theme.test.js
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { CheckboxFacade } from '../index'
 
-describe('CheckboxFacade.theme', () => {
+xdescribe('CheckboxFacade.theme', () => {
   describe('with the default theme', () => {
     const variables = CheckboxFacade.generateTheme()
 

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/__tests__/ToggleFacade.test.js
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/__tests__/ToggleFacade.test.js
@@ -27,7 +27,7 @@ import { expect, mount, within } from '@instructure/ui-test-utils'
 
 import { ToggleFacade } from '../index'
 
-describe('<ToggleFacade />', async () => {
+xdescribe('<ToggleFacade />', async () => {
   it('should render', async () => {
     const subject = await mount(<ToggleFacade>label text</ToggleFacade>)
     const toggleFacade = within(subject.getDOMNode())

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/__tests__/theme.test.js
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { ToggleFacade } from '../index'
 
-describe('ToggleFacade.theme', () => {
+xdescribe('ToggleFacade.theme', () => {
   describe('with the default theme', () => {
     const variables = ToggleFacade.generateTheme()
 

--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.js
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.js
@@ -28,7 +28,7 @@ import { expect, mount, stub, wait } from '@instructure/ui-test-utils'
 import { Checkbox } from '../index'
 import { CheckboxLocator } from '../CheckboxLocator'
 
-describe('<Checkbox />', async () => {
+xdescribe('<Checkbox />', async () => {
   it('renders an input with type "checkbox"', async () => {
     await mount(
       <Checkbox

--- a/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.js
+++ b/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.js
@@ -30,7 +30,7 @@ import { CheckboxGroupLocator } from '../CheckboxGroupLocator'
 import { CheckboxGroup } from '../index'
 import { Checkbox } from '../../Checkbox'
 
-describe('<CheckboxGroup />', async () => {
+xdescribe('<CheckboxGroup />', async () => {
   it('adds the name props to all Checkbox types', async () => {
     await mount(
       <CheckboxGroup name="sports" description="Select your favorite sports">

--- a/packages/ui-code-editor/src/CodeEditor/__tests__/CodeEditor.test.js
+++ b/packages/ui-code-editor/src/CodeEditor/__tests__/CodeEditor.test.js
@@ -28,7 +28,7 @@ import { CodeEditor } from '../index'
 
 import { CodeEditorLocator } from '../CodeEditorLocator'
 
-describe('<CodeEditor />', async () => {
+xdescribe('<CodeEditor />', async () => {
   it('should render', async () => {
     await mount(<CodeEditor label="foo" />)
     const editor = await CodeEditorLocator.find()

--- a/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.js
+++ b/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.js
@@ -37,7 +37,7 @@ import Examples from '../__examples__/DateInput.examples'
 import { DateInput } from '../index'
 import { DateInputLocator } from '../DateInputLocator'
 
-describe('<DateInput />', async () => {
+xdescribe('<DateInput />', async () => {
   beforeEach(async () => {
     stub(console, 'warn') // suppress experimental warnings
   })

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/__tests__/DrawerContent.test.js
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/__tests__/DrawerContent.test.js
@@ -29,7 +29,7 @@ import styles from '../styles.css'
 
 import { DrawerContentLocator } from '../DrawerContentLocator'
 
-describe('<DrawerContent />', async () => {
+xdescribe('<DrawerContent />', async () => {
   it('should render', async () => {
     await mount(
       <DrawerContent label="DrawerContentTest">Hello World</DrawerContent>

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.js
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.js
@@ -29,7 +29,7 @@ import styles from '../styles.css'
 
 import { DrawerTrayLocator } from '../DrawerTrayLocator'
 
-describe('<DrawerTray />', async () => {
+xdescribe('<DrawerTray />', async () => {
   it(`should place the tray correctly with placement=start`, async () => {
     await mount(
       <DrawerTray

--- a/packages/ui-drawer-layout/src/DrawerLayout/__tests__/DrawerLayout.test.js
+++ b/packages/ui-drawer-layout/src/DrawerLayout/__tests__/DrawerLayout.test.js
@@ -29,7 +29,7 @@ import { expect, mount, stub, wait } from '@instructure/ui-test-utils'
 import DrawerLayoutFixture from '../__fixtures__/DrawerLayout.fixture'
 import { DrawerLayoutLocator } from '../DrawerLayoutLocator'
 
-describe('<DrawerLayout />', async () => {
+xdescribe('<DrawerLayout />', async () => {
   it('should render', async () => {
     await mount(<DrawerLayoutFixture />)
     const layout = await DrawerLayoutLocator.find()

--- a/packages/ui-motion/src/Transition/__tests__/Transition.test.js
+++ b/packages/ui-motion/src/Transition/__tests__/Transition.test.js
@@ -35,7 +35,7 @@ import {
 import { Transition } from '../index'
 import styles from '../styles.css'
 
-describe('<Transition />', async () => {
+xdescribe('<Transition />', async () => {
   const types = [
     'fade',
     'scale',

--- a/packages/ui-overlays/src/Mask/__tests__/Mask.test.js
+++ b/packages/ui-overlays/src/Mask/__tests__/Mask.test.js
@@ -28,7 +28,7 @@ import { expect, mount, spy, stub, within } from '@instructure/ui-test-utils'
 import { Mask } from '../index'
 import styles from '../styles.css'
 
-describe('<Mask />', async () => {
+xdescribe('<Mask />', async () => {
   it('should render', async () => {
     const subject = await mount(<Mask />)
     expect(subject.getDOMNode()).to.exist()

--- a/packages/ui-overlays/src/Overlay/__tests__/Overlay.test.js
+++ b/packages/ui-overlays/src/Overlay/__tests__/Overlay.test.js
@@ -29,7 +29,7 @@ import { Overlay } from '../index'
 
 import { OverlayLocator } from '../OverlayLocator'
 
-describe('<Overlay />', async () => {
+xdescribe('<Overlay />', async () => {
   it('should render nothing when closed', async () => {
     await mount(<Overlay label="Overlay Example" />)
     const overlay = await OverlayLocator.find({ expectEmpty: true })

--- a/packages/ui-progress/src/Progress/__tests__/Progress.test.js
+++ b/packages/ui-progress/src/Progress/__tests__/Progress.test.js
@@ -30,7 +30,7 @@ import { ProgressLocator } from '../ProgressLocator'
 import { ProgressCircleLocator } from '../../ProgressCircle/ProgressCircleLocator'
 import { ProgressBarLocator } from '../../ProgressBar/ProgressBarLocator'
 
-describe('<Progress />', async () => {
+xdescribe('<Progress />', async () => {
   it('should render', async () => {
     await mount(<Progress label="Chapters read" valueMax={60} valueNow={30} />)
     expect(await ProgressLocator.find()).to.exist()

--- a/packages/ui-progress/src/ProgressBar/__tests__/ProgressBar.test.js
+++ b/packages/ui-progress/src/ProgressBar/__tests__/ProgressBar.test.js
@@ -28,7 +28,7 @@ import { expect, mount } from '@instructure/ui-test-utils'
 import { ProgressBar } from '../index'
 import { ProgressBarLocator } from '../ProgressBarLocator'
 
-describe('<ProgressBar />', async () => {
+xdescribe('<ProgressBar />', async () => {
   it('should render', async () => {
     await mount(
       <ProgressBar

--- a/packages/ui-progress/src/ProgressBar/__tests__/theme.test.js
+++ b/packages/ui-progress/src/ProgressBar/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { ProgressBar } from '../index'
 
-describe('ProgressBar.theme', () => {
+xdescribe('ProgressBar.theme', () => {
   describe('with the default theme', () => {
     const variables = ProgressBar.generateTheme()
 

--- a/packages/ui-progress/src/ProgressCircle/__tests__/ProgressCircle.test.js
+++ b/packages/ui-progress/src/ProgressCircle/__tests__/ProgressCircle.test.js
@@ -28,7 +28,7 @@ import { expect, mount } from '@instructure/ui-test-utils'
 import { ProgressCircle } from '../index'
 import { ProgressCircleLocator } from '../ProgressCircleLocator'
 
-describe('<ProgressCircle />', async () => {
+xdescribe('<ProgressCircle />', async () => {
   it('should render', async () => {
     await mount(
       <ProgressCircle

--- a/packages/ui-progress/src/ProgressCircle/__tests__/theme.test.js
+++ b/packages/ui-progress/src/ProgressCircle/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { ProgressCircle } from '../index'
 
-describe('ProgressCircle.theme', () => {
+xdescribe('ProgressCircle.theme', () => {
   describe('with the default theme', () => {
     const variables = ProgressCircle.generateTheme()
 

--- a/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.js
+++ b/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.js
@@ -28,7 +28,7 @@ import { expect, mount, stub, wait } from '@instructure/ui-test-utils'
 import { RadioInput } from '../index'
 import { RadioInputLocator } from '../RadioInputLocator'
 
-describe('<RadioInput />', async () => {
+xdescribe('<RadioInput />', async () => {
   it('renders an input with type "radio"', async () => {
     await mount(
       <RadioInput label="fake label" value="someValue" name="someName" />

--- a/packages/ui-radio-input/src/RadioInput/__tests__/theme.test.js
+++ b/packages/ui-radio-input/src/RadioInput/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { RadioInput } from '../index'
 
-describe('RadioInput.theme', () => {
+xdescribe('RadioInput.theme', () => {
   describe('with the default theme', () => {
     const variables = RadioInput.generateTheme()
 

--- a/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.js
+++ b/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.js
@@ -30,7 +30,7 @@ import { RadioInputGroup } from '../index'
 
 import { RadioInputGroupLocator } from '../RadioInputGroupLocator'
 
-describe('<RadioInputGroup />', async () => {
+xdescribe('<RadioInputGroup />', async () => {
   it('adds the name props to all RadioInput types', async () => {
     await mount(
       <RadioInputGroup name="fruit" description="Select a fruit">

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.js
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.js
@@ -28,7 +28,7 @@ import { expect, mount, stub } from '@instructure/ui-test-utils'
 import { RangeInput } from '../index'
 import { RangeInputLocator } from '../RangeInputLocator'
 
-describe('<RangeInput />', async () => {
+xdescribe('<RangeInput />', async () => {
   it('renders an input with type "range"', async () => {
     await mount(<RangeInput label="Opacity" name="opacity" max={100} min={0} />)
     const rangeInput = await RangeInputLocator.find()

--- a/packages/ui-select/src/Select/__tests__/Select.test.js
+++ b/packages/ui-select/src/Select/__tests__/Select.test.js
@@ -35,7 +35,7 @@ import { Select } from '../index'
 import { SelectLocator } from '../SelectLocator'
 import SelectExamples from '../__examples__/Select.examples'
 
-describe('<Select />', async () => {
+xdescribe('<Select />', async () => {
   beforeEach(async () => {
     stub(console, 'warn') // suppress experimental warnings
   })

--- a/packages/ui-select/src/Select/__tests__/theme.test.js
+++ b/packages/ui-select/src/Select/__tests__/theme.test.js
@@ -27,7 +27,7 @@ import { contrast } from '@instructure/ui-color-utils'
 
 import { Select } from '../index'
 
-describe('Select.theme', () => {
+xdescribe('Select.theme', () => {
   describe('with the default theme', () => {
     const variables = Select.generateTheme()
 


### PR DESCRIPTION
Closes: INSTUI-2828

In order to see if the relevant tests pass on `next` branch, we need to disable tests of unmigrated
components. Will turn tests back when migrating component to emotion.