### PR TITLE
test(ui-drawer-layout): deactivate flaky VRT check

### DIFF
--- a/packages/ui-drawer-layout/src/DrawerLayout/__examples__/DrawerLayout.examples.js
+++ b/packages/ui-drawer-layout/src/DrawerLayout/__examples__/DrawerLayout.examples.js
@@ -69,5 +69,12 @@ export default {
       as: 'div',
       borderWidth: 'small'
     }
+  },
+  getParameters: () => {
+    // Todo: fix chromatic test
+    // This test is very flaky, probably because of the animation
+    // (chromatic screenshots have few px diff).
+    // Couldn't find any fix for it so far.
+    return { disable: true }
   }
 }


### PR DESCRIPTION
This test is very flaky, probably because of the animation (chromatic screenshots have few px diff).
Couldn't find any fix for it so far. Added TODO to try again later (maybe better tools or configs
will be available).