### PR TITLE
docs(console): add documentation for the log commands

### DIFF
--- a/packages/console/macro.js
+++ b/packages/console/macro.js
@@ -52,6 +52,29 @@ function macro({ babel, references, state }) {
     })
   })
 }
-module.exports = exports.error = exports.warn = exports.warnDeprecated = exports.info = exports.assert = exports.debug = exports.log = createMacro(
-  macro
-)
+
+module.exports = createMacro(macro)
+/**
+ * Logs a message to the console if its not a production build.
+ * @param isSuppressed Must be false to log anything.
+ * @param message The message to log.
+ * @param rest anything else to log.
+ * @type {function(isSuppressed: boolean, message: string, rest: ...*): *}
+ */
+exports.error = exports.warn = createMacro(macro)
+
+/**
+ * Logs a deprecation message to the console if its not a production build and
+ * the `OMIT_INSTUI_DEPRECATION_WARNINGS` env var is not set or is set to `false`
+ * @param isSuppressed Must be false to log anything.
+ * @param message The message to log.
+ * @param rest anything else to log.
+ * @type {function(isSuppressed: boolean, message: string, rest: ...*): *}
+ */
+exports.warnDeprecated = createMacro(macro)
+
+/**
+ * Logs a message to the console.
+ * @type {function(rest: ...*): *}
+ */
+exports.info = exports.assert = exports.debug = exports.log = createMacro(macro)


### PR DESCRIPTION
This will get rid of the warnings in WebStorm and add nice hints how to use it.