### PR TITLE
chore(ui-babel-preset): add option to change browserlists config to babel-preset

### DIFF
--- a/packages/__examples__/babel.config.js
+++ b/packages/__examples__/babel.config.js
@@ -21,6 +21,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+const browserslistConfig = require('@instructure/browserslist-config-instui')
+
 module.exports = {
-  presets: ['@instructure/ui-babel-preset']
+  presets: [
+    [
+      require('@instructure/ui-babel-preset'),
+      {
+        // we have to do this ugly hack because the `component-examples-loader` does not seem
+        // to like the code processed by babel-loader with a preset that does not include the ie
+        // releated transform plugins
+        browserslistConfig: [...browserslistConfig, 'ie >= 11']
+      }
+    ]
+  ]
 }

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -32,7 +32,8 @@ module.exports = function (
     node: false,
     removeConsole: false,
     transformImports: true,
-    importTransforms: {}
+    importTransforms: {},
+    browserslistConfig: undefined
   }
 ) {
   const envPresetConfig = opts.node ? getNodeEnvConfig() : getWebEnvConfig(opts)
@@ -178,12 +179,16 @@ function getNodeEnvConfig() {
 }
 
 function getWebEnvConfig(opts) {
+  const browserslistConfig =
+    opts.browserslistConfig ||
+    loadConfig(
+      'browserslist',
+      require('@instructure/browserslist-config-instui')
+    )
+
   return {
     targets: {
-      browsers: loadConfig(
-        'browserslist',
-        require('@instructure/browserslist-config-instui')
-      )
+      browsers: browserslistConfig
     },
     useBuiltIns: 'entry',
     corejs: 3,


### PR DESCRIPTION

Added back the ie field to the browserlists config in case of storybook build.

There is an issue with the storybook production build with babel-preset env when the browserlists config does not contain the ie reference. The issue might be that our own `component-examples-loader` cannot process such syntax that is outputted by the babel-loader.
I tried to pinpoint which babel-preset plugin could be missing by comparing the used plugins when ie is in our browserlists config and when it is not, but I could not find a plugin configuration that would output correct code.
Here is the plugins used by babel-loader when ie is in the browserlists config:


```js
with IE
[storybook]   proposal-numeric-separator { "ie":"11" }
[storybook]   proposal-logical-assignment-operators { "ie":"11", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-nullish-coalescing-operator { "ie":"11" }
[storybook]   proposal-optional-chaining { "ie":"11" }
[storybook]   proposal-json-strings { "ie":"11" }
[storybook]   proposal-optional-catch-binding { "ie":"11" }
[storybook]   transform-parameters { "ie":"11" }
[storybook]   proposal-async-generator-functions { "ie":"11" }
[storybook]   proposal-object-rest-spread { "ie":"11" }
[storybook]   transform-dotall-regex { "ie":"11" }
[storybook]   proposal-unicode-property-regex { "ie":"11" }
[storybook]   transform-named-capturing-groups-regex { "ie":"11" }
[storybook]   transform-async-to-generator { "ie":"11" }
[storybook]   transform-exponentiation-operator { "ie":"11" }
[storybook]   transform-template-literals { "ie":"11" }
[storybook]   transform-literals { "ie":"11" }
[storybook]   transform-function-name { "ie":"11" }
[storybook]   transform-arrow-functions { "ie":"11" }
[storybook]   transform-classes { "ie":"11" }
[storybook]   transform-object-super { "ie":"11" }
[storybook]   transform-shorthand-properties { "ie":"11" }
[storybook]   transform-duplicate-keys { "ie":"11" }
[storybook]   transform-computed-properties { "ie":"11" }
[storybook]   transform-for-of { "ie":"11" }
[storybook]   transform-sticky-regex { "ie":"11" }
[storybook]   transform-unicode-escapes { "ie":"11" }
[storybook]   transform-unicode-regex { "ie":"11" }
[storybook]   transform-spread { "ie":"11" }
[storybook]   transform-destructuring { "ie":"11" }
[storybook]   transform-block-scoping { "ie":"11" }
[storybook]   transform-new-target { "ie":"11" }
[storybook]   transform-regenerator { "ie":"11" }
[storybook]   proposal-export-namespace-from { "ie":"11", "ios":"13.4", "safari":"13.1" }
[storybook]   transform-modules-commonjs { "chrome":"88", "edge":"88", "firefox":"85", "ie":"11", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-dynamic-import { "chrome":"88", "edge":"88", "firefox":"85", "ie":"11", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-top-level-await { "chrome":"88", "edge":"88", "firefox":"85", "ie":"11", "ios":"13.4", "opera":"72", "safari":"13.1" }
```

and without ie:

```js
without IE
[storybook]   syntax-numeric-separator { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-logical-assignment-operators { "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-nullish-coalescing-operator {}
[storybook]   syntax-optional-chaining { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-json-strings { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-optional-catch-binding { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-async-generators { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-object-rest-spread { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-export-namespace-from { "ios":"13.4", "safari":"13.1" }
[storybook]   transform-modules-commonjs { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   proposal-dynamic-import { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
[storybook]   syntax-top-level-await { "chrome":"88", "edge":"88", "firefox":"85", "ios":"13.4", "opera":"72", "safari":"13.1" }
```