### PR TITLE
INSTUI-2895 - speed up iconography page

### DIFF
--- a/packages/ui-docs-client/src/Glyph/index.js
+++ b/packages/ui-docs-client/src/Glyph/index.js
@@ -23,10 +23,9 @@
  */
 
 /** @jsx jsx */
-import { Component } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { IconButton } from '@instructure/ui-buttons'
 import { InlineSVG } from '@instructure/ui-svg-images'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 import { withStyle, jsx } from '@instructure/emotion'
@@ -54,7 +53,7 @@ class Variant extends Component {
   }
 
   render() {
-    const { glyph, variant, name } = this.props
+    const { glyph, variant, name, styles } = this.props
     let icon
     if (glyph.src) {
       icon = <InlineSVG src={glyph.src} title={`${name} (${variant})`} />
@@ -63,7 +62,7 @@ class Variant extends Component {
       icon = <Icon title={`${name} (${variant})`} />
     } else if (glyph.classes) {
       icon = (
-        <span>
+        <span css={styles.iconFontWrapper}>
           <i className={`${glyph.classes.join(' ')}`} aria-hidden="true" />
           <ScreenReaderContent>{`${name} (${variant})`}</ScreenReaderContent>
         </span>
@@ -71,14 +70,10 @@ class Variant extends Component {
     }
 
     return (
-      <IconButton
-        size="large"
-        onClick={this.handleClick}
-        renderIcon={icon}
-        withBorder={false}
-        withBackground={false}
-        screenReaderLabel="View Usage"
-      />
+      <button css={styles.button} onClick={this.handleClick}>
+        {icon}
+        <ScreenReaderContent>View Usage</ScreenReaderContent>
+      </button>
     )
   }
 }

--- a/packages/ui-docs-client/src/Glyph/styles.js
+++ b/packages/ui-docs-client/src/Glyph/styles.js
@@ -59,6 +59,71 @@ const generateStyle = (componentTheme, props, state) => {
       position: 'relative',
       overflow: 'hidden',
       marginBottom: '0.5rem'
+    },
+    iconFontWrapper: {
+      label: 'glyph__iconFontWrapper',
+      height: '1em'
+    },
+    button: {
+      label: 'glyph__button',
+      appearance: 'none',
+      textDecoration: 'none',
+      touchAction: 'manipulation',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      boxSizing: 'border-box',
+      padding: 0,
+      margin: 0,
+      border: 0,
+      borderRadius: '0.25rem',
+      background: 'none',
+      color: componentTheme.glyphColor,
+      width: '3rem',
+      height: '3rem',
+      fontSize: '1.625rem',
+      lineHeight: 1,
+      transition: 'background 0.2s',
+      cursor: 'pointer',
+      position: 'relative',
+      transform: 'none',
+
+      '&::-moz-focus-inner': {
+        border: '0' /* removes default dotted focus outline in Firefox */
+      },
+      '*': {
+        pointerEvents:
+          'none' /* Ensures that button or link is always the event target */
+      },
+      '&:focus': {
+        outline: 'none',
+        transform: 'none',
+
+        '&::before': {
+          opacity: 1,
+          transform: 'scale(1)'
+        }
+      },
+      '&:hover': {
+        backgroundColor: componentTheme.glyphHoverBackgroundColor
+      },
+
+      '&::before': {
+        pointerEvents: 'none',
+        content: '""',
+        position: 'absolute',
+        borderStyle: 'solid',
+        borderWidth: '0.125rem',
+        borderColor: componentTheme.glyphFocusBorderColor,
+        opacity: 0,
+        borderRadius: '0.4327rem',
+        top: '-0.3125rem',
+        left: '-0.3125rem',
+        right: '-0.3125rem',
+        bottom: '-0.3125rem',
+        transition: 'all 0.2s',
+        transform: 'scale(0.95)'
+      }
     }
   }
 }

--- a/packages/ui-docs-client/src/Glyph/theme.js
+++ b/packages/ui-docs-client/src/Glyph/theme.js
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import { alpha } from '@instructure/ui-color-utils'
+
 /**
  * Generates the theme object for the component from the theme and provided additional information
  * @param  {Object} theme The actual theme object.
@@ -54,7 +56,10 @@ const generateComponentTheme = (theme) => {
       transparent 25%,
       transparent 75%,
       ${colorCheckerboardInverse} 75%,
-      ${colorCheckerboardInverse}`
+      ${colorCheckerboardInverse}`,
+    glyphColor: colors?.textDarkest,
+    glyphHoverBackgroundColor: alpha(colors?.textDarkest, 10),
+    glyphFocusBorderColor: colors?.borderBrand
   }
 
   return {


### PR DESCRIPTION
Closes: INSTUI-2895

To improve performance of the iconography page, refactored the Glyph component not to use
IconButton. It is a html button with its own styling now.
TEST PLAN:
Iconography page looks the same as before, just loads faster.