### PR TITLE
INSTUI-2808 - add spacing between single checkbox and messages

### DIFF
--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -33,6 +33,7 @@
     "@instructure/ui-svg-images": "^7.4.1",
     "@instructure/ui-testable": "^7.4.1",
     "@instructure/ui-utils": "^7.4.1",
+    "@instructure/ui-view": "^7.4.1",
     "@instructure/uid": "^7.4.1",
     "keycode": "^2",
     "prop-types": "^15"

--- a/packages/ui-checkbox/src/Checkbox/index.js
+++ b/packages/ui-checkbox/src/Checkbox/index.js
@@ -35,6 +35,7 @@ import { uid } from '@instructure/uid'
 import { isActiveElement } from '@instructure/ui-dom-utils'
 import { omitProps } from '@instructure/ui-react-utils'
 import { testable } from '@instructure/ui-testable'
+import { View } from '@instructure/ui-view'
 
 import { withStyle, jsx } from '@instructure/emotion'
 
@@ -273,11 +274,20 @@ class Checkbox extends Component {
     }
   }
 
+  renderMessages() {
+    const { messages } = this.props
+
+    return messages && messages.length > 0 ? (
+      <View display="block" margin="small 0 0">
+        <FormFieldMessages messages={messages} />
+      </View>
+    ) : null
+  }
+
   render() {
     const {
       disabled,
       readOnly,
-      messages,
       value,
       onKeyDown,
       onFocus,
@@ -323,7 +333,7 @@ class Checkbox extends Component {
         />
         <label htmlFor={this.id} css={styles.control}>
           {this.renderFacade()}
-          <FormFieldMessages messages={messages} />
+          {this.renderMessages()}
         </label>
       </div>
     )


### PR DESCRIPTION
Closes: INSTUI-2808

Fixed bug: added spacing between the single checkbox and its error/info messages.
TEST PLAN:
When `messages` are passed to a single `Checkbox`, the messages are not supposed to be pressed up to
the label anymore.

BREAKING CHANGE:
VISUAL CHANGE: Since there is more space between the checkbox and the messages, it can potentially break layouts (vertically more pixels).