### PR TITLE
fix(emotion): add componentId to match with component name in docs (INSTUI-2997)

### DIFF
--- a/packages/emotion/src/EmotionThemeProvider/README.md
+++ b/packages/emotion/src/EmotionThemeProvider/README.md
@@ -130,8 +130,11 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
             infoIconBackground: "darkblue",
             infoBorderColor: "darkblue"
           },
-          'List.Item': {
+          [List.Item.componentId]: {
             color: "red"
+          },
+          'InlineList.Item': {
+            color: "blue"
           }
         },
         themeOverrides: {
@@ -165,6 +168,14 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
         <List.Item>These List.Items have red color.</List.Item>
         <List.Item>These List.Items have red color.</List.Item>
       </List>
+      <div>
+        <InlineList delimiter="pipe" margin="large 0">
+          <InlineList.Item>This text should be blue</InlineList.Item>
+          <InlineList.Item>10pts</InlineList.Item>
+          <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
+          <InlineList.Item><Link href="#">Pipe Separator</Link></InlineList.Item>
+        </InlineList>
+      </div>
     </EmotionThemeProvider>
   </div>
 ```

--- a/packages/emotion/src/EmotionThemeProvider/README.md
+++ b/packages/emotion/src/EmotionThemeProvider/README.md
@@ -130,8 +130,8 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
             infoIconBackground: "darkblue",
             infoBorderColor: "darkblue"
           },
-          'InlineList.Item': {
-            color:"red"
+          'List.Item': {
+            color: "red"
           }
         },
         themeOverrides: {
@@ -160,9 +160,11 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
       <Alert variant="info" margin="small">
         My background should be light gray in 'canvas' theme, and the icon background should be dark blue in any theme.
       </Alert>
-      <InlineList margin="large 0">
-        <InlineList.Item>My color should be red</InlineList.Item>
-      </InlineList>
+      <List margin="large 0">
+        <List.Item>These List.Items have red color.</List.Item>
+        <List.Item>These List.Items have red color.</List.Item>
+        <List.Item>These List.Items have red color.</List.Item>
+      </List>
     </EmotionThemeProvider>
   </div>
 ```

--- a/packages/emotion/src/EmotionThemeProvider/README.md
+++ b/packages/emotion/src/EmotionThemeProvider/README.md
@@ -129,12 +129,15 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
           Alert: {
             infoIconBackground: "darkblue",
             infoBorderColor: "darkblue"
+          },
+          'InlineList.Item': {
+            color:"red"
           }
         },
         themeOverrides: {
           canvas: {
             colors: {
-              backgroundLightest: 'lightgray'
+              backgroundLightest: "lightgray"
             },
             componentOverrides: {
               Alert: {
@@ -157,6 +160,9 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
       <Alert variant="info" margin="small">
         My background should be light gray in 'canvas' theme, and the icon background should be dark blue in any theme.
       </Alert>
+      <InlineList margin="large 0">
+        <InlineList.Item>My color should be red</InlineList.Item>
+      </InlineList>
     </EmotionThemeProvider>
   </div>
 ```

--- a/packages/emotion/src/getComponentThemeOverride.ts
+++ b/packages/emotion/src/getComponentThemeOverride.ts
@@ -40,7 +40,9 @@ export const getComponentThemeOverride = (
   props: any
 ) => {
   const componentOverride =
-    theme?.componentOverrides && theme.componentOverrides[componentName]
+    theme?.componentOverrides &&
+    (theme.componentOverrides[componentName[0]] ||
+      theme.componentOverrides[componentName[1]])
 
   return { ...componentOverride, ...(props?.themeOverride ?? {}) }
 }

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -102,6 +102,7 @@ import { useTheme } from './useTheme'
 const withStyle = decorator(
   (ComposedComponent: any, generateStyle: any, generateComponentTheme: any) => {
     const displayName = ComposedComponent.displayName || ComposedComponent.name
+
     const WithStyle = forwardRef((props, ref) => {
       const theme = useTheme()
       const dir = useTextDirectionContext()
@@ -111,7 +112,7 @@ const withStyle = decorator(
       }
       const themeOverride = getComponentThemeOverride(
         theme,
-        displayName,
+        [displayName, ComposedComponent.componentId],
         componentProps
       )
       const componentTheme =

--- a/packages/ui-a11y-content/src/ScreenReaderContent/index.tsx
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/index.tsx
@@ -46,6 +46,8 @@ category: components/utilities
 **/
 @withStyle(generateStyle, null)
 class ScreenReaderContent extends Component<Props> {
+  static componentId = 'ScreenReaderContent'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -77,6 +77,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Alert extends Component<Props> {
+  static componentId = 'Alert'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-avatar/src/Avatar/index.tsx
+++ b/packages/ui-avatar/src/Avatar/index.tsx
@@ -64,6 +64,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Avatar extends Component<Props> {
+  static componentId = 'Avatar'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-badge/src/Badge/index.tsx
+++ b/packages/ui-badge/src/Badge/index.tsx
@@ -68,6 +68,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Badge extends Component<Props> {
+  static componentId = 'Badge'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-billboard/src/Billboard/index.tsx
+++ b/packages/ui-billboard/src/Billboard/index.tsx
@@ -69,6 +69,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Billboard extends Component<Props> {
+  static componentId = 'Billboard'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
@@ -47,6 +47,8 @@ id: Breadcrumb.Link
 
 @testable()
 class BreadcrumbLink extends Component<Props> {
+  static componentId = 'Breadcrumb.Link'
+
   static propTypes = {
     /**
      * Content to render as the crumb, generally should be text.

--- a/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
@@ -59,6 +59,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Breadcrumb extends Component<Props> {
+  static componentId = 'Breadcrumb'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -84,6 +84,8 @@ category: components/utilities
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class BaseButton extends Component<Props> {
+  static componentId = 'BaseButton'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-buttons/src/Button/index.tsx
+++ b/packages/ui-buttons/src/Button/index.tsx
@@ -63,6 +63,8 @@ category: components
 @withStyle(null, generateComponentTheme)
 @testable()
 class Button extends Component<Props> {
+  static componentId = 'Button'
+
   static propTypes = {
     /**
      * Specifies the `Button` children.

--- a/packages/ui-buttons/src/CloseButton/index.tsx
+++ b/packages/ui-buttons/src/CloseButton/index.tsx
@@ -69,6 +69,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class CloseButton extends Component<Props> {
+  static componentId = 'CloseButton'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-buttons/src/CondensedButton/index.tsx
+++ b/packages/ui-buttons/src/CondensedButton/index.tsx
@@ -59,6 +59,8 @@ category: components
 @withStyle(null, generateComponentTheme)
 @testable()
 class CondensedButton extends Component<Props> {
+  static componentId = 'CondensedButton'
+
   static propTypes = {
     /**
      * Specifies the `CondensedButton` children.

--- a/packages/ui-buttons/src/IconButton/index.tsx
+++ b/packages/ui-buttons/src/IconButton/index.tsx
@@ -66,6 +66,8 @@ category: components
 @withStyle(null, generateComponentTheme)
 @testable()
 class IconButton extends Component<Props> {
+  static componentId = 'IconButton'
+
   static propTypes = {
     /**
      * An icon, or function returning an icon (identical to the `renderIcon` prop).

--- a/packages/ui-buttons/src/ToggleButton/index.tsx
+++ b/packages/ui-buttons/src/ToggleButton/index.tsx
@@ -57,6 +57,8 @@ category: components
 
 @testable()
 class ToggleButton extends Component<Props> {
+  static componentId = 'ToggleButton'
+
   static propTypes = {
     /**
      * Text to output only to screen readers

--- a/packages/ui-byline/src/Byline/index.tsx
+++ b/packages/ui-byline/src/Byline/index.tsx
@@ -57,6 +57,8 @@ category: components
 
 @withStyle(generateStyle, generateComponentTheme)
 class Byline extends Component<Props> {
+  static componentId = 'Byline'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-calendar/src/Calendar/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/Day/index.tsx
@@ -66,6 +66,8 @@ id: Calendar.Day
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Day extends Component<Props> {
+  static componentId = 'Calendar.Day'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -67,6 +67,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Calendar extends Component<Props> {
+  static componentId = 'Calendar'
+
   static Day = Day
   static DAY_COUNT = 42 // 6 weeks visible
 

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/index.tsx
@@ -51,6 +51,8 @@ parent: Checkbox
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class CheckboxFacade extends Component<Props> {
+  static componentId = 'CheckboxFacade'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/index.tsx
@@ -51,6 +51,8 @@ parent: Checkbox
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class ToggleFacade extends Component<Props> {
+  static componentId = 'ToggleFacade'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -78,6 +78,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Checkbox extends Component<Props> {
+  static componentId = 'Checkbox'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-checkbox/src/CheckboxGroup/index.tsx
+++ b/packages/ui-checkbox/src/CheckboxGroup/index.tsx
@@ -62,6 +62,8 @@ category: components
 
 @testable()
 class CheckboxGroup extends Component<Props> {
+  static componentId = 'CheckboxGroup'
+
   static propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.node.isRequired,

--- a/packages/ui-code-editor/src/CodeEditor/index.tsx
+++ b/packages/ui-code-editor/src/CodeEditor/index.tsx
@@ -70,6 +70,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class CodeEditor extends Component<Props> {
+  static componentId = 'CodeEditor'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -90,6 +90,8 @@ category: components
 @withStyle(generateStyle, null)
 @testable()
 class DateInput extends Component<Props> {
+  static componentId = 'DateInput'
+
   static Day = Calendar.Day
 
   static propTypes = {

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -58,6 +58,8 @@ category: components/utilities
 **/
 
 class Dialog extends Component<Props> {
+  static componentId = 'Dialog'
+
   static propTypes = {
     /**
      * The children to be rendered within the `<Dialog />`

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -53,6 +53,8 @@ id: DrawerLayout.Content
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class DrawerContent extends Component<Props> {
+  static componentId = 'DrawerLayout.Content'
+
   static locatorAttribute = 'data-drawer-content'
   static propTypes = {
     label: PropTypes.string.isRequired,

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -81,6 +81,8 @@ id: DrawerLayout.Tray
 @bidirectional()
 @testable()
 class DrawerTray extends Component<Props> {
+  static componentId = 'DrawerLayout.Tray'
+
   static locatorAttribute = 'data-drawer-tray'
   static propTypes = {
     label: PropTypes.string.isRequired,

--- a/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
@@ -62,6 +62,8 @@ category: components
 @bidirectional()
 @testable()
 class DrawerLayout extends Component<Props> {
+  static componentId = 'DrawerLayout'
+
   static locatorAttribute = 'data-drawer-layout'
   static propTypes = {
     /**

--- a/packages/ui-editable/src/InPlaceEdit/index.tsx
+++ b/packages/ui-editable/src/InPlaceEdit/index.tsx
@@ -60,6 +60,7 @@ category: components
 **/
 @withStyle(generateStyle, null)
 class InPlaceEdit extends Component<Props> {
+  static componentId = 'InPlaceEdit'
   static propTypes = {
     /**
      * Function to render the view mode component.

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -92,6 +92,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class FileDrop extends Component<Props, State> {
+  static componentId = 'FileDrop'
+
   static propTypes = {
     /**
      * The id of the input (to link it to its label for a11y)

--- a/packages/ui-flex/src/Flex/Item/index.tsx
+++ b/packages/ui-flex/src/Flex/Item/index.tsx
@@ -58,6 +58,8 @@ id: Flex.Item
 **/
 @withStyle(generateStyle)
 class Item extends Component<Props> {
+  static componentId = 'Flex.Item'
+
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
     this.props.makeStyles()

--- a/packages/ui-flex/src/Flex/index.tsx
+++ b/packages/ui-flex/src/Flex/index.tsx
@@ -67,6 +67,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Flex extends Component<Props> {
+  static componentId = 'Flex'
+
   constructor(props: Props) {
     super(props)
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message

--- a/packages/ui-form-field/src/FormField/index.tsx
+++ b/packages/ui-form-field/src/FormField/index.tsx
@@ -49,6 +49,8 @@ category: components
 ---
 **/
 class FormField extends Component<Props> {
+  static componentId = 'FormField'
+
   static propTypes = {
     label: PropTypes.node.isRequired,
     /**

--- a/packages/ui-form-field/src/FormFieldGroup/index.tsx
+++ b/packages/ui-form-field/src/FormFieldGroup/index.tsx
@@ -58,6 +58,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class FormFieldGroup extends Component<Props> {
+  static componentId = 'FormFieldGroup'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-form-field/src/FormFieldLabel/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLabel/index.tsx
@@ -56,6 +56,8 @@ example: true
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class FormFieldLabel extends Component<Props> {
+  static componentId = 'FormFieldLabel'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-form-field/src/FormFieldLayout/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/index.tsx
@@ -67,6 +67,8 @@ parent: FormField
 **/
 @withStyle(generateStyle)
 class FormFieldLayout extends Component<Props> {
+  static componentId = 'FormFieldLayout'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-form-field/src/FormFieldMessage/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessage/index.tsx
@@ -56,6 +56,8 @@ example: true
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class FormFieldMessage extends Component<Props> {
+  static componentId = 'FormFieldMessage'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-form-field/src/FormFieldMessages/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessages/index.tsx
@@ -62,6 +62,8 @@ example: true
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class FormFieldMessages extends Component<Props> {
+  static componentId = 'FormFieldMessages'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-grid/src/Grid/index.tsx
+++ b/packages/ui-grid/src/Grid/index.tsx
@@ -61,6 +61,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Grid extends Component<Props> {
+  static componentId = 'Grid'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-grid/src/GridCol/index.tsx
+++ b/packages/ui-grid/src/GridCol/index.tsx
@@ -75,6 +75,8 @@ id: Grid.Col
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class GridCol extends Component<Props> {
+  static componentId = 'Grid.Col'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-grid/src/GridRow/index.tsx
+++ b/packages/ui-grid/src/GridRow/index.tsx
@@ -62,6 +62,8 @@ id: Grid.Row
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class GridRow extends Component<Props> {
+  static componentId = 'Grid.Row'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-heading/src/Heading/index.tsx
+++ b/packages/ui-heading/src/Heading/index.tsx
@@ -59,6 +59,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Heading extends Component<Props> {
+  static componentId = 'Heading'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-img/src/Img/index.tsx
+++ b/packages/ui-img/src/Img/index.tsx
@@ -63,6 +63,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Img extends Component<Props> {
+  static componentId = 'Img'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-link/src/Link/index.tsx
+++ b/packages/ui-link/src/Link/index.tsx
@@ -69,6 +69,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Link extends Component<Props> {
+  static componentId = 'Link'
+
   static propTypes = {
     /**
      * The text and/or icon displayed by the link

--- a/packages/ui-list/src/InlineList/InlineListItem/index.tsx
+++ b/packages/ui-list/src/InlineList/InlineListItem/index.tsx
@@ -63,6 +63,8 @@ id: InlineList.Item
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class InlineListItem extends Component<Props> {
+  static componentId = 'InlineList.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-list/src/List/ListItem/index.tsx
+++ b/packages/ui-list/src/List/ListItem/index.tsx
@@ -64,6 +64,8 @@ id: List.Item
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ListItem extends Component<Props> {
+  static componentId = 'List.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-list/src/List/index.tsx
+++ b/packages/ui-list/src/List/index.tsx
@@ -67,6 +67,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class List extends Component<Props> {
+  static componentId = 'List'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -67,6 +67,8 @@ id: Menu.Item
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class MenuItem extends Component<Props> {
+  static componentId = 'Menu.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
@@ -71,6 +71,8 @@ id: Menu.Group
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class MenuItemGroup extends Component<Props> {
+  static componentId = 'Menu.Group'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
@@ -48,6 +48,8 @@ id: Menu.Separator
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class MenuItemSeparator extends Component<Props> {
+  static componentId = 'Menu.Separator'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-menu/src/Menu/index.tsx
+++ b/packages/ui-menu/src/Menu/index.tsx
@@ -90,6 +90,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Menu extends Component<Props> {
+  static componentId = 'Menu'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-metric/src/Metric/index.tsx
+++ b/packages/ui-metric/src/Metric/index.tsx
@@ -49,6 +49,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Metric extends Component<Props> {
+  static componentId = 'Metric'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-metric/src/MetricGroup/index.tsx
+++ b/packages/ui-metric/src/MetricGroup/index.tsx
@@ -46,6 +46,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class MetricGroup extends Component<Props> {
+  static componentId = 'MetricGroup'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-modal/src/Modal/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/index.tsx
@@ -53,6 +53,8 @@ id: Modal.Body
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ModalBody extends Component<Props> {
+  static componentId = 'Modal.Body'
+
   static propTypes = {
     children: PropTypes.node,
     padding: ThemeablePropTypes.spacing,

--- a/packages/ui-modal/src/Modal/ModalFooter/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalFooter/index.tsx
@@ -47,6 +47,8 @@ id: Modal.Footer
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ModalFooter extends Component<Props> {
+  static componentId = 'Modal.Footer'
+
   static propTypes = {
     children: PropTypes.node,
     variant: PropTypes.oneOf(['default', 'inverse']),

--- a/packages/ui-modal/src/Modal/ModalHeader/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalHeader/index.tsx
@@ -52,6 +52,8 @@ id: Modal.Header
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ModalHeader extends Component<Props> {
+  static componentId = 'Modal.Header'
+
   static propTypes = {
     children: PropTypes.node,
     variant: PropTypes.oneOf(['default', 'inverse']),

--- a/packages/ui-modal/src/Modal/index.tsx
+++ b/packages/ui-modal/src/Modal/index.tsx
@@ -90,6 +90,8 @@ tags: overlay, portal, dialog
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Modal extends Component<Props> {
+  static componentId = 'Modal'
+
   static propTypes = {
     /**
      * An accessible label for the `<Modal />` content

--- a/packages/ui-motion/src/Transition/index.tsx
+++ b/packages/ui-motion/src/Transition/index.tsx
@@ -72,6 +72,8 @@ category: components/utilities
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Transition extends Component<Props> {
+  static componentId = 'Transition'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-navigation/src/AppNav/Item/index.tsx
+++ b/packages/ui-navigation/src/AppNav/Item/index.tsx
@@ -66,6 +66,8 @@ id: AppNav.Item
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Item extends Component<Props> {
+  static componentId = 'AppNav.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-navigation/src/AppNav/index.tsx
+++ b/packages/ui-navigation/src/AppNav/index.tsx
@@ -64,6 +64,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class AppNav extends Component<Props> {
+  static componentId = 'AppNav'
+
   static propTypes = {
     /**
      * Screenreader label for the overall navigation

--- a/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
@@ -55,6 +55,8 @@ id: Navigation.Item
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class NavigationItem extends Component<Props> {
+  static componentId = 'Navigation.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-navigation/src/Navigation/index.tsx
+++ b/packages/ui-navigation/src/Navigation/index.tsx
@@ -66,6 +66,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Navigation extends Component<Props> {
+  static componentId = 'Navigation'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -78,6 +78,8 @@ id: NumberInput
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class NumberInput extends Component<Props> {
+  static componentId = 'NumberInput'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-options/src/Options/Item/index.tsx
+++ b/packages/ui-options/src/Options/Item/index.tsx
@@ -57,6 +57,8 @@ id: Options.Item
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class Item extends Component<Props> {
+  static componentId = 'Options.Item'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-options/src/Options/Separator/index.tsx
+++ b/packages/ui-options/src/Options/Separator/index.tsx
@@ -48,6 +48,8 @@ id: Options.Separator
 **/
 @withStyle(generateStyles, generateComponentTheme)
 class Separator extends Component<Props> {
+  static componentId = 'Options.Separator'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -63,6 +63,8 @@ category: components
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class Options extends Component<Props> {
+  static componentId = 'Options'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-overlays/src/Mask/index.tsx
+++ b/packages/ui-overlays/src/Mask/index.tsx
@@ -50,6 +50,8 @@ category: components/utilities
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Mask extends Component<Props> {
+  static componentId = 'Mask'
+
   static propTypes = {
     onDismiss: PropTypes.func,
     placement: PropTypes.oneOf(['top', 'center', 'bottom', 'stretch']),

--- a/packages/ui-pages/src/Pages/Page/index.tsx
+++ b/packages/ui-pages/src/Pages/Page/index.tsx
@@ -44,6 +44,8 @@ id: Pages.Page
 ---
 **/
 class Page extends Component<Props> {
+  static componentId = 'Pages.Page'
+
   static propTypes = {
     /**
      * The children to be rendered

--- a/packages/ui-pages/src/Pages/index.tsx
+++ b/packages/ui-pages/src/Pages/index.tsx
@@ -60,6 +60,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Pages extends Component<Props> {
+  static componentId = 'Pages'
+
   static propTypes = {
     children: Children.oneOf([Page]),
 

--- a/packages/ui-pagination/src/Pagination/PaginationArrowButton/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationArrowButton/index.tsx
@@ -48,6 +48,8 @@ id: Pagination.Navigation
 **/
 @testable()
 class PaginationArrowButton extends Component<Props> {
+  static componentId = 'Pagination.Navigation'
+
   static propTypes = {
     direction: PropTypes.oneOf(['next', 'prev']),
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,

--- a/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
@@ -41,6 +41,8 @@ id: Pagination.Page
 
 @testable()
 class PaginationButton extends Component<Props> {
+  static componentId = 'Pagination.Page'
+
   static propTypes = {
     /**
      * Content to render as page selection

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -84,6 +84,8 @@ category: components
 @withStyle(generateStyle, null)
 @testable()
 class Pagination extends Component<Props> {
+  static componentId = 'Pagination'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-pill/src/Pill/index.tsx
+++ b/packages/ui-pill/src/Pill/index.tsx
@@ -54,6 +54,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Pill extends Component<Props> {
+  static componentId = 'Pill'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -106,6 +106,8 @@ tags: overlay, portal, dialog
 @bidirectional()
 @testable()
 class Popover extends Component<Props> {
+  static componentId = 'Popover'
+
   static propTypes = {
     /**
      * Whether or not the `<Popover />` content is shown

--- a/packages/ui-position/src/Position/index.tsx
+++ b/packages/ui-position/src/Position/index.tsx
@@ -77,6 +77,8 @@ category: components/utilities
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Position extends Component<Props> {
+  static componentId = 'Position'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-progress/src/ProgressBar/index.tsx
+++ b/packages/ui-progress/src/ProgressBar/index.tsx
@@ -60,6 +60,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ProgressBar extends Component<Props> {
+  static componentId = 'ProgressBar'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-progress/src/ProgressCircle/index.tsx
+++ b/packages/ui-progress/src/ProgressCircle/index.tsx
@@ -63,6 +63,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ProgressCircle extends Component<Props> {
+  static componentId = 'ProgressCircle'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -61,6 +61,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class RadioInput extends Component<Props> {
+  static componentId = 'RadioInput'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -59,6 +59,8 @@ category: components
 **/
 @testable()
 class RadioInputGroup extends Component<Props> {
+  static componentId = 'RadioInputGroup'
+
   static propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.node.isRequired,

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -67,6 +67,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class RangeInput extends Component<Props> {
+  static componentId = 'RangeInput'
+
   static propTypes = {
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,

--- a/packages/ui-rating/src/Rating/index.tsx
+++ b/packages/ui-rating/src/Rating/index.tsx
@@ -55,6 +55,8 @@ category: components
 @withStyle(generateStyle)
 @testable()
 class Rating extends Component<Props> {
+  static componentId = 'Rating'
+
   static propTypes = {
     /**
      * A label is required for accessibility

--- a/packages/ui-rating/src/RatingIcon/index.tsx
+++ b/packages/ui-rating/src/RatingIcon/index.tsx
@@ -51,6 +51,8 @@ id: Rating.Icon
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class RatingIcon extends Component<Props> {
+  static componentId = 'Rating.Icon'
+
   static propTypes = {
     animationDelay: PropTypes.number,
     animateFill: PropTypes.bool,

--- a/packages/ui-select/src/Select/Group/index.tsx
+++ b/packages/ui-select/src/Select/Group/index.tsx
@@ -41,6 +41,8 @@ id: Select.Group
 @module Group
 **/
 class Group extends Component<Props> {
+  static componentId = 'Select.Group'
+
   static propTypes = {
     /**
      * The label associated with the group options.

--- a/packages/ui-select/src/Select/Option/index.tsx
+++ b/packages/ui-select/src/Select/Option/index.tsx
@@ -42,6 +42,8 @@ id: Select.Option
 @module Option
 **/
 class Option extends Component<Props> {
+  static componentId = 'Select.Option'
+
   static propTypes = {
     /**
      * The id for the option.

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -104,6 +104,8 @@ tags: autocomplete, typeahead, combobox, dropdown, search, form
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Select extends Component<Props> {
+  static componentId = 'Select'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-simple-select/src/SimpleSelect/Group/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/Group/index.tsx
@@ -39,6 +39,8 @@ id: SimpleSelect.Group
 ---
 **/
 class Group extends Component<Props> {
+  static componentId = 'SimpleSelect.Group'
+
   static propTypes = {
     /**
      * The label associated with the group options.

--- a/packages/ui-simple-select/src/SimpleSelect/Option/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/Option/index.tsx
@@ -40,6 +40,8 @@ id: SimpleSelect.Option
 ---
 **/
 class Option extends Component<Props> {
+  static componentId = 'SimpleSelect.Option'
+
   static propTypes = {
     /**
      * The id for the option.

--- a/packages/ui-simple-select/src/SimpleSelect/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/index.tsx
@@ -79,6 +79,8 @@ tags: form, field, dropdown
 **/
 @testable()
 class SimpleSelect extends Component<Props> {
+  static componentId = 'SimpleSelect'
+
   static Option = Option
   static Group = Group
   static propTypes = {

--- a/packages/ui-spinner/src/Spinner/index.tsx
+++ b/packages/ui-spinner/src/Spinner/index.tsx
@@ -55,6 +55,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Spinner extends Component<Props> {
+  static componentId = 'Spinner'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-svg-images/src/InlineSVG/index.tsx
+++ b/packages/ui-svg-images/src/InlineSVG/index.tsx
@@ -67,6 +67,8 @@ category: components/utilities
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class InlineSVG extends Component<Props> {
+  static componentId = 'InlineSVG'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,
@@ -244,7 +246,8 @@ class InlineSVG extends Component<Props> {
 function parseAttributes(src) {
   const attributes = {}
   const SVGAttributesRegExp = /<svg\s+([^>]*)\s*>/
-  const namesAndValuesRegExp = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/g
+  const namesAndValuesRegExp =
+    /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/g
 
   if (typeof src === 'string') {
     const attributesMatches = SVGAttributesRegExp.exec(src)

--- a/packages/ui-svg-images/src/SVGIcon/index.tsx
+++ b/packages/ui-svg-images/src/SVGIcon/index.tsx
@@ -52,6 +52,8 @@ category: components/utilities
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class SVGIcon extends Component<Props> {
+  static componentId = 'SVGIcon'
+
   static propTypes = {
     // @ts-expect-error ts-migrate(2783) FIXME: 'makeStyles' is specified more than once, so this ... Remove this comment to see the full error message
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -55,6 +55,8 @@ id: Table.Body
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Body extends Component<Props> {
+  static componentId = 'Table.Body'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     /**

--- a/packages/ui-table/src/Table/Cell/index.tsx
+++ b/packages/ui-table/src/Table/Cell/index.tsx
@@ -50,6 +50,8 @@ id: Table.Cell
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Cell extends Component<Props> {
+  static componentId = 'Table.Cell'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -57,6 +57,8 @@ id: Table.ColHeader
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class ColHeader extends Component<Props> {
+  static componentId = 'Table.ColHeader'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -60,6 +60,8 @@ id: Table.Head
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Head extends Component<Props> {
+  static componentId = 'Table.Head'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     /**

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -59,6 +59,8 @@ id: Table.Row
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Row extends Component<Props> {
+  static componentId = 'Table.Row'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     /**

--- a/packages/ui-table/src/Table/RowHeader/index.tsx
+++ b/packages/ui-table/src/Table/RowHeader/index.tsx
@@ -49,6 +49,8 @@ id: Table.RowHeader
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class RowHeader extends Component<Props> {
+  static componentId = 'Table.RowHeader'
+
   /* eslint-disable react/require-default-props */
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -64,6 +64,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Table extends Component<Props> {
+  static componentId = 'Table'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tabs/src/Tabs/Panel/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Panel/index.tsx
@@ -59,6 +59,8 @@ id: Tabs.Panel
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Panel extends Component<Props> {
+  static componentId = 'Tabs.Panel'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tabs/src/Tabs/Tab/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Tab/index.tsx
@@ -55,6 +55,8 @@ id: Tabs.Tab
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Tab extends Component<Props> {
+  static componentId = 'Tabs.Tab'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tabs/src/Tabs/index.tsx
+++ b/packages/ui-tabs/src/Tabs/index.tsx
@@ -79,6 +79,8 @@ category: components
 @bidirectional()
 @testable()
 class Tabs extends Component<Props> {
+  static componentId = 'Tabs'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tag/src/Tag/index.tsx
+++ b/packages/ui-tag/src/Tag/index.tsx
@@ -65,6 +65,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Tag extends Component<Props> {
+  static componentId = 'Tag'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -75,6 +75,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class TextArea extends Component<Props> {
+  static componentId = 'TextArea'
+
   static propTypes = {
     label: PropTypes.node.isRequired,
     id: PropTypes.string,

--- a/packages/ui-text-input/src/TextInput/index.tsx
+++ b/packages/ui-text-input/src/TextInput/index.tsx
@@ -77,6 +77,8 @@ tags: form, field
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class TextInput extends Component<Props> {
+  static componentId = 'TextInput'
+
   static propTypes = {
     /**
      * The form field label.

--- a/packages/ui-text/src/Text/index.tsx
+++ b/packages/ui-text/src/Text/index.tsx
@@ -63,6 +63,8 @@ category: components
 **/
 @withStyle(generateStyle, generateComponentTheme)
 class Text extends Component<Props> {
+  static componentId = 'Text'
+
   static propTypes = {
     /**
      * the element type to render as

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -83,6 +83,8 @@ category: components
 
 @testable()
 class TimeSelect extends Component<Props> {
+  static componentId = 'TimeSelect'
+
   static propTypes = {
     /**
      * The form field label.

--- a/packages/ui-toggle-details/src/ToggleDetails/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/index.tsx
@@ -64,6 +64,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ToggleDetails extends Component<Props> {
+  static componentId = 'ToggleDetails'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-toggle-details/src/ToggleGroup/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleGroup/index.tsx
@@ -65,6 +65,8 @@ category: components
 **/
 @testable()
 class ToggleGroup extends Component<Props> {
+  static componentId = 'ToggleGroup'
+
   static propTypes = {
     /**
      * the content to show and hide

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -70,6 +70,8 @@ category: components
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Tooltip extends Component<Props> {
+  static componentId = 'Tooltip'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tray/src/Tray/index.tsx
+++ b/packages/ui-tray/src/Tray/index.tsx
@@ -80,6 +80,8 @@ category: components
 @bidirectional()
 @testable()
 class Tray extends Component<Props> {
+  static componentId = 'Tray'
+
   static propTypes = {
     label: PropTypes.string.isRequired,
     children: PropTypes.node,

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
@@ -68,6 +68,8 @@ id: TreeBrowser.Button
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class TreeButton extends Component<Props> {
+  static componentId = 'TreeBrowser.Button'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
@@ -79,6 +79,8 @@ id: TreeBrowser.Collection
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class TreeCollection extends Component<Props> {
+  static componentId = 'TreeBrowser.Collection'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.tsx
@@ -65,6 +65,8 @@ in the TreeBrowser.
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class TreeNode extends Component<Props> {
+  static componentId = 'TreeBrowser.Node'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -74,6 +74,8 @@ category: components
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class TreeBrowser extends Component<Props> {
+  static componentId = 'TreeBrowser'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-truncate-text/src/TruncateText/index.tsx
+++ b/packages/ui-truncate-text/src/TruncateText/index.tsx
@@ -63,6 +63,8 @@ category: components
 @testable()
 @hack(['shouldTruncateWhenInvisible'])
 class TruncateText extends Component<Props> {
+  static componentId = 'TruncateText'
+
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
     makeStyles: PropTypes.func,

--- a/packages/ui-view/src/ContextView/index.tsx
+++ b/packages/ui-view/src/ContextView/index.tsx
@@ -67,6 +67,8 @@ category: components
 
 @withStyle(generateStyle, generateComponentTheme)
 class ContextView extends Component<Props> {
+  static componentId = 'ContextView'
+
   static propTypes = {
     /**
      * The element to render as the component root

--- a/packages/ui-view/src/View/index.tsx
+++ b/packages/ui-view/src/View/index.tsx
@@ -118,6 +118,8 @@ category: components
 @bidirectional()
 @withStyle(generateStyle, generateComponentTheme)
 class View extends Component<Props> {
+  static componentId = 'View'
+
   static propTypes = {
     /**
      * The element to render as the component root, `span` by default


### PR DESCRIPTION
ui-a11y-content,ui-alerts,ui-avatar,ui-badge,ui-billboard,ui-breadcrumb,ui-buttons,ui-byline,ui-calendar,ui-checkbox,ui-code-editor,ui-date-input,ui-dialog,ui-drawer-layout,ui-editable,ui-file-drop,ui-flex,ui-form-field,ui-grid,ui-heading,ui-img,ui-link,ui-list,ui-menu,ui-metric,ui-modal,ui-motion,ui-navigation,ui-number-input,ui-options,ui-overlays,ui-pages,ui-pagination,ui-pill,ui-popover,ui-position,ui-progress,ui-radio-input,ui-range-input,ui-rating,ui-select,ui-simple-select,ui-spinner,ui-svg-images,ui-table,ui-tabs,ui-tag,ui-text-area,ui-text-input,ui-text,ui-time-select,ui-toggle-details,ui-tooltip,ui-tray,ui-tree-browser,ui-truncate-text,ui-view