### PR TITLE
refactor: refactor `addResizeListener` usage to ResizeObserver

### DIFF
--- a/docs/guides/v8-deprecations.md
+++ b/docs/guides/v8-deprecations.md
@@ -1,0 +1,30 @@
+---
+title: Deprecated Utilites, Properties and Components in Version 8.0
+category: Guides
+order: 2
+---
+
+# Deprecated Utilites, Properties and Components in Version 8.0
+
+```javascript
+---
+embed: true
+---
+<ToggleBlockquote
+  summary="Important"
+>
+  <ToggleBlockquote.Paragraph>
+    The following utilities, properties and components are deprecated in v8, and <strong>will be permanently deleted in v9.0.</strong>
+  </ToggleBlockquote.Paragraph>
+</ToggleBlockquote>
+```
+
+The tables below show what will be removed and what are they replaced with. We also marked if there are [codemods](#ui-codemods) available.
+
+- [Deprecated Utilities](#v8-deprecations/#deprecated-utilites)
+
+### Deprecated Utilities
+
+| Utility                                 | Substitute                                                                                                |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [addResizeListener](#addResizeListener) | Use tha native [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) utility. |

--- a/docs/guides/v8-deprecations.md
+++ b/docs/guides/v8-deprecations.md
@@ -25,6 +25,6 @@ The tables below show what will be removed and what are they replaced with. We a
 
 ### Deprecated Utilities
 
-| Utility                                 | Substitute                                                                                                |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [addResizeListener](#addResizeListener) | Use tha native [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) utility. |
+| Utility                                 | Substitute                                                                                                                                          |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [addResizeListener](#addResizeListener) | Use the native [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) utility. Example usage: [here](#addResizeListener) |

--- a/packages/ui-dom-utils/src/addResizeListener.js
+++ b/packages/ui-dom-utils/src/addResizeListener.js
@@ -26,15 +26,17 @@ import { findDOMNode } from './findDOMNode'
 import { getBoundingClientRect } from './getBoundingClientRect'
 import { requestAnimationFrame } from './requestAnimationFrame'
 
-// TODO: replace with https://wicg.github.io/ResizeObserver/ when it's supported
-
 /**
  * ---
  * category: utilities/DOM
  * ---
+ * ### This utility is deprecated since version __8.0__ and will be permanently deleted in version 9.0.
+ * *Please use the native [DOM ResizeObserver API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) instead of this.*
+ *
+ * Adds a listener to an element and calls a specified handler function whenever the size changes.
+ * @deprecated since version 8.0
  * @module
- * Adds a listener to an element and calls a specified handler
- * function whenever the size changes
+ *
  *
  * @param {ReactComponent|DomNode} el - component or DOM node
  * @param {function} handler - function to run when resize occurs

--- a/packages/ui-dom-utils/src/addResizeListener.js
+++ b/packages/ui-dom-utils/src/addResizeListener.js
@@ -33,6 +33,25 @@ import { requestAnimationFrame } from './requestAnimationFrame'
  * ### This utility is deprecated since version __8.0__ and will be permanently deleted in version 9.0.
  * *Please use the native [DOM ResizeObserver API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) instead of this.*
  *
+ *
+ * Example usage of the `ResizeObserver`:
+ *  ```js
+ *    const observer = new ResizeObserver((entries) => {
+ *    for (let entry of entries) {
+ *       const size = {
+ *        width: entry.contentRect.width
+ *       }
+ *
+ *       if (size.width !== origSize.width) {
+ *         // call your handler function here
+ *         this._debounced(size)
+ *      }
+ *     }
+ *   })
+ *
+ *   observer.observe(content)
+ *   ```
+ *
  * Adds a listener to an element and calls a specified handler function whenever the size changes.
  * @deprecated since version 8.0
  * @module

--- a/packages/ui-responsive/src/addElementQueryMatchListener.js
+++ b/packages/ui-responsive/src/addElementQueryMatchListener.js
@@ -33,7 +33,10 @@ import { debounce } from '@instructure/debounce'
  * Given an object of named queries, listens for changes in the
  * element size and notifies which queries match via a function
  * callback. The callback method is only called when the query
- * matches change, not on all element resizes.
+ * matches change, not on all element resizes. (If you are looking
+ * to call a method on all element resizes use
+ * [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) instead)
+ *
  *
  * This function shares an interface with
  * [addMediaQueryMatchListener](#addMediaQueryMatchListener)
@@ -105,12 +108,7 @@ function addElementQueryMatchListener(query, el, cb) {
 
   elementResizeListener.observe(node)
 
-  const newMatches = update({ width, height }, query, node, matches)
-
-  if (newMatches) {
-    matches = newMatches
-    cb(matches)
-  }
+  update({ width, height })
 
   return {
     remove() {

--- a/packages/ui-tabs/src/Tabs/index.js
+++ b/packages/ui-tabs/src/Tabs/index.js
@@ -39,10 +39,7 @@ import { error } from '@instructure/console/macro'
 import { uid } from '@instructure/uid'
 import { testable } from '@instructure/ui-testable'
 import { Focusable } from '@instructure/ui-focusable'
-import {
-  addResizeListener,
-  getBoundingClientRect
-} from '@instructure/ui-dom-utils'
+import { getBoundingClientRect } from '@instructure/ui-dom-utils'
 import { debounce } from '@instructure/debounce'
 import { px } from '@instructure/ui-utils'
 import { bidirectional } from '@instructure/ui-i18n'
@@ -206,13 +203,23 @@ class Tabs extends Component {
       leading: true,
       trailing: true
     })
-    this._resizeListener = addResizeListener(this._tabList, this._debounced)
     this._tabListPosition = getBoundingClientRect(this._tabList)
+    this._resizeListener = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        const { width: newWidth } = entry.contentRect
+
+        if (this._tabListPosition.width !== newWidth) {
+          this._debounced()
+        }
+      }
+    })
+
+    this._resizeListener.observe(this._tabList)
   }
 
   cancelScrollOverflow() {
     if (this._resizeListener) {
-      this._resizeListener.remove()
+      this._resizeListener.disconnect()
     }
 
     if (this._debounced) {

--- a/packages/ui-text-area/src/TextArea/index.js
+++ b/packages/ui-text-area/src/TextArea/index.js
@@ -30,9 +30,9 @@ import { controllable } from '@instructure/ui-prop-types'
 import { FormField, FormPropTypes } from '@instructure/ui-form-field'
 import {
   addEventListener,
-  addResizeListener,
   isActiveElement,
-  requestAnimationFrame
+  requestAnimationFrame,
+  getBoundingClientRect
 } from '@instructure/ui-dom-utils'
 import { debounce } from '@instructure/debounce'
 import { withStyle, jsx } from '@instructure/emotion'
@@ -172,7 +172,7 @@ class TextArea extends Component {
     }
 
     if (this._textareaResizeListener) {
-      this._textareaResizeListener.remove()
+      this._textareaResizeListener.disconnect()
     }
 
     if (this._request) {
@@ -209,11 +209,18 @@ class TextArea extends Component {
       }
 
       if (this._textarea && !this._textareaResizeListener) {
-        this._textareaResizeListener = addResizeListener(
-          this._textarea,
-          this._textareaResize,
-          ['height']
-        )
+        const { height: origHeight } = getBoundingClientRect(this._textarea)
+        this._textareaResizeListener = new ResizeObserver((entries) => {
+          for (let entry of entries) {
+            const { height } = entry.contentRect
+
+            if (origHeight !== height) {
+              this._textareaResize()
+            }
+          }
+        })
+
+        this._textareaResizeListener.observe(this._textarea)
       }
 
       this._request = requestAnimationFrame(this.grow)


### PR DESCRIPTION
Closes: INSTUI-2875

Refactor `addResizeListener` to the native DOM ResizeObserver API in all places.
Created v8
deprecation guide.
Add info about deprecation to the `addResizeListener` doc page.
TEST PLAN:
Test the affected components.