### PR TITLE
INSTUI-2871 : Fix package imports, fix wrong test call in main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:patchset": "npm-run-all lint:commit lint:changes test:jest test",
     "pretest:merge": "yarn bootstrap && yarn check",
     "test:merge": "npm-run-all lint:commit lint test",
-    "test:all": "npm-run-all test:jest test:karma",
+    "test:all": "npm-run-all test:jest test",
     "test:watch": "ui-test --watch --no-headless",
     "test:changes": "ui-test --changed",
     "test": "ui-test",

--- a/packages/canvas-high-contrast-theme/babel.config.js
+++ b/packages/canvas-high-contrast-theme/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/canvas-high-contrast-theme/package.json
+++ b/packages/canvas-high-contrast-theme/package.json
@@ -3,14 +3,7 @@
   "version": "7.4.0",
   "description": "A high contrast theme for Canvas LMS made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    },
-    "./package.json": "./package.json"
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/canvas-theme/babel.config.js
+++ b/packages/canvas-theme/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/canvas-theme/package.json
+++ b/packages/canvas-theme/package.json
@@ -3,14 +3,7 @@
   "version": "7.4.0",
   "description": "A theme for Canvas LMS made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    },
-    "./package.json": "./package.json"
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -4,12 +4,6 @@
   "description": "A babel macro made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "type": "commonjs",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/debounce/babel.config.js
+++ b/packages/debounce/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/debounce/package.json
+++ b/packages/debounce/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A debounce util made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "repository": {

--- a/packages/instructure-theme/babel.config.js
+++ b/packages/instructure-theme/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/instructure-theme/package.json
+++ b/packages/instructure-theme/package.json
@@ -3,14 +3,7 @@
   "version": "7.4.0",
   "description": "A theme for Instructure made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    },
-    "./package.json": "./package.json"
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/instui-config/package.json
+++ b/packages/instui-config/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.0",
   "description": "A package containing Instructure UI specific configuration data for operations such as upgrades and codemod scripts",
   "author": "Instructure, Inc. Engineering and Product Design",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"

--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.0",
   "description": "A package containing template files to generate a react app configured with Instructure UI presets.",
   "author": "Instructure, Inc. Engineering and Product Design",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"

--- a/packages/template-component/package.json
+++ b/packages/template-component/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.0",
   "description": "A package containing template files to generate an instructure-ui component.",
   "author": "Instructure, Inc. Engineering and Product Design",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"

--- a/packages/template-component/template/package.json.ejs
+++ b/packages/template-component/template/package.json.ejs
@@ -3,15 +3,9 @@
   "version": "<%= VERSION %>",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"
@@ -22,7 +16,7 @@
     "lint": "ui-test --lint",
     "lint:fix": "ui-test --lint --fix",
     "clean": "ui-build --clean",
-    "build": "ui-build",
+    "build": "ui-build --modules es,cjs",
     "build:watch": "ui-build --watch",
     "build:types": "ui-scripts --types"
   },

--- a/packages/template-package/package.json
+++ b/packages/template-package/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.0",
   "description": "A package containing template files to generate an instructure-ui package.",
   "author": "Instructure, Inc. Engineering and Product Design",
+  "type": "commonjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"

--- a/packages/template-package/template/package.json.ejs
+++ b/packages/template-package/template/package.json.ejs
@@ -3,16 +3,10 @@
   "version": "<%= VERSION %>",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"

--- a/packages/ui-a11y-content/babel.config.js
+++ b/packages/ui-a11y-content/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-a11y-content/package.json
+++ b/packages/ui-a11y-content/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Utility components that enhance the user experience of those that navigate the web with a screen reader or keyboard.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-a11y-utils/babel.config.js
+++ b/packages/ui-a11y-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-a11y-utils/package.json
+++ b/packages/ui-a11y-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A collection of utilities for managing focus and screen reader behavior",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-alerts/babel.config.js
+++ b/packages/ui-alerts/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-alerts/package.json
+++ b/packages/ui-alerts/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "An alert component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-avatar/babel.config.js
+++ b/packages/ui-avatar/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "An image or letters that represents a user.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-axe-check/babel.config.js
+++ b/packages/ui-axe-check/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-axe-check/package.json
+++ b/packages/ui-axe-check/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI a11y testing library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "repository": {

--- a/packages/ui-badge/babel.config.js
+++ b/packages/ui-badge/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-badge/package.json
+++ b/packages/ui-badge/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A badge component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-billboard/babel.config.js
+++ b/packages/ui-billboard/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-billboard/package.json
+++ b/packages/ui-billboard/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component to display empty states, 404 pages, redirects, etc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-breadcrumb/babel.config.js
+++ b/packages/ui-breadcrumb/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-breadcrumb/package.json
+++ b/packages/ui-breadcrumb/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A breadcrumb component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-buttons/babel.config.js
+++ b/packages/ui-buttons/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Accessible button components",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-byline/babel.config.js
+++ b/packages/ui-byline/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-byline/package.json
+++ b/packages/ui-byline/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A Byline component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-calendar/babel.config.js
+++ b/packages/ui-calendar/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-calendar/package.json
+++ b/packages/ui-calendar/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A calendar component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-checkbox/babel.config.js
+++ b/packages/ui-checkbox/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": " styled HTML input type='checkbox' component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-code-editor/babel.config.js
+++ b/packages/ui-code-editor/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-code-editor/package.json
+++ b/packages/ui-code-editor/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-color-utils/babel.config.js
+++ b/packages/ui-color-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-color-utils/package.json
+++ b/packages/ui-color-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A color utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-component-examples/package.json
+++ b/packages/ui-component-examples/package.json
@@ -3,6 +3,7 @@
   "version": "7.4.0",
   "description": "A utility for automatically generating component examples",
   "author": "Instructure, Inc. Engineering and Product Design",
+  "type": "commonjs",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/ui-date-input/babel.config.js
+++ b/packages/ui-date-input/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-date-input/package.json
+++ b/packages/ui-date-input/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-decorator/babel.config.js
+++ b/packages/ui-decorator/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-decorator/package.json
+++ b/packages/ui-decorator/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A utility to wrap (decorates) a React component class adding functionality.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-dialog/babel.config.js
+++ b/packages/ui-dialog/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A utility component for managing keyboard accessibility and screen reader behavior",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-docs-client/babel.config.js
+++ b/packages/ui-docs-client/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-docs-client/package.json
+++ b/packages/ui-docs-client/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A React application to display documentation made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-docs-plugin/babel.config.js
+++ b/packages/ui-docs-plugin/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-docs-plugin/package.json
+++ b/packages/ui-docs-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "7.4.0",
   "description": "A webpack plugin to generate documentation made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
+  "type": "commonjs",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",

--- a/packages/ui-dom-utils/babel.config.js
+++ b/packages/ui-dom-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-dom-utils/package.json
+++ b/packages/ui-dom-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A DOM utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-drawer-layout/babel.config.js
+++ b/packages/ui-drawer-layout/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-drawer-layout/package.json
+++ b/packages/ui-drawer-layout/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A main-content-plus-tray layout component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-editable/babel.config.js
+++ b/packages/ui-editable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-editable/package.json
+++ b/packages/ui-editable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-expandable/babel.config.js
+++ b/packages/ui-expandable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-expandable/package.json
+++ b/packages/ui-expandable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A utility component for show/hide functionality",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-file-drop/babel.config.js
+++ b/packages/ui-file-drop/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A flexible facade for an HTML file input",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-flex/babel.config.js
+++ b/packages/ui-flex/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-flex/package.json
+++ b/packages/ui-flex/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component that makes it easy to align content using flexbox CSS",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-focusable/babel.config.js
+++ b/packages/ui-focusable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-focusable/package.json
+++ b/packages/ui-focusable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A utility used to identify when an element receives focus.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-focusable/src/FocusableView/__examples__/FocusableView.examples.js
+++ b/packages/ui-focusable/src/FocusableView/__examples__/FocusableView.examples.js
@@ -21,17 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-export default {
-  sections: 'color',
-  getComponentProps: (props) => {
-    return {
-      focused: true,
-      children: 'Focused'
-    }
-  },
-  getExampleProps: (props) => {
-    return {
-      background: props.color === 'inverse' ? 'primary-inverse' : 'primary'
-    }
-  }
+
+module.exports = {
+  presets: [
+    [
+      require('@instructure/ui-babel-preset'),
+      {
+        coverage: Boolean(process.env.COVERAGE),
+        esModules: Boolean(process.env.ES_MODULES),
+        removeConsole: process.env.NODE_ENV === 'production',
+        transformImports: Boolean(process.env.TRANSFORM_IMPORTS)
+      }
+    ]
+  ]
 }

--- a/packages/ui-focusable/src/FocusableView/__examples__/FocusableView.examples.js
+++ b/packages/ui-focusable/src/FocusableView/__examples__/FocusableView.examples.js
@@ -22,16 +22,17 @@
  * SOFTWARE.
  */
 
-module.exports = {
-  presets: [
-    [
-      require('@instructure/ui-babel-preset'),
-      {
-        coverage: Boolean(process.env.COVERAGE),
-        esModules: Boolean(process.env.ES_MODULES),
-        removeConsole: process.env.NODE_ENV === 'production',
-        transformImports: Boolean(process.env.TRANSFORM_IMPORTS)
-      }
-    ]
-  ]
+export default {
+  sections: 'color',
+  getComponentProps: (props) => {
+    return {
+      focused: true,
+      children: 'Focused'
+    }
+  },
+  getExampleProps: (props) => {
+    return {
+      background: props.color === 'inverse' ? 'primary-inverse' : 'primary'
+    }
+  }
 }

--- a/packages/ui-form-field/babel.config.js
+++ b/packages/ui-form-field/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-form-field/package.json
+++ b/packages/ui-form-field/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Form layout components.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-grid/babel.config.js
+++ b/packages/ui-grid/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-grid/package.json
+++ b/packages/ui-grid/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A Grid component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-heading/babel.config.js
+++ b/packages/ui-heading/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-heading/package.json
+++ b/packages/ui-heading/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for creating typographic headings",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-i18n/babel.config.js
+++ b/packages/ui-i18n/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-i18n/package.json
+++ b/packages/ui-i18n/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Helper components and utilities for internationalization.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-icons/babel.config.js
+++ b/packages/ui-icons/babel.config.js
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 module.exports = {
   presets: [
     [

--- a/packages/ui-icons/package.json
+++ b/packages/ui-icons/package.json
@@ -4,12 +4,6 @@
   "description": "Icon set for Instructure, Inc. products",
   "author": "Instructure, Inc. Engineering and Product Design",
   "type": "commonjs",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-img/babel.config.js
+++ b/packages/ui-img/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-img/package.json
+++ b/packages/ui-img/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "An accessible image component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-link/babel.config.js
+++ b/packages/ui-link/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-link/package.json
+++ b/packages/ui-link/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for creating links",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-list/babel.config.js
+++ b/packages/ui-list/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-list/package.json
+++ b/packages/ui-list/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Components for displaying vertical or horizontal lists.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-menu/babel.config.js
+++ b/packages/ui-menu/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A dropdown menu component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-metric/babel.config.js
+++ b/packages/ui-metric/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-metric/package.json
+++ b/packages/ui-metric/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component for displaying Metrics",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-modal/babel.config.js
+++ b/packages/ui-modal/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for displaying content in a dialog overlay",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-motion/babel.config.js
+++ b/packages/ui-motion/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-navigation/babel.config.js
+++ b/packages/ui-navigation/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-navigation/package.json
+++ b/packages/ui-navigation/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Main and application level navigational components",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-number-input/babel.config.js
+++ b/packages/ui-number-input/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-number-input/package.json
+++ b/packages/ui-number-input/package.json
@@ -5,13 +5,7 @@
   "author": "Instructure, Inc. Engineering and Product Design",
   "homepage": "https://instructure.github.io/instructure-ui/",
   "license": "MIT",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-options/babel.config.js
+++ b/packages/ui-options/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES)

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A view-only component for composing interactive lists and menus.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-overlays/babel.config.js
+++ b/packages/ui-overlays/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-overlays/package.json
+++ b/packages/ui-overlays/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-pages/babel.config.js
+++ b/packages/ui-pages/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-pages/package.json
+++ b/packages/ui-pages/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-pagination/babel.config.js
+++ b/packages/ui-pagination/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-pagination/package.json
+++ b/packages/ui-pagination/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-pill/babel.config.js
+++ b/packages/ui-pill/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component to communicate concise status.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-popover/babel.config.js
+++ b/packages/ui-popover/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-popover/package.json
+++ b/packages/ui-popover/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for hiding or showing content based on user interaction.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-portal/babel.config.js
+++ b/packages/ui-portal/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-position/babel.config.js
+++ b/packages/ui-position/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-position/package.json
+++ b/packages/ui-position/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for positioning content with respect to a designated target.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-progress/babel.config.js
+++ b/packages/ui-progress/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-progress/package.json
+++ b/packages/ui-progress/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Styled HTML <progress /> elements for showing completion of a task",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-prop-types/babel.config.js
+++ b/packages/ui-prop-types/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-prop-types/package.json
+++ b/packages/ui-prop-types/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-radio-input/babel.config.js
+++ b/packages/ui-radio-input/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-radio-input/package.json
+++ b/packages/ui-radio-input/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled HTML input type='radio' element",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-range-input/babel.config.js
+++ b/packages/ui-range-input/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-range-input/package.json
+++ b/packages/ui-range-input/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled HTML range input",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-rating/babel.config.js
+++ b/packages/ui-rating/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-rating/package.json
+++ b/packages/ui-rating/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A static rating component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-react-utils/babel.config.js
+++ b/packages/ui-react-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-react-utils/package.json
+++ b/packages/ui-react-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A React utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-responsive/babel.config.js
+++ b/packages/ui-responsive/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-responsive/package.json
+++ b/packages/ui-responsive/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component that allows for rendering a component differently based on either the element or the viewport size",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-select/babel.config.js
+++ b/packages/ui-select/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for select and autocomplete behavior.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-selectable/babel.config.js
+++ b/packages/ui-selectable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-selectable/package.json
+++ b/packages/ui-selectable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-simple-select/babel.config.js
+++ b/packages/ui-simple-select/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-simple-select/package.json
+++ b/packages/ui-simple-select/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for standard select element behavior.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-spinner/babel.config.js
+++ b/packages/ui-spinner/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A spinner/loading component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-stylesheet/babel.config.js
+++ b/packages/ui-stylesheet/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-stylesheet/package.json
+++ b/packages/ui-stylesheet/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A wrapper around a Glamor StyleSheet.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-svg-images/babel.config.js
+++ b/packages/ui-svg-images/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-svg-images/package.json
+++ b/packages/ui-svg-images/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-table/babel.config.js
+++ b/packages/ui-table/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled HTML table component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-tabs/babel.config.js
+++ b/packages/ui-tabs/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-tabs/package.json
+++ b/packages/ui-tabs/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-tag/babel.config.js
+++ b/packages/ui-tag/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-tag/package.json
+++ b/packages/ui-tag/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A tag component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-test-locator/babel.config.js
+++ b/packages/ui-test-locator/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-test-locator/package.json
+++ b/packages/ui-test-locator/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A locator component for finding components by their defined selector in tests.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-test-queries/babel.config.js
+++ b/packages/ui-test-queries/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-test-queries/package.json
+++ b/packages/ui-test-queries/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Helpers and utilities for queries in UI tests.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-test-sandbox/babel.config.js
+++ b/packages/ui-test-sandbox/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-test-sandbox/package.json
+++ b/packages/ui-test-sandbox/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A wrapper for sinon test sandbox and associated utilities.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-test-utils/babel.config.js
+++ b/packages/ui-test-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-test-utils/package.json
+++ b/packages/ui-test-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI testing library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "repository": {

--- a/packages/ui-testable/babel.config.js
+++ b/packages/ui-testable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-testable/package.json
+++ b/packages/ui-testable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component test utility made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-text-area/babel.config.js
+++ b/packages/ui-text-area/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-text-area/package.json
+++ b/packages/ui-text-area/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled HTML text area component",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-text-input/babel.config.js
+++ b/packages/ui-text-input/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-text-input/package.json
+++ b/packages/ui-text-input/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled HTML text input component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-text/babel.config.js
+++ b/packages/ui-text/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-text/package.json
+++ b/packages/ui-text/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for styling textual content",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-theme-tokens/babel.config.js
+++ b/packages/ui-theme-tokens/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-theme-tokens/package.json
+++ b/packages/ui-theme-tokens/package.json
@@ -3,17 +3,7 @@
   "version": "7.4.0",
   "description": "Cross-platform theme tokens for Instructure products",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    },
-    "./lib/canvas": "./lib/canvas/index.js",
-    "./lib/canvasHighContrast": "./lib/canvasHighContrast/index.js",
-    "./lib/instructure": "./lib/instructure/index.js",
-    "./package.json": "./package.json"
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-themeable/babel.config.js
+++ b/packages/ui-themeable/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-themeable/package.json
+++ b/packages/ui-themeable/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-themes/babel.config.js
+++ b/packages/ui-themes/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -3,7 +3,7 @@
   "version": "7.4.0",
   "description": "A library of @instructure/ui-themeable themes",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./es/index.js",
   "repository": {

--- a/packages/ui-time-select/babel.config.js
+++ b/packages/ui-time-select/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-time-select/package.json
+++ b/packages/ui-time-select/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for selecting time values.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-toggle-details/babel.config.js
+++ b/packages/ui-toggle-details/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-toggle-details/package.json
+++ b/packages/ui-toggle-details/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A styled toggleable, accordion-like component.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-tooltip/babel.config.js
+++ b/packages/ui-tooltip/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-tooltip/package.json
+++ b/packages/ui-tooltip/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for showing small text-only overlays on hover/focus.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-tray/babel.config.js
+++ b/packages/ui-tray/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-tray/package.json
+++ b/packages/ui-tray/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "Tray component for secondary/menu content",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-tree-browser/babel.config.js
+++ b/packages/ui-tree-browser/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for displaying a hierarchical view of information",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui-truncate-text/babel.config.js
+++ b/packages/ui-truncate-text/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-truncate-text/package.json
+++ b/packages/ui-truncate-text/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A TruncateText component made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-utils/babel.config.js
+++ b/packages/ui-utils/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A collection of utilities for UI components",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {

--- a/packages/ui-view/babel.config.js
+++ b/packages/ui-view/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui-view/package.json
+++ b/packages/ui-view/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A component for basic styles including spacing, sizing, borders, display, positioning, and focus states.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/ui/babel.config.js
+++ b/packages/ui/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A meta package exporting all UI components",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",

--- a/packages/uid/babel.config.js
+++ b/packages/uid/babel.config.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-export default {
+module.exports = {
   presets: [
     [
-      '@instructure/ui-babel-preset',
+      require('@instructure/ui-babel-preset'),
       {
         coverage: Boolean(process.env.COVERAGE),
         esModules: Boolean(process.env.ES_MODULES),

--- a/packages/uid/package.json
+++ b/packages/uid/package.json
@@ -3,13 +3,7 @@
   "version": "7.4.0",
   "description": "A unique (CSS-safe) id generator made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
-  "type": "module",
-  "exports": {
-    ".": {
-      "require": "./lib/index.js",
-      "default": "./es/index.js"
-    }
-  },
+  "type": "commonjs",
   "module": "./es/index.js",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
this is the same PR as https://github.com/instructure/instructure-ui/pull/387 just for master.

TEST PLAN:
`bootstrap, build:docs, test:all, dev` works, publishing the package into a private local registry and using it in a test app works an non-exported paths from `@instructure/<component>/es` can be imported.