### PR TITLE
INSTUI-2975: fix template app generation error

### DIFF
--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -32,6 +32,6 @@
     "@instructure/ui-scripts": "^8.0.0",
     "@instructure/ui-stylelint-config": "^8.0.0",
     "@instructure/ui-webpack-config": "^8.0.0",
-    "html-webpack-plugin": "^3.2.0"
+    "html-webpack-plugin": "^4"
   }
 }

--- a/packages/template-app/template/webpack.config.js.ejs
+++ b/packages/template-app/template/webpack.config.js.ejs
@@ -41,8 +41,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './src/index.html',
-      favicon: './favicon.ico'
+      template: './src/index.html'
     })
   ]
 }

--- a/packages/ui-template-scripts/lib/utils/createFromTemplate.js
+++ b/packages/ui-template-scripts/lib/utils/createFromTemplate.js
@@ -99,9 +99,16 @@ module.exports = (argv = {}) => {
       })
     } else if (fse.statSync(currentPath).isFile()) {
       const data = fse.readFileSync(currentPath, 'utf-8')
-
-      const result = template(data)(values)
-
+      let result
+      try {
+        // by default lodash tries to interpret ES6 string literals as its own
+        // literals, disable this behaviour. For details see
+        // https://github.com/lodash/lodash/issues/399
+        result = template(data, { interpolate: /<%=([\s\S]+?)%>/g })(values)
+      } catch (err) {
+        console.error(`Error generating ${destPath}`)
+        throw err
+      }
       const extension = path.extname(currentPath)
       const basename =
         extension === '.ejs'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10024,7 +10024,7 @@ html-webpack-plugin@^3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-html-webpack-plugin@^4.0.0:
+html-webpack-plugin@^4, html-webpack-plugin@^4.0.0:
   version "4.5.2"
   resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
   integrity sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==


### PR DESCRIPTION
template-app was throwing an error when running.

To test:
1. Add the following to the main `package.json` in the `scripts` part: `"generate:app": "instui create app --name packages/test123",`
2. run this command
3. in the genrated app in package.json rename name to `test123`
4. try out the scripts in the generated `package.json`