### PR TITLE
fix: Add CommonJS build to @instructure/ui-themes

### DIFF
--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -5,7 +5,7 @@
   "author": "Instructure, Inc. Engineering and Product Design",
   "type": "commonjs",
   "module": "./es/index.js",
-  "main": "./es/index.js",
+  "main": "./lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/instructure/instructure-ui.git"
@@ -16,7 +16,7 @@
     "lint": "ui-test --lint",
     "lint:fix": "ui-test --lint --fix",
     "clean": "ui-build --clean",
-    "build": "ui-build",
+    "build": "ui-build --modules es,cjs",
     "build:watch": "ui-build --watch"
   },
   "license": "MIT",


### PR DESCRIPTION
Looks like `@instructure/ui-themes` is missing a CommonJS build, which Canvas needs since it requires in those themes in several places where we run Jest tests.