### PR TITLE
refactor(XXLocator): Allow importing from es/ again.

### DIFF
--- a/packages/ui-buttons/src/ToggleButton/ToggleButtonLocator.js
+++ b/packages/ui-buttons/src/ToggleButton/ToggleButtonLocator.js
@@ -25,7 +25,8 @@
 import { locator } from '@instructure/ui-test-locator'
 import { find, parseQueryArguments } from '@instructure/ui-test-queries'
 
-import { TooltipLocator } from '@instructure/ui-tooltip'
+// eslint-disable-next-line no-restricted-imports
+import { TooltipLocator } from '@instructure/ui-tooltip/es/Tooltip/TooltipLocator'
 
 import { ToggleButton } from './index'
 

--- a/packages/ui-calendar/src/index.js
+++ b/packages/ui-calendar/src/index.js
@@ -22,4 +22,3 @@
  * SOFTWARE.
  */
 export { Calendar } from './Calendar'
-export { CalendarLocator } from './Calendar/CalendarLocator'

--- a/packages/ui-date-input/src/DateInput/DateInputLocator.js
+++ b/packages/ui-date-input/src/DateInput/DateInputLocator.js
@@ -23,8 +23,10 @@
  */
 import { locator } from '@instructure/ui-test-locator'
 
-import { CalendarLocator } from '@instructure/ui-calendar'
-import { PopoverLocator } from '@instructure/ui-popover'
+/* eslint-disable no-restricted-imports */
+import { CalendarLocator } from '@instructure/ui-calendar/es/Calendar/CalendarLocator'
+import { PopoverLocator } from '@instructure/ui-popover/es/Popover/PopoverLocator'
+/* eslint-enable no-restricted-imports */
 
 import { DateInput } from './index'
 

--- a/packages/ui-menu/src/Menu/MenuLocator.js
+++ b/packages/ui-menu/src/Menu/MenuLocator.js
@@ -24,7 +24,8 @@
 import { locator } from '@instructure/ui-test-locator'
 import { parseQueryArguments } from '@instructure/ui-test-queries'
 
-import { PopoverLocator } from '@instructure/ui-popover'
+// eslint-disable-next-line no-restricted-imports
+import { PopoverLocator } from '@instructure/ui-popover/es/Popover/PopoverLocator'
 
 import { Menu } from './index'
 

--- a/packages/ui-navigation/src/Navigation/NavigationItem/NavigationItemLocator.js
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/NavigationItemLocator.js
@@ -22,7 +22,8 @@
  * SOFTWARE.
  */
 import { locator } from '@instructure/ui-test-locator'
-import { TooltipLocator } from '@instructure/ui-tooltip'
+// eslint-disable-next-line no-restricted-imports
+import { TooltipLocator } from '@instructure/ui-tooltip/es/Tooltip/TooltipLocator'
 
 import { NavigationItem } from './index'
 

--- a/packages/ui-options/src/index.js
+++ b/packages/ui-options/src/index.js
@@ -23,4 +23,3 @@
  */
 
 export { Options } from './Options'
-export { OptionsLocator } from './Options/OptionsLocator'

--- a/packages/ui-pagination/src/Pagination/PaginationArrowButton/PaginationArrowButtonLocator.js
+++ b/packages/ui-pagination/src/Pagination/PaginationArrowButton/PaginationArrowButtonLocator.js
@@ -24,7 +24,8 @@
 
 import { locator } from '@instructure/ui-test-locator'
 import { find } from '@instructure/ui-test-queries'
-import { TooltipLocator } from '@instructure/ui-tooltip'
+// eslint-disable-next-line no-restricted-imports
+import { TooltipLocator } from '@instructure/ui-tooltip/es/Tooltip/TooltipLocator'
 
 import { PaginationArrowButton } from './index'
 

--- a/packages/ui-pill/src/Pill/PillLocator.js
+++ b/packages/ui-pill/src/Pill/PillLocator.js
@@ -24,7 +24,8 @@
 
 import { locator } from '@instructure/ui-test-locator'
 import { parseQueryArguments } from '@instructure/ui-test-queries'
-import { TooltipLocator } from '@instructure/ui-tooltip'
+// eslint-disable-next-line no-restricted-imports
+import { TooltipLocator } from '@instructure/ui-tooltip/es/Tooltip/TooltipLocator'
 
 import { Pill } from './index'
 

--- a/packages/ui-popover/src/Popover/PopoverLocator.js
+++ b/packages/ui-popover/src/Popover/PopoverLocator.js
@@ -23,7 +23,8 @@
  */
 
 import { locator } from '@instructure/ui-test-locator'
-import { PositionLocator } from '@instructure/ui-position'
+// eslint-disable-next-line no-restricted-imports
+import { PositionLocator } from '@instructure/ui-position/es/Position/PositionLocator'
 
 import { Popover } from './index'
 import { PopoverTriggerLocator } from './PopoverTriggerLocator'

--- a/packages/ui-popover/src/index.js
+++ b/packages/ui-popover/src/index.js
@@ -22,4 +22,3 @@
  * SOFTWARE.
  */
 export { Popover } from './Popover'
-export { PopoverLocator } from './Popover/PopoverLocator'

--- a/packages/ui-position/src/index.js
+++ b/packages/ui-position/src/index.js
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 export { Position } from './Position'
-export { PositionLocator } from './Position/PositionLocator'
 
 export { calculateElementPosition } from './calculateElementPosition'
 export { executeMirrorFunction } from './executeMirrorFunction'

--- a/packages/ui-select/src/Select/SelectLocator.js
+++ b/packages/ui-select/src/Select/SelectLocator.js
@@ -23,10 +23,12 @@
  */
 import { locator } from '@instructure/ui-test-locator'
 
-import { OptionsLocator } from '@instructure/ui-options'
-import { PopoverLocator } from '@instructure/ui-popover'
+/* eslint-disable no-restricted-imports */
+import { OptionsLocator } from '@instructure/ui-options/es/Options/OptionsLocator'
+import { PopoverLocator } from '@instructure/ui-popover/es/Popover/PopoverLocator'
+/* eslint-enable no-restricted-imports */
 
-import { Select } from '../index'
+import { Select } from './index'
 
 export const SelectLocator = locator(Select.selector, {
   findInput: (...args) => locator('input').find(...args),

--- a/packages/ui-select/src/index.js
+++ b/packages/ui-select/src/index.js
@@ -23,4 +23,3 @@
  */
 
 export { Select } from './Select'
-export { SelectLocator } from './Select/SelectLocator'

--- a/packages/ui-simple-select/src/SimpleSelect/SimpleSelectLocator.js
+++ b/packages/ui-simple-select/src/SimpleSelect/SimpleSelectLocator.js
@@ -23,7 +23,9 @@
  */
 import { locator } from '@instructure/ui-test-locator'
 
-import { SelectLocator } from '@instructure/ui-select'
+/* eslint-disable no-restricted-imports */
+import { SelectLocator } from '@instructure/ui-select/es/Select/SelectLocator'
+/* eslint-enable no-restricted-imports */
 
 import { SimpleSelect } from './index'
 

--- a/packages/ui-time-select/src/TimeSelect/TimeSelectLocator.js
+++ b/packages/ui-time-select/src/TimeSelect/TimeSelectLocator.js
@@ -23,7 +23,9 @@
  */
 import { locator } from '@instructure/ui-test-locator'
 
-import { SelectLocator } from '@instructure/ui-select'
+/* eslint-disable no-restricted-imports */
+import { SelectLocator } from '@instructure/ui-select/es/Select/SelectLocator'
+/* eslint-enable no-restricted-imports */
 
 import { TimeSelect } from './index'
 

--- a/packages/ui-tooltip/src/Tooltip/TooltipLocator.js
+++ b/packages/ui-tooltip/src/Tooltip/TooltipLocator.js
@@ -24,7 +24,8 @@
 
 import { locator } from '@instructure/ui-test-locator'
 import { parseQueryArguments } from '@instructure/ui-test-queries'
-import { PopoverLocator } from '@instructure/ui-popover/'
+// eslint-disable-next-line no-restricted-imports
+import { PopoverLocator } from '@instructure/ui-popover/es/Popover/PopoverLocator'
 import { Tooltip } from './index'
 
 export const customMethods = {

--- a/packages/ui-tooltip/src/index.js
+++ b/packages/ui-tooltip/src/index.js
@@ -22,4 +22,3 @@
  * SOFTWARE.
  */
 export { Tooltip } from './Tooltip'
-export { TooltipLocator } from './Tooltip/TooltipLocator'


### PR DESCRIPTION
This is a revert of this commit: https://github.com/instructure/instructure-ui/commit/579ab2f4f0bfe9e46590e25a4c5743b28a445761 
This is no longer needed because with module type = commonJS we can import from any place again. Also it broke apps because `ui-test-locator` is declared as a `devDependency `