### PR TITLE
INSTUI-2928 - fix vertical scrollbar on code editors

### DIFF
--- a/packages/ui-code-editor/package.json
+++ b/packages/ui-code-editor/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-test-locator": "^7.5.0",
     "@instructure/ui-testable": "^7.5.0",
     "@instructure/uid": "^7.5.0",
-    "codemirror": "^5.48.4",
+    "codemirror": "5.48.4",
     "prop-types": "^15",
     "react-codemirror2": "^7.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,10 +5825,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@^5.48.4:
-  version "5.59.4"
-  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.59.4.tgz#bfc11c8ce32b04818e8d661bbd790a94f4b3a6f3"
-  integrity sha512-achw5JBgx8QPcACDDn+EUUXmCYzx/zxEtOGXyjvLEvYY8GleUrnfm5D+Zb+UjShHggXKDT9AXrbkBZX6a0YSQg==
+codemirror@5.48.4:
+  version "5.48.4"
+  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.48.4.tgz#4210fbe92be79a88f0eea348fab3ae78da85ce47"
+  integrity sha512-pUhZXDQ6qXSpWdwlgAwHEkd4imA0kf83hINmUEzJpmG80T/XLtDDEzZo8f6PQLuRCcUQhmzqqIo3ZPTRaWByRA==
 
 codesandbox-api@^0.0.22:
   version "0.0.22"


### PR DESCRIPTION
Closes: INSTUI-2918

Codemirror was updated, and the new version was causing vertical scrollbars to appear even if the
content fit the box. Downgraded to version 5.48.4 with which it worked as intended.