### PR TITLE
style(ui-tabs): change the color of unselected tabs to the same as se…

### DIFF
--- a/packages/ui-tabs/src/Tabs/Tab/__tests__/theme.test.js
+++ b/packages/ui-tabs/src/Tabs/Tab/__tests__/theme.test.js
@@ -34,7 +34,7 @@ describe('Tab.theme', async () => {
       it('should ensure text and tab background meet 3:1 contrast', async () => {
         expect(
           contrast(
-            variables.secondarySelectedColor,
+            variables.secondaryColor,
             variables.secondarySelectedBackground
           )
         ).to.be.above(3)
@@ -49,7 +49,7 @@ describe('Tab.theme', async () => {
       it('should ensure text and tab background meet 4.5:1 contrast', async () => {
         expect(
           contrast(
-            variables.secondarySelectedColor,
+            variables.secondaryColor,
             variables.secondarySelectedBackground
           )
         ).to.be.above(4.5)

--- a/packages/ui-tabs/src/Tabs/Tab/theme.js
+++ b/packages/ui-tabs/src/Tabs/Tab/theme.js
@@ -33,9 +33,11 @@ export default function generator({ colors, typography, stacking }) {
     defaultlHoverBorderColor: colors.borderMedium,
     defaultSelectedBorderColor: colors.borderBrand,
 
-    secondaryColor: colors.textBrand,
+    secondaryColor: colors.textDarkest,
     secondarySelectedBackground: colors.backgroundLightest,
     secondarySelectedBorderColor: colors.borderMedium,
+
+    // TODO: remove secondarySelectedColor in v8, it is now the same as secondaryColor
     secondarySelectedColor: colors.textDarkest,
 
     zIndex: stacking.above
@@ -47,7 +49,9 @@ generator.canvas = function (variables) {
     defaultColor: variables['ic-brand-font-color-dark'],
     defaultSelectedBorderColor: variables['ic-brand-primary'],
 
-    secondaryColor: variables['ic-brand-primary'],
+    secondaryColor: variables['ic-brand-font-color-dark'],
+
+    // TODO: remove secondarySelectedColor in v8, it is now the same as secondaryColor
     secondarySelectedColor: variables['ic-brand-font-color-dark']
   }
 }


### PR DESCRIPTION
…lected ones

Closes: INSTUI-2884

This will keep the colors of normal and secondary tabs consistent. In v8, the
`secondarySelectedColor` theme variable will be deprecated.
TEST PLAN:
check changes in docs app; run tests

Connected bugfix on next branch:
- Jira ticket: INSTUI-2835
- https://github.com/instructure/instructure-ui/pull/394