### PR TITLE
chore: add vrt checks on v7_maintenance branch

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -4,9 +4,11 @@ on:
     branches:
       - master
       - next
+      - v7_maintenance
   pull_request:
     branches:
       - master
+      - v7_maintenance
 jobs:
   chromatic_deployment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added v7_maintenance branch to the vrt worflow, so chromatic tests run on push events and PR-s.