### PR TITLE
fix(ui-number-input): use decimal inputMode for NumberInput

### DIFF
--- a/packages/ui-number-input/src/NumberInput/index.js
+++ b/packages/ui-number-input/src/NumberInput/index.js
@@ -316,7 +316,7 @@ class NumberInput extends Component {
               aria-invalid={this.invalid ? 'true' : null}
               id={this.id}
               type="text"
-              inputMode="numeric"
+              inputMode="decimal"
               placeholder={placeholder}
               ref={this.handleRef}
               required={isRequired}


### PR DESCRIPTION
Closes: QUIZ-8283

TEST PLAN:
iphone users can input decimals in NumberInputs