### PR TITLE
INSTUI-2932 : Replace <Flex> with <span> in Button to improve performance

### DIFF
--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -45,6 +45,7 @@
     "@instructure/ui-tooltip": "8.5.0",
     "@instructure/ui-utils": "8.5.0",
     "@instructure/ui-view": "8.5.0",
+    "@instructure/ui-i18n": "8.5.0",
     "keycode": "^2",
     "prop-types": "^15"
   },

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -38,7 +38,6 @@
     "@instructure/ui-a11y-utils": "8.5.0",
     "@instructure/ui-color-utils": "8.5.0",
     "@instructure/ui-dom-utils": "8.5.0",
-    "@instructure/ui-flex": "8.5.0",
     "@instructure/ui-icons": "8.5.0",
     "@instructure/ui-position": "8.5.0",
     "@instructure/ui-react-utils": "8.5.0",

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -45,7 +45,6 @@
     "@instructure/ui-tooltip": "8.5.0",
     "@instructure/ui-utils": "8.5.0",
     "@instructure/ui-view": "8.5.0",
-    "@instructure/ui-i18n": "8.5.0",
     "keycode": "^2",
     "prop-types": "^15"
   },

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -39,7 +39,6 @@ import { isActiveElement } from '@instructure/ui-dom-utils'
 
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 import { View } from '@instructure/ui-view'
-import { Flex } from '@instructure/ui-flex'
 
 import {
   withStyle,
@@ -343,7 +342,7 @@ class BaseButton extends Component<Props> {
   }
 
   renderChildren() {
-    const { renderIcon, children, textAlign, isCondensed, styles } = this.props
+    const { renderIcon, children, styles } = this.props
 
     const wrappedChildren = <span css={styles.children}>{children}</span>
 
@@ -357,38 +356,21 @@ class BaseButton extends Component<Props> {
     )
 
     const flexChildren = hasOnlyIconVisible ? (
-      <Flex.Item>
+      <span css={styles.flexOnlyIcon}>
         {wrappedIcon}
         {children}
-      </Flex.Item>
+      </span>
     ) : (
       [
-        <Flex.Item
-          key="icon"
-          padding={`0 ${isCondensed ? 'xx-small' : 'x-small'} 0 0`}
-        >
+        <span key="icon" css={styles.flexIcon}>
           {wrappedIcon}
-        </Flex.Item>,
-        <Flex.Item key="children" shouldShrink>
+        </span>,
+        <span key="children" css={styles.flexIconChildren}>
           {wrappedChildren}
-        </Flex.Item>
+        </span>
       ]
     )
-
-    const flexProps = {
-      shouldShrink: true,
-      height: '100%',
-      width: '100%',
-      justifyItems:
-        hasOnlyIconVisible || textAlign === 'center' ? 'center' : 'start'
-    } as {
-      shouldShrink: boolean
-      height: string
-      width: string
-      justifyItems: 'center' | 'start'
-    }
-
-    return <Flex {...flexProps}>{flexChildren}</Flex>
+    return <span css={styles.flex}>{flexChildren}</span>
   }
 
   render() {

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -36,7 +36,6 @@ import {
   InteractionType
 } from '@instructure/ui-react-utils'
 import { isActiveElement } from '@instructure/ui-dom-utils'
-import { bidirectional } from '@instructure/ui-i18n'
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 import { View } from '@instructure/ui-view'
 
@@ -73,7 +72,6 @@ type Props = {
   onKeyDown?: (...args: any[]) => any
   renderIcon?: React.ReactNode | ((...args: any[]) => any)
   tabIndex?: number | string
-  dir?: any // TODO: PropTypes.oneOf(Object.values(bidirectional.DIRECTION))
 }
 
 /**
@@ -82,7 +80,6 @@ category: components/utilities
 ---
 **/
 
-@bidirectional()
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class BaseButton extends Component<Props> {
@@ -187,10 +184,7 @@ class BaseButton extends Component<Props> {
     /**
      * Specifies the tabindex of the `Button`.
      */
-    tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    //@ts-expect-error FIXME:
-    // eslint-disable-next-line react/require-default-props
-    dir: PropTypes.oneOf(Object.values(bidirectional.DIRECTION))
+    tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   }
 
   static defaultProps = {

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -36,7 +36,7 @@ import {
   InteractionType
 } from '@instructure/ui-react-utils'
 import { isActiveElement } from '@instructure/ui-dom-utils'
-
+import { bidirectional } from '@instructure/ui-i18n'
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 import { View } from '@instructure/ui-view'
 
@@ -73,6 +73,7 @@ type Props = {
   onKeyDown?: (...args: any[]) => any
   renderIcon?: React.ReactNode | ((...args: any[]) => any)
   tabIndex?: number | string
+  dir?: any // TODO: PropTypes.oneOf(Object.values(bidirectional.DIRECTION))
 }
 
 /**
@@ -81,6 +82,7 @@ category: components/utilities
 ---
 **/
 
+@bidirectional()
 @withStyle(generateStyles, generateComponentTheme)
 @testable()
 class BaseButton extends Component<Props> {
@@ -185,7 +187,10 @@ class BaseButton extends Component<Props> {
     /**
      * Specifies the tabindex of the `Button`.
      */
-    tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    //@ts-expect-error FIXME:
+    // eslint-disable-next-line react/require-default-props
+    dir: PropTypes.oneOf(Object.values(bidirectional.DIRECTION))
   }
 
   static defaultProps = {
@@ -356,21 +361,21 @@ class BaseButton extends Component<Props> {
     )
 
     const flexChildren = hasOnlyIconVisible ? (
-      <span css={styles.flexOnlyIcon}>
+      <span css={styles.iconOnly}>
         {wrappedIcon}
         {children}
       </span>
     ) : (
       [
-        <span key="icon" css={styles.flexIcon}>
+        <span key="icon" css={styles.iconWrapper}>
           {wrappedIcon}
         </span>,
-        <span key="children" css={styles.flexIconChildren}>
+        <span key="children" css={styles.childrenWrapper}>
           {wrappedChildren}
         </span>
       ]
     )
-    return <span css={styles.flex}>{flexChildren}</span>
+    return <span css={styles.childrenLayout}>{flexChildren}</span>
   }
 
   render() {

--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -22,9 +22,6 @@
  * SOFTWARE.
  */
 
-import { DIRECTION } from '@instructure/ui-i18n'
-import { mirrorShorthandEdges } from '@instructure/emotion'
-
 /**
  * ---
  * private: true
@@ -44,8 +41,7 @@ const generateStyle = (componentTheme, props, state) => {
     shape,
     withBackground,
     withBorder,
-    isCondensed,
-    dir
+    isCondensed
   } = props
 
   const { isDisabled, hasOnlyIconVisible } = state
@@ -275,16 +271,6 @@ const generateStyle = (componentTheme, props, state) => {
         }
   }
 
-  const isRtlDirection = dir === DIRECTION.rtl
-  let iconWrapperPadding = `0 ${
-    isCondensed
-      ? componentTheme.iconTextGapCondensed
-      : componentTheme.iconTextGap
-  } 0 0`
-  iconWrapperPadding = isRtlDirection
-    ? mirrorShorthandEdges(iconWrapperPadding)!
-    : iconWrapperPadding
-
   return {
     baseButton: {
       label: 'baseButton',
@@ -403,7 +389,9 @@ const generateStyle = (componentTheme, props, state) => {
       label: 'baseButton__iconWrapper',
       boxSizing: 'border-box',
       minWidth: '0.0625rem',
-      padding: iconWrapperPadding,
+      paddingInlineEnd: isCondensed
+        ? componentTheme.iconTextGapCondensed
+        : componentTheme.iconTextGap,
       flexShrink: 0,
       maxWidth: '100%',
       overflowX: 'visible',

--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -356,6 +356,42 @@ const generateStyle = (componentTheme, props, state) => {
 
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       ...sizeVariants[size].iconSVG
+    },
+
+    flex: {
+      label: 'baseButton__flex',
+      display: 'flex',
+      height: '100%',
+      width: '100%',
+      justifyContent:
+        hasOnlyIconVisible || textAlign === 'center' ? 'center' : 'flex-start',
+      boxSizing: 'border-box', // TODO these are from Flex, are they enough?
+      alignItems: 'center',
+      flexDirection: 'row'
+    },
+
+    flexOnlyIcon: {
+      label: 'baseButton__flexOnlyIcon',
+      boxSizing: 'border-box',
+      minWidth: '0.0625rem'
+    },
+
+    flexIcon: {
+      label: 'baseButton__flexIcon',
+      boxSizing: 'border-box',
+      minWidth: '0.0625rem',
+      padding: `0 ${
+        isCondensed
+          ? componentTheme.iconTextGapCondensed
+          : componentTheme.iconTextGap
+      } 0 0`
+    },
+
+    flexIconChildren: {
+      label: 'baseButton__flexIconChildren',
+      boxSizing: 'border-box',
+      minWidth: '0.0625rem',
+      flexShrink: 1
     }
   }
 }

--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -365,7 +365,7 @@ const generateStyle = (componentTheme, props, state) => {
       width: '100%',
       justifyContent:
         hasOnlyIconVisible || textAlign === 'center' ? 'center' : 'flex-start',
-      boxSizing: 'border-box', // TODO these are from Flex, are they enough?
+      boxSizing: 'border-box',
       alignItems: 'center',
       flexDirection: 'row'
     },

--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -22,6 +22,9 @@
  * SOFTWARE.
  */
 
+import { DIRECTION } from '@instructure/ui-i18n'
+import { mirrorShorthandEdges } from '@instructure/emotion'
+
 /**
  * ---
  * private: true
@@ -41,7 +44,8 @@ const generateStyle = (componentTheme, props, state) => {
     shape,
     withBackground,
     withBorder,
-    isCondensed
+    isCondensed,
+    dir
   } = props
 
   const { isDisabled, hasOnlyIconVisible } = state
@@ -271,6 +275,16 @@ const generateStyle = (componentTheme, props, state) => {
         }
   }
 
+  const isRtlDirection = dir === DIRECTION.rtl
+  let iconWrapperPadding = `0 ${
+    isCondensed
+      ? componentTheme.iconTextGapCondensed
+      : componentTheme.iconTextGap
+  } 0 0`
+  iconWrapperPadding = isRtlDirection
+    ? mirrorShorthandEdges(iconWrapperPadding)!
+    : iconWrapperPadding
+
   return {
     baseButton: {
       label: 'baseButton',
@@ -358,8 +372,8 @@ const generateStyle = (componentTheme, props, state) => {
       ...sizeVariants[size].iconSVG
     },
 
-    flex: {
-      label: 'baseButton__flex',
+    childrenLayout: {
+      label: 'baseButton__childrenLayout',
       display: 'flex',
       height: '100%',
       width: '100%',
@@ -367,31 +381,45 @@ const generateStyle = (componentTheme, props, state) => {
         hasOnlyIconVisible || textAlign === 'center' ? 'center' : 'flex-start',
       boxSizing: 'border-box',
       alignItems: 'center',
-      flexDirection: 'row'
+      flexDirection: 'row',
+      maxWidth: '100%',
+      overflowX: 'visible',
+      overflowY: 'visible',
+      unicodeBidi: 'isolate'
     },
 
-    flexOnlyIcon: {
-      label: 'baseButton__flexOnlyIcon',
-      boxSizing: 'border-box',
-      minWidth: '0.0625rem'
-    },
-
-    flexIcon: {
-      label: 'baseButton__flexIcon',
+    iconOnly: {
+      label: 'baseButton__iconOnly',
       boxSizing: 'border-box',
       minWidth: '0.0625rem',
-      padding: `0 ${
-        isCondensed
-          ? componentTheme.iconTextGapCondensed
-          : componentTheme.iconTextGap
-      } 0 0`
+      flexShrink: 0,
+      maxWidth: '100%',
+      overflowX: 'visible',
+      overflowY: 'visible',
+      unicodeBidi: 'isolate'
     },
 
-    flexIconChildren: {
-      label: 'baseButton__flexIconChildren',
+    iconWrapper: {
+      label: 'baseButton__iconWrapper',
       boxSizing: 'border-box',
       minWidth: '0.0625rem',
-      flexShrink: 1
+      padding: iconWrapperPadding,
+      flexShrink: 0,
+      maxWidth: '100%',
+      overflowX: 'visible',
+      overflowY: 'visible',
+      unicodeBidi: 'isolate'
+    },
+
+    childrenWrapper: {
+      label: 'baseButton__childrenWrapper',
+      boxSizing: 'border-box',
+      minWidth: '0.0625rem',
+      flexShrink: 1,
+      maxWidth: '100%',
+      overflowX: 'visible',
+      overflowY: 'visible',
+      unicodeBidi: 'isolate'
     }
   }
 }

--- a/packages/ui-buttons/src/BaseButton/theme.ts
+++ b/packages/ui-buttons/src/BaseButton/theme.ts
@@ -135,6 +135,8 @@ const generateComponentTheme = (theme) => {
     iconSizeSmall: '1rem',
     iconSizeMedium: '1.25rem',
     iconSizeLarge: '1.625rem',
+    iconTextGap: spacing.xSmall,
+    iconTextGapCondensed: spacing.xxSmall,
 
     ...generateButtonThemeVars({
       style: 'primary',


### PR DESCRIPTION
Replace the Flex component with simple span inside BaseButton for better performance. In the testing tool it resulted in ~40% performance improvement testing 100 times with a Button that has an icon and text:

BUTTON_ICON_IUIx100	832.9ms  // old, 8.4.0 code
BUTTON_ICON_IUIx100	504.4ms  // new code in this PR

It should improve performance with other types of button too, albeit to a lesser degree