### PR TITLE
INSTUI-2917 - refactor: add css :-webkit-any() selector to :is()

### DIFF
--- a/packages/ui-byline/src/Byline/styles.js
+++ b/packages/ui-byline/src/Byline/styles.js
@@ -43,7 +43,7 @@ const generateStyle = (componentTheme, props, state) => {
   return {
     byline: {
       label: 'byline',
-      '&, &:is(figure)': {
+      '&, &:is(figure), &:-webkit-any(figure)': {
         display: 'flex',
         background: componentTheme.background,
         margin: 0,
@@ -59,7 +59,7 @@ const generateStyle = (componentTheme, props, state) => {
     },
     caption: {
       label: 'byline__caption',
-      '&, &:is(figcaption)': {
+      '&, &:is(figcaption), &:-webkit-any(figcaption)': {
         color: componentTheme.color,
         margin: 0,
         padding: 0

--- a/packages/ui-form-field/src/FormFieldLabel/styles.js
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.js
@@ -42,7 +42,7 @@ const generateStyle = (componentTheme, props, state) => {
   return {
     formFieldLabel: {
       label: 'formFieldLabel',
-      '&, &:is(label)': {
+      '&, &:is(label), &:-webkit-any(label)': {
         all: 'initial',
         display: 'block',
         ...(hasContent && {

--- a/packages/ui-heading/src/Heading/styles.js
+++ b/packages/ui-heading/src/Heading/styles.js
@@ -115,7 +115,7 @@ const generateStyle = (componentTheme, props) => {
       margin: 0,
 
       // NOTE: the input styles exist to accommodate the InPlaceEdit component
-      '&:is(input)[type]': {
+      '&:is(input)[type], &:-webkit-any(input)[type]': {
         ...inputStyle
       },
 

--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -104,17 +104,17 @@ const generateStyle = (componentTheme, props, state) => {
 
   return {
     link: {
-      '&, &:is(a), &:is(button)': {
+      '&, &:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
         ...baseStyle
       },
-      '&:is(a), &:is(button)': {
+      '&:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
         ...isClickableStyle
       },
-      '&:is(button)': {
+      '&:is(button), &:-webkit-any(button)': {
         ...buttonStyle
       },
       ...(inverseStyle && {
-        '&, &:is(a):link, &:is(a):visited, &:is(button)': {
+        '&, &:is(a):link, &:-webkit-any(a):link, &:is(a):visited, &:-webkit-any(a):visited, &:is(button), &:-webkit-any(button)': {
           color: componentTheme.colorInverse,
           '&:focus': {
             outlineColor: componentTheme.focusInverseIconOutlineColor

--- a/packages/ui-menu/src/Menu/MenuItem/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.js
@@ -106,7 +106,7 @@ const generateStyle = (componentTheme, props, state) => {
         border: '0'
       },
       ...disabledStyles,
-      '&:is(a)': {
+      '&:is(a), &:-webkit-any(a)': {
         '&, &:link, &:visited, &:active, &:hover, &:focus': {
           textDecoration: 'none'
         }

--- a/packages/ui-navigation/src/AppNav/Item/styles.js
+++ b/packages/ui-navigation/src/AppNav/Item/styles.js
@@ -38,7 +38,7 @@ const generateStyle = (componentTheme, props) => {
   return {
     item: {
       label: 'item',
-      '&, &:is(a), &:is(button)': {
+      '&, &:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
         appearance: 'none',
         overflow: 'visible',
         direction: 'inherit',

--- a/packages/ui-radio-input/src/RadioInput/styles.js
+++ b/packages/ui-radio-input/src/RadioInput/styles.js
@@ -257,7 +257,7 @@ const generateStyle = (componentTheme, props, state) => {
     },
     input: {
       label: 'radioInput__input',
-      '&, &:is(input)[type="radio"]': {
+      '&, &:is(input)[type="radio"], &:-webkit-any(input)[type="radio"]': {
         padding: '0',
         margin: '0',
         fontSize: 'inherit',

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -155,10 +155,10 @@ const generateStyle = (componentTheme, props, state) => {
       },
 
       // NOTE: the input styles exist to accommodate the InPlaceEdit component
-      '&:is(input)[type]': {
+      '&:is(input)[type], &:-webkit-any(input)[type]': {
         ...inputStyle
       },
-      '&, &:is(input)[type]': {
+      '&, &:is(input)[type], &:-webkit-any(input)[type]': {
         ...baseStyle
       }
     }


### PR DESCRIPTION
Closes: INSTUI-2917

Chromatic tests use Chrome v84 for snapshots, which doesn't support the newer `:is()` css selector.
Extend the usages with the older `:-webkit-any()` selector.