### PR TITLE
INSTUI-2892 - add codemod for themeable util imports

### DIFF
--- a/docs/guides/themeable-to-emotion-migration-guide.md
+++ b/docs/guides/themeable-to-emotion-migration-guide.md
@@ -410,8 +410,6 @@ import { Children, Component } from 'react'
 - Replace the `styles.css` import with the style generator (`generateStyle`) import from `styles.js`.
 - Don't forget to update the dependencies in `package.json`.
 
-Note: these utils were moved from `ui-themeable` to the `emotion` package: ThemeablePropValues, ThemeablePropTypes, makeThemeVars, getShorthandPropValue, mirrorShorthandCorners, mirrorShorthandEdges. Update the import where needed.
-
 ```js
 // before
 import { themeable } from '@instructure/ui-themeable'
@@ -422,6 +420,12 @@ import styles from './styles.css'
 import { withStyle, jsx } from '@instructure/emotion'
 import generateComponentTheme from './theme'
 import generateStyle from './styles'
+```
+
+**Note:** these utils were moved from `ui-themeable` to the `emotion` package: ThemeablePropValues, ThemeablePropTypes, makeThemeVars, getShorthandPropValue, mirrorShorthandCorners, mirrorShorthandEdges. Update the import where needed. We provided a codemod for these import transformations:
+
+```bash
+npx @instructure/instui-cli codemod --scope-modifications imports -v 8
 ```
 
 ##### 3. decorator

--- a/packages/instui-config/codemod-configs/v8/imports.config.js
+++ b/packages/instui-config/codemod-configs/v8/imports.config.js
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports = () => {
+  return {
+    transforms: [
+      {
+        where: {
+          packageName: '@instructure/ui-themeable',
+          moduleNames: [
+            'ThemeablePropValues',
+            'ThemeablePropTypes',
+            'makeThemeVars',
+            'getShorthandPropValue',
+            'mirrorShorthandCorners',
+            'mirrorShorthandEdges'
+          ]
+        },
+        transform: {
+          importType: 'named',
+          importPath: '@instructure/emotion'
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes: INSTUI-2892

Some utils were moved from `ui-themeable` to `emotion` package, so we made a codemod to take care of
the import transforms.