### PR TITLE
chore(ui-docs-client): change location handling in main searchbar --V7

### DIFF
--- a/packages/ui-docs-client/src/Search/index.js
+++ b/packages/ui-docs-client/src/Search/index.js
@@ -65,7 +65,7 @@ class Search extends Component {
 
       this._options.push({
         id: `doc${i}`,
-        value: `${window.location.origin}/#${option}`,
+        value: `#${option}`,
         label: option,
         groupLabel: doc.category,
         tags: doc.tags


### PR DESCRIPTION
Had to change how the current way of handling the location change works for the main search bar (on the top of the page at the #index page), because the current solution overrides the selected version in the url.

Changed it so it only rewrites the #hash part of the url.