### PR TITLE
INSTUI-2959 - docs: update deprecated theme usage info in docs

### DIFF
--- a/packages/canvas-high-contrast-theme/README.md
+++ b/packages/canvas-high-contrast-theme/README.md
@@ -6,12 +6,12 @@ category: packages
 
 [![npm][npm]][npm-url]
 [![build-status][build-status]][build-status-url]
-[![MIT License][license-badge]][LICENSE]
+[![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 
 A high contrast UI component theme for Canvas LMS made by Instructure Inc.
 
-This theme meets the WCAG 2 Level AA 4.5:1 minimum contrast requirements. 
+This theme meets the WCAG 2 Level AA 4.5:1 minimum contrast requirements.
 
 ### Installation
 
@@ -25,23 +25,34 @@ Before mounting (rendering) your React application:
 
 ```js
 import { theme } from '@instructure/canvas-high-contrast-theme'
-theme.use()
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={theme}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 To override the variables:
 
 ```js
-theme.use({ overrides: { colors: { brand: 'red' } } })
+import { theme } from '@instructure/canvas-high-contrast-theme'
+const themeOverrides = { colors: { brand: 'red' } }
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={{ ...theme, ...themeOverrides }}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 [npm]: https://img.shields.io/npm/v/@instructure/canvas-high-contrast-theme.svg
 [npm-url]: https://npmjs.com/package/@instructure/canvas-high-contrast-theme
-
 [build-status]: https://travis-ci.org/instructure/instructure-ui.svg?branch=master
-[build-status-url]: https://travis-ci.org/instructure/instructure-ui "Travis CI"
-
+[build-status-url]: https://travis-ci.org/instructure/instructure-ui 'Travis CI'
 [license-badge]: https://img.shields.io/npm/l/instructure-ui.svg?style=flat-square
 [license]: https://github.com/instructure/instructure-ui/blob/master/LICENSE
-
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
 [coc]: https://github.com/instructure/instructure-ui/blob/master/CODE_OF_CONDUCT.md

--- a/packages/canvas-theme/README.md
+++ b/packages/canvas-theme/README.md
@@ -6,12 +6,12 @@ category: packages
 
 [![npm][npm]][npm-url]&nbsp;
 [![build-status][build-status]][build-status-url]&nbsp;
-[![MIT License][license-badge]][LICENSE]&nbsp;
+[![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 
 A UI component theme for Canvas LMS made by Instructure Inc.
 
-This theme has a 3:1 minimum contrast requirement. 
+This theme has a 3:1 minimum contrast requirement.
 
 ### Installation
 
@@ -25,23 +25,34 @@ Before mounting (rendering) your React application:
 
 ```js
 import { theme } from '@instructure/canvas-theme'
-theme.use()
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={theme}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 To override the variables:
 
 ```js
-theme.use({ overrides: { colors: { brand: 'red' } } })
+import { theme } from '@instructure/canvas-theme'
+const themeOverrides = { colors: { brand: 'red' } }
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={{ ...theme, ...themeOverrides }}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 [npm]: https://img.shields.io/npm/v/@instructure/canvas-theme.svg
 [npm-url]: https://npmjs.com/package/@instructure/canvas-theme
-
 [build-status]: https://travis-ci.org/instructure/instructure-ui.svg?branch=master
-[build-status-url]: https://travis-ci.org/instructure/instructure-ui "Travis CI"
-
+[build-status-url]: https://travis-ci.org/instructure/instructure-ui 'Travis CI'
 [license-badge]: https://img.shields.io/npm/l/instructure-ui.svg?style=flat-square
 [license]: https://github.com/instructure/instructure-ui/blob/master/LICENSE
-
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
 [coc]: https://github.com/instructure/instructure-ui/blob/master/CODE_OF_CONDUCT.md

--- a/packages/instructure-theme/README.md
+++ b/packages/instructure-theme/README.md
@@ -6,12 +6,12 @@ category: packages
 
 [![npm][npm]][npm-url]
 [![build-status][build-status]][build-status-url]
-[![MIT License][license-badge]][LICENSE]
+[![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 
 A UI component theme for Instructure made by Instructure Inc.
 
-This theme has a 3:1 minimum contrast requirement. 
+This theme has a 3:1 minimum contrast requirement.
 
 ### Installation
 
@@ -25,23 +25,34 @@ Before mounting (rendering) your React application:
 
 ```js
 import { theme } from '@instructure/instructure-theme'
-theme.use()
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={theme}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 To override the variables:
 
 ```js
-theme.use({ overrides: { colors: { brand: 'red' } } })
+import { theme } from '@instructure/instructure-theme'
+const themeOverrides = { colors: { brand: 'red' } }
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={{ ...theme, ...themeOverrides }}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 [npm]: https://img.shields.io/npm/v/@instructure/instructure-theme.svg
 [npm-url]: https://npmjs.com/package/@instructure/instructure-theme
-
 [build-status]: https://travis-ci.org/instructure/instructure-ui.svg?branch=master
-[build-status-url]: https://travis-ci.org/instructure/instructure-ui "Travis CI"
-
+[build-status-url]: https://travis-ci.org/instructure/instructure-ui 'Travis CI'
 [license-badge]: https://img.shields.io/npm/l/instructure-ui.svg?style=flat-square
 [license]: https://github.com/instructure/instructure-ui/blob/master/LICENSE
-
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
 [coc]: https://github.com/instructure/instructure-ui/blob/master/CODE_OF_CONDUCT.md

--- a/packages/ui-docs-client/src/App/index.js
+++ b/packages/ui-docs-client/src/App/index.js
@@ -310,7 +310,6 @@ class App extends Component {
           themeKey={themeKey}
           variables={theme.resource}
           requirePath={theme.requirePath}
-          immutable={theme.resource.immutable}
         />
       </View>
     )

--- a/packages/ui-docs-client/src/Theme/index.js
+++ b/packages/ui-docs-client/src/Theme/index.js
@@ -39,12 +39,10 @@ class Theme extends Component {
     themeKey: PropTypes.string.isRequired,
     variables: PropTypes.object.isRequired,
     requirePath: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    immutable: PropTypes.bool
+    description: PropTypes.string
   }
 
   static defaultProps = {
-    immutable: false,
     description: undefined
   }
 
@@ -212,10 +210,6 @@ class Theme extends Component {
       }
     })
 
-    const params = this.props.immutable
-      ? '/* this theme does not allow overrides */'
-      : `{ overrides: { colors: { brand: 'red' } } }`
-
     return (
       <div>
         {description && (
@@ -234,9 +228,15 @@ class Theme extends Component {
 
             ${'```js'}
             // before mounting your React application:
-            import theme from '${this.props.requirePath}'
+            import { theme } from '${this.props.requirePath}'
+            const themeOverrides = { colors: { brand: 'red' } }
 
-            theme.use(${params})
+            ReactDOM.render(
+              <EmotionThemeProvider theme={{ ...theme, ...themeOverrides }}>
+                <App />
+              </EmotionThemeProvider>,
+              element
+            )
             ${'```'}
           `}
           title={`${themeKey} Theme Usage in applications`}

--- a/packages/ui-themes/README.md
+++ b/packages/ui-themes/README.md
@@ -6,7 +6,7 @@ category: packages
 
 [![npm][npm]][npm-url]&nbsp;
 [![build-status][build-status]][build-status-url]&nbsp;
-[![MIT License][license-badge]][LICENSE]&nbsp;
+[![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 
 ### Installation
@@ -21,30 +21,47 @@ Before mounting (rendering) your React application:
 
 ```js
 import { canvas } from '@instructure/ui-themes'
-canvas.use()
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={canvas}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 To override the variables:
 
 ```js
-theme.use({ overrides: { colors: { brand: 'red' } } })
+import { canvas } from '@instructure/ui-themes'
+const themeOverrides = { colors: { brand: 'red' } }
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={{ ...canvas, ...themeOverrides }}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 To use the high contrast theme:
 
 ```js
 import { canvasHighContrast } from '@instructure/ui-themes'
-canvasHighContrast.use()
+
+ReactDOM.render(
+  <EmotionThemeProvider theme={canvasHighContrast}>
+    <App />
+  </EmotionThemeProvider>,
+  element
+)
 ```
 
 [npm]: https://img.shields.io/npm/v/@instructure/ui-themes.svg
 [npm-url]: https://npmjs.com/package/@instructure/ui-themes
-
 [build-status]: https://travis-ci.org/instructure/instructure-ui.svg?branch=master
-[build-status-url]: https://travis-ci.org/instructure/instructure-ui "Travis CI"
-
+[build-status-url]: https://travis-ci.org/instructure/instructure-ui 'Travis CI'
 [license-badge]: https://img.shields.io/npm/l/instructure-ui.svg?style=flat-square
 [license]: https://github.com/instructure/instructure-ui/blob/master/LICENSE
-
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
 [coc]: https://github.com/instructure/instructure-ui/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Closes: INSTUI-2959

There were a few places in the docs where we still showed the deprecated "theme.use()" method.
Updated it to the v8 version.