### PR TITLE
INSTUI-2918 - fix prefixed css selector grouping

### DIFF
--- a/packages/ui-byline/src/Byline/styles.js
+++ b/packages/ui-byline/src/Byline/styles.js
@@ -40,17 +40,29 @@ const generateStyle = (componentTheme, props, state) => {
     center: { alignItems: 'center' }
   }
 
+  const bylineStyles = {
+    display: 'flex',
+    background: componentTheme.background,
+    margin: 0,
+    padding: 0,
+    fontFamily: componentTheme.fontFamily,
+    ...alignContentVariants[alignContent]
+  }
+
+  const captionStyles = {
+    color: componentTheme.color,
+    margin: 0,
+    padding: 0
+  }
+
   return {
     byline: {
       label: 'byline',
-      '&, &:is(figure), &:-webkit-any(figure)': {
-        display: 'flex',
-        background: componentTheme.background,
-        margin: 0,
-        padding: 0,
-        fontFamily: componentTheme.fontFamily,
-        ...alignContentVariants[alignContent]
-      }
+      ...bylineStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(figure)': bylineStyles,
+      '&:-webkit-any(figure)': bylineStyles
     },
     figure: {
       label: 'byline__figure',
@@ -59,11 +71,11 @@ const generateStyle = (componentTheme, props, state) => {
     },
     caption: {
       label: 'byline__caption',
-      '&, &:is(figcaption), &:-webkit-any(figcaption)': {
-        color: componentTheme.color,
-        margin: 0,
-        padding: 0
-      }
+      ...captionStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(figcaption)': captionStyles,
+      '&:-webkit-any(figcaption)': captionStyles
     },
     title: {
       label: 'byline__title',

--- a/packages/ui-form-field/src/FormFieldLabel/styles.js
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.js
@@ -39,22 +39,28 @@ const generateStyle = (componentTheme, props, state) => {
 
   const hasContent = hasVisibleChildren(children)
 
+  const labelStyles = {
+    all: 'initial',
+    display: 'block',
+    ...(hasContent && {
+      color: componentTheme.color,
+      fontFamily: componentTheme.fontFamily,
+      fontWeight: componentTheme.fontWeight,
+      fontSize: componentTheme.fontSize,
+      lineHeight: componentTheme.lineHeight,
+      margin: 0,
+      textAlign: 'inherit'
+    })
+  }
+
   return {
     formFieldLabel: {
       label: 'formFieldLabel',
-      '&, &:is(label), &:-webkit-any(label)': {
-        all: 'initial',
-        display: 'block',
-        ...(hasContent && {
-          color: componentTheme.color,
-          fontFamily: componentTheme.fontFamily,
-          fontWeight: componentTheme.fontWeight,
-          fontSize: componentTheme.fontSize,
-          lineHeight: componentTheme.lineHeight,
-          margin: 0,
-          textAlign: 'inherit'
-        })
-      }
+      ...labelStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(label)': labelStyles,
+      '&:-webkit-any(label)': labelStyles
     }
   }
 }

--- a/packages/ui-heading/src/Heading/styles.js
+++ b/packages/ui-heading/src/Heading/styles.js
@@ -89,7 +89,7 @@ const generateStyle = (componentTheme, props) => {
     none: {}
   }
 
-  const inputStyle = {
+  const inputStyles = {
     outline: 0,
     appearance: 'none',
     boxSizing: 'border-box',
@@ -115,9 +115,9 @@ const generateStyle = (componentTheme, props) => {
       margin: 0,
 
       // NOTE: the input styles exist to accommodate the InPlaceEdit component
-      '&:is(input)[type], &:-webkit-any(input)[type]': {
-        ...inputStyle
-      },
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(input)[type]': inputStyles,
+      '&:-webkit-any(input)[type]': inputStyles,
 
       ...levelStyles[level],
       ...colorStyles[color],

--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -37,8 +37,42 @@ const generateStyle = (componentTheme, props, state) => {
   const { containsTruncateText, hasVisibleChildren } = state
   const inverseStyle = color === 'link-inverse'
 
+  const baseStyles = {
+    boxSizing: 'border-box',
+    fontFamily: componentTheme.fontFamily,
+    fontWeight: componentTheme.fontWeight,
+    transition: 'outline-color 0.2s',
+    verticalAlign: 'baseline',
+
+    // set up focus styles
+    outlineColor: 'transparent',
+    outlineWidth: componentTheme.focusOutlineWidth,
+    outlineStyle: componentTheme.focusOutlineStyle,
+    outlineOffset: '0.25rem',
+
+    // If TruncateText is used in Link with icon, align the icon and the text vertically
+    ...(renderIcon &&
+      containsTruncateText &&
+      hasVisibleChildren && {
+        alignItems: 'center'
+      }),
+
+    '&:focus': {
+      outlineColor: componentTheme.focusOutlineColor
+    },
+    '&[aria-disabled]': {
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
+      opacity: '0.5'
+    },
+    '&::-moz-focus-inner': {
+      border: 0 // removes default dotted focus outline in Firefox
+    }
+  }
+
   // If Link is a button or link, it should look clickable
-  const isClickableStyle = {
+  const isClickableStyles = {
+    ...baseStyles,
     cursor: 'pointer',
     color: componentTheme.color,
     textDecoration: isWithinText
@@ -67,62 +101,32 @@ const generateStyle = (componentTheme, props, state) => {
     textAlign: 'inherit'
   }
 
-  // If TruncateText is used in Link with icon, align the icon and the text vertically
-  const truncateStyle =
-    renderIcon && containsTruncateText && hasVisibleChildren
-      ? { alignItems: 'center' }
-      : {}
-
-  const baseStyle = {
-    label: 'link',
-    boxSizing: 'border-box',
-    fontFamily: componentTheme.fontFamily,
-    fontWeight: componentTheme.fontWeight,
-    transition: 'outline-color 0.2s',
-    verticalAlign: 'baseline',
-
-    // set up focus styles
-    outlineColor: 'transparent',
-    outlineWidth: componentTheme.focusOutlineWidth,
-    outlineStyle: componentTheme.focusOutlineStyle,
-    outlineOffset: '0.25rem',
-
-    ...truncateStyle,
-
+  const inverseStyles = {
+    color: componentTheme.colorInverse,
     '&:focus': {
-      outlineColor: componentTheme.focusOutlineColor
+      outlineColor: componentTheme.focusInverseIconOutlineColor
     },
-    '&[aria-disabled]': {
-      cursor: 'not-allowed',
-      pointerEvents: 'none',
-      opacity: '0.5'
-    },
-    '&::-moz-focus-inner': {
-      border: 0 // removes default dotted focus outline in Firefox
+    '&:hover, &:focus, &:active': {
+      color: componentTheme.colorInverse
     }
   }
 
   return {
     link: {
-      '&, &:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
-        ...baseStyle
-      },
-      '&:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
-        ...isClickableStyle
-      },
-      '&:is(button), &:-webkit-any(button)': {
-        ...buttonStyle
-      },
+      label: 'link',
+      ...baseStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(a), &:is(button)': isClickableStyles,
+      '&:-webkit-any(a), &:-webkit-any(button)': isClickableStyles,
+
+      '&:is(button)': buttonStyle,
+      '&:-webkit-any(button)': buttonStyle,
+
       ...(inverseStyle && {
-        '&, &:is(a):link, &:-webkit-any(a):link, &:is(a):visited, &:-webkit-any(a):visited, &:is(button), &:-webkit-any(button)': {
-          color: componentTheme.colorInverse,
-          '&:focus': {
-            outlineColor: componentTheme.focusInverseIconOutlineColor
-          },
-          '&:hover, &:focus, &:active': {
-            color: componentTheme.colorInverse
-          }
-        }
+        ...inverseStyles,
+        '&:is(a):link, &:is(a):visited, &:is(button)': inverseStyles,
+        '&:-webkit-any(a):link, &:-webkit-any(a):visited, &:-webkit-any(button)': inverseStyles
       })
     },
     icon: {

--- a/packages/ui-menu/src/Menu/MenuItem/styles.js
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.js
@@ -50,12 +50,14 @@ const generateStyle = (componentTheme, props, state) => {
         paddingInlineStart: componentTheme.labelPadding
       }
     : {}
+
   const roleIconStyles = isRadioOrCheckbox
     ? {
         insetInlineStart: componentTheme.iconPadding,
         insetInlineEnd: 'auto'
       }
     : {}
+
   const disabledStyles = disabled
     ? {
         cursor: 'not-allowed',
@@ -63,6 +65,9 @@ const generateStyle = (componentTheme, props, state) => {
         opacity: 0.5
       }
     : {}
+
+  const linkStyles = { textDecoration: 'none' }
+
   return {
     menuItem: {
       label: 'menuItem',
@@ -106,10 +111,13 @@ const generateStyle = (componentTheme, props, state) => {
         border: '0'
       },
       ...disabledStyles,
-      '&:is(a), &:-webkit-any(a)': {
-        '&, &:link, &:visited, &:active, &:hover, &:focus': {
-          textDecoration: 'none'
-        }
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(a)': {
+        '&, &:link, &:visited, &:active, &:hover, &:focus': linkStyles
+      },
+      '&:-webkit-any(a)': {
+        '&, &:link, &:visited, &:active, &:hover, &:focus': linkStyles
       }
     },
     icon: {

--- a/packages/ui-navigation/src/AppNav/Item/styles.js
+++ b/packages/ui-navigation/src/AppNav/Item/styles.js
@@ -35,33 +35,39 @@
 const generateStyle = (componentTheme, props) => {
   const { isSelected, isDisabled } = props
 
+  const itemStyles = {
+    appearance: 'none',
+    overflow: 'visible',
+    direction: 'inherit',
+    margin: '0',
+    textDecoration: 'none',
+    userSelect: 'none',
+    touchAction: 'manipulation',
+    background: 'transparent',
+    border: 'none',
+    outline: 'none',
+    lineHeight: componentTheme.height,
+    padding: `0 ${componentTheme.padding}`,
+    alignItems: 'flex-start',
+
+    '&:hover': {
+      textDecoration: 'underline',
+      textDecorationColor: componentTheme.textColor
+    },
+    ...(isDisabled && {
+      pointerEvents: 'none',
+      opacity: 0.5
+    })
+  }
+
   return {
     item: {
       label: 'item',
-      '&, &:is(a), &:-webkit-any(a), &:is(button), &:-webkit-any(button)': {
-        appearance: 'none',
-        overflow: 'visible',
-        direction: 'inherit',
-        margin: '0',
-        textDecoration: 'none',
-        userSelect: 'none',
-        touchAction: 'manipulation',
-        background: 'transparent',
-        border: 'none',
-        outline: 'none',
-        lineHeight: componentTheme.height,
-        padding: `0 ${componentTheme.padding}`,
-        alignItems: 'flex-start',
+      ...itemStyles,
 
-        '&:hover': {
-          textDecoration: 'underline',
-          textDecorationColor: componentTheme.textColor
-        },
-        ...(isDisabled && {
-          pointerEvents: 'none',
-          opacity: 0.5
-        })
-      }
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(a), &:is(button)': itemStyles,
+      '&:-webkit-any(a), &:-webkit-any(button)': itemStyles
     },
 
     label: {

--- a/packages/ui-radio-input/src/RadioInput/styles.js
+++ b/packages/ui-radio-input/src/RadioInput/styles.js
@@ -238,6 +238,18 @@ const generateStyle = (componentTheme, props, state) => {
     }
   }
 
+  const inputStyles = {
+    padding: '0',
+    margin: '0',
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    width: 'auto',
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    opacity: 0.0001 /* selenium cannot find fully transparent elements */
+  }
+
   return {
     radioInput: {
       label: 'radioInput',
@@ -257,17 +269,11 @@ const generateStyle = (componentTheme, props, state) => {
     },
     input: {
       label: 'radioInput__input',
-      '&, &:is(input)[type="radio"], &:-webkit-any(input)[type="radio"]': {
-        padding: '0',
-        margin: '0',
-        fontSize: 'inherit',
-        lineHeight: 'inherit',
-        width: 'auto',
-        position: 'absolute',
-        top: '0',
-        left: '0',
-        opacity: 0.0001 /* selenium cannot find fully transparent elements */
-      }
+      ...inputStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(input)[type="radio"]': inputStyles,
+      '&:-webkit-any(input)[type="radio"]': inputStyles
     },
     control: {
       label: 'radioInput__control',

--- a/packages/ui-text/src/Text/styles.js
+++ b/packages/ui-text/src/Text/styles.js
@@ -90,7 +90,7 @@ const generateStyle = (componentTheme, props, state) => {
     expanded: componentTheme.letterSpacingExpanded
   }
 
-  const baseStyle = {
+  const baseStyles = {
     '&:focus': {
       outline: 'none'
     },
@@ -104,7 +104,8 @@ const generateStyle = (componentTheme, props, state) => {
     ...(transform ? { textTransform: transform } : {})
   }
 
-  const inputStyle = {
+  const inputStyles = {
+    ...baseStyles,
     outline: 0,
     appearance: 'none',
     boxSizing: 'border-box',
@@ -126,6 +127,12 @@ const generateStyle = (componentTheme, props, state) => {
     text: {
       label: 'text',
       fontFamily: componentTheme.fontFamily,
+      ...baseStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(input)[type]': inputStyles,
+      '&:-webkit-any(input)[type]': inputStyles,
+
       'sub, sup': {
         fontSize: '75%',
         lineHeight: 0,
@@ -152,14 +159,6 @@ const generateStyle = (componentTheme, props, state) => {
         display: 'block',
         padding: 0,
         margin: componentTheme.paragraphMargin
-      },
-
-      // NOTE: the input styles exist to accommodate the InPlaceEdit component
-      '&:is(input)[type], &:-webkit-any(input)[type]': {
-        ...inputStyle
-      },
-      '&, &:is(input)[type], &:-webkit-any(input)[type]': {
-        ...baseStyle
       }
     }
   }


### PR DESCRIPTION
Closes: INSTUI-2918

Needed to separate the vendor prefixed css selectors to different groups, because if any one of them
in the group is invalid in a browser, the whole group counts as invalid. See more info here:
https://www.w3.org/TR/selectors-3/#grouping.