### PR TITLE
chore: deploy docs to netlfiy instead of github pages when releasing

### DIFF
--- a/.github/workflows/deploy-docs-to-netlify.yml
+++ b/.github/workflows/deploy-docs-to-netlify.yml
@@ -1,17 +1,11 @@
-name: AUTO docs deploy to netlify - on master
-on:
-  push:
-    branches:
-      - master
-  workflow_dispatch:
+name: Docs deploy to netlify - on master
+on: [workflow_dispatch]
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy docs to Netlify.
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Install packages.
         run: yarn install
       - name: Set up project.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,36 +41,23 @@ jobs:
         run: git tag -a v$(./.github/workflows/calculateVersion.sh) -m v$(./.github/workflows/calculateVersion.sh)
       - name: Push tags
         run: git push origin v$(./.github/workflows/calculateVersion.sh)
-  deploy:
+  deploy-docs:
     needs: release
     if: "startsWith(github.event.head_commit.message, 'chore(release)')"
     runs-on: ubuntu-latest
-    name: Deploy docs
+    name: Deploy docs to Netlify
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Install packages.
         run: yarn install
       - name: Set up project.
         run: yarn bootstrap
-      - name: Run tests.
-        run: yarn test:patchset
-      - name: Set up git identity
-        run: git config --global user.name "instructure-ui-ci" && git config --global user.email "instructure-ui-ci@instructure.com"
-      - name: Remove __build__ folder
-        run: rm -rf packages/__docs__/__build__
-      - name: Create __build__ folder
-        run: mkdir packages/__docs__/__build__
-      - name: Checkout gh-pages
-        run: git checkout gh-pages
-      - name: Checkout master
-        run: git checkout master
-      - name: Clone gh-pages branch to __build__ folder
-        run: git clone .git --branch gh-pages packages/__docs__/__build__
-      - name: Build docs
+      - name: Build docs-app.
         run: yarn build:docs
-      - name: Commit and push changes to local copy
-        run: cd ./packages/__docs__/__build__  && git add --all && git commit -m "Publishing to gh-pages" && git push origin gh-pages
-      - name: Publish
-        run: git checkout gh-pages && git push origin gh-pages && git checkout master
+      - name: Copy redirects config file to the __build__ directory.
+        run: cp ./packages/__docs__/_redirects ./packages/__docs__/__build__
+      - name: Deploy built docs-app to Netlify.
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: npx netlify deploy --prod --dir ./packages/__docs__/__build__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
     name: Deploy docs to Netlify
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install packages.
         run: yarn install
       - name: Set up project.


### PR DESCRIPTION
replaced the current github pages docs steps with the netlify deploy in the release workflow