### PR TITLE
fix(ui-list,ui-view): remove invalid "deprecated prop value" warnings

### DIFF
--- a/packages/ui-list/src/List/__examples__/List.examples.js
+++ b/packages/ui-list/src/List/__examples__/List.examples.js
@@ -27,6 +27,9 @@ import { List } from '../index'
 export default {
   excludeProps: ['variant'],
   sectionProp: 'size',
+  propValues: {
+    delimiter: ['none', 'dashed', 'solid']
+  },
   getComponentProps: (props) => {
     return {
       children: [

--- a/packages/ui-list/src/List/index.js
+++ b/packages/ui-list/src/List/index.js
@@ -50,9 +50,7 @@ category: components
 ---
 **/
 @deprecated('8.0.0', {
-  variant: 'List with the isUnstyled boolean or InlineList',
-  delimiter:
-    'with delimiter set to [pipe, slash, arrow] will only be available when using [InlineList] as of version 8.0.0.'
+  variant: 'List with the isUnstyled boolean or InlineList'
 })
 @testable()
 @themeable(theme, styles)
@@ -66,14 +64,12 @@ class List extends Component {
     /**
      * One of: none, dashed, solid
      */
-    delimiter: PropTypes.oneOf([
-      'none',
-      'dashed',
-      'solid',
-      'pipe',
-      'slash',
-      'arrow'
-    ]),
+    delimiter: deprecated.deprecatePropValues(
+      PropTypes.oneOf(['none', 'dashed', 'solid', 'pipe', 'slash', 'arrow']),
+      ['pipe', 'slash', 'arrow'],
+      ({ propValue }) =>
+        `with 'delimiter' set to ${propValue} will only be available when using [InlineList] as of version 8.0.0.`
+    ),
     /**
      * When set, renders the List Items without a list style type.
      */

--- a/packages/ui-view/src/View/__examples__/View.examples.js
+++ b/packages/ui-view/src/View/__examples__/View.examples.js
@@ -32,46 +32,87 @@ export default {
     shadow: [undefined, ...Object.values(SHADOW_TYPES)],
     borderWidth: [...Object.values(BORDER_WIDTHS)],
     borderRadius: [...Object.values(BORDER_RADII)],
-    position: ['relative', 'static']
+    borderColor: [
+      'transparent',
+      'primary',
+      'secondary',
+      'brand',
+      'info',
+      'success',
+      'warning',
+      'alert',
+      'danger'
+    ],
+    background: [
+      'transparent',
+      'primary',
+      'secondary',
+      'primary-inverse',
+      'brand',
+      'info',
+      'alert',
+      'success',
+      'danger',
+      'warning'
+    ]
   },
   getComponentProps: (props) => {
     return {
+      position: 'relative',
       padding: 'medium',
       display: 'block',
       children: 'Some content for the View',
       focusColor: 'info',
       focusPosition: 'offset',
-      borderColor: 'info',
       overflowX: 'visible',
       overflowY: 'visible',
-      shouldAnimateFocus: false
+      shouldAnimateFocus: false,
+      ...(props.background !== 'primary' && {
+        borderColor: 'info',
+        borderRadius: undefined,
+        borderWidth: undefined,
+        shadow: undefined
+      }),
+      ...((props.borderRadius !== '0' ||
+        props.borderWidth !== '0' ||
+        props.borderColor !== 'info' ||
+        props.shadow !== undefined) && {
+        textAlign: 'start'
+      }),
+      ...((props.borderRadius !== '0' ||
+        props.borderWidth !== 'small' ||
+        props.textAlign !== 'start' ||
+        props.shadow !== undefined) && {
+        borderColor: 'info'
+      })
     }
   },
   excludeProps: [
+    'as',
+    'position',
+    'elementRef',
     'padding',
+    'margin',
     'shouldAnimateFocus',
     'display',
     'withVisualDebug',
     'focusColor',
     'focusPosition',
-    'borderColor',
     'overflowX',
     'overflowY',
     'visualDebug',
     'focused'
   ],
   filter: (props) => {
-    const backgroundsToIgnore = ['default', 'light', 'inverse']
-
     return (
       // Border radius and border width list 0 in addition to none in their object values
       // so we filter those here as they are redundant
       props.borderRadius === 'none' ||
       props.borderWidth === 'none' ||
+      props.borderColor === 'transparent' ||
       props.background === 'transparent' ||
       (props.focusPosition === 'inset' && !props.withFocusOutline) ||
-      (props.withFocusOutline && props.position !== 'relative') ||
-      backgroundsToIgnore.includes(props.background)
+      (props.withFocusOutline && props.position !== 'relative')
     )
   }
 }

--- a/packages/ui-view/src/View/index.js
+++ b/packages/ui-view/src/View/index.js
@@ -57,12 +57,7 @@ category: components
 **/
 @deprecated('8.0.0', {
   focused: 'withFocusOutline',
-  visualDebug: 'withVisualDebug',
-  background: `In version 8.0.0,
-    the value <default> for background will be changed to <primary>,
-    the value <light> for background will be changed to <secondary>,
-    the value <inverse> for background will be changed to <primary-inverse>.
-    Use these values instead.`
+  visualDebug: 'withVisualDebug'
 })
 @bidirectional()
 @themeable(theme, styles, themeAdapter)
@@ -164,21 +159,30 @@ class View extends Component {
     /**
      * Designates the background style of the `<View />`
      */
-    background: PropTypes.oneOf([
-      'transparent',
-      'primary',
-      'secondary',
-      'primary-inverse',
-      'brand',
-      'info',
-      'alert',
-      'success',
-      'danger',
-      'warning',
-      'default',
-      'light',
-      'inverse'
-    ]),
+    background: deprecated.deprecatePropValues(
+      PropTypes.oneOf([
+        'transparent',
+        'primary',
+        'secondary',
+        'primary-inverse',
+        'brand',
+        'info',
+        'alert',
+        'success',
+        'danger',
+        'warning',
+        'default',
+        'light',
+        'inverse'
+      ]),
+      ['default', 'inverse', 'light'],
+      ({ propName, propValue }) =>
+        `In version 8.0.0, the value '${propValue}' for \`${propName}\` will be changed to ${(() => {
+          if (propValue === 'default') return `'primary'`
+          if (propValue === 'light') return `'secondary'`
+          if (propValue === 'inverse') return `'primary-inverse'`
+        })()}. Use that value instead.`
+    ),
 
     /**
      * Controls the shadow depth for the `<View />`


### PR DESCRIPTION
Reverted to the usage of `deprecated.deprecatePropValues()` in View and List, so it doesn't spam the
console with invalid deprecation errors on View's `background` and List's `delimiter` props. Also
made some filters for View's Storybook example generation.

Closes: INSTUI-2992