### PR TITLE
fix(ui-menu): fix Menu keyboard navigation on submenus

### DIFF
--- a/packages/ui-menu/src/Menu/MenuItem/index.js
+++ b/packages/ui-menu/src/Menu/MenuItem/index.js
@@ -125,10 +125,11 @@ class MenuItem extends Component {
   componentDidUpdate() {
     this.props.makeStyles()
   }
+
   componentWillUnmount() {
     const context = this.context
 
-    if (context && context.registerMenuItem) {
+    if (context && context.removeMenuItem) {
       context.removeMenuItem(this)
     }
   }

--- a/packages/ui-menu/src/Menu/index.js
+++ b/packages/ui-menu/src/Menu/index.js
@@ -233,29 +233,14 @@ class Menu extends Component {
   static contextType = MenuContext
 
   registerMenuItem = (item) => {
-    const { type } = item.props
-
-    // if the item is a flyout trigger
-    // we only want to add it to the parent Menu items list
-    if (this.context && this.context.registerMenuItem && type === 'flyout') {
-      this.context.registerMenuItem(item)
-    } else if (this.getMenuItemIndex(item) < 0) {
-      this._menuItems.push(item)
-    }
+    this._menuItems.push(item)
   }
 
   removeMenuItem = (item) => {
-    const { type } = item.props
-    // if the item is a flyout trigger
-    // we only want to remove it from the parent Menu items list
-    if (this.context && this.context.removeMenuItem && type === 'flyout') {
-      this.context.removeMenuItem(item)
-    } else {
-      const index = this.getMenuItemIndex(item)
-      error(index >= 0, '[Menu] Could not find registered menu item.')
-      if (index >= 0) {
-        this._menuItems.splice(index, 1)
-      }
+    const index = this.getMenuItemIndex(item)
+    error(index >= 0, '[Menu] Could not find registered menu item.')
+    if (index >= 0) {
+      this._menuItems.splice(index, 1)
     }
   }
 


### PR DESCRIPTION
Closes: INSTUI-2983

Fixed a bug where you couldn't highlight a submenu trigger with keyboard navigation.
TEST PLAN:
You can tab through all items in the Menu, including the submenu triggers.