### PR TITLE
fix(ui-dialog): fix page scrolling up when Menu opens

### DIFF
--- a/packages/__examples__/package.json
+++ b/packages/__examples__/package.json
@@ -30,7 +30,7 @@
     "@instructure/ui-component-examples": "8.3.0",
     "@instructure/ui-i18n": "8.3.0",
     "@instructure/ui-icons": "8.3.0",
-    "@instructure/ui-tooltip": "8.3.0",
+    "@instructure/ui-modal": "8.3.0",
     "@instructure/ui-view": "8.3.0",
     "@instructure/ui-webpack-config": "8.3.0",
     "@storybook/addons": "^6.1.18",

--- a/packages/__examples__/renderExample.js
+++ b/packages/__examples__/renderExample.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import React, { useState } from 'react'
 import { View } from '@instructure/ui-view'
-import { Tooltip } from '@instructure/ui-tooltip'
-import { IconButton } from '@instructure/ui-buttons'
+import { Modal } from '@instructure/ui-modal'
+import { IconButton, CloseButton } from '@instructure/ui-buttons'
 import { IconInfoLine } from '@instructure/ui-icons'
 
 export function renderExample({
@@ -34,6 +34,12 @@ export function renderExample({
   exampleProps,
   key
 }) {
+  const [isInfoOpen, setIsInfoOpen] = useState(false)
+
+  const toggleInfoModal = () => {
+    setIsInfoOpen(!isInfoOpen)
+  }
+
   return (
     <View
       key={key}
@@ -47,17 +53,33 @@ export function renderExample({
       {...exampleProps}
     >
       <Component {...componentProps} />
-      <Tooltip
-        renderTip={<pre>{JSON.stringify(componentProps, null, 2)}</pre>}
-        placement="bottom"
-        on={['click']}
+      <IconButton
+        size="small"
+        renderIcon={IconInfoLine}
+        screenReaderLabel="props"
+        onClick={toggleInfoModal}
+      />
+      <Modal
+        open={isInfoOpen}
+        onDismiss={toggleInfoModal}
+        size="auto"
+        label={`${Component.displayName} example`}
+        shouldCloseOnDocumentClick
+        variant="inverse"
       >
-        <IconButton
-          size="small"
-          renderIcon={IconInfoLine}
-          screenReaderLabel="props"
-        />
-      </Tooltip>
+        <Modal.Header>
+          <CloseButton
+            placement="end"
+            offset="small"
+            onClick={toggleInfoModal}
+            screenReaderLabel="Close"
+            color="primary-inverse"
+          />
+        </Modal.Header>
+        <Modal.Body>
+          <pre>{JSON.stringify(componentProps, null, 2)}</pre>
+        </Modal.Body>
+      </Modal>
     </View>
   )
 }

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -178,13 +178,20 @@ class Dialog extends Component<Props> {
     this._raf.push(
       // @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{ cancel: () => void; }' is not ... Remove this comment to see the full error message
       requestAnimationFrame(() => {
-        // @ts-expect-error ts-migrate(2322) FIXME: Type 'FocusRegion' is not assignable to type 'null... Remove this comment to see the full error message
-        this._focusRegion = FocusRegionManager.activateRegion(
-          this.contentElement,
-          {
-            ...options
-          }
-        )
+        // It needs to wait a heartbeat until the content is fully loaded
+        // inside the dialog. If it contains a focusable element, it will
+        // get focused on open, and browsers scroll to the focused element.
+        // If the css is not fully applied, the element may not be in their
+        // final position, making the page jump.
+        setTimeout(() => {
+          // @ts-expect-error ts-migrate(2322) FIXME: Type 'FocusRegion' is not assignable to type 'null... Remove this comment to see the full error message
+          this._focusRegion = FocusRegionManager.activateRegion(
+            this.contentElement,
+            {
+              ...options
+            }
+          )
+        }, 0)
       })
     )
   }

--- a/packages/ui-menu/src/Menu/__examples__/Menu.examples.tsx
+++ b/packages/ui-menu/src/Menu/__examples__/Menu.examples.tsx
@@ -68,7 +68,7 @@ export default {
       dir: props.dir,
       as: 'div',
       width: '100%',
-      height: '20rem',
+      height: '30rem',
       margin: 'large',
       padding: 'large',
       textAlign: 'center'

--- a/packages/ui-menu/src/Menu/__examples__/Menu.examples.tsx
+++ b/packages/ui-menu/src/Menu/__examples__/Menu.examples.tsx
@@ -27,6 +27,7 @@ import React from 'react'
 import { Menu, MenuItem, MenuItemSeparator, MenuItemGroup } from '../index'
 
 export default {
+  sectionProp: 'placement',
   maxExamplesPerPage: 20,
   maxExamples: 200,
   excludeProps: [


### PR DESCRIPTION
Closes: INSTUI-3008

If a Dialog contains a focusable item, that item gets focused when the dialog opens. The browsers
automatically scroll the the focused element, but if the content and its css is not yet fully
loaded, the position of the focusable item might be not yet calculated, making the page jump to the
top. Now we wait a heartbeat before focusing the element. This fix affects other components using
`Dialog` under the hood: `DrawerLayout`, `Modal`, `Overlay`, `Popover` and `Tray`, and components
using these (e.g. Menu).