### PR TITLE
INSTUI-2908 - fix html tag based styling

### DIFF
--- a/packages/ui-byline/src/Byline/styles.js
+++ b/packages/ui-byline/src/Byline/styles.js
@@ -43,12 +43,14 @@ const generateStyle = (componentTheme, props, state) => {
   return {
     byline: {
       label: 'byline',
-      display: 'flex',
-      background: componentTheme.background,
-      margin: 0,
-      padding: 0,
-      fontFamily: componentTheme.fontFamily,
-      ...alignContentVariants[alignContent]
+      '&, &:is(figure)': {
+        display: 'flex',
+        background: componentTheme.background,
+        margin: 0,
+        padding: 0,
+        fontFamily: componentTheme.fontFamily,
+        ...alignContentVariants[alignContent]
+      }
     },
     figure: {
       label: 'byline__figure',
@@ -57,9 +59,11 @@ const generateStyle = (componentTheme, props, state) => {
     },
     caption: {
       label: 'byline__caption',
-      color: componentTheme.color,
-      margin: 0,
-      padding: 0
+      '&, &:is(figcaption)': {
+        color: componentTheme.color,
+        margin: 0,
+        padding: 0
+      }
     },
     title: {
       label: 'byline__title',

--- a/packages/ui-form-field/src/FormFieldLabel/styles.js
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.js
@@ -42,17 +42,19 @@ const generateStyle = (componentTheme, props, state) => {
   return {
     formFieldLabel: {
       label: 'formFieldLabel',
-      all: 'initial',
-      display: 'block',
-      ...(hasContent && {
-        color: componentTheme.color,
-        fontFamily: componentTheme.fontFamily,
-        fontWeight: componentTheme.fontWeight,
-        fontSize: componentTheme.fontSize,
-        lineHeight: componentTheme.lineHeight,
-        margin: 0,
-        textAlign: 'inherit'
-      })
+      '&, &:is(label)': {
+        all: 'initial',
+        display: 'block',
+        ...(hasContent && {
+          color: componentTheme.color,
+          fontFamily: componentTheme.fontFamily,
+          fontWeight: componentTheme.fontWeight,
+          fontSize: componentTheme.fontSize,
+          lineHeight: componentTheme.lineHeight,
+          margin: 0,
+          textAlign: 'inherit'
+        })
+      }
     }
   }
 }

--- a/packages/ui-heading/src/Heading/styles.js
+++ b/packages/ui-heading/src/Heading/styles.js
@@ -32,7 +32,9 @@
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (componentTheme, { level, color, border, as }) => {
+const generateStyle = (componentTheme, props) => {
+  const { level, color, border } = props
+
   const levelStyles = {
     h1: {
       fontFamily: componentTheme.h1FontFamily,
@@ -60,7 +62,7 @@ const generateStyle = (componentTheme, { level, color, border, as }) => {
       fontWeight: componentTheme.h5FontWeight
     },
     reset: {
-      margin: '0',
+      margin: 0,
       fontSize: 'inherit',
       fontWeight: 'inherit',
       lineHeight: 'inherit'
@@ -88,13 +90,13 @@ const generateStyle = (componentTheme, { level, color, border, as }) => {
   }
 
   const inputStyle = {
-    outline: '0',
+    outline: 0,
     appearance: 'none',
     boxSizing: 'border-box',
     background: 'none',
     border: 'none',
-    borderRadius: '0',
-    padding: '0',
+    borderRadius: 0,
+    padding: 0,
     margin: '-0.375rem 0 0 0',
     color: 'inherit',
     height: 'auto',
@@ -112,8 +114,10 @@ const generateStyle = (componentTheme, { level, color, border, as }) => {
       lineHeight: componentTheme.lineHeight,
       margin: 0,
 
-      ...(as === 'input' && inputStyle),
-      '&[type]': inputStyle,
+      // NOTE: the input styles exist to accommodate the InPlaceEdit component
+      '&:is(input)[type]': {
+        ...inputStyle
+      },
 
       ...levelStyles[level],
       ...colorStyles[color],

--- a/packages/ui-link/src/Link/index.js
+++ b/packages/ui-link/src/Link/index.js
@@ -154,8 +154,7 @@ class Link extends Component {
   makeStyleProps = () => {
     return {
       containsTruncateText: this.containsTruncateText,
-      hasVisibleChildren: this.hasVisibleChildren,
-      elementType: this.element
+      hasVisibleChildren: this.hasVisibleChildren
     }
   }
 

--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -34,74 +34,38 @@
  */
 const generateStyle = (componentTheme, props, state) => {
   const { isWithinText, renderIcon, iconPlacement, color } = props
-  const { containsTruncateText, hasVisibleChildren, elementType } = state
+  const { containsTruncateText, hasVisibleChildren } = state
   const inverseStyle = color === 'link-inverse'
 
   // If Link is a button or link, it should look clickable
-  const buttonOrLinkStyle =
-    elementType === 'button' || elementType === 'a'
-      ? {
-          cursor: 'pointer',
-          color: inverseStyle
-            ? componentTheme.colorInverse
-            : componentTheme.color,
-          textDecoration: isWithinText
-            ? componentTheme.textDecorationWithinText
-            : componentTheme.textDecorationOutsideText,
-          '&:focus': {
-            color: inverseStyle
-              ? componentTheme.colorInverse
-              : componentTheme.color
-          },
-          '&:hover, &:active': {
-            color: inverseStyle
-              ? componentTheme.colorInverse
-              : componentTheme.hoverColor,
-            textDecoration: isWithinText
-              ? componentTheme.hoverTextDecorationWithinText
-              : componentTheme.hoverTextDecorationOutsideText
-          }
-        }
-      : {}
-
-  let inverseStyleSelectors = {}
-  if (inverseStyle) {
-    if (elementType === 'a') {
-      inverseStyleSelectors = {
-        '&:link, &:visited': {
-          color: componentTheme.colorInverse
-        },
-        '&:link:focus, &:visited:focus': {
-          outlineColor: componentTheme.focusInverseIconOutlineColor
-        },
-        '&:link:hover, &:link:focus, &:link:active, &:visited:hover, &:visited:focus, &:visited:active': {
-          color: componentTheme.colorInverse
-        }
-      }
-    } else {
-      inverseStyleSelectors = {
-        color: componentTheme.colorInverse,
-        '&:hover, &:focus, &:active': {
-          color: componentTheme.colorInverse
-        }
-      }
+  const isClickableStyle = {
+    cursor: 'pointer',
+    color: componentTheme.color,
+    textDecoration: isWithinText
+      ? componentTheme.textDecorationWithinText
+      : componentTheme.textDecorationOutsideText,
+    '&:focus': {
+      color: componentTheme.color
+    },
+    '&:hover, &:active': {
+      color: componentTheme.hoverColor,
+      textDecoration: isWithinText
+        ? componentTheme.hoverTextDecorationWithinText
+        : componentTheme.hoverTextDecorationOutsideText
     }
   }
 
-  const buttonStyle =
-    elementType === 'button'
-      ? {
-          appearance: 'none',
-          userSelect: 'text',
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          fontSize: '1em',
-          margin: 0,
-          padding: 0,
-          textAlign: 'inherit'
-        }
-      : {}
+  const buttonStyle = {
+    appearance: 'none',
+    userSelect: 'text',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '1em',
+    margin: 0,
+    padding: 0,
+    textAlign: 'inherit'
+  }
 
   // If TruncateText is used in Link with icon, align the icon and the text vertically
   const truncateStyle =
@@ -109,25 +73,24 @@ const generateStyle = (componentTheme, props, state) => {
       ? { alignItems: 'center' }
       : {}
 
-  const linkStyles = {
+  const baseStyle = {
     label: 'link',
+    boxSizing: 'border-box',
     fontFamily: componentTheme.fontFamily,
     fontWeight: componentTheme.fontWeight,
     transition: 'outline-color 0.2s',
     verticalAlign: 'baseline',
+
     // set up focus styles
     outlineColor: 'transparent',
     outlineWidth: componentTheme.focusOutlineWidth,
     outlineStyle: componentTheme.focusOutlineStyle,
     outlineOffset: '0.25rem',
+
     ...truncateStyle,
-    ...buttonStyle,
-    ...buttonOrLinkStyle,
-    ...inverseStyleSelectors,
+
     '&:focus': {
-      outlineColor: inverseStyle
-        ? componentTheme.focusInverseIconOutlineColor
-        : componentTheme.focusOutlineColor
+      outlineColor: componentTheme.focusOutlineColor
     },
     '&[aria-disabled]': {
       cursor: 'not-allowed',
@@ -139,24 +102,39 @@ const generateStyle = (componentTheme, props, state) => {
     }
   }
 
-  const iconStyles = renderIcon
-    ? {
-        label: 'icon',
+  return {
+    link: {
+      '&, &:is(a), &:is(button)': {
+        ...baseStyle
+      },
+      '&:is(a), &:is(button)': {
+        ...isClickableStyle
+      },
+      '&:is(button)': {
+        ...buttonStyle
+      },
+      ...(inverseStyle && {
+        '&, &:is(a):link, &:is(a):visited, &:is(button)': {
+          color: componentTheme.colorInverse,
+          '&:focus': {
+            outlineColor: componentTheme.focusInverseIconOutlineColor
+          },
+          '&:hover, &:focus, &:active': {
+            color: componentTheme.colorInverse
+          }
+        }
+      })
+    },
+    icon: {
+      label: 'icon',
+      ...(renderIcon && {
         fontSize: componentTheme.iconSize,
         boxSizing: 'border-box',
         paddingInlineStart:
           iconPlacement === 'start' ? 0 : componentTheme.iconPlusTextMargin,
         paddingInlineEnd:
           iconPlacement === 'start' ? componentTheme.iconPlusTextMargin : 0
-      }
-    : {}
-
-  return {
-    link: {
-      ...linkStyles
-    },
-    icon: {
-      ...iconStyles
+      })
     }
   }
 }

--- a/packages/ui-menu/src/Menu/MenuItem/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.js
@@ -88,6 +88,7 @@ const generateStyle = (componentTheme, props, state) => {
       // and menuitemradio are selected twice with control+
       // option+space. So we set the display to block.
       display: 'block',
+      textDecoration: 'none',
       ...roleStyles,
       '&:focus,  &:active,  &:hover': {
         background: componentTheme.activeBackground,
@@ -104,8 +105,12 @@ const generateStyle = (componentTheme, props, state) => {
         margin: '0',
         border: '0'
       },
-      textDecoration: 'none',
-      ...disabledStyles
+      ...disabledStyles,
+      '&:is(a)': {
+        '&, &:link, &:visited, &:active, &:hover, &:focus': {
+          textDecoration: 'none'
+        }
+      }
     },
     icon: {
       label: 'menuItem__icon',

--- a/packages/ui-navigation/src/AppNav/Item/styles.js
+++ b/packages/ui-navigation/src/AppNav/Item/styles.js
@@ -34,40 +34,36 @@
  */
 const generateStyle = (componentTheme, props) => {
   const { isSelected, isDisabled } = props
-  const disabledStyles = isDisabled
-    ? {
-        pointerEvents: 'none',
-        opacity: 0.5
-      }
-    : {}
-  const selectedStyles = isSelected
-    ? {
-        color: componentTheme.textColorSelected,
-        textDecoration: 'underline'
-      }
-    : {}
+
   return {
     item: {
       label: 'item',
-      appearance: 'none',
-      overflow: 'visible',
-      direction: 'inherit',
-      margin: '0',
-      textDecoration: 'none',
-      userSelect: 'none',
-      touchAction: 'manipulation',
-      background: 'transparent',
-      border: 'none',
-      outline: 'none',
-      lineHeight: componentTheme.height,
-      padding: `0 ${componentTheme.padding}`,
-      alignItems: 'flex-start',
-      '&:hover': {
-        textDecoration: 'underline',
-        textDecorationColor: componentTheme.textColor
-      },
-      ...disabledStyles
+      '&, &:is(a), &:is(button)': {
+        appearance: 'none',
+        overflow: 'visible',
+        direction: 'inherit',
+        margin: '0',
+        textDecoration: 'none',
+        userSelect: 'none',
+        touchAction: 'manipulation',
+        background: 'transparent',
+        border: 'none',
+        outline: 'none',
+        lineHeight: componentTheme.height,
+        padding: `0 ${componentTheme.padding}`,
+        alignItems: 'flex-start',
+
+        '&:hover': {
+          textDecoration: 'underline',
+          textDecorationColor: componentTheme.textColor
+        },
+        ...(isDisabled && {
+          pointerEvents: 'none',
+          opacity: 0.5
+        })
+      }
     },
+
     label: {
       label: 'item__label',
       whiteSpace: 'nowrap',
@@ -77,7 +73,11 @@ const generateStyle = (componentTheme, props) => {
       fontSize: componentTheme.fontSize,
       fontWeight: componentTheme.fontWeight,
       color: componentTheme.textColor,
-      ...selectedStyles
+
+      ...(isSelected && {
+        color: componentTheme.textColorSelected,
+        textDecoration: 'underline'
+      })
     }
   }
 }

--- a/packages/ui-radio-input/src/RadioInput/styles.js
+++ b/packages/ui-radio-input/src/RadioInput/styles.js
@@ -257,15 +257,17 @@ const generateStyle = (componentTheme, props, state) => {
     },
     input: {
       label: 'radioInput__input',
-      padding: '0',
-      margin: '0',
-      fontSize: 'inherit',
-      lineHeight: 'inherit',
-      width: 'auto',
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      opacity: 0.0001 /* selenium cannot find fully transparent elements */
+      '&, &:is(input)[type="radio"]': {
+        padding: '0',
+        margin: '0',
+        fontSize: 'inherit',
+        lineHeight: 'inherit',
+        width: 'auto',
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        opacity: 0.0001 /* selenium cannot find fully transparent elements */
+      }
     },
     control: {
       label: 'radioInput__control',

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -41,8 +41,7 @@ const generateStyle = (componentTheme, props, state) => {
     transform,
     lineHeight,
     letterSpacing,
-    color,
-    as
+    color
   } = props
 
   const colorVariants = {
@@ -87,8 +86,8 @@ const generateStyle = (componentTheme, props, state) => {
 
   const letterSpacingVariants = {
     normal: componentTheme.letterSpacingNormal,
-    condensed: componentTheme.letterSpacingNormal,
-    expanded: componentTheme.letterSpacingNormal
+    condensed: componentTheme.letterSpacingCondensed,
+    expanded: componentTheme.letterSpacingExpanded
   }
 
   const baseStyle = {

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -91,7 +91,7 @@ const generateStyle = (componentTheme, props, state) => {
     expanded: componentTheme.letterSpacingNormal
   }
 
-  const inputAndTextStyle = {
+  const baseStyle = {
     '&:focus': {
       outline: 'none'
     },
@@ -105,7 +105,6 @@ const generateStyle = (componentTheme, props, state) => {
     ...(transform ? { textTransform: transform } : {})
   }
 
-  // NOTE: the input styles exist to accommodate the InPlaceEdit component
   const inputStyle = {
     outline: 0,
     appearance: 'none',
@@ -121,8 +120,7 @@ const generateStyle = (componentTheme, props, state) => {
     lineHeight: 'inherit',
     textAlign: 'start',
     boxShadow: 'none',
-    display: 'block',
-    ...inputAndTextStyle
+    display: 'block'
   }
 
   return {
@@ -156,9 +154,14 @@ const generateStyle = (componentTheme, props, state) => {
         padding: 0,
         margin: componentTheme.paragraphMargin
       },
-      ...inputAndTextStyle,
-      ...(as === 'input' && inputStyle),
-      '&[type]': inputStyle
+
+      // NOTE: the input styles exist to accommodate the InPlaceEdit component
+      '&:is(input)[type]': {
+        ...inputStyle
+      },
+      '&, &:is(input)[type]': {
+        ...baseStyle
+      }
     }
   }
 }


### PR DESCRIPTION
During the Emotion Migration we used a workaround to style items with selectors strengthened with html tag selectors, eg.: `input.root[type]`.

This turned out to be a bad decision, because most of our components accept an "as" property (if you want to render the component "as button" instead of the default "as a" for example). If you pass a complex component instead of a string to the "as" prop though, the new solution didn't apply the styles, because the elementType was a function instead of a valid html tag name.

Refactored the code to use the css `&:is(input)` selectors, because they apply as css classes once the DOM is fully rendered and the component is boiled down to the final html element.