### PR TITLE
Remove babel-plugin-add-import-extension

### DIFF
--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -74,7 +74,6 @@ module.exports = function (
       }
     ])
   }
-
   // Work around https://github.com/babel/babel/issues/10261, which causes
   // Babel to not use the runtime helpers for things like _objectSpread.
   // Remove this once that babel issue is fixed
@@ -107,8 +106,7 @@ module.exports = function (
       }
     ],
     require('@babel/plugin-syntax-dynamic-import').default,
-    require('babel-plugin-transform-undefined-to-void'),
-    require('babel-plugin-add-import-extension')
+    require('babel-plugin-transform-undefined-to-void')
   ])
 
   if (process.env.NODE_ENV === 'production') {

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -35,7 +35,6 @@
     "@instructure/browserslist-config-instui": "^8.2.1",
     "@instructure/config-loader": "^8.2.1",
     "babel-loader": "^8.1.0",
-    "babel-plugin-add-import-extension": "^1.4.3",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-macros": "^3",


### PR DESCRIPTION
Removed `babel-plugin-add-import-extension` because it interfered with `webpack` since we are using the
`babel-loader` to transpile `.ts` files on the fly in development and this plugin injected `.js` extensions to the
imports which made the `docs-app` unusable in dev mode.