### PR TITLE
INSTUI-2976 : Fix ui-link not displaying outline on focus

### DIFF
--- a/packages/ui-link/src/Link/styles.js
+++ b/packages/ui-link/src/Link/styles.js
@@ -79,7 +79,8 @@ const generateStyle = (componentTheme, props, state) => {
       ? componentTheme.textDecorationWithinText
       : componentTheme.textDecorationOutsideText,
     '&:focus': {
-      color: componentTheme.color
+      color: componentTheme.color,
+      outlineColor: componentTheme.focusOutlineColor
     },
     '&:hover, &:active': {
       color: componentTheme.hoverColor,


### PR DESCRIPTION
Link outline was not showing because of a CSS issue