### PR TITLE
INSTUI-2964 - list root items too when `showRootCollection` is `false`

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -339,6 +339,74 @@ class Example extends React.Component {
 render(<Example/>)
 ```
 
+### showRootCollection
+
+The `showRootCollection` prop sets whether the root collection (specified in `rootId` prop) is displayed or to begin with its immediate sub-collections and items instead. It defaults to `true`.
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      showRootCollection: true
+    }
+  }
+
+  handleSwitch = () => {
+    this.setState({ showRootCollection: !this.state.showRootCollection })
+  }
+
+  render () {
+    return (
+      <>
+        <View display="block" margin="none none medium">
+          <Checkbox
+            label="showRootCollection"
+            variant="toggle"
+            size="medium"
+            checked={this.state.showRootCollection}
+            onChange={this.handleSwitch}
+          />
+        </View>
+
+        <TreeBrowser
+          collections={{
+            1: {
+              id: 1,
+              name: "Assignments",
+              collections: [2,3],
+              items: [3, 5],
+              descriptor: "Class Assignments"
+            },
+            2: { id: 2, name: "English Assignments", collections: [4], items: [] },
+            3: { id: 3, name: "Math Assignments", collections: [5], items: [1,2] },
+            4: { id: 4, name: "Reading Assignments", collections: [], items: [4] },
+            5: { id: 5, name: "Advanced Math Assignments", items: [5]}
+          }}
+          items={{
+            1: { id: 1, name: "Addition Worksheet" },
+            2: { id: 2, name: "Subtraction Worksheet" },
+            3: { id: 3, name: "General Questions" },
+            4: { id: 4, name: "Vogon Poetry" },
+            5: { id: 5, name: "Bistromath", descriptor: "Explain the Bistromathic Drive" }
+          }}
+          defaultExpanded={[1, 3]}
+          rootId={1}
+          showRootCollection={this.state.showRootCollection}
+        />
+      </>
+    )
+  }
+}
+
+render(<Example/>)
+
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/styles.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/styles.js
@@ -258,7 +258,7 @@ const generateStyles = (componentTheme, props) => {
           ? componentTheme.selectedBackgroundColor
           : componentTheme.hoverBackgroundColor,
 
-        '[class$=-treeButton__textName],[class$=-treeButton__textDescriptor],[class$=-treeButton__icon]': {
+        '[class$=-treeButton__textName], [class$=-treeButton__textDescriptor], [class$=-treeButton__icon], [class$=-treeButton__node]': {
           color: componentTheme.hoverTextColor
         }
       },
@@ -315,8 +315,7 @@ const generateStyles = (componentTheme, props) => {
       ...sizeMap[size][variant].thumbnail
     },
     node: {
-      label: 'treeButton_node',
-      color: componentTheme.hoverTextColor,
+      label: 'treeButton__node',
       ...textStyle,
       ...textNameStyle
     }

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.js
@@ -23,6 +23,7 @@
  */
 
 /** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 

--- a/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
@@ -254,7 +254,7 @@ describe('<TreeBrowser />', async () => {
 
       const items = await tree.findAllItems()
 
-      expect(items.length).to.equal(2)
+      expect(items.length).to.equal(3)
     })
 
     it('should render first keyed collection if showRootCollection is true and rootId specified', async () => {

--- a/packages/ui-tree-browser/src/TreeBrowser/index.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.js
@@ -202,14 +202,10 @@ class TreeBrowser extends Component {
   }
 
   get collections() {
-    const { collections, rootId, showRootCollection } = this.props
+    const { collections, rootId } = this.props
 
-    if (typeof rootId !== 'undefined' && showRootCollection) {
+    if (typeof rootId !== 'undefined') {
       return [collections[rootId]]
-    } else if (typeof rootId !== 'undefined') {
-      return collections[rootId].collections
-        .map((id) => collections[id])
-        .filter((collection) => collection != null)
     } else {
       return Object.keys(collections)
         .map((id) => collections[id])
@@ -358,6 +354,11 @@ class TreeBrowser extends Component {
     }
   }
 
+  getIsFlattened = (collection) => {
+    const { rootId, showRootCollection } = this.props
+    return !showRootCollection && rootId && collection.id === rootId
+  }
+
   getCollectionProps(collection) {
     return {
       id: collection.id,
@@ -368,7 +369,8 @@ class TreeBrowser extends Component {
       collections: this.getSubCollections(collection),
       renderBeforeItems: collection.renderBeforeItems,
       renderAfterItems: collection.renderAfterItems,
-      containerRef: collection.containerRef
+      containerRef: collection.containerRef,
+      isCollectionFlattened: this.getIsFlattened(collection)
     }
   }
 


### PR DESCRIPTION
Closes: INSTUI-2964

Fixed the error when the items of the root collection are not rendered when `showRootCollection` is
set to `false`. Added an interactive example on the docs page to show how `showRootCollection`
works.

TEST PLAN:
Root items are rendered too when `showRootCollection` is set to false. The `aria-level` values are
correct on every level.