### PR TITLE
feat(ui-table): add `stackedSortByLabel` prop to `Table.ColHeader`

### DIFF
--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -41,6 +41,7 @@ type Props = {
   makeStyles?: (...args: any[]) => any
   styles?: any
   id: string
+  stackedSortByLabel: string
   width?: string | number
   textAlign?: 'start' | 'center' | 'end'
   sortDirection?: 'none' | 'ascending' | 'descending'
@@ -63,10 +64,16 @@ class ColHeader extends Component<Props> {
     // eslint-disable-next-line react/require-default-props
     styles: PropTypes.object,
     /**
-     * A unique id for this column. When sortable table is in stacked layout,
-     * id is also used as option in combobox.
+     * A unique id for this column. The `id` is also used as option in combobox,
+     * when sortable table is in stacked layout,
+     * and no `stackedSortByLabel` is provided.
      */
     id: PropTypes.string.isRequired,
+    /**
+     * A custom string to display as option text in the combobox (instead of
+     * using the `id` prop), when sortable table is in stacked layout.
+     */
+    stackedSortByLabel: PropTypes.string,
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     /**
      * Control the width of column.
@@ -94,6 +101,7 @@ class ColHeader extends Component<Props> {
   static defaultProps = {
     textAlign: 'start',
     sortDirection: 'none',
+    stackedSortByLabel: undefined,
     children: null,
     scope: 'col'
   }
@@ -136,14 +144,8 @@ class ColHeader extends Component<Props> {
   }
 
   render() {
-    const {
-      onRequestSort,
-      width,
-      children,
-      sortDirection,
-      scope,
-      styles
-    } = this.props
+    const { onRequestSort, width, children, sortDirection, scope, styles } =
+      this.props
 
     return (
       <th

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -129,10 +129,13 @@ class Head extends Component<Props> {
     Children.forEach(row.props.children, (colHeader) => {
       count += 1
       if (matchComponentTypes(colHeader, [ColHeader])) {
-        const { id, sortDirection, onRequestSort } = colHeader.props
+        const { id, stackedSortByLabel, sortDirection, onRequestSort } =
+          colHeader.props
+
+        const label = stackedSortByLabel || id
 
         if (onRequestSort) {
-          options.push(id)
+          options.push({ id, label })
           // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           clickHandlers[id] = onRequestSort
           if (sortDirection !== 'none') {
@@ -167,19 +170,19 @@ class Head extends Component<Props> {
               onChange={handleSelect}
             >
               {/* @ts-expect-error ts-migrate(7005) FIXME: Variable 'options' implicitly has an 'any[]' type. */}
-              {options.map((option) => (
+              {options.map(({ id, label }) => (
                 <SimpleSelect.Option
-                  id={option}
-                  key={option}
-                  value={option}
+                  id={id}
+                  key={id}
+                  value={id}
                   renderBeforeLabel={
                     // @ts-expect-error ts-migrate(7005) FIXME: Variable 'selectedOption' implicitly has an 'any' ... Remove this comment to see the full error message
-                    option === selectedOption
+                    id === selectedOption
                       ? IconCheckLine
                       : () => <IconCheckLine style={{ color: 'transparent' }} />
                   }
                 >
-                  {option}
+                  {label}
                 </SimpleSelect.Option>
               ))}
             </SimpleSelect>

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -240,7 +240,9 @@ render(
 
 ### A sortable table using our Responsive component
 
-Resize the window to see how column headers transition into a Select for sorting table content when the traditional Table Header is no longer clickable. The Table layout itself switches from the horizontal view to the stacked view allowing content to be viewed without horizontal scrolling. See [Responsive](#Responsive) for more examples.
+Resize the window to see how column headers transition into a `Select` for sorting table content when the traditional Table Header is no longer clickable. The Table layout itself switches from the horizontal view to the stacked view allowing content to be viewed without horizontal scrolling. See [Responsive](#Responsive) for more examples.
+
+By default, the options in the `Select` for sorting in stacked layout are generated from the `id` property of the `Table.ColHeader` components. If you want to display custom strings, use the `stackedSortByLabel` property.
 
 ```javascript
 ---
@@ -313,6 +315,7 @@ class SortableTable extends React.Component {
                     <Table.ColHeader
                       key={id}
                       id={id}
+                      stackedSortByLabel={text}
                       onRequestSort={this.handleSort}
                       sortDirection={id === sortBy ? direction : 'none'}
                     >
@@ -352,19 +355,19 @@ render(
     caption="Top rated movies"
     headers={[
       {
-        id: 'Rank',
+        id: 'rank',
         text: 'Rank',
       },
       {
-        id: 'Title',
+        id: 'title',
         text: 'Title',
       },
       {
-        id: 'Year',
+        id: 'year',
         text: 'Year',
       },
       {
-        id: 'Rating',
+        id: 'rating',
         text: 'Rating',
         renderCell: (rating) => rating.toFixed(1),
       },
@@ -372,38 +375,38 @@ render(
     rows={[
       {
         id: '1',
-        Rank: 1,
-        Title: 'The Shawshank Redemption',
-        Year: 1994,
-        Rating: 9.3,
+        rank: 1,
+        title: 'The Shawshank Redemption',
+        year: 1994,
+        rating: 9.3,
       },
       {
         id: '2',
-        Rank: 2,
-        Title: 'The Godfather',
-        Year: 1972,
-        Rating: 9.2,
+        rank: 2,
+        title: 'The Godfather',
+        year: 1972,
+        rating: 9.2,
       },
       {
         id: '3',
-        Rank: 3,
-        Title: 'The Godfather: Part II',
-        Year: 1974,
-        Rating: 9.0,
+        rank: 3,
+        title: 'The Godfather: Part II',
+        year: 1974,
+        rating: 9.0,
       },
       {
         id: '4',
-        Rank: 4,
-        Title: 'The Dark Knight',
-        Year: 2008,
-        Rating: 9.0,
+        rank: 4,
+        title: 'The Dark Knight',
+        year: 2008,
+        rating: 9.0,
       },
       {
         id: '5',
-        Rank: 5,
-        Title: '12 Angry Men',
-        Year: 1957,
-        Rating: 8.9,
+        rank: 5,
+        title: '12 Angry Men',
+        year: 1957,
+        rating: 8.9,
       },
     ]}
   />

--- a/packages/ui-table/src/Table/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/__tests__/Table.test.tsx
@@ -263,6 +263,31 @@ describe('<Table />', async () => {
       expect(sortFoo).to.have.been.calledOnce()
     })
 
+    it('can display custom label in the select in stacked layout', async () => {
+      await renderSortableTable(
+        {
+          stackedSortByLabel: 'Custom Text'
+        },
+        {
+          // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 0.
+          onRequestSort: stub()
+        },
+        'stacked'
+      )
+      const select = await SimpleSelectLocator.find()
+      const input = await select.findInput()
+
+      await input.click()
+
+      const list = await select.findOptionsList()
+      const options = await list.findAll('[role="option"]')
+
+      // with stackedSortByLabel provided
+      expect(options[0].text()).to.equal('Custom Text')
+      // the id by default
+      expect(options[1].text()).to.equal('bar')
+    })
+
     it('can render check mark for sorted column in stacked layout', async () => {
       await renderSortableTable(
         {


### PR DESCRIPTION
Closes: INSTUI-3116

The new `stackedSortByLabel` prop will allow users to set custom strings to the labels appearing in
the "sort by" select of a sortable table with stacked layout. It is using the `id` prop by default,
which is not always a user-friendly string. It will also allow to display longer, more descriptive
labels.