### PR TITLE
INSTUI-3017 - fix page scrolling up when Menu opens

### DIFF
--- a/packages/ui-dialog/src/Dialog/index.js
+++ b/packages/ui-dialog/src/Dialog/index.js
@@ -149,9 +149,19 @@ class Dialog extends Component {
     } = this.props
 
     this._raf.push(requestAnimationFrame(() => {
-      this._focusRegion = FocusRegionManager.activateRegion(this.contentElement, {
-        ...options
-      })
+      // It needs to wait a heartbeat until the content is fully loaded
+      // inside the dialog. If it contains a focusable element, it will
+      // get focused on open, and browsers scroll to the focused element.
+      // If the css is not fully applied, the element may not be in their
+      // final position, making the page jump.
+      setTimeout(() => {
+        this._focusRegion = FocusRegionManager.activateRegion(
+          this.contentElement,
+          {
+            ...options
+          }
+        )
+      }, 0)
     }))
   }
 


### PR DESCRIPTION
refs: INSTUI-3017

If a Dialog contains a focusable item, that item gets focused when the dialog opens. The browsers
automatically scroll the the focused element, but if the content and its css is not yet fully
loaded, the position of the focusable item might be not yet calculated, making the page jump to the
top. Now we wait a heartbeat before focusing the element. This fix affects other components using
`Dialog` under the hood: `DrawerLayout`, `Modal`, `Overlay`, `Popover` and `Tray`, and components
using these (e.g. Menu).