### PR TITLE
chore: remove `ui-scripts` source code from docs app

### DIFF
--- a/packages/__docs__/buildScripts/build-docs.js
+++ b/packages/__docs__/buildScripts/build-docs.js
@@ -98,6 +98,7 @@ const options = {
     '**/template-package/**',
     '**/ui-component-examples/src/**',
     '**/ui-test-*/src/**',
+    '**/ui-scripts/src/**',
 
     // deprecated packages and modules:
     '**/InputModeListener.{js,ts}'


### PR DESCRIPTION
only the readme.md file will be shown for this package