### PR TITLE
INSTUI-3108 : add Babel assumptions that speed up the code

### DIFF
--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -157,7 +157,11 @@ module.exports = function (
     plugins,
     // see https://babeljs.io/docs/en/assumptions
     assumptions: {
-      setPublicClassFields: true
+      constantReexports: true, //assume that re-exported modules dont change
+      ignoreFunctionLength: true, // assume that we never call function.length
+      noDocumentAll: true, // assume we never use document.all
+      noNewArrows: true, // assume we never instantiate arrow functions with new
+      setPublicClassFields: true // assume public class fields never shadow getters
     }
   }
 }


### PR DESCRIPTION
Add some assumptions that likely speed up the code by assuming that we never use some rare JS
functionality. If we use them it will be a nasty bug!

If you think that one of them shoul not be enabled say so in the review