### PR TITLE
feat(ui-tree-browser): allow tree browser to render before, after nodes

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -36,6 +36,7 @@ example: true
 ```
 
 ### Managing State
+
 `<TreeBrowser />` can be fully controlled. The following example uses the `onCollectionToggle` callback function to set the state. It then uses the `expanded` prop to configure which collections are open or closed.
 
 ```js
@@ -105,6 +106,7 @@ render(<Example/>)
 ```
 
 ### Customizing Icons
+
 All of the `<TreeBrowser>` icons are customizable. The following example sets custom icons for the expanded and collapsed state of the collections along with each of the items.
 
 ```js
@@ -177,8 +179,8 @@ example: true
 />
 ```
 
-
 ### Thumbnails
+
 An example of a `<TreeBrowser />` with thumbnail images.
 
 ```js
@@ -205,6 +207,97 @@ example: true
   size="large"
 />
 ```
+
+### Collection Props
+
+An example of a `<TreeBrowser />` with different collection props.
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      expanded: false
+    }
+  }
+
+  renderInput = () => {
+    const { expanded } = this.state
+    if (expanded) {
+      return (
+        <View as="div" padding="xx-small" onFocus={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
+          <TextInput placeholder="Enter new group name" display="inline-block" width="12rem"/>
+          <IconButton onClick={(e) => this.setExpand(e, !expanded)} margin="0 0 0 small" ><IconXSolid/></IconButton>
+          <IconButton onClick={(e) => this.setExpand(e, !expanded)} margin="0 0 0 small" ><IconCheckSolid/></IconButton>
+        </View>
+      )
+    }
+
+    return (
+      <View as="div">
+        Create New Group
+      </View>
+    )
+  }
+
+  setExpand = (e, expanded) => {
+    e.stopPropagation()
+    this.setState({expanded})
+    this._node.focus()
+  }
+
+  renderNode = () => {
+    const { expanded } = this.state
+    return (
+      <TreeBrowser.Node
+        containerRef={(el) => this._node = el}
+        onClick={(e) => this.setExpand(e, !expanded)}
+        itemIcon={this.state.expanded ? '' : <IconPlusLine /> }
+        size="large"
+      >
+        {this.renderInput()}
+      </TreeBrowser.Node>
+    )
+  }
+
+  render () {
+    return (
+      <TreeBrowser
+        selectionType="single"
+        size="large"
+        collections={{
+          1: {
+            id: 1,
+            name: "Grade 1",
+            collections: [2],
+          },
+          2: {
+            id: 2,
+            name: "Math Outcomes",
+            collections: [],
+            items: [1, 2],
+            descriptor: "1 Group | 2 Outcomes",
+            renderAfterItems: this.renderNode()
+          }
+        }}
+        items={{
+          1: { id: 1, name: "Can add" },
+          2: { id: 2, name: "Can subtract" },
+        }}
+        showRootCollection={true}
+        rootId={1}
+      />
+    )
+  }
+}
+
+render(<Example/>)
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/__tests__/TreeButton.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/__tests__/TreeButton.test.js
@@ -23,7 +23,7 @@
  */
 
 import React from 'react'
-import { expect, mount, locator } from '@instructure/ui-test-utils'
+import { expect, mount, locator, stub } from '@instructure/ui-test-utils'
 
 import { TreeButton } from '../index'
 import styles from '../styles.css'
@@ -42,6 +42,19 @@ describe('<TreeButton />', async () => {
       await mount(<TreeButton id="1" selected={true} />)
       const treeButton = await TreeButtonLocator.find()
       expect(treeButton.hasClass(styles['selected'])).to.be.true()
+    })
+  })
+
+  describe('containerRef', async () => {
+    it('should call with parent element', async () => {
+      const containerRef = stub()
+      await mount(
+        <div id="1">
+          <TreeButton id="2" containerRef={containerRef} />
+        </div>
+      )
+      const div = document.getElementById('1')
+      expect(containerRef).to.have.been.calledWith(div)
     })
   })
 

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/styles.css
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/styles.css
@@ -66,6 +66,10 @@
       visibility: hidden;
     }
 
+    &.node {
+      color: var(--hoverTextColor);
+    }
+
     .textName,
     .textDescriptor,
     .icon {

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/__tests__/TreeCollection.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/__tests__/TreeCollection.test.js
@@ -119,6 +119,24 @@ describe('<TreeCollection />', async () => {
       expect(item.getAttribute('aria-expanded')).to.exist()
     })
 
+    it('should support the containerRef prop', async () => {
+      const containerRef = stub()
+      await mount(
+        <TreeCollection
+          id={1}
+          containerRef={containerRef}
+          name="Coll 1"
+          collections={[
+            { id: 2, name: 'Coll 2', descriptor: 'Another Descriptor' }
+          ]}
+          items={[{ id: 1, name: 'Item 1' }]}
+        />
+      )
+      const collection = await TreeCollectionLocator.find()
+      const item = await collection.findItem()
+      expect(containerRef).to.have.been.calledWith(item.getDOMNode())
+    })
+
     it('should pass an aria-selected attribute to its list item', async () => {
       await mount(
         <TreeCollection

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeNode/__tests__/TreeNode.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeNode/__tests__/TreeNode.test.js
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react'
+import {
+  expect,
+  mount,
+  locator,
+  within,
+  stub
+} from '@instructure/ui-test-utils'
+
+import { TreeNode } from '../index'
+import styles from '../../TreeButton/styles.css'
+
+const TreeNodeLocator = locator(TreeNode.selector)
+
+describe('<TreeNode />', async () => {
+  it('should render children', async () => {
+    const subject = await mount(
+      <TreeNode>
+        <button>Hello World</button>
+      </TreeNode>
+    )
+    const item = within(subject.getDOMNode())
+    expect(item.find('Hello World')).to.exist()
+  })
+
+  it('supports containerRef prop', async () => {
+    const containerRef = stub()
+    const node = (
+      <div id="1">
+        <TreeNode containerRef={containerRef}>
+          <button>Hello World</button>
+        </TreeNode>
+      </div>
+    )
+    await mount(node)
+    const div = document.getElementById('1')
+    expect(containerRef).to.have.been.calledWith(div)
+  })
+
+  describe('selected', async () => {
+    it('should take the selected class if it is selected', async () => {
+      await mount(
+        <TreeNode id="1" selected={true}>
+          <div> Hello!</div>
+        </TreeNode>
+      )
+      const item = await TreeNodeLocator.find()
+      expect(item.hasClass(styles['selected'])).to.be.true()
+    })
+
+    it('should take the focused class if it is focused', async () => {
+      await mount(
+        <TreeNode id="1" focused={true}>
+          <input />
+        </TreeNode>
+      )
+      const item = await TreeNodeLocator.find()
+      expect(item.hasClass(styles['focused'])).to.be.true()
+    })
+  })
+})

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 - present Instructure, Inc.
+ * Copyright (c) 2021 - present Instructure, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,85 +26,62 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
+import { Img } from '@instructure/ui-img'
+import { callRenderProp } from '@instructure/ui-react-utils'
 import { themeable } from '@instructure/ui-themeable'
 import { testable } from '@instructure/ui-testable'
 import { isIE11 } from '@instructure/ui-utils'
-import { Img } from '@instructure/ui-img'
-import { callRenderProp } from '@instructure/ui-react-utils'
 
-import styles from './styles.css'
-import theme from './theme'
+import styles from '../TreeButton/styles.css'
+import theme from '../TreeButton/theme'
 
 /**
 ---
 parent: TreeBrowser
+id: TreeNode
 ---
 **/
 
 @testable()
 @themeable(theme, styles)
-class TreeButton extends Component {
+class TreeNode extends Component {
   static propTypes = {
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    name: PropTypes.string,
-    descriptor: PropTypes.string,
-    type: PropTypes.string,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     variant: PropTypes.oneOf(['folderTree', 'indent']),
-    collectionIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-    collectionIconExpanded: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.func
-    ]),
-    itemIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-    thumbnail: PropTypes.string,
-    onClick: PropTypes.func,
-    expanded: PropTypes.bool,
     selected: PropTypes.bool,
     focused: PropTypes.bool,
-    containerRef: function () {}
+    itemIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    thumbnail: PropTypes.string,
+    /**
+     * The children to be rendered within the `<TreeNode />`
+     */
+    children: PropTypes.node,
+    /**
+     * A function that returns a reference to the parent li element
+     */
+    containerRef: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    onClick: PropTypes.func
   }
 
   static defaultProps = {
-    type: 'treeButton',
+    id: undefined,
     size: 'medium',
     variant: 'folderTree',
     selected: false,
     focused: false,
-    onClick: function () {},
-    id: undefined,
-    name: undefined,
-    collectionIcon: undefined,
-    collectionIconExpanded: undefined,
+    children: undefined,
     itemIcon: undefined,
     thumbnail: undefined,
-    expanded: false,
-    descriptor: undefined,
-    containerRef: function () {}
+    containerRef: function () {},
+    parentRef: undefined,
+    onKeyDown: undefined,
+    onClick: undefined
   }
 
-  renderImage() {
-    const { type } = this.props
-    switch (type) {
-      case 'collection':
-        return this.renderCollectionIcon()
-      case 'item':
-        return this.renderItemImage()
-      default:
-        break
-    }
-  }
-
-  renderCollectionIcon() {
-    const { expanded, collectionIcon, collectionIconExpanded } = this.props
-
-    if (collectionIcon || collectionIconExpanded) {
-      return (
-        <div className={styles.icon}>
-          {callRenderProp(expanded ? collectionIconExpanded : collectionIcon)}
-        </div>
-      )
-    }
+  handleRef = (el) => {
+    el && this.props.containerRef(el.parentElement)
   }
 
   renderItemImage() {
@@ -123,54 +100,35 @@ class TreeButton extends Component {
     }
   }
 
-  handleRef = (el) => {
-    el && this.props.containerRef(el.parentElement)
-  }
-
   render() {
-    const {
-      name,
-      descriptor,
-      expanded,
-      selected,
-      focused,
-      variant,
-      size
-    } = this.props
+    const { selected, focused, variant, size, children } = this.props
 
     const classes = {
       [styles.root]: true,
       [styles[size]]: true,
       [styles[variant]]: true,
-      [styles.expanded]: expanded,
+      [styles.expanded]: false,
       [styles.selected]: selected,
       [styles.focused]: focused,
       [styles.ie11]: isIE11
     }
 
-    // VoiceOver can't navigate without the buttons, even though they don't do anything
+    const classesText = {
+      [styles.text]: true,
+      [styles.textName]: true,
+      [styles.node]: true
+    }
+
     return (
-      <button
-        ref={this.handleRef}
-        tabIndex={-1}
-        type="button"
-        className={classnames(classes)}
-      >
+      <div ref={this.handleRef} tabIndex={-1} className={classnames(classes)}>
         <span className={styles.layout}>
-          {this.renderImage()}
-          <span className={styles.text}>
-            <span className={styles.textName}>{name}</span>
-            {descriptor ? (
-              <span className={styles.textDescriptor} title={descriptor}>
-                {descriptor}
-              </span>
-            ) : null}
-          </span>
+          {this.renderItemImage()}
+          <span className={classnames(classesText)}>{children}</span>
         </span>
-      </button>
+      </div>
     )
   }
 }
 
-export default TreeButton
-export { TreeButton }
+export default TreeNode
+export { TreeNode }

--- a/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
@@ -25,6 +25,7 @@
 import React from 'react'
 import { expect, mount, stub, wait } from '@instructure/ui-test-utils'
 import { TreeBrowser } from '../index'
+import { TreeNode } from '../TreeNode'
 
 import { TreeBrowserLocator } from '../TreeBrowserLocator'
 
@@ -393,6 +394,39 @@ describe('<TreeBrowser />', async () => {
       await wait(() => {
         expect(onCollectionClick).to.have.been.calledThrice()
       })
+    })
+
+    it('should render before, after nodes of the provided collection', async () => {
+      await mount(
+        <TreeBrowser
+          collections={{
+            2: {
+              id: 2,
+              name: 'Root Directory',
+              collections: [],
+              items: [],
+              renderBeforeCollections: (
+                <TreeNode>
+                  <input id="input-before" />
+                </TreeNode>
+              ),
+              renderAfterItems: (
+                <TreeNode>
+                  <input id="input-after" />
+                </TreeNode>
+              )
+            }
+          }}
+          items={{}}
+          expanded={[2]}
+          rootId={2}
+        />
+      )
+      const tree = await TreeBrowserLocator.find()
+      const contentBefore = await tree.find('#input-before')
+      expect(contentBefore).to.exist()
+      const contentAfter = await tree.find('#input-after')
+      expect(contentAfter).to.exist()
     })
   })
 

--- a/packages/ui-tree-browser/src/TreeBrowser/index.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.js
@@ -34,7 +34,7 @@ import { controllable } from '@instructure/ui-prop-types'
 import { testable } from '@instructure/ui-testable'
 
 import { TreeCollection } from './TreeCollection'
-import { TreeButton } from './TreeButton'
+import { TreeNode } from './TreeNode'
 
 import styles from './styles.css'
 import theme from './theme'
@@ -51,7 +51,8 @@ class TreeBrowser extends Component {
     /**
      * a normalized hash of collections, keyed by id, that contain an
      * :id, :name, :items (an array of item ids), :collections (an array of
-     * collection ids), and optional :descriptor text.
+     * collection ids), optional :descriptor text, optional :containerRef function,
+     * an optional :renderBeforeCollections TreeNode, and an optional :renderAfterItems TreeNode.
      * Each collection must have a unique id.
      */
     collections: PropTypes.object.isRequired,
@@ -65,7 +66,7 @@ class TreeBrowser extends Component {
      * if no root is specified, all collections will be rendered
      * at the top level
      **/
-    rootId: PropTypes.number,
+    rootId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
      * an array of expanded collection ids, must be accompanied by an 'onCollectionToggle' prop
      */
@@ -130,6 +131,8 @@ class TreeBrowser extends Component {
     expanded: undefined,
     treeLabel: undefined
   }
+
+  static Node = TreeNode
 
   constructor(props) {
     super(props)
@@ -250,7 +253,8 @@ class TreeBrowser extends Component {
 
   moveFocus(delta) {
     const nodes = this.getNavigableNodes()
-    const active = nodes.indexOf(window.document.activeElement)
+    const closest = window.document.activeElement.closest('[role="treeitem"]')
+    const active = nodes.indexOf(closest)
     let next = active + delta
     if (next < 0) {
       next = 0
@@ -349,7 +353,10 @@ class TreeBrowser extends Component {
       descriptor: collection.descriptor,
       expanded: this.getExpandedIndex(this.expanded, collection.id) >= 0,
       items: this.getItems(collection),
-      collections: this.getSubCollections(collection)
+      collections: this.getSubCollections(collection),
+      renderBeforeCollections: collection.renderBeforeCollections,
+      renderAfterItems: collection.renderAfterItems,
+      containerRef: collection.containerRef
     }
 
     return props


### PR DESCRIPTION
closes OUT-4216

test-plan:
- run docs app locally
- ensure before/afterCollection props work as expected
- test the above with VO/NVDA