### PR TITLE
chore: delete accidentally reappeared deprecated packages

### DIFF
--- a/packages/ui-docs-client/tsconfig.build.json
+++ b/packages/ui-docs-client/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "./types"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/__examples__/**/*", "src/**/__tests__/**/*"]
-}

--- a/packages/ui-docs-client/tsconfig.json
+++ b/packages/ui-docs-client/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {}
-}

--- a/packages/ui-docs-plugin/tsconfig.build.json
+++ b/packages/ui-docs-plugin/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "./types"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/__examples__/**/*", "src/**/__tests__/**/*"]
-}

--- a/packages/ui-docs-plugin/tsconfig.json
+++ b/packages/ui-docs-plugin/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {}
-}

--- a/packages/ui-postcss-config/tsconfig.build.json
+++ b/packages/ui-postcss-config/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "./types"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/__examples__/**/*", "src/**/__tests__/**/*"]
-}

--- a/packages/ui-postcss-config/tsconfig.json
+++ b/packages/ui-postcss-config/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {}
-}

--- a/packages/ui-stylesheet/tsconfig.build.json
+++ b/packages/ui-stylesheet/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "./types"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/__examples__/**/*", "src/**/__tests__/**/*"]
-}

--- a/packages/ui-stylesheet/tsconfig.json
+++ b/packages/ui-stylesheet/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {}
-}

--- a/packages/ui-themeable/tsconfig.build.json
+++ b/packages/ui-themeable/tsconfig.build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "./types"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/__examples__/**/*", "src/**/__tests__/**/*"]
-}

--- a/packages/ui-themeable/tsconfig.json
+++ b/packages/ui-themeable/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {}
-}


### PR DESCRIPTION
Some of our formerly deleted packages reappeared when running a script generating typescript configs
in all packages. Removed unnecessary packages and config files.