### PR TITLE
chore: set up memoizer for styling (INSTUI-3121)

### DIFF
--- a/packages/emotion/src/memoize.tsx
+++ b/packages/emotion/src/memoize.tsx
@@ -25,7 +25,7 @@
 import { memoize } from 'lodash'
 
 const fnToMemoize = (
-  displayName: any,
+  _displayName: any,
   componentProps: any,
   extraArgs: any,
   componentTheme: any,

--- a/packages/emotion/src/memoize.tsx
+++ b/packages/emotion/src/memoize.tsx
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+// @ts-expect-error ts-migrate(7016) FIXME: Could not find a declaration file for module 'loda... Remove this comment to see the full error message
+import { memoize } from 'lodash'
+
+const fnToMemoize = (
+  displayName: any,
+  componentProps: any,
+  extraArgs: any,
+  componentTheme: any,
+  generateStyle: any,
+  bidirectionalPolyfill: any,
+  dir: any
+) => {
+  return bidirectionalPolyfill(
+    generateStyle(componentTheme, componentProps, extraArgs),
+    dir
+  )
+}
+const memoized = memoize(
+  fnToMemoize,
+  (displayName: any, componentProps: any, extraArgs: any) =>
+    displayName + JSON.stringify(componentProps) + JSON.stringify(extraArgs)
+)
+
+export default memoized

--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -75,7 +75,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant'])
 class Alert extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-avatar/src/Avatar/index.tsx
+++ b/packages/ui-avatar/src/Avatar/index.tsx
@@ -61,7 +61,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size', 'shape', 'src'])
 @testable()
 class Avatar extends Component<Props> {
   static propTypes = {
@@ -123,12 +123,12 @@ class Avatar extends Component<Props> {
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.state)
+    this.props.makeStyles({ loaded: this.state.loaded })
   }
 
   componentDidUpdate() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.state)
+    this.props.makeStyles({ loaded: this.state.loaded })
   }
 
   makeInitialsFromName() {

--- a/packages/ui-avatar/src/Avatar/styles.ts
+++ b/packages/ui-avatar/src/Avatar/styles.ts
@@ -29,11 +29,18 @@
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
+ * @param  {string} props.size
+ * @param  {string} props.shape
+ * @param  {string} props.src
  * @param  {Object} state the state of the component, the style is applied to
+ * @param  {string} state.loaded
  * @return {Object} The final style object, which will be used in the component
  */
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'componentTheme' implicitly has an 'any'... Remove this comment to see the full error message
-const generateStyle = (componentTheme, { size, shape, src }, { loaded }) => {
+const generateStyle = (componentTheme, props, state) => {
+  const { size, shape, src } = props
+  const { loaded } = state
+
   const sizeStyles = {
     auto: {
       fontSize: 'inherit',

--- a/packages/ui-badge/src/Badge/index.tsx
+++ b/packages/ui-badge/src/Badge/index.tsx
@@ -65,7 +65,13 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'type',
+  'variant',
+  'placement',
+  'standalone',
+  'pulse'
+])
 @testable()
 class Badge extends Component<Props> {
   static propTypes = {
@@ -162,13 +168,8 @@ class Badge extends Component<Props> {
   }
 
   renderOutput() {
-    const {
-      count,
-      countUntil,
-      formatOverflowText,
-      formatOutput,
-      type
-    } = this.props
+    const { count, countUntil, formatOverflowText, formatOutput, type } =
+      this.props
 
     // If the badge count is >= than the countUntil limit, format the badge text
     // via the formatOverflowText function prop

--- a/packages/ui-billboard/src/Billboard/index.tsx
+++ b/packages/ui-billboard/src/Billboard/index.tsx
@@ -67,7 +67,14 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'href',
+  'onClick',
+  'disabled',
+  'hero',
+  'heading'
+])
 class Billboard extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
@@ -56,7 +56,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size'])
 @testable()
 class Breadcrumb extends Component<Props> {
   static propTypes = {

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -81,7 +81,15 @@ category: components/utilities
 ---
 **/
 
-@withStyle(generateStyles, generateComponentTheme)
+@withStyle(generateStyles, generateComponentTheme, [
+  'size',
+  'color',
+  'textAlign',
+  'shape',
+  'withBackground',
+  'withBorder',
+  'isCondensed'
+])
 @testable()
 class BaseButton extends Component<Props> {
   static propTypes = {
@@ -216,14 +224,16 @@ class BaseButton extends Component<Props> {
   _rootElement = null
 
   componentDidMount() {
+    const { isDisabled, hasOnlyIconVisible } = this.makeStylesVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ isDisabled, hasOnlyIconVisible })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
+    const { isDisabled, hasOnlyIconVisible } = this.makeStylesVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ isDisabled, hasOnlyIconVisible })
   }
 
   get makeStylesVariables() {

--- a/packages/ui-buttons/src/CloseButton/index.tsx
+++ b/packages/ui-buttons/src/CloseButton/index.tsx
@@ -66,7 +66,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['placement', 'offset'])
 @testable()
 class CloseButton extends Component<Props> {
   static propTypes = {

--- a/packages/ui-byline/src/Byline/index.tsx
+++ b/packages/ui-byline/src/Byline/index.tsx
@@ -55,7 +55,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['alignContent', 'size'])
 class Byline extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-calendar/src/Calendar/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/Day/index.tsx
@@ -63,7 +63,11 @@ parent: Calendar
 id: Calendar.Day
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'sOutsideMonth',
+  'isSelected',
+  'isToday'
+])
 @testable()
 class Day extends Component<Props> {
   static propTypes = {
@@ -142,13 +146,13 @@ class Day extends Component<Props> {
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ isDisabled: this.makeStylesVariables.isDisabled })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ isDisabled: this.makeStylesVariables.isDisabled })
   }
 
   get makeStylesVariables() {

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -64,7 +64,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class Calendar extends Component<Props> {
   static Day = Day

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/index.tsx
@@ -49,7 +49,13 @@ type Props = {
 parent: Checkbox
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'checked',
+  'focused',
+  'hovered',
+  'indeterminate'
+])
 class CheckboxFacade extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/index.tsx
@@ -49,7 +49,12 @@ type Props = {
 parent: Checkbox
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'checked',
+  'focused',
+  'labelPlacement'
+])
 class ToggleFacade extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -75,7 +75,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['inline', 'disabled'])
 @testable()
 class Checkbox extends Component<Props> {
   static propTypes = {

--- a/packages/ui-code-editor/src/CodeEditor/index.tsx
+++ b/packages/ui-code-editor/src/CodeEditor/index.tsx
@@ -67,7 +67,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['attachment'])
 @testable()
 class CodeEditor extends Component<Props> {
   static propTypes = {
@@ -163,15 +163,8 @@ class CodeEditor extends Component<Props> {
   }
 
   render() {
-    const {
-      value,
-      label,
-      attachment,
-      readOnly,
-      onChange,
-      styles,
-      ...rest
-    } = this.props
+    const { value, label, attachment, readOnly, onChange, styles, ...rest } =
+      this.props
 
     return (
       <div css={styles.codeEditor}>

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -87,7 +87,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, null)
+@withStyle(generateStyle, null, [])
 @testable()
 class DateInput extends Component<Props> {
   static Day = Calendar.Day

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -50,7 +50,7 @@ parent: DrawerLayout
 id: DrawerLayout.Content
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['shouldTransition'])
 @testable()
 class DrawerContent extends Component<Props> {
   static locatorAttribute = 'data-drawer-content'

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -77,7 +77,7 @@ parent: DrawerLayout
 id: DrawerLayout.Tray
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['border'])
 @bidirectional()
 @testable()
 class DrawerTray extends Component<Props> {
@@ -208,7 +208,9 @@ class DrawerTray extends Component<Props> {
     portalOpen: false
   }
   componentDidMount() {
-    ;(this.props as any).makeStyles(this.makeStyleProps())
+    ;(this.props as any).makeStyles({
+      placement: this.makeStyleProps().placement
+    })
   }
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevState' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps: any, prevState: any, snapshot: any) {
@@ -217,7 +219,9 @@ class DrawerTray extends Component<Props> {
         transitioning: true
       })
     }
-    ;(this.props as any).makeStyles(this.makeStyleProps())
+    ;(this.props as any).makeStyles({
+      placement: this.makeStyleProps().placement
+    })
   }
   makeStyleProps = () => {
     return {

--- a/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
@@ -58,7 +58,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, null)
+@withStyle(generateStyle, null, [])
 @bidirectional()
 @testable()
 class DrawerLayout extends Component<Props> {

--- a/packages/ui-editable/src/InPlaceEdit/index.tsx
+++ b/packages/ui-editable/src/InPlaceEdit/index.tsx
@@ -58,7 +58,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, null)
+@withStyle(generateStyle, null, [])
 class InPlaceEdit extends Component<Props> {
   static propTypes = {
     /**

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -89,7 +89,7 @@ type State = any
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['height'])
 @testable()
 class FileDrop extends Component<Props, State> {
   static propTypes = {
@@ -240,11 +240,33 @@ class FileDrop extends Component<Props, State> {
     ;(this as any).messagesId = uid('FileDrop-messages')
   }
   componentDidMount() {
-    ;(this.props as any).makeStyles(this.makeStyleProps())
+    const {
+      functionallyDisabled,
+      visuallyDisabled,
+      dragRejected,
+      dragAccepted
+    } = this.makeStyleProps()
+    ;(this.props as any).makeStyles({
+      functionallyDisabled,
+      visuallyDisabled,
+      dragRejected,
+      dragAccepted
+    })
   }
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps: Props, prevState: State, snapshot: any) {
-    ;(this.props as any).makeStyles(this.makeStyleProps())
+    const {
+      functionallyDisabled,
+      visuallyDisabled,
+      dragRejected,
+      dragAccepted
+    } = this.makeStyleProps()
+    ;(this.props as any).makeStyles({
+      functionallyDisabled,
+      visuallyDisabled,
+      dragRejected,
+      dragAccepted
+    })
   }
   makeStyleProps = () => {
     return {
@@ -349,12 +371,8 @@ class FileDrop extends Component<Props, State> {
     return [accepted, rejected]
   }
   handleChange = (e: any) => {
-    const {
-      onDrop,
-      onDropAccepted,
-      onDropRejected,
-      shouldEnablePreview
-    } = this.props
+    const { onDrop, onDropAccepted, onDropRejected, shouldEnablePreview } =
+      this.props
     const fileList = this.getDataTransferItems(e, shouldEnablePreview)
     const [accepted, rejected] = this.parseFiles(fileList)
     e.preventDefault()

--- a/packages/ui-flex/src/Flex/index.tsx
+++ b/packages/ui-flex/src/Flex/index.tsx
@@ -65,7 +65,12 @@ category: components
 ---
 @module Flex
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'justifyItems',
+  'wrap',
+  'direction',
+  'alignItems'
+])
 class Flex extends Component<Props> {
   constructor(props: Props) {
     super(props)

--- a/packages/ui-flex/src/Flex/styles.ts
+++ b/packages/ui-flex/src/Flex/styles.ts
@@ -38,13 +38,13 @@
  */
 // @ts-expect-error ts-migrate(6133) FIXME: 'state' is declared but its value is never read.
 const generateStyle = (componentTheme: any, props: any, state: any) => {
-  const { justifyItems, wrap, direction } = props
+  const { justifyItems, wrap, direction, alignItems: alignItemsProp } = props
 
   // align-items css prop
   // When flex direction is row, 'center' is the most useful default because it
   // vertically aligns Items. For column direction, though, we want 'stretch'.
   const alignItems =
-    props.alignItems ||
+    alignItemsProp ||
     (direction === 'column' || direction === 'column-reverse'
       ? 'stretch'
       : 'center')

--- a/packages/ui-form-field/src/FormFieldGroup/index.tsx
+++ b/packages/ui-form-field/src/FormFieldGroup/index.tsx
@@ -56,7 +56,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['disabled'])
 class FormFieldGroup extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
@@ -103,13 +103,13 @@ class FormFieldGroup extends Component<Props> {
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ invalid: this.makeStylesVariables.invalid })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ invalid: this.makeStylesVariables.invalid })
   }
 
   get makeStylesVariables() {

--- a/packages/ui-form-field/src/FormFieldLabel/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLabel/index.tsx
@@ -54,7 +54,7 @@ example: true
 ```
 
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['children'])
 class FormFieldLabel extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldLayout/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/index.tsx
@@ -65,7 +65,7 @@ type Props = {
 parent: FormField
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, null, ['inline'])
 class FormFieldLayout extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldMessage/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessage/index.tsx
@@ -54,7 +54,7 @@ example: true
 <FormFieldMessage variant="error">Invalid value</FormFieldMessage>
 ```
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant'])
 class FormFieldMessage extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-form-field/src/FormFieldMessages/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessages/index.tsx
@@ -60,7 +60,7 @@ example: true
 ]} />
 ```
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 class FormFieldMessages extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-grid/src/Grid/index.tsx
+++ b/packages/ui-grid/src/Grid/index.tsx
@@ -59,7 +59,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['startAt', 'visualDebug'])
 class Grid extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-grid/src/GridCol/index.tsx
+++ b/packages/ui-grid/src/GridCol/index.tsx
@@ -73,7 +73,18 @@ parent: Grid
 id: Grid.Col
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'vAlign',
+  'textAlign',
+  'rowSpacing',
+  'colSpacing',
+  'isLastRow',
+  'isLastCol',
+  'startAt',
+  'visualDebug',
+  'width',
+  'offset'
+])
 class GridCol extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-grid/src/GridCol/styles.ts
+++ b/packages/ui-grid/src/GridCol/styles.ts
@@ -44,6 +44,7 @@ const generateStyle = (componentTheme, props, state) => {
     startAt,
     visualDebug
   } = props
+  let { width, offset } = props
 
   const rowSpacingVariants = {
     small: { marginBottom: componentTheme.spacingSmall },
@@ -108,8 +109,6 @@ const generateStyle = (componentTheme, props, state) => {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'breakpoint' implicitly has an 'any' typ... Remove this comment to see the full error message
   const getColSize = (breakpoint) => {
-    let { width } = props
-
     if (!width) return
 
     if (width && typeof width === 'object') {
@@ -121,8 +120,6 @@ const generateStyle = (componentTheme, props, state) => {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'breakpoint' implicitly has an 'any' typ... Remove this comment to see the full error message
   const getColOffset = (breakpoint) => {
-    let { offset } = props
-
     if (!offset) return
 
     if (offset && typeof offset === 'object') {

--- a/packages/ui-grid/src/GridRow/index.tsx
+++ b/packages/ui-grid/src/GridRow/index.tsx
@@ -60,7 +60,15 @@ parent: Grid
 id: Grid.Row
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'hAlign',
+  'vAlign',
+  'rowSpacing',
+  'colSpacing',
+  'isLastRow',
+  'startAt',
+  'visualDebug'
+])
 class GridRow extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-heading/src/Heading/index.tsx
+++ b/packages/ui-heading/src/Heading/index.tsx
@@ -56,7 +56,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['level', 'color', 'border'])
 @testable()
 class Heading extends Component<Props> {
   static propTypes = {

--- a/packages/ui-img/src/Img/index.tsx
+++ b/packages/ui-img/src/Img/index.tsx
@@ -60,7 +60,13 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'overlay',
+  'withBlur',
+  'withGrayscale',
+  'src',
+  'constrain'
+])
 @testable()
 class Img extends Component<Props> {
   static propTypes = {
@@ -114,13 +120,15 @@ class Img extends Component<Props> {
   }
 
   componentDidMount() {
+    const { supportsObjectFit, hasBackground } = this.makeStylesVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ supportsObjectFit, hasBackground })
   }
 
   componentDidUpdate() {
+    const { supportsObjectFit, hasBackground } = this.makeStylesVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({ supportsObjectFit, hasBackground })
   }
 
   get makeStylesVariables() {

--- a/packages/ui-link/src/Link/index.tsx
+++ b/packages/ui-link/src/Link/index.tsx
@@ -66,7 +66,12 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'isWithinText',
+  'renderIcon',
+  'iconPlacement',
+  'color'
+])
 @testable()
 class Link extends Component<Props> {
   static propTypes = {
@@ -162,14 +167,16 @@ class Link extends Component<Props> {
   state = { hasFocus: false }
 
   componentDidMount() {
+    const { containsTruncateText, hasVisibleChildren } = this.makeStyleProps()
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ containsTruncateText, hasVisibleChildren })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
+    const { containsTruncateText, hasVisibleChildren } = this.makeStyleProps()
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ containsTruncateText, hasVisibleChildren })
   }
 
   makeStyleProps = () => {

--- a/packages/ui-list/src/List/index.tsx
+++ b/packages/ui-list/src/List/index.tsx
@@ -64,7 +64,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['isUnstyled', 'as'])
 @testable()
 class List extends Component<Props> {
   static propTypes = {

--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -64,7 +64,7 @@ parent: Menu
 id: Menu.Item
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['type', 'disabled'])
 @testable()
 class MenuItem extends Component<Props> {
   static propTypes = {

--- a/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
@@ -68,7 +68,7 @@ parent: Menu
 id: Menu.Group
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class MenuItemGroup extends Component<Props> {
   static propTypes = {

--- a/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
@@ -45,7 +45,7 @@ id: Menu.Separator
 ---
 @module MenuItemSeparator
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class MenuItemSeparator extends Component<Props> {
   static propTypes = {

--- a/packages/ui-metric/src/Metric/index.tsx
+++ b/packages/ui-metric/src/Metric/index.tsx
@@ -46,7 +46,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['textAlign'])
 @testable()
 class Metric extends Component<Props> {
   static propTypes = {
@@ -81,13 +81,8 @@ class Metric extends Component<Props> {
   }
 
   render() {
-    const {
-      textAlign,
-      renderLabel,
-      renderValue,
-      isGroupChild,
-      ...rest
-    } = this.props
+    const { textAlign, renderLabel, renderValue, isGroupChild, ...rest } =
+      this.props
 
     return (
       <div

--- a/packages/ui-metric/src/MetricGroup/index.tsx
+++ b/packages/ui-metric/src/MetricGroup/index.tsx
@@ -43,7 +43,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class MetricGroup extends Component<Props> {
   static propTypes = {

--- a/packages/ui-modal/src/Modal/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/index.tsx
@@ -50,7 +50,7 @@ parent: Modal
 id: Modal.Body
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant'])
 @testable()
 class ModalBody extends Component<Props> {
   static propTypes = {
@@ -88,15 +88,8 @@ class ModalBody extends Component<Props> {
   }
 
   render() {
-    const {
-      as,
-      elementRef,
-      overflow,
-      variant,
-      padding,
-      children,
-      ...rest
-    } = this.props
+    const { as, elementRef, overflow, variant, padding, children, ...rest } =
+      this.props
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'omitViewProps' does not exist on type 't... Remove this comment to see the full error message
     const passthroughProps = View.omitViewProps(

--- a/packages/ui-modal/src/Modal/ModalFooter/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalFooter/index.tsx
@@ -44,7 +44,7 @@ parent: Modal
 id: Modal.Footer
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant'])
 @testable()
 class ModalFooter extends Component<Props> {
   static propTypes = {

--- a/packages/ui-modal/src/Modal/ModalHeader/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalHeader/index.tsx
@@ -49,7 +49,7 @@ parent: Modal
 id: Modal.Header
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant'])
 @testable()
 class ModalHeader extends Component<Props> {
   static propTypes = {
@@ -69,13 +69,17 @@ class ModalHeader extends Component<Props> {
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({
+      withCloseButton: this.makeStyleProps().withCloseButton
+    })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({
+      withCloseButton: this.makeStyleProps().withCloseButton
+    })
   }
 
   makeStyleProps = () => {

--- a/packages/ui-modal/src/Modal/index.tsx
+++ b/packages/ui-modal/src/Modal/index.tsx
@@ -87,7 +87,11 @@ category: components
 tags: overlay, portal, dialog
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'variant',
+  'overflow'
+])
 @testable()
 class Modal extends Component<Props> {
   static propTypes = {

--- a/packages/ui-motion/src/Transition/index.tsx
+++ b/packages/ui-motion/src/Transition/index.tsx
@@ -69,7 +69,7 @@ category: components/utilities
 ---
 @module Transition
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['type'])
 @testable()
 class Transition extends Component<Props> {
   static propTypes = {

--- a/packages/ui-navigation/src/AppNav/index.tsx
+++ b/packages/ui-navigation/src/AppNav/index.tsx
@@ -61,7 +61,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class AppNav extends Component<Props> {
   static propTypes = {

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -75,7 +75,7 @@ category: components
 id: NumberInput
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size'])
 @testable()
 class NumberInput extends Component<Props> {
   static propTypes = {
@@ -233,13 +233,15 @@ class NumberInput extends Component<Props> {
   }
 
   componentDidMount() {
+    const { interaction, hasFocus, invalid } = this.makeStyleVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleVariables)
+    this.props.makeStyles({ interaction, hasFocus, invalid })
   }
 
   componentDidUpdate() {
+    const { interaction, hasFocus, invalid } = this.makeStyleVariables
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleVariables)
+    this.props.makeStyles({ interaction, hasFocus, invalid })
   }
 
   get makeStyleVariables() {

--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -60,7 +60,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyles, generateComponentTheme)
+@withStyle(generateStyles, generateComponentTheme, [])
 @testable()
 class Options extends Component<Props> {
   static propTypes = {

--- a/packages/ui-overlays/src/Mask/index.tsx
+++ b/packages/ui-overlays/src/Mask/index.tsx
@@ -48,7 +48,7 @@ type Props = {
 category: components/utilities
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['placement', 'fullscreen'])
 class Mask extends Component<Props> {
   static propTypes = {
     onDismiss: PropTypes.func,

--- a/packages/ui-pages/src/Pages/index.tsx
+++ b/packages/ui-pages/src/Pages/index.tsx
@@ -58,7 +58,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 class Pages extends Component<Props> {
   static propTypes = {
     children: Children.oneOf([Page]),

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -303,9 +303,9 @@ class Pagination extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'label' implicitly has an 'any' type.
   renderArrowButton(label, direction, currentPageIndex) {
-    // @ts-expect-error ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
     // eslint-disable-next-line react/prop-types
     const { onClick, disabled } =
+      // @ts-expect-error FIXME: Object is possibly 'null' or 'undefined'.
       this.props.children[currentPageIndex + direction].props
 
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -81,7 +81,7 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, null)
+@withStyle(generateStyle, null, [])
 @testable()
 class Pagination extends Component<Props> {
   static propTypes = {
@@ -305,9 +305,8 @@ class Pagination extends Component<Props> {
   renderArrowButton(label, direction, currentPageIndex) {
     // @ts-expect-error ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
     // eslint-disable-next-line react/prop-types
-    const { onClick, disabled } = this.props.children[
-      currentPageIndex + direction
-    ].props
+    const { onClick, disabled } =
+      this.props.children[currentPageIndex + direction].props
 
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
     const handleButtonRef = (el) => {

--- a/packages/ui-pill/src/Pill/index.tsx
+++ b/packages/ui-pill/src/Pill/index.tsx
@@ -51,7 +51,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['color'])
 @testable()
 class Pill extends Component<Props> {
   static propTypes = {

--- a/packages/ui-position/src/Position/index.tsx
+++ b/packages/ui-position/src/Position/index.tsx
@@ -74,7 +74,7 @@ type Props = {
 category: components/utilities
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class Position extends Component<Props> {
   static propTypes = {

--- a/packages/ui-progress/src/ProgressBar/index.tsx
+++ b/packages/ui-progress/src/ProgressBar/index.tsx
@@ -57,7 +57,13 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'valueNow',
+  'valueMax',
+  'size',
+  'color',
+  'meterColor'
+])
 @testable()
 class ProgressBar extends Component<Props> {
   static propTypes = {

--- a/packages/ui-progress/src/ProgressCircle/index.tsx
+++ b/packages/ui-progress/src/ProgressCircle/index.tsx
@@ -60,7 +60,13 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'color',
+  'meterColor',
+  'valueNow',
+  'valueMax'
+])
 @testable()
 class ProgressCircle extends Component<Props> {
   static propTypes = {
@@ -188,13 +194,17 @@ class ProgressCircle extends Component<Props> {
     }
 
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({
+      shouldAnimateOnMount: this.makeStylesVariables.shouldAnimateOnMount
+    })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStylesVariables)
+    this.props.makeStyles({
+      shouldAnimateOnMount: this.makeStylesVariables.shouldAnimateOnMount
+    })
   }
 
   componentWillUnmount() {

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -58,7 +58,13 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'disabled',
+  'variant',
+  'context',
+  'size',
+  'inline'
+])
 @testable()
 class RadioInput extends Component<Props> {
   static propTypes = {

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -64,7 +64,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size'])
 @testable()
 class RangeInput extends Component<Props> {
   static propTypes = {

--- a/packages/ui-rating/src/Rating/index.tsx
+++ b/packages/ui-rating/src/Rating/index.tsx
@@ -52,7 +52,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle)
+@withStyle(generateStyle, null, [])
 @testable()
 class Rating extends Component<Props> {
   static propTypes = {
@@ -146,14 +146,8 @@ class Rating extends Component<Props> {
   }
 
   render() {
-    const {
-      iconCount,
-      animateFill,
-      size,
-      margin,
-      label,
-      formatValueText
-    } = this.props
+    const { iconCount, animateFill, size, margin, label, formatValueText } =
+      this.props
 
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
     const valueText = label + ' ' + formatValueText(this.filled, iconCount)

--- a/packages/ui-rating/src/RatingIcon/index.tsx
+++ b/packages/ui-rating/src/RatingIcon/index.tsx
@@ -49,7 +49,7 @@ parent: Rating
 id: Rating.Icon
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size'])
 class RatingIcon extends Component<Props> {
   static propTypes = {
     animationDelay: PropTypes.number,
@@ -83,7 +83,7 @@ class RatingIcon extends Component<Props> {
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ filled: this.makeStyleProps().filled })
     if (this.props.animateFill) {
       // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'Timeout' is not assignable to pa... Remove this comment to see the full error message
       this._timeouts.push(setTimeout(this.fill, this.props.animationDelay))
@@ -100,7 +100,7 @@ class RatingIcon extends Component<Props> {
       this.fill()
     }
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ filled: this.makeStyleProps().filled })
   }
 
   componentWillUnmount() {

--- a/packages/ui-rating/src/RatingIcon/styles.ts
+++ b/packages/ui-rating/src/RatingIcon/styles.ts
@@ -35,6 +35,7 @@
 // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'componentTheme' implicitly has an 'any'... Remove this comment to see the full error message
 const generateStyle = (componentTheme, props, state) => {
   const { size } = props
+  const { filled } = state
 
   const sizeVariants = {
     small: { fontSize: componentTheme.smallIconFontSize },
@@ -61,7 +62,7 @@ const generateStyle = (componentTheme, props, state) => {
       verticalAlign: 'bottom',
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       ...sizeVariants[size],
-      color: state.filled
+      color: filled
         ? componentTheme.iconFilledColor
         : componentTheme.iconEmptyColor
     }

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -101,7 +101,7 @@ category: components
 tags: autocomplete, typeahead, combobox, dropdown, search, form
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size'])
 @testable()
 class Select extends Component<Props> {
   static propTypes = {
@@ -640,12 +640,8 @@ class Select extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'data' implicitly has an 'any' type.
   renderList(data) {
     const { getListProps, getOptionProps, getDisabledOptionProps } = data
-    const {
-      isShowingOptions,
-      optionsMaxWidth,
-      visibleOptionsCount,
-      children
-    } = this.props
+    const { isShowingOptions, optionsMaxWidth, visibleOptionsCount, children } =
+      this.props
 
     let lastWasGroup = false
     const viewProps = isShowingOptions

--- a/packages/ui-spinner/src/Spinner/index.tsx
+++ b/packages/ui-spinner/src/Spinner/index.tsx
@@ -52,7 +52,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size', 'variant'])
 @testable()
 class Spinner extends Component<Props> {
   static propTypes = {

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -53,7 +53,7 @@ parent: Table
 id: Table.Body
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 class Body extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Cell/index.tsx
+++ b/packages/ui-table/src/Table/Cell/index.tsx
@@ -48,7 +48,7 @@ parent: Table
 id: Table.Cell
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['textAlign'])
 class Cell extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -54,7 +54,10 @@ parent: Table
 id: Table.ColHeader
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'onRequestSort',
+  'textAlign'
+])
 class ColHeader extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {
@@ -136,14 +139,8 @@ class ColHeader extends Component<Props> {
   }
 
   render() {
-    const {
-      onRequestSort,
-      width,
-      children,
-      sortDirection,
-      scope,
-      styles
-    } = this.props
+    const { onRequestSort, width, children, sortDirection, scope, styles } =
+      this.props
 
     return (
       <th

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -58,7 +58,7 @@ parent: Table
 id: Table.Head
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 class Head extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -57,7 +57,7 @@ parent: Table
 id: Table.Row
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['hover', 'isStacked'])
 class Row extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/RowHeader/index.tsx
+++ b/packages/ui-table/src/Table/RowHeader/index.tsx
@@ -47,7 +47,7 @@ parent: Table
 id: Table.RowHeader
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['textAlign'])
 class RowHeader extends Component<Props> {
   /* eslint-disable react/require-default-props */
   static propTypes = {

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -62,7 +62,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['layout'])
 class Table extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props
@@ -147,15 +147,8 @@ class Table extends Component<Props> {
   }
 
   render() {
-    const {
-      margin,
-      elementRef,
-      layout,
-      caption,
-      children,
-      hover,
-      styles
-    } = this.props
+    const { margin, elementRef, layout, caption, children, hover, styles } =
+      this.props
     const isStacked = layout === 'stacked'
     const headers = isStacked ? this.getHeaders() : null
 

--- a/packages/ui-tabs/src/Tabs/Panel/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Panel/index.tsx
@@ -57,7 +57,7 @@ parent: Tabs
 id: Tabs.Panel
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['maxHeight'])
 class Panel extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-tabs/src/Tabs/Tab/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Tab/index.tsx
@@ -53,7 +53,11 @@ parent: Tabs
 id: Tabs.Tab
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'variant',
+  'isSelected',
+  'isDisabled'
+])
 class Tab extends Component<Props> {
   static propTypes = {
     // eslint-disable-next-line react/require-default-props

--- a/packages/ui-tabs/src/Tabs/index.tsx
+++ b/packages/ui-tabs/src/Tabs/index.tsx
@@ -75,7 +75,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['variant', 'tabOverflow'])
 @bidirectional()
 @testable()
 class Tabs extends Component<Props> {

--- a/packages/ui-tag/src/Tag/index.tsx
+++ b/packages/ui-tag/src/Tag/index.tsx
@@ -62,7 +62,13 @@ category: components
 ---
 **/
 
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'variant',
+  'size',
+  'dismissible',
+  'onClick',
+  'disabled'
+])
 @testable()
 class Tag extends Component<Props> {
   static propTypes = {

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -72,7 +72,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['disabled', 'size'])
 @testable()
 class TextArea extends Component<Props> {
   static propTypes = {

--- a/packages/ui-text-input/src/TextInput/index.tsx
+++ b/packages/ui-text-input/src/TextInput/index.tsx
@@ -74,7 +74,7 @@ category: components
 tags: form, field
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, ['size', 'textAlign', 'as'])
 @testable()
 class TextInput extends Component<Props> {
   static propTypes = {
@@ -234,14 +234,16 @@ class TextInput extends Component<Props> {
   }
 
   componentDidMount() {
+    const { disabled, invalid, focused } = this.makeStyleProps()
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ disabled, invalid, focused })
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'prevProps' is declared but its value is never rea... Remove this comment to see the full error message
   componentDidUpdate(prevProps, prevState, snapshot) {
+    const { disabled, invalid, focused } = this.makeStyleProps()
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles(this.makeStyleProps())
+    this.props.makeStyles({ disabled, invalid, focused })
   }
 
   makeStyleProps = () => {

--- a/packages/ui-text/src/Text/index.tsx
+++ b/packages/ui-text/src/Text/index.tsx
@@ -61,7 +61,16 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'size',
+  'wrap',
+  'weight',
+  'fontStyle',
+  'transform',
+  'lineHeight',
+  'letterSpacing',
+  'color'
+])
 class Text extends Component<Props> {
   static propTypes = {
     /**

--- a/packages/ui-toggle-details/src/ToggleDetails/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/index.tsx
@@ -61,7 +61,12 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'fluidWidth',
+  'iconPosition',
+  'size',
+  'variant'
+])
 @testable()
 class ToggleDetails extends Component<Props> {
   static propTypes = {

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -67,7 +67,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 class Tooltip extends Component<Props> {
   static propTypes = {

--- a/packages/ui-tray/src/Tray/index.tsx
+++ b/packages/ui-tray/src/Tray/index.tsx
@@ -76,7 +76,12 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'border',
+  'shadow',
+  'size',
+  'placement'
+])
 @bidirectional()
 @testable()
 class Tray extends Component<Props> {

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
@@ -65,7 +65,13 @@ id: TreeBrowser.Button
 
 // Todo: merge TreeButton and TreeNode: TreeButton should be a special type of TreeNode
 
-@withStyle(generateStyles, generateComponentTheme)
+@withStyle(generateStyles, generateComponentTheme, [
+  'size',
+  'variant',
+  'selected',
+  'focused',
+  'level'
+])
 @testable()
 class TreeButton extends Component<Props> {
   static propTypes = {
@@ -157,12 +163,8 @@ class TreeButton extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.
   renderCollectionIcon() {
-    const {
-      expanded,
-      collectionIcon,
-      collectionIconExpanded,
-      styles
-    } = this.props
+    const { expanded, collectionIcon, collectionIconExpanded, styles } =
+      this.props
 
     if (collectionIcon || collectionIconExpanded) {
       return (

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
@@ -76,7 +76,7 @@ id: TreeBrowser.Collection
 ---
 **/
 
-@withStyle(generateStyles, generateComponentTheme)
+@withStyle(generateStyles, generateComponentTheme, ['size', 'variant'])
 @testable()
 class TreeCollection extends Component<Props> {
   static propTypes = {
@@ -232,13 +232,8 @@ class TreeCollection extends Component<Props> {
   }
 
   renderChildren() {
-    const {
-      collections,
-      items,
-      id,
-      renderBeforeItems,
-      renderAfterItems
-    } = this.props
+    const { collections, items, id, renderBeforeItems, renderAfterItems } =
+      this.props
 
     let position = 1
     return (
@@ -354,13 +349,8 @@ class TreeCollection extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'item' implicitly has an 'any' type.
   renderItemNode(item, position) {
-    const {
-      selection,
-      onItemClick,
-      onKeyDown,
-      getItemProps,
-      styles
-    } = this.props
+    const { selection, onItemClick, onKeyDown, getItemProps, styles } =
+      this.props
 
     const ariaSelected = {}
 

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -71,7 +71,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyles, generateComponentTheme)
+@withStyle(generateStyles, generateComponentTheme, [])
 @testable()
 class TreeBrowser extends Component<Props> {
   static propTypes = {

--- a/packages/ui-truncate-text/src/TruncateText/index.tsx
+++ b/packages/ui-truncate-text/src/TruncateText/index.tsx
@@ -59,7 +59,7 @@ type Props = {
 category: components
 ---
 **/
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [])
 @testable()
 @hack(['shouldTruncateWhenInvisible'])
 class TruncateText extends Component<Props> {

--- a/packages/ui-view/src/View/index.tsx
+++ b/packages/ui-view/src/View/index.tsx
@@ -116,7 +116,34 @@ category: components
 @module View
 **/
 @bidirectional()
-@withStyle(generateStyle, generateComponentTheme)
+@withStyle(generateStyle, generateComponentTheme, [
+  'borderRadius',
+  'borderWidth',
+  'margin',
+  'padding',
+  'position',
+  'display',
+  'focusPosition',
+  'textAlign',
+  'borderColor',
+  'background',
+  'stacking',
+  'shadow',
+  'overflowY',
+  'overflowX',
+  'insetBlockEnd',
+  'insetBlockStart',
+  'insetInlineEnd',
+  'insetInlineStart',
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'withVisualDebug',
+  'dir'
+])
 class View extends Component<Props> {
   static propTypes = {
     /**


### PR DESCRIPTION
(emotion,ui-alerts,ui-avatar,ui-badge,ui-billboard,ui-breadcrumb,ui-buttons,ui-byline,ui-calendar,ui-checkbox,ui-code-editor,ui-date-input,ui-drawer-layout,ui-editable,ui-file-drop,ui-flex,ui-form-field,ui-grid,ui-heading,ui-img,ui-link,ui-list,ui-menu,ui-metric,ui-modal,ui-motion,ui-navigation,ui-number-input,ui-options,ui-overlays,ui-pages,ui-pagination,ui-pill,ui-position,ui-progress,ui-radio-input,ui-range-input,ui-rating,ui-select,ui-spinner,ui-table,ui-tabs,ui-tag,ui-text-area,ui-text-input,ui-text,ui-toggle-details,ui-tooltip,ui-tray,ui-tree-browser,ui-truncate-text,ui-view)
Closes: INSTUI-3121