### PR TITLE
INSTUI-2698 Tooltips don't dismiss when hovered over

### DIFF
--- a/packages/ui-tooltip/src/Tooltip/README.md
+++ b/packages/ui-tooltip/src/Tooltip/README.md
@@ -5,12 +5,13 @@ describes: Tooltip
 Tooltips are small text-only contextual overlays that are triggered by hover/focus. Use anywhere additional explanation might be needed but space is limited on the triggering element.
 
 > ### What about 'focusable' elements?
-> Content provided to the `renderTip` prop __should not contain any focusable elements__. If you'd like to do
-that you should use the [Popover](#Popover) component and handle focus management yourself or
-consider using a [Modal](#Modal) or a [Tray](#Tray) as those will work better on smaller screens.
-
+>
+> Content provided to the `renderTip` prop **should not contain any focusable elements**. If you'd like to do
+> that you should use the [Popover](#Popover) component and handle focus management yourself or
+> consider using a [Modal](#Modal) or a [Tray](#Tray) as those will work better on smaller screens.
 
 #### Uncontrolled Tooltips
+
 ```js
 ---
 example: true
@@ -74,19 +75,29 @@ class Example extends React.Component {
 
   render () {
     return (
-      <Tooltip
-        renderTip="Hello. I'm a tool tip"
-        isShowingContent={this.state.isShowingContent}
-        onShowContent={(e) => {
-          this.setState({ isShowingContent: true })
-        }}
-        onHideContent={(e) => {
-          this.setState({ isShowingContent: false })
-        }}
-      >
-        <Link href="#">Hover or focus me</Link>
-      </Tooltip>
-    )
+      <>
+        <p>
+        <Tooltip
+          renderTip="Hello. I'm a tool tip"
+          isShowingContent={this.state.isShowingContent}
+          onShowContent={(e) => {
+            console.log("expecting to show tooltip")
+          }}
+          onHideContent={(e) => {
+            console.log("expecting to hide tooltip")
+          }}
+        >
+          <Link href="#">This link has a tooltip</Link>
+        </Tooltip>
+        </p>
+        <Checkbox label="show tooltip?" variant="toggle"
+                  value="toggled"
+                  onChange={(event) => {
+                    this.setState({isShowingContent: event.target.checked})
+                  }}
+        />
+    </>
+  )
   }
 }
 

--- a/packages/ui-tooltip/src/Tooltip/README.md
+++ b/packages/ui-tooltip/src/Tooltip/README.md
@@ -90,11 +90,13 @@ class Example extends React.Component {
           <Link href="#">This link has a tooltip</Link>
         </Tooltip>
         </p>
-        <Checkbox label="show tooltip?" variant="toggle"
-                  value="toggled"
-                  onChange={(event) => {
-                    this.setState({isShowingContent: event.target.checked})
-                  }}
+        <Checkbox
+          label="show tooltip?"
+          variant="toggle"
+          value="toggled"
+          onChange={(event) => {
+            this.setState({isShowingContent: event.target.checked})
+          }}
         />
     </>
   )

--- a/packages/ui-tooltip/src/Tooltip/__tests__/Tooltip.test.js
+++ b/packages/ui-tooltip/src/Tooltip/__tests__/Tooltip.test.js
@@ -236,7 +236,9 @@ describe('<Tooltip />', async () => {
       await subject.setProps({ isShowingContent: true })
 
       await trigger.mouseOut()
-      expect(onHideContent).to.have.been.calledOnce()
+      await wait(() => {
+        expect(onHideContent).to.have.been.calledOnce()
+      })
     })
   })
 


### PR DESCRIPTION
https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html

Persistent
The intent of this condition is to ensure users have adequate time to perceive the additional content after it becomes visible. Users with disabilities may require more time for many reasons, such as to change magnification, move the pointer, or simply to bring the new content into their visual field. Once it appears, the content should remain visible until:

The user removes hover or focus from the trigger and the additional content, consistent with the typical user experience