### PR TITLE
chore: add deploy preview to PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -33,6 +33,7 @@ jobs:
         run: echo "::set-output name=preview_url::$(npx netlify deploy --dir ./packages/__docs__/__build__ | grep "Website Draft URL" | awk '{print $4}')"
       - name: Add Comment to PR with the preview URL.
         # only run this step if the previous step has not failed
+        # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
         if: ${{ steps.deploy_to_netlify.outcome == 'success' }}
         uses: actions-cool/maintain-one-comment@v2.0.0
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         name: Install Node 15
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,8 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v2
         name: Install Node 15
         with:
@@ -17,3 +15,10 @@ jobs:
         run: yarn bootstrap
       - name: Run test for the patchset
         run: yarn test:patchset
+      - name: Build docs-app
+        run: yarn build:docs
+      - name: Deploy preview docs.
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: npx netlify deploy --dir ./packages/__docs__/__build__

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,12 +21,19 @@ jobs:
         run: yarn build:docs
       - name: Deploy preview docs.
         id: deploy_to_netlify
+        # since repository secrets are not exposed to forked repos this step
+        # would always would fail for those PRs, so it's better just to
+        # ignore the failure here
+        # see: https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+        continue-on-error: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         # set <preview_url> variable to be available for the following steps
         run: echo "::set-output name=preview_url::$(npx netlify deploy --dir ./packages/__docs__/__build__ | grep "Website Draft URL" | awk '{print $4}')"
       - name: Add Comment to PR with the preview URL.
+        # only run this step if the previous step has not failed
+        if: ${{ steps.deploy_to_netlify.outcome == 'success' }}
         uses: actions-cool/maintain-one-comment@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,7 +18,15 @@ jobs:
       - name: Build docs-app
         run: yarn build:docs
       - name: Deploy preview docs.
+        id: deploy_to_netlify
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        run: npx netlify deploy --dir ./packages/__docs__/__build__
+        # set <preview_url> variable to be available for the following steps
+        run: echo "::set-output name=preview_url::$(npx netlify deploy --dir ./packages/__docs__/__build__ | grep "Website Draft URL" | awk '{print $4}')"
+      - name: Add Comment to PR with the preview URL.
+        uses: actions-cool/maintain-one-comment@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Preview URL: ${{ steps.deploy_to_netlify.outputs.preview_url }}


### PR DESCRIPTION
This PR contains some changes which enhances the current pr_validation workflow with the following:

- build the documentation app from the branch of the PR
- deploy it to netlify
- a github bot will create (and update) a comment with the most recent preview URL