### PR TITLE
INSTUI-2956 - backport fix to remove line extending into root icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     ],
     "*.css": [
       "stylelint",
-      "prettier --write",
       "git add"
     ],
     "*.{json,jsx,md,mdx,html}": [

--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -5,34 +5,73 @@ describes: TreeBrowser
 The `<TreeBrowser/>` component provides a keyboard accessible tree structure. The component expects
 to receive a normalized data structure, examples can be seen at https://github.com/paularmstrong/normalizr.
 
+### Size
+
 ```js
 ---
 example: true
+render: false
 ---
-<TreeBrowser
-  collections={{
-    1: {
-      id: 1,
-      name: "Assignments",
-      collections: [2,3],
-      items: [3],
-      descriptor: "Class Assignments"
-    },
-    2: { id: 2, name: "English Assignments", collections: [4], items: [] },
-    3: { id: 3, name: "Math Assignments", collections: [5], items: [1,2] },
-    4: { id: 4, name: "Reading Assignments", collections: [], items: [4] },
-    5: { id: 5, name: "Advanced Math Assignments", items: [5]}
-  }}
-  items={{
-    1: { id: 1, name: "Addition Worksheet" },
-    2: { id: 2, name: "Subtraction Worksheet" },
-    3: { id: 3, name: "General Questions" },
-    4: { id: 4, name: "Vogon Poetry" },
-    5: { id: 5, name: "Bistromath", descriptor: "Explain the Bistromathic Drive" }
-  }}
-  defaultExpanded={[1, 3]}
-  rootId={1}
-/>
+  class Example extends React.Component {
+    constructor (props) {
+      super(props)
+      this.state = {
+        size: 'medium'
+      }
+
+      this.sizes = ['small', 'medium', 'large']
+    }
+
+    handleSizeSelect = (e, size) => {
+      this.setState({ size })
+    };
+
+    render () {
+      return (
+        <>
+          <View display="block" margin="none none medium">
+            <RadioInputGroup
+              name="treeBrowserSize"
+              defaultValue="medium"
+              description={<ScreenReaderContent>TreeBrowser size selector</ScreenReaderContent>}
+              variant="toggle"
+              onChange={this.handleSizeSelect}
+            >
+              {this.sizes.map((size) => <RadioInput key={size} label={size} value={size} />)}
+            </RadioInputGroup>
+          </View>
+
+          <TreeBrowser
+            size={this.state.size}
+            collections={{
+              1: {
+                id: 1,
+                name: "Assignments",
+                collections: [2,3],
+                items: [3],
+                descriptor: "Class Assignments"
+              },
+              2: { id: 2, name: "English Assignments", collections: [4], items: [] },
+              3: { id: 3, name: "Math Assignments", collections: [5], items: [1,2] },
+              4: { id: 4, name: "Reading Assignments", collections: [], items: [4] },
+              5: { id: 5, name: "Advanced Math Assignments", items: [5]}
+            }}
+            items={{
+              1: { id: 1, name: "Addition Worksheet" },
+              2: { id: 2, name: "Subtraction Worksheet" },
+              3: { id: 3, name: "General Questions" },
+              4: { id: 4, name: "Vogon Poetry" },
+              5: { id: 5, name: "Bistromath", descriptor: "Explain the Bistromathic Drive" }
+            }}
+            defaultExpanded={[1, 3]}
+            rootId={1}
+          />
+        </>
+      )
+    }
+  }
+
+render(<Example/>)
 ```
 
 ### Managing State

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/styles.css
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/styles.css
@@ -73,8 +73,8 @@ here, so hardcoding until this problem is hopefully resolved in Edge 16
     .list {
       margin-inline-start: calc(var(--baseSpacingSmall) * 2);
       margin-inline-end: 0;
-      padding-top: var(--baseSpacingSmall);
-      margin-top: calc(-1 * var(--baseSpacingSmall));
+      padding-top: calc(1.75 * var(--baseSpacingSmall));
+      margin-top: calc(-1.75 * var(--baseSpacingSmall));
     }
   }
 }
@@ -109,8 +109,8 @@ here, so hardcoding until this problem is hopefully resolved in Edge 16
     .list {
       margin-inline-start: calc(var(--baseSpacingLarge) * 2);
       margin-inline-end: 0;
-      padding-top: var(--baseSpacingLarge);
-      margin-top: calc(-1 * var(--baseSpacingLarge));
+      padding-top: calc(0.75 * var(--baseSpacingLarge));
+      margin-top: calc(-0.75 * var(--baseSpacingLarge));
     }
   }
 }


### PR DESCRIPTION
Closes: INSTUI-2956

Backporting fix from PR #460: Tweaked the vertical line of "large" sized collections not to extend
into the collection icon.
Also tweaked the "small" sized collection to have the line ending closer
to the icon.
Added a size selector in the first example of TreeBrowser to be able to preview all
available sizes.