### PR TITLE
INSTUI-2835 change the color of unselected tabs to the same as selected ones

### DIFF
--- a/packages/ui-tabs/src/Tabs/Tab/__tests__/theme.test.js
+++ b/packages/ui-tabs/src/Tabs/Tab/__tests__/theme.test.js
@@ -36,7 +36,7 @@ describe('Tab.theme', async () => {
       it('should ensure text and tab background meet 3:1 contrast', async () => {
         expect(
           contrast(
-            variables.secondarySelectedColor,
+            variables.secondaryColor,
             variables.secondarySelectedBackground
           )
         ).to.be.above(3)
@@ -51,7 +51,7 @@ describe('Tab.theme', async () => {
       it('should ensure text and tab background meet 4.5:1 contrast', async () => {
         expect(
           contrast(
-            variables.secondarySelectedColor,
+            variables.secondaryColor,
             variables.secondarySelectedBackground
           )
         ).to.be.above(4.5)

--- a/packages/ui-tabs/src/Tabs/Tab/styles.js
+++ b/packages/ui-tabs/src/Tabs/Tab/styles.js
@@ -97,14 +97,9 @@ const generateStyle = (componentTheme, props, state) => {
         borderBottomColor: componentTheme.secondarySelectedBackground
       }),
 
-      ...((isSelected || isDisabled) && {
-        color: componentTheme.secondarySelectedColor
-      }),
-
       '&:first-of-type': { marginInlineStart: '0' },
 
       '&:hover': {
-        color: componentTheme.secondarySelectedColor,
         ...(!isDisabled &&
           !isSelected && {
             background: componentTheme.secondarySelectedBackground,

--- a/packages/ui-tabs/src/Tabs/Tab/theme.js
+++ b/packages/ui-tabs/src/Tabs/Tab/theme.js
@@ -36,8 +36,7 @@ const generateComponentTheme = (theme, themeOverride = {}) => {
       defaultColor: theme['ic-brand-font-color-dark'],
       defaultSelectedBorderColor: theme['ic-brand-primary'],
 
-      secondaryColor: theme['ic-brand-primary'],
-      secondarySelectedColor: theme['ic-brand-font-color-dark']
+      secondaryColor: theme['ic-brand-font-color-dark']
     }
   }
 
@@ -51,10 +50,9 @@ const generateComponentTheme = (theme, themeOverride = {}) => {
     defaultHoverBorderColor: colors?.borderMedium,
     defaultSelectedBorderColor: colors?.borderBrand,
 
-    secondaryColor: colors?.textBrand,
+    secondaryColor: colors?.textDarkest,
     secondarySelectedBackground: colors?.backgroundLightest,
     secondarySelectedBorderColor: colors?.borderMedium,
-    secondarySelectedColor: colors?.textDarkest,
 
     zIndex: stacking?.above
   }


### PR DESCRIPTION
This will keep the colors of normal and secondary tabs consistent

TEST PLAN:
check changes in docs app; run tests

BREAKING CHANGE:
SecondarySelectedColor style was removed, now just secondaryColor determines the color of the
secondary tab.

VISUAL CHANGE:
SecondaryColor changed to textDarkest, in the Canvas theme to
ic-brand-font-color-dark