### PR TITLE
chore(ui-scripts): fix release tagging on npm (INSTUI-2979)

### DIFF
--- a/.github/workflows/manual-release-to-npm-and-deploy-to-legacy-gh-pages.yml
+++ b/.github/workflows/manual-release-to-npm-and-deploy-to-legacy-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_EMAIL: ${{secrets.NPM_EMAIL}}
           NPM_USERNAME: ${{secrets.NPM_USERNAME}}
-        run: yarn release
+        run: yarn release maintenance
   tag:
     needs: release
     if: "startsWith(github.event.head_commit.message, 'chore(release)')"

--- a/.github/workflows/manual-release-to-npm.yml
+++ b/.github/workflows/manual-release-to-npm.yml
@@ -19,7 +19,7 @@ jobs:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_EMAIL: ${{secrets.NPM_EMAIL}}
           NPM_USERNAME: ${{secrets.NPM_USERNAME}}
-        run: yarn release
+        run: yarn release maintenance
   tag:
     needs: release
     if: "startsWith(github.event.head_commit.message, 'chore(release)')"

--- a/packages/ui-scripts/lib/fix-publish.js
+++ b/packages/ui-scripts/lib/fix-publish.js
@@ -40,13 +40,18 @@ const { createNPMRCFile } = require('./utils/npm')
 
 try {
   const pkgJSON = getPackageJSON()
-  // optional version argument
-  // ui-scripts --fix-publish 5.12.2
+  // Arguments
+  // 1: version to publish. If current version, use 'latest' otherwise e.g.: 8.1.3
+  // 2: publish type. defaults to latest. If set to 'maintenance', it will publish with vx_maintenance tag
+  // e.g.: ui-scripts --fix-publish 5.12.2 maintenance
+  const releaseVersion =
+    process.argv[3] === 'latest' ? pkgJSON.version : process.argv[3]
   fixPublish(
     pkgJSON.name,
     pkgJSON.version,
-    process.argv[3] || pkgJSON.version,
-    getConfig(pkgJSON)
+    releaseVersion,
+    getConfig(pkgJSON),
+    process.argv[4]
   )
 } catch (err) {
   error(err)
@@ -57,9 +62,16 @@ async function fixPublish(
   packageName,
   currentVersion,
   releaseVersion,
-  config = {}
+  config = {},
+  releaseType = 'latest'
 ) {
-  const npmTag = currentVersion === releaseVersion ? 'latest' : 'rc'
+  //If on legacy branch, and it is a release, its tag should say vx_maintenance
+  const releaseTag =
+    releaseType === 'maintenance'
+      ? `v${currentVersion.split('.')[0]}_maintenance`
+      : 'latest'
+
+  const npmTag = currentVersion === releaseVersion ? releaseTag : 'snapshot'
 
   setupGit()
   createNPMRCFile(config)

--- a/packages/ui-scripts/lib/fix-publish.js
+++ b/packages/ui-scripts/lib/fix-publish.js
@@ -48,25 +48,25 @@ try {
     process.argv[3] === 'current' || !process.argv[3]
       ? pkgJSON.version
       : process.argv[3]
-  fixPublish(
-    pkgJSON.name,
-    pkgJSON.version,
-    releaseVersion,
-    getConfig(pkgJSON),
-    process.argv[4]
-  )
+  fixPublish({
+    packageName: pkgJSON.name,
+    currentVersion: pkgJSON.version,
+    releaseVersion: releaseVersion,
+    config: getConfig(pkgJSON),
+    releaseType: process.argv[4]
+  })
 } catch (err) {
   error(err)
   process.exit(1)
 }
 
-async function fixPublish(
+async function fixPublish({
   packageName,
   currentVersion,
   releaseVersion,
   config = {},
   releaseType = 'latest'
-) {
+}) {
   //If on legacy branch, and it is a release, its tag should say vx_maintenance
   const releaseTag =
     releaseType === 'maintenance'

--- a/packages/ui-scripts/lib/fix-publish.js
+++ b/packages/ui-scripts/lib/fix-publish.js
@@ -41,11 +41,13 @@ const { createNPMRCFile } = require('./utils/npm')
 try {
   const pkgJSON = getPackageJSON()
   // Arguments
-  // 1: version to publish. If current version, use 'latest' otherwise e.g.: 8.1.3
-  // 2: publish type. defaults to latest. If set to 'maintenance', it will publish with vx_maintenance tag
+  // 1: version to publish. If current version, use 'current' otherwise e.g.: 8.1.3
+  // 2: publish type. defaults to current. If set to 'maintenance', it will publish with vx_maintenance tag
   // e.g.: ui-scripts --fix-publish 5.12.2 maintenance
   const releaseVersion =
-    process.argv[3] === 'latest' ? pkgJSON.version : process.argv[3]
+    process.argv[3] === 'current' || !process.argv[3]
+      ? pkgJSON.version
+      : process.argv[3]
   fixPublish(
     pkgJSON.name,
     pkgJSON.version,

--- a/packages/ui-scripts/lib/publish.js
+++ b/packages/ui-scripts/lib/publish.js
@@ -43,7 +43,12 @@ try {
 }
 
 async function publish(options) {
-  const { packageName, currentVersion, packageConfig, releaseType } = options
+  const {
+    packageName,
+    currentVersion,
+    packageConfig,
+    releaseType = 'latest'
+  } = options
 
   //If on legacy branch, and it is a release, its tag should say vx_maintenance
   const releaseTag =

--- a/packages/ui-scripts/lib/publish.js
+++ b/packages/ui-scripts/lib/publish.js
@@ -34,7 +34,8 @@ try {
   publish({
     packageName: pkgJSON.name,
     currentVersion: pkgJSON.version,
-    packageConfig: getConfig(pkgJSON)
+    packageConfig: getConfig(pkgJSON),
+    releaseType: process.argv[3]
   })
 } catch (err) {
   error(err)
@@ -42,7 +43,14 @@ try {
 }
 
 async function publish(options) {
-  const { packageName, currentVersion, packageConfig } = options
+  const { packageName, currentVersion, packageConfig, releaseType } = options
+
+  //If on legacy branch, and it is a release, its tag should say vx_maintenance
+  const releaseTag =
+    releaseType === 'maintenance'
+      ? `v${currentVersion.split('.')[0]}_maintenance`
+      : 'latest'
+
   //Set up git user.name and user.email
   setupGit()
   //create NPM RC and try to auth in to npm
@@ -56,7 +64,7 @@ async function publish(options) {
   info(infoMessage)
 
   const versionToRelease = isRelease ? currentVersion : 'prerelease'
-  const tag = isRelease ? 'latest' : 'snapshot'
+  const tag = isRelease ? releaseTag : 'snapshot'
   try {
     await publishPackages(packageName, versionToRelease, tag)
   } catch (e) {

--- a/packages/ui-scripts/lib/publish.js
+++ b/packages/ui-scripts/lib/publish.js
@@ -30,7 +30,9 @@ const { getConfig } = require('./utils/config')
 
 try {
   const pkgJSON = getPackageJSON()
-
+  // Arguments
+  // 1: publish type. defaults to latest. If set to 'maintenance', it will publish with vx_maintenance tag
+  // e.g.: ui-scripts --publish maintenance
   publish({
     packageName: pkgJSON.name,
     currentVersion: pkgJSON.version,


### PR DESCRIPTION
not on current version release tag: vx_maintenance

Closes: INSTUI-2979