### PR TITLE
refactor(emotion,multiple): add annotations to new functions

### DIFF
--- a/docs/patterns/UsingIcons.md
+++ b/docs/patterns/UsingIcons.md
@@ -7,18 +7,20 @@ id: UsingIcons
 ## Using Icons
 
 ### Accessibility
+
 By default, the icon's `role` is set to `presentation`. However, when the `title` prop is set, the role attribute is set to `img`. Include the `description` prop to further describe the icon.
 
 ```js
 ---
 example: true
 ---
-<View as="div" margin="small" padding="medium" background="default">
+<View as="div" margin="small" padding="medium" background="primary">
   <Text as="div" size="large">I <IconHeartLine color="error" title="Love" /> New York</Text>
 </View>
 ```
 
 ### Line vs Solid
+
 The default choice for iconography is the `Line` version. However, when an icon appears on a dark or colored background, the `Solid` version should be used.
 
 ```js
@@ -35,12 +37,14 @@ example: true
 ```
 
 ### Changing the Icon Size
+
 By default, icons are set to a size of 1em, so they will scale to match the font-size of their parent element. To change the size of the icon, use one of the predefined options for the `size` prop. If you need a size that is not offered via the size prop, adjust the font-size on the icon's parent element.
+
 ```js
 ---
 example: true
 ---
-<View as="div" margin="small" padding="medium" background="default">
+<View as="div" margin="small" padding="medium" background="primary">
   <Flex wrap="wrap">
     <Flex.Item padding="small" shouldGrow>
       <Heading>I <IconHeartLine /> the size of my parent heading </Heading>
@@ -65,12 +69,14 @@ example: true
 ```
 
 ### Changing the Icon Color
+
 To change the color of the icon, use one of the predefined options for the `color` prop. By default the icon inherits the color of its parent element. However, it can be changed by setting the icon to one of the theme colors via the color property.
+
 ```js
 ---
 example: true
 ---
-<View as="div" margin="small" padding="medium" background="default">
+<View as="div" margin="small" padding="medium" background="primary">
   <Flex wrap="wrap">
     <Flex.Item padding="small" shouldGrow>
       <Text color="brand">I am inheriting my parent's color <IconHeartLine /></Text>

--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -197,6 +197,9 @@ You need to use the content of the `styles.css` and convert it to css-in-js. Use
 
 ```js
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/emotion/src/EmotionThemeProvider/index.js
+++ b/packages/emotion/src/EmotionThemeProvider/index.js
@@ -25,8 +25,13 @@ import React from 'react'
 import { ThemeProvider } from 'emotion-theming'
 import { merge } from 'lodash'
 
+/**
+ * ---
+ * category: utilities/themes
+ * ---
+ */
 function EmotionThemeProvider({ children, theme = {} }) {
-  //if fuction is given to theme prop, Emotion will repleace the theme with the return value
+  // if function is given to theme prop, Emotion will replace the theme with the return value
   const getTheme = (theme) => (ancestorTheme = {}) => {
     const themeName = ancestorTheme.key
     const themeBasedOverride = theme?.themes?.[themeName]

--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -23,4 +23,5 @@
  */
 export { jsx, css, keyframes } from '@emotion/core'
 export { EmotionThemeProvider } from './EmotionThemeProvider'
-export { useTheme, withStyle, useStyle } from './styleUtils'
+export { useTheme, useStyle } from './styleUtils'
+export { withStyle } from './withStyle'

--- a/packages/emotion/src/withStyle.js
+++ b/packages/emotion/src/withStyle.js
@@ -1,0 +1,141 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React, { forwardRef, useState } from 'react'
+import { decorator } from '@instructure/ui-decorator'
+import { isEqual } from 'lodash'
+import hoistNonReactStatics from 'hoist-non-react-statics'
+import { useTextDirectionContext } from '@instructure/ui-i18n'
+import { bidirectionalPolyfill } from './styleUtils/polyFill'
+import { getThemeOverride, useTheme } from './styleUtils'
+
+/**
+ * ---
+ * category: utilities/themes
+ * ---
+ * Decorator which adds a `makeStyles` function and
+ * the generated `styles` object to the decorated Component's props.
+ *
+ * @param {function} generateStyle - The function that returns the component's style object
+ * @param {function} generateComponentTheme - The function that returns the component's theme variables object
+ * @returns {ReactElement} The decorated WithStyle Component
+ *
+ * @example
+ * class ExampleComponent extends React.Component {
+ *
+ *  componentDidUpdate() {
+ *    this.props.makeStyles()
+ *
+ * }
+ *  componentDidMount() {
+ *    this.props.makeStyles()
+ * }
+ *
+ *  render() {
+ *    const { propVal1, styles, ...props } = this.props
+ *
+ *    return (
+ *      <Element css={styles.root} >...</Element>
+ *    )
+ *  }
+ * }
+ */
+const withStyle = decorator(
+  (ComposedComponent, generateStyle, generateComponentTheme) => {
+    const WithStyle = forwardRef((props, ref) => {
+      const theme = useTheme()
+      const dir = useTextDirectionContext()
+      const componentProps = {
+        ...ComposedComponent.defaultProps,
+        ...props
+      }
+      const themeOverride = getThemeOverride(
+        theme,
+        ComposedComponent.displayName,
+        componentProps
+      )
+
+      const componentTheme =
+        typeof generateComponentTheme === 'function'
+          ? generateComponentTheme(theme, themeOverride)
+          : {}
+      const [styles, setStyles] = useState(
+        generateStyle
+          ? bidirectionalPolyfill(
+              generateStyle(componentTheme, componentProps, {}),
+              dir
+            )
+          : {}
+      )
+
+      const makeStyleHandler = (...extraArgs) => {
+        const calculatedStyles = bidirectionalPolyfill(
+          generateStyle(componentTheme, componentProps, ...extraArgs),
+          dir
+        )
+
+        if (!isEqual(calculatedStyles, styles)) {
+          setStyles(calculatedStyles)
+        }
+      }
+
+      return (
+        <ComposedComponent
+          ref={ref}
+          makeStyles={makeStyleHandler}
+          styles={styles}
+          {...props}
+        />
+      )
+    })
+
+    hoistNonReactStatics(WithStyle, ComposedComponent)
+
+    // we have to pass these on, because sometimes we need to
+    // access propTypes of the component in other components
+    // (mainly in the `omitProps` method)
+    WithStyle.propTypes = ComposedComponent.propTypes
+    WithStyle.defaultProps = ComposedComponent.defaultProps
+
+    // we are exposing the theme generator for the docs generation
+    WithStyle.generateComponentTheme = generateComponentTheme
+
+    // we have to add defaults to makeStyles and styles added by this decorator
+    // eslint-disable-next-line no-param-reassign
+    ComposedComponent.defaultProps = {
+      ...ComposedComponent.defaultProps,
+      makeStyles: () => {},
+      styles: {}
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      WithStyle.displayName = `WithStyle(${ComposedComponent.displayName})`
+    }
+
+    return WithStyle
+  }
+)
+
+export default withStyle
+export { withStyle }

--- a/packages/ui-alerts/src/Alert/styles.js
+++ b/packages/ui-alerts/src/Alert/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-avatar/src/Avatar/styles.js
+++ b/packages/ui-avatar/src/Avatar/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-badge/src/Badge/styles.js
+++ b/packages/ui-badge/src/Badge/styles.js
@@ -33,6 +33,9 @@ const pulseAnimation = keyframes`
   }`
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-billboard/src/Billboard/styles.js
+++ b/packages/ui-billboard/src/Billboard/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-breadcrumb/src/Breadcrumb/styles.js
+++ b/packages/ui-breadcrumb/src/Breadcrumb/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-buttons/src/BaseButton/styles.js
+++ b/packages/ui-buttons/src/BaseButton/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-buttons/src/CloseButton/styles.js
+++ b/packages/ui-buttons/src/CloseButton/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-byline/src/Byline/styles.js
+++ b/packages/ui-byline/src/Byline/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/styles.js
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.js
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-checkbox/src/Checkbox/styles.js
+++ b/packages/ui-checkbox/src/Checkbox/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-docs-client/src/Document/index.js
+++ b/packages/ui-docs-client/src/Document/index.js
@@ -84,7 +84,7 @@ class Document extends Component {
 
   renderTheme(doc) {
     const { themeKey } = this.props
-    const { generateComponentTheme } = doc.resource
+    const generateComponentTheme = doc?.resource?.generateComponentTheme
 
     const themeVariables = ThemeRegistry.getRegisteredTheme(themeKey).variables
     const theme =

--- a/packages/ui-editable/src/InPlaceEdit/styles.js
+++ b/packages/ui-editable/src/InPlaceEdit/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-file-drop/src/FileDrop/styles.js
+++ b/packages/ui-file-drop/src/FileDrop/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-flex/src/Flex/Item/styles.js
+++ b/packages/ui-flex/src/Flex/Item/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-flex/src/Flex/styles.js
+++ b/packages/ui-flex/src/Flex/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-focusable/src/Focusable/README.md
+++ b/packages/ui-focusable/src/Focusable/README.md
@@ -21,7 +21,7 @@ example: true
         margin="small 0"
         placement="bottom"
         as="div"
-        background="default"
+        background="primary"
         padding="small"
         borderWidth="small"
         display="block"

--- a/packages/ui-form-field/src/FormFieldGroup/styles.js
+++ b/packages/ui-form-field/src/FormFieldGroup/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-form-field/src/FormFieldLabel/styles.js
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.js
@@ -25,6 +25,9 @@
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-form-field/src/FormFieldLayout/styles.js
+++ b/packages/ui-form-field/src/FormFieldLayout/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-form-field/src/FormFieldMessage/styles.js
+++ b/packages/ui-form-field/src/FormFieldMessage/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-form-field/src/FormFieldMessages/styles.js
+++ b/packages/ui-form-field/src/FormFieldMessages/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-grid/src/Grid/styles.js
+++ b/packages/ui-grid/src/Grid/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-grid/src/GridCol/styles.js
+++ b/packages/ui-grid/src/GridCol/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-grid/src/GridRow/styles.js
+++ b/packages/ui-grid/src/GridRow/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-heading/src/Heading/styles.js
+++ b/packages/ui-heading/src/Heading/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-i18n/src/ApplyTextDirection/README.md
+++ b/packages/ui-i18n/src/ApplyTextDirection/README.md
@@ -6,7 +6,7 @@ A utility component used to manage text direction. In addition to appending the 
 its underlying DOM node, `<ApplyTextDirection />` also creates a direction context which can be
 consumed by child components that have implemented [bidirectional](#bidirectional).
 
-If no `dir` prop is supplied, `<ApplyTextDirection />` will fallback to its parent context if it 
+If no `dir` prop is supplied, `<ApplyTextDirection />` will fallback to its parent context if it
 exists. Otherwise it queries for and uses the documentElement `dir` attribute and defaults to `ltr`
 if it is not found.
 
@@ -17,7 +17,7 @@ example: true
 <ApplyTextDirection dir="rtl">
   <View
     display="block"
-    background="default"
+    background="primary"
     padding="large"
     borderWidth="none none none large"
   >
@@ -36,7 +36,7 @@ example: true
 <ApplyTextDirection dir="rtl">
   <View
     display="block"
-    background="default"
+    background="primary"
     padding="large"
     borderWidth="none none none large"
   >
@@ -46,7 +46,7 @@ example: true
   <ApplyTextDirection dir="ltr">
     <View
       display="block"
-      background="default"
+      background="primary"
       padding="large"
       borderWidth="none none none large"
     >

--- a/packages/ui-i18n/src/ApplyTextDirection/index.js
+++ b/packages/ui-i18n/src/ApplyTextDirection/index.js
@@ -28,6 +28,11 @@ import { getElementType } from '@instructure/ui-react-utils'
 
 import { DIRECTION, TextDirectionContext } from '../TextDirectionContext'
 
+/**
+---
+category: components/utilities
+---
+**/
 const ApplyTextDirection = (props) => {
   const context = useTextDirectionContext()
   const dir = props.dir || context

--- a/packages/ui-img/src/Img/styles.js
+++ b/packages/ui-img/src/Img/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-list/src/InlineList/InlineListItem/styles.js
+++ b/packages/ui-list/src/InlineList/InlineListItem/styles.js
@@ -25,6 +25,9 @@
 import { error } from '@instructure/console/macro'
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-list/src/List/ListItem/styles.js
+++ b/packages/ui-list/src/List/ListItem/styles.js
@@ -25,6 +25,9 @@
 import { error } from '@instructure/console/macro'
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-list/src/List/styles.js
+++ b/packages/ui-list/src/List/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-menu/src/Menu/MenuItem/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-menu/src/Menu/MenuItemGroup/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-menu/src/Menu/MenuItemSeparator/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItemSeparator/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-menu/src/Menu/styles.js
+++ b/packages/ui-menu/src/Menu/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-metric/src/Metric/styles.js
+++ b/packages/ui-metric/src/Metric/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-metric/src/MetricGroup/styles.js
+++ b/packages/ui-metric/src/MetricGroup/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-modal/src/Modal/ModalBody/styles.js
+++ b/packages/ui-modal/src/Modal/ModalBody/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-modal/src/Modal/ModalFooter/styles.js
+++ b/packages/ui-modal/src/Modal/ModalFooter/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-modal/src/Modal/ModalHeader/styles.js
+++ b/packages/ui-modal/src/Modal/ModalHeader/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-modal/src/Modal/styles.js
+++ b/packages/ui-modal/src/Modal/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-navigation/src/AppNav/Item/styles.js
+++ b/packages/ui-navigation/src/AppNav/Item/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-navigation/src/AppNav/styles.js
+++ b/packages/ui-navigation/src/AppNav/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-navigation/src/Navigation/NavigationItem/styles.js
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-navigation/src/Navigation/styles.js
+++ b/packages/ui-navigation/src/Navigation/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} themeOverride User provided overrides of the default theme mapping.

--- a/packages/ui-number-input/src/NumberInput/styles.js
+++ b/packages/ui-number-input/src/NumberInput/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-options/src/Options/Item/styles.js
+++ b/packages/ui-options/src/Options/Item/styles.js
@@ -25,6 +25,9 @@
 import { matchComponentTypes } from '@instructure/ui-react-utils'
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-options/src/Options/Separator/styles.js
+++ b/packages/ui-options/src/Options/Separator/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-options/src/Options/styles.js
+++ b/packages/ui-options/src/Options/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-overlays/src/Mask/styles.js
+++ b/packages/ui-overlays/src/Mask/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-pages/src/Pages/styles.js
+++ b/packages/ui-pages/src/Pages/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-pagination/src/Pagination/styles.js
+++ b/packages/ui-pagination/src/Pagination/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-pill/src/Pill/styles.js
+++ b/packages/ui-pill/src/Pill/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-position/src/Position/styles.js
+++ b/packages/ui-position/src/Position/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-rating/src/Rating/styles.js
+++ b/packages/ui-rating/src/Rating/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-rating/src/RatingIcon/styles.js
+++ b/packages/ui-rating/src/RatingIcon/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-spinner/src/Spinner/styles.js
+++ b/packages/ui-spinner/src/Spinner/styles.js
@@ -47,6 +47,9 @@ const morph = keyframes`
     }`
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-svg-images/src/InlineSVG/styles.js
+++ b/packages/ui-svg-images/src/InlineSVG/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-svg-images/src/SVGIcon/styles.js
+++ b/packages/ui-svg-images/src/SVGIcon/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/Body/styles.js
+++ b/packages/ui-table/src/Table/Body/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/Cell/styles.js
+++ b/packages/ui-table/src/Table/Cell/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/ColHeader/styles.js
+++ b/packages/ui-table/src/Table/ColHeader/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/Head/styles.js
+++ b/packages/ui-table/src/Table/Head/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/Row/styles.js
+++ b/packages/ui-table/src/Table/Row/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/RowHeader/styles.js
+++ b/packages/ui-table/src/Table/RowHeader/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-table/src/Table/styles.js
+++ b/packages/ui-table/src/Table/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tabs/src/Tabs/Panel/styles.js
+++ b/packages/ui-tabs/src/Tabs/Panel/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tabs/src/Tabs/Tab/styles.js
+++ b/packages/ui-tabs/src/Tabs/Tab/styles.js
@@ -33,6 +33,9 @@ const selectedTab = keyframes`
   }`
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tabs/src/Tabs/styles.js
+++ b/packages/ui-tabs/src/Tabs/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tag/src/Tag/styles.js
+++ b/packages/ui-tag/src/Tag/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-text-area/src/TextArea/styles.js
+++ b/packages/ui-text-area/src/TextArea/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-text-input/src/TextInput/styles.js
+++ b/packages/ui-text-input/src/TextInput/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tooltip/src/Tooltip/styles.js
+++ b/packages/ui-tooltip/src/Tooltip/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-tray/src/Tray/styles.js
+++ b/packages/ui-tray/src/Tray/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-truncate-text/src/TruncateText/styles.js
+++ b/packages/ui-truncate-text/src/TruncateText/styles.js
@@ -23,6 +23,9 @@
  */
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-view/src/ContextView/styles.js
+++ b/packages/ui-view/src/ContextView/styles.js
@@ -223,6 +223,9 @@ const getArrowPlacementVariant = (placement, background, theme) => {
 }
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/packages/ui-view/src/View/styles.js
+++ b/packages/ui-view/src/View/styles.js
@@ -314,6 +314,9 @@ const getFocusStyles = (props, componentTheme) => {
 }
 
 /**
+ * ---
+ * private: true
+ * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to

--- a/rfcs/DragDropContext/README.md
+++ b/rfcs/DragDropContext/README.md
@@ -5,28 +5,29 @@ title: DragDropContext
 ---
 
 ## DragDropContext Component
+
 It is likely that the terms "draggable" or "drag and drop" will be used to refer
 to the `DragDropContext` components, particularly `DragSource`.
 
-
 ### Summary
+
 This component effectively wraps the HOCs provided by `react-dnd` and provides
 actual components with a simplified API for basic drag and drop functionality.
 
-
 ### Use Cases
+
 This component only aims to provide basic drag and drop functionality. Most use
 cases for it would likely involve further abstraction into some kind of draggable
 layout component. A sortable grid of cards or a list of items that can be
 reordered are two examples.
 
-
 ### Other Implementations
+
 [react-dnd](https://github.com/react-dnd/react-dnd)
 [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd)
 
-
 ### Functional Requirements and API
+
 This component should not be concerned with maintaining the order or position of
 its children. It only serves to communicate what is being dragged where. Any
 sorting or ordering of children should be managed externally.
@@ -48,8 +49,8 @@ the component that can react to a dropped item. Draggable items don't necessaril
 need to live within a `DropTarget`, but it is needed to communicate a successful
 drop.
 
-
 ### Examples
+
 ```javascript
 
 // single drop zone, multiple draggable items
@@ -73,7 +74,7 @@ drop.
         {(provided) => (
           <View
             padding="small"
-            background="default"
+            background="primary"
             shadow={provided.isDragging ? 'above' : null}
           >
             <span>Drag Me!</span>
@@ -192,68 +193,72 @@ drop.
 ```
 
 ### DragDropContext Properties
-| Prop     | Type     | Default  | Notes    |
-|----------|----------|----------|----------|
-| children | oneOf: function, element | | An element or function that returns an element. |
-| onDragStart | function | (start) => {} | A callback that fires when an item starts being dragged. |
-| onDragUpdate | function | (update) => {} | A callback that fires when item's position has changed. |
-| onDragEnd | function | (end) => {} | A callback that fires when dragging has stopped. |
+
+| Prop         | Type                     | Default        | Notes                                                    |
+| ------------ | ------------------------ | -------------- | -------------------------------------------------------- |
+| children     | oneOf: function, element |                | An element or function that returns an element.          |
+| onDragStart  | function                 | (start) => {}  | A callback that fires when an item starts being dragged. |
+| onDragUpdate | function                 | (update) => {} | A callback that fires when item's position has changed.  |
+| onDragEnd    | function                 | (end) => {}    | A callback that fires when dragging has stopped.         |
 
 ### DropTarget Properties
-| Prop     | Type     | Default  | Notes    |
-|----------|----------|----------|----------|
-| accepts | string[] | | A string or array of strings denoting the compatible types of draggable items. Not setting an accepts prop would allow any target in the region to be dropped here. |
-| children | oneOf: function, element | | An element or function that returns an element. |
+
+| Prop     | Type                     | Default | Notes                                                                                                                                                               |
+| -------- | ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| accepts  | string[]                 |         | A string or array of strings denoting the compatible types of draggable items. Not setting an accepts prop would allow any target in the region to be dropped here. |
+| children | oneOf: function, element |         | An element or function that returns an element.                                                                                                                     |
 
 ### DragSource Properties
-| Prop     | Type     | Default  | Notes    |
-|----------|----------|----------|----------|
-| type | string | 'any' | A string used to associate a `DragSource` with compatible `DropTargets`. Not setting a type would allow a target to be dropped in any group in the region. |
-| children | oneOf: function, element | | An element or function that returns an element. |
+
+| Prop     | Type                     | Default | Notes                                                                                                                                                      |
+| -------- | ------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type     | string                   | 'any'   | A string used to associate a `DragSource` with compatible `DropTargets`. Not setting a type would allow a target to be dropped in any group in the region. |
+| children | oneOf: function, element |         | An element or function that returns an element.                                                                                                            |
 
 ### DragHandle Properties
-| Prop     | Type     | Default  | Notes    |
-|----------|----------|----------|----------|
-| children | element | | An element to use as the draggable point of a DragSource |
 
+| Prop     | Type    | Default | Notes                                                    |
+| -------- | ------- | ------- | -------------------------------------------------------- |
+| children | element |         | An element to use as the draggable point of a DragSource |
 
 ### Dependencies
+
 - react-dnd
 - react-dnd-html5-backend
 - react-dnd-touch-backend
 - ui-utils
 
-
 ### Theme Variables
+
 n/a
 
-
 ### Accessibility Requirements
+
 n/a. a11y considerations will only be needed for any layers of abstraction on top
 of `DragDropContext`, where elements may be focused or reordered.
 
-
 ### Internationalization Requirements
+
 n/a. i18n considerations will also only be needed for components built off this one,
 not `DragDropContext` itself. Providing internationalized assistive text to describe
 dragging or sorting actions would be the primary consideration.
 
-
 ### Other Things to Consider
+
 - We will certainly want to build other components on top of this one, such as a
-sortable layout.
+  sortable layout.
 - Because this implementation utilizes `react-dnd` we are also reliant on its
-backends. Unless we were to write our own backend, we'd be working around limitations
-of the HTML5 drag and drop API. Most of which should be already managed by
-`react-dnd` or mostly avoidable, but it's worth mentioning.
+  backends. Unless we were to write our own backend, we'd be working around limitations
+  of the HTML5 drag and drop API. Most of which should be already managed by
+  `react-dnd` or mostly avoidable, but it's worth mentioning.
 - One particular limitation of the HTML5 backend is that the drag preview is always
-somewhat transparent. There is a work around for some (not all) use cases so this
-limitation should be communicated to design.
-- `react-dnd` also only allows *either* the HTML5 backend or the touch backend to be
-used. If we need to support touch events, we will need to utilize a third-party
-combined backend or provide our own logic to conditionally use the appropriate
-backend.
+  somewhat transparent. There is a work around for some (not all) use cases so this
+  limitation should be communicated to design.
+- `react-dnd` also only allows _either_ the HTML5 backend or the touch backend to be
+  used. If we need to support touch events, we will need to utilize a third-party
+  combined backend or provide our own logic to conditionally use the appropriate
+  backend.
 - It may be difficult to use some components with `DragDropContext`, particularly
-those that require specific children, such as a `List` that requires only
-`List.Item`s as immediate children. However, we expect new components to be purpose
-built for draggable use cases, so this likely won't be an issue.
+  those that require specific children, such as a `List` that requires only
+  `List.Item`s as immediate children. However, we expect new components to be purpose
+  built for draggable use cases, so this likely won't be an issue.


### PR DESCRIPTION
Needed to add annotations to our new functions so they appear in the right place on the docs
page.
Fixed errors: page load failed on renderTheme and View with depreacted `background="default"`.