### PR TITLE
INSTUI-2957: fix null pointer exception in Select

### DIFF
--- a/packages/ui-select/src/Select/index.js
+++ b/packages/ui-select/src/Select/index.js
@@ -360,7 +360,7 @@ class Select extends Component {
     this.props.listRef(node)
 
     // store option height to calculate list maxHeight
-    if (node) {
+    if (node && node.querySelector('[role="option"]')) {
       this._optionHeight = node.querySelector('[role="option"]').offsetHeight
     }
   }


### PR DESCRIPTION
Select crashes in multi select mode when selecting all elements and then clicking outside the component