### PR TITLE
INSTUI-2863 -  stop tooltip from "jumping" on show

### DIFF
--- a/packages/ui-position/src/calculateElementPosition.js
+++ b/packages/ui-position/src/calculateElementPosition.js
@@ -296,9 +296,14 @@ class PositionData {
   }
 
   get style() {
+    // when rendered offscreen first, element has no dimension on first calculation,
+    // so we hide it offscreen until measurements are completed
+    const { width, height } = this.element.size
+    const elementNotFullyRendered = width === 0 && height === 0
+
     return {
       top: 0,
-      left: 0,
+      left: elementNotFullyRendered ? '-9999em' : 0,
       minWidth: this.minWidth,
       minHeight: this.minHeight,
       position: 'absolute',


### PR DESCRIPTION
Closes: INSTUI-2863

After the "themeable to emotion" migration of the tooltip component it started jumping on show. The
fix was found in `ui-position`: we should hide the component offscreen until it has a non-zero
height and width to measure for the positioning.