### PR TITLE
feat(ui-options): add option to recolor the icon of Option.Item

### DIFF
--- a/packages/ui-options/src/Options/Item/__tests__/Item.test.tsx
+++ b/packages/ui-options/src/Options/Item/__tests__/Item.test.tsx
@@ -146,6 +146,51 @@ describe('<Item />', async () => {
     expect(icon).to.exist()
   })
 
+  it('should render colored icon before label', async () => {
+    await mount(
+      <Item
+        renderBeforeLabel={(props) => {
+          return (
+            <IconCheckSolid
+              {...(props.variant === 'default' && { color: 'warning' })}
+            />
+          )
+        }}
+      >
+        Hello World
+      </Item>
+    )
+    const item = await ItemLocator.find()
+    const content = await item.find('[class$=-optionItem__content--before]')
+    const icon = await content.find('svg[name="IconCheck"]')
+    const iconStyle = getComputedStyle(icon.getDOMNode())
+
+    expect(iconStyle.fill).to.equal('rgb(252, 94, 19)')
+  })
+
+  it('should render colored icon after highlighted label', async () => {
+    await mount(
+      <Item
+        variant="highlighted"
+        renderAfterLabel={(props) => {
+          return (
+            <IconCheckSolid
+              {...(props.variant === 'highlighted' && { color: 'success' })}
+            />
+          )
+        }}
+      >
+        Hello World
+      </Item>
+    )
+    const item = await ItemLocator.find()
+    const content = await item.find('[class$=-optionItem__content--after]')
+    const icon = await content.find('svg[name="IconCheck"]')
+    const iconStyle = getComputedStyle(icon.getDOMNode())
+
+    expect(iconStyle.fill).to.equal('rgb(0, 172, 24)')
+  })
+
   it('should render nested lists', async () => {
     await mount(
       <Item>

--- a/packages/ui-options/src/Options/Item/index.tsx
+++ b/packages/ui-options/src/Options/Item/index.tsx
@@ -83,10 +83,12 @@ class Item extends Component<Props> {
     role: PropTypes.string,
     /**
      * Content to render before the label
+     * (if you pass a function, it has the `props` as its parameter)
      */
     renderBeforeLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     /**
      * Content to render after the label
+     * (if you pass a function, it has the `props` as its parameter)
      */
     renderAfterLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
@@ -114,7 +116,7 @@ class Item extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'renderLabel' implicitly has an 'any' ty... Remove this comment to see the full error message
   renderContent(renderLabel, contentVariant) {
-    const { styles } = this.props
+    const { styles, variant, as, role, children } = this.props
 
     return (
       <span
@@ -122,7 +124,12 @@ class Item extends Component<Props> {
         role="presentation"
         aria-hidden="true"
       >
-        {callRenderProp(renderLabel)}
+        {callRenderProp(renderLabel, {
+          variant,
+          as,
+          role,
+          children
+        })}
       </span>
     )
   }

--- a/packages/ui-options/src/Options/README.md
+++ b/packages/ui-options/src/Options/README.md
@@ -167,3 +167,132 @@ render(
   ]} />
 )
 ```
+
+You can recolor the text and the background of the items for their `default`, `highlighted` and `selected` variants.
+
+By default, the icons in the `Option.Item` have the same color as the text. If you want to set the color of the icon separately, pass a function to the `renderBeforeLabel` or `renderAfterLabel` prop. This function will have a `props` parameter, so you can access the properties of that `Option.Item` (e.g. the current `variant`).
+
+```js
+---
+render: false
+example: true
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      highlighted: -1,
+      selected: -1
+    }
+  }
+
+  handleKeyDown = (event) => {
+    const { highlighted } = this.state
+    let index = highlighted
+
+    if (event.keyCode === 40 && highlighted < this.props.options.length - 1) {
+      // down arrow
+      event.preventDefault()
+      index = highlighted + 1
+    } else if (event.keyCode === 38 && highlighted > 0) {
+      // up arrow
+      event.preventDefault()
+      index = highlighted - 1
+    } else if (event.keyCode === 13 && highlighted > -1) {
+      // enter
+      this.setState({ selected: index })
+    }
+    this.setState({ highlighted: index })
+  }
+
+  handleFocus = (event, index) => {
+    this.setState({ highlighted: index })
+  }
+
+  handleMouseOver = (event, index) => {
+    this.setState({ highlighted: index })
+  }
+
+  handleClick = (event, index) => {
+    this.setState({ selected: index })
+  }
+
+  render () {
+    return (
+      <View
+        display="block"
+        width="300px"
+        shadow="above"
+      >
+        <Options onKeyDown={this.handleKeyDown} tabIndex="0">
+          {this.props.options.map((option, index) => {
+            let variant = 'default'
+            if (this.state.highlighted === index) {
+              variant = 'highlighted'
+            } else if (this.state.selected === index) {
+              variant = 'selected'
+            }
+            return (
+              <Options.Item
+                key={option.label}
+                variant={variant}
+                tabIndex="-1"
+                onMouseOver={(e) => this.handleMouseOver(e, index)}
+                onFocus={(e) => this.handleFocus(e, index)}
+                onClick={(e) => this.handleClick(e, index)}
+                {...option.extraProps}
+              >
+                { option.label }
+              </Options.Item>
+            )
+          })}
+        </Options>
+      </View>
+    )
+  }
+}
+
+render(
+  <Example options={[
+    {
+      label: 'Default item',
+      extraProps: {
+        renderBeforeLabel: IconCheckSolid
+      }
+    },
+    {
+      label: 'Text is green',
+      extraProps: {
+        renderBeforeLabel: IconCheckSolid,
+        themeOverride: { color: "#00AC18" }
+      }
+    },
+    {
+      label: 'Highlighted text is black',
+      extraProps: {
+        renderBeforeLabel: IconCheckSolid,
+        themeOverride: { highlightedLabelColor: "#2D3B45" }
+
+      }
+    },
+    {
+      label: 'Highlighted background is purple',
+      extraProps: {
+        renderBeforeLabel: IconCheckSolid,
+        themeOverride: { highlightedBackground: "#BF32A4" }
+      }
+    },
+    {
+      label: 'Only the icon is red',
+      extraProps: {
+        renderBeforeLabel: (props) => {
+          return <IconCheckSolid
+            {...(props.variant === "default" && { color: 'warning' }) }
+          />
+        }
+      }
+    }
+  ]} />
+)
+```

--- a/packages/ui-options/src/Options/README.md
+++ b/packages/ui-options/src/Options/README.md
@@ -170,7 +170,7 @@ render(
 
 You can recolor the text and the background of the items for their `default`, `highlighted` and `selected` variants.
 
-By default, the icons in the `Option.Item` have the same color as the text. If you want to set the color of the icon separately, pass a function to the `renderBeforeLabel` or `renderAfterLabel` prop. This function will have a `props` parameter, so you can access the properties of that `Option.Item` (e.g. the current `variant`).
+By default, the icons in the `Option.Item` have the same color as the text. If you want to set the color of the icon separately, pass a function to the `renderBeforeLabel` or `renderAfterLabel` prop. This function will have a `props` parameter, so you can access the properties of that `Option.Item` (e.g. the current `variant`). The available props are: `[ variant, as, role, children ]`.
 
 ```js
 ---

--- a/packages/ui-select/src/Select/README.md
+++ b/packages/ui-select/src/Select/README.md
@@ -1059,6 +1059,152 @@ render(
 )
 ```
 
+### Icons
+
+To display icons (or other elements) before or after an option, pass it via the `renderBeforeLabel` and `renderAfterLabel` prop to `Select.Option`. You can pass a function as well, which will have a `props` parameter, so you can access the properties of that `Select.Option` (e.g. if it is currently `isHighlighted`). The available props are: `[ id, isDisabled, isSelected, isHighlighted, children ]`.
+
+```javascript
+---
+example: true
+render: false
+---
+class SingleSelectExample extends React.Component {
+  state = {
+    inputValue: this.props.options[0].label,
+    isShowingOptions: false,
+    highlightedOptionId: null,
+    selectedOptionId: this.props.options[0].id,
+    announcement: null
+  }
+
+  getOptionById (queryId) {
+    return this.props.options.find(({ id }) => id === queryId)
+  }
+
+  handleShowOptions = (event) => {
+    this.setState({
+      isShowingOptions: true
+    })
+  }
+
+  handleHideOptions = (event) => {
+    const { selectedOptionId } = this.state
+    const option = this.getOptionById(selectedOptionId).label
+    this.setState({
+      isShowingOptions: false,
+      highlightedOptionId: null,
+      inputValue: selectedOptionId ? option : '',
+      announcement: 'List collapsed.'
+    })
+  }
+
+  handleBlur = (event) => {
+    this.setState({
+      highlightedOptionId: null
+    })
+  }
+
+  handleHighlightOption = (event, { id }) => {
+    event.persist()
+    const optionsAvailable = `${this.props.options.length} options available.`
+    const nowOpen = !this.state.isShowingOptions ? `List expanded. ${optionsAvailable}` : ''
+    const option = this.getOptionById(id).label
+    this.setState((state) => ({
+      highlightedOptionId: id,
+      inputValue: event.type === 'keydown' ? option : state.inputValue,
+      announcement: `${option} ${nowOpen}`
+    }))
+  }
+
+  handleSelectOption = (event, { id }) => {
+    const option = this.getOptionById(id).label
+    this.setState({
+      selectedOptionId: id,
+      inputValue: option,
+      isShowingOptions: false,
+      announcement: `"${option}" selected. List collapsed.`
+    })
+  }
+
+  render () {
+    const {
+      inputValue,
+      isShowingOptions,
+      highlightedOptionId,
+      selectedOptionId,
+      announcement
+    } = this.state
+
+    return (
+      <div>
+        <Select
+          renderLabel="Option Icons"
+          assistiveText="Use arrow keys to navigate options."
+          inputValue={inputValue}
+          isShowingOptions={isShowingOptions}
+          onBlur={this.handleBlur}
+          onRequestShowOptions={this.handleShowOptions}
+          onRequestHideOptions={this.handleHideOptions}
+          onRequestHighlightOption={this.handleHighlightOption}
+          onRequestSelectOption={this.handleSelectOption}
+        >
+          {this.props.options.map((option) => {
+            return (
+              <Select.Option
+                id={option.id}
+                key={option.id}
+                isHighlighted={option.id === highlightedOptionId}
+                isSelected={option.id === selectedOptionId}
+                renderBeforeLabel={option.renderBeforeLabel}
+              >
+                { option.label }
+              </Select.Option>
+            )
+          })}
+        </Select>
+        <Alert
+          liveRegion={() => document.getElementById('flash-messages')}
+          liveRegionPoliteness="assertive"
+          screenReaderOnly
+        >
+          { announcement }
+        </Alert>
+      </div>
+    )
+  }
+}
+
+render(
+  <View>
+    <SingleSelectExample
+      options={[
+        {
+          id: 'opt1',
+          label: 'Text',
+          renderBeforeLabel: 'XY'
+        },
+        {
+          id: 'opt2',
+          label: 'Icon',
+          renderBeforeLabel: <IconCheckSolid />
+        },
+        {
+          id: 'opt3',
+          label: 'Colored Icon',
+          renderBeforeLabel: (props) => {
+            let color = 'brand'
+            if (props.isHighlighted) color = 'primary-inverse'
+            if (props.isSelected) color = 'primary'
+            if (props.isDisabled) color = 'warning'
+            return <IconInstructureSolid color={color} />
+          }
+        }
+      ]}
+    />
+  </View>
+)
+```
+
 #### Providing assistive text for screen readers
 
 It's important to ensure screen reader users receive instruction and feedback while interacting with a `Select`, but screen reader support for the `combobox` role varies. The `assistiveText` prop should always be used to explain how a keyboard user can make a selection. Additionally, a live region should be updated with feedback as the component is interacted with, such as when options are filtered or highlighted. Using an [Alert](#Alert) with the `screenReaderOnly` prop is the easiest way to do this.

--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -31,6 +31,7 @@ import {
   generateA11yTests
 } from '@instructure/ui-test-utils'
 
+import { IconCheckSolid } from '@instructure/ui-icons'
 import { Select } from '../index'
 import { SelectLocator } from '../SelectLocator'
 import SelectExamples from '../__examples__/Select.examples'
@@ -437,6 +438,44 @@ describe('<Select />', async () => {
       const listbox = await list.find('ul[role="listbox"]')
 
       expect(listRef).to.have.been.calledWith(listbox.getDOMNode())
+    })
+
+    it('should render dynamically colored icons before option', async () => {
+      const renderBeforeLabel = (props: any) => {
+        return (
+          <IconCheckSolid color={props.isHighlighted ? 'warning' : 'brand'} />
+        )
+      }
+
+      await mount(
+        <Select renderLabel="Choose an option" isShowingOptions>
+          <Select.Option
+            id="0"
+            isHighlighted
+            renderBeforeLabel={renderBeforeLabel}
+          >
+            ungrouped option one
+          </Select.Option>
+          <Select.Option id="1" renderBeforeLabel={renderBeforeLabel}>
+            grouped option one
+          </Select.Option>
+        </Select>
+      )
+      const select = await SelectLocator.find()
+      const input = await select.findInput()
+
+      await input.click()
+
+      const list = await select.findOptionsList()
+      const listbox = await list.find('ul[role="listbox"]')
+      const itemIcons = await listbox.findAll('li [role="presentation"] svg')
+
+      expect(getComputedStyle(itemIcons[0].getDOMNode()).fill).to.equal(
+        'rgb(252, 94, 19)'
+      )
+      expect(getComputedStyle(itemIcons[1].getDOMNode()).fill).to.equal(
+        'rgb(0, 142, 226)'
+      )
     })
   })
 

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -560,6 +560,18 @@ class Select extends Component<Props> {
       children
     } = option.props
 
+    const getRenderLabel = (renderLabel: any) => {
+      return typeof renderLabel === 'function'
+        ? renderLabel.bind(null, {
+            id,
+            isDisabled,
+            isSelected,
+            isHighlighted,
+            children
+          })
+        : renderLabel
+    }
+
     let optionProps = {
       // passthrough props
       ...omitProps(option.props, {
@@ -569,8 +581,8 @@ class Select extends Component<Props> {
       // props from selectable
       ...getOptionProps({ id }),
       // Options.Item props
-      renderBeforeLabel,
-      renderAfterLabel
+      renderBeforeLabel: getRenderLabel(renderBeforeLabel),
+      renderAfterLabel: getRenderLabel(renderAfterLabel)
     }
     // should option be treated as highlighted or selected
     if (isSelected) {

--- a/packages/ui-simple-select/package.json
+++ b/packages/ui-simple-select/package.json
@@ -39,7 +39,8 @@
     "@instructure/ui-babel-preset": "8.5.0",
     "@instructure/ui-color-utils": "8.5.0",
     "@instructure/ui-test-locator": "8.5.0",
-    "@instructure/ui-test-utils": "8.5.0"
+    "@instructure/ui-test-utils": "8.5.0",
+    "@instructure/ui-icons": "8.5.0"
   },
   "peerDependencies": {
     "react": "^16.8"

--- a/packages/ui-simple-select/src/SimpleSelect/README.md
+++ b/packages/ui-simple-select/src/SimpleSelect/README.md
@@ -5,6 +5,7 @@ describes: SimpleSelect
 `SimpleSelect` is a higher level abstraction of [Select](#Select) that closely parallels the functionality of standard HTML `<select>` elements. It does not support autocomplete behavior and is much less configurable than [Select](#Select). However, because it is more opinionated, `SimpleSelect` can be implemented with very little boilerplate.
 
 ### Uncontrolled
+
 For the most basic implementations, `SimpleSelect` can be uncontrolled. If desired, the `defaultValue` prop can be used to set the initial selection.
 
 ```javascript
@@ -13,7 +14,11 @@ example: true
 render: true
 ---
 <SimpleSelect renderLabel="Uncontrolled Select">
-  <SimpleSelect.Option id="foo" value="foo">
+  <SimpleSelect.Option id="foo" value="foo"
+                       renderBeforeLabel={(props) => {
+                         console.log(props)
+                         return <IconCheckSolid />
+                       }}>
     Foo
   </SimpleSelect.Option>
   <SimpleSelect.Option id="bar" value="bar">
@@ -26,6 +31,7 @@ render: true
 ```
 
 ### Controlled
+
 To use `SimpleSelect` controlled, simply provide the `value` prop the string that corresponds to the selected option's `value` prop. The `onChange` callback can be used to update the value stored in state.
 
 ```javascript
@@ -89,6 +95,7 @@ render(
 ```
 
 ### Groups
+
 Like a HTML `<select>` element, `SimpleSelect` supports option groups. `SimpleSelect.Group` only requires the `renderLabel` prop be provided.
 
 ```javascript
@@ -113,5 +120,45 @@ render: true
       Option four
     </SimpleSelect.Option>
   </SimpleSelect.Group>
+</SimpleSelect>
+```
+
+### Icons
+
+To display icons (or other elements) before or after an option, pass it via the `renderBeforeLabel` and `renderAfterLabel` prop to `SimpleSelect.Option`. You can pass a function as well, which will have a `props` parameter, so you can access the properties of that `SimpleSelect.Option` (e.g. if it is currently `isHighlighted`). The available props are: `[ id, isDisabled, isSelected, isHighlighted, children ]` (same as for `Select.Option`).
+
+```javascript
+---
+example: true
+render: true
+---
+<SimpleSelect renderLabel="Option Icons">
+  <SimpleSelect.Option
+    id="text"
+    value="text"
+    renderBeforeLabel={'XY'}
+  >
+    Text
+  </SimpleSelect.Option>
+  <SimpleSelect.Option
+    id="icon"
+    value="icon"
+    renderBeforeLabel={<IconCheckSolid />}
+  >
+    Icon
+  </SimpleSelect.Option>
+  <SimpleSelect.Option
+    id="coloredIcon"
+    value="coloredIcon"
+    renderBeforeLabel={(props) => {
+      let color = 'brand'
+      if (props.isHighlighted) color = 'primary-inverse'
+      if (props.isSelected) color = 'primary'
+      if (props.isDisabled) color = 'warning'
+      return <IconInstructureSolid color={color} />
+    }}
+  >
+    Colored Icon
+  </SimpleSelect.Option>
 </SimpleSelect>
 ```

--- a/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
@@ -31,6 +31,7 @@ import {
   generateA11yTests
 } from '@instructure/ui-test-utils'
 
+import { IconCheckSolid } from '@instructure/ui-icons'
 import { SimpleSelect } from '../index'
 import { SimpleSelectLocator } from '../SimpleSelectLocator'
 import SimpleSelectExamples from '../__examples__/SimpleSelect.examples'
@@ -329,6 +330,47 @@ describe('<SimpleSelect />', async () => {
 
       expect(inputRef).to.have.been.calledWith(input.getDOMNode())
     })
+  })
+
+  it('should render dynamically colored icons before option', async () => {
+    const renderBeforeLabel = (props: any) => {
+      return <IconCheckSolid color={props.isDisabled ? 'warning' : 'brand'} />
+    }
+
+    await mount(
+      <SimpleSelect renderLabel="Choose an option">
+        <SimpleSelect.Option
+          id="0"
+          value="0"
+          isDisabled
+          renderBeforeLabel={renderBeforeLabel}
+        >
+          ungrouped option one
+        </SimpleSelect.Option>
+        <SimpleSelect.Option
+          id="1"
+          value="1"
+          renderBeforeLabel={renderBeforeLabel}
+        >
+          grouped option one
+        </SimpleSelect.Option>
+      </SimpleSelect>
+    )
+    const select = await SimpleSelectLocator.find()
+    const input = await select.findInput()
+
+    await input.click()
+
+    const list = await select.findOptionsList()
+    const listbox = await list.find('ul[role="listbox"]')
+    const itemIcons = await listbox.findAll('li [role="presentation"] svg')
+
+    expect(getComputedStyle(itemIcons[0].getDOMNode()).fill).to.equal(
+      'rgb(252, 94, 19)'
+    )
+    expect(getComputedStyle(itemIcons[1].getDOMNode()).fill).to.equal(
+      'rgb(0, 142, 226)'
+    )
   })
 
   describe('list', async () => {

--- a/packages/ui-simple-select/src/SimpleSelect/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/index.tsx
@@ -507,6 +507,25 @@ class SimpleSelect extends Component<Props> {
       renderAfterLabel,
       ...rest
     } = option.props
+
+    const isDisabled = option.props.isDisabled
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'highlightedOptionId' does not exist on t... Remove this comment to see the full error message
+    const isSelected = id === this.state.selectedOptionId
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'highlightedOptionId' does not exist on t... Remove this comment to see the full error message
+    const isHighlighted = id === this.state.highlightedOptionId
+
+    const getRenderLabel = (renderLabel: any) => {
+      return typeof renderLabel === 'function'
+        ? renderLabel.bind(null, {
+            id,
+            isDisabled,
+            isSelected,
+            isHighlighted,
+            children
+          })
+        : renderLabel
+    }
+
     return (
       <Select.Option
         id={id}
@@ -518,8 +537,8 @@ class SimpleSelect extends Component<Props> {
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'selectedOptionId' does not exist on type... Remove this comment to see the full error message
         isSelected={id === this.state.selectedOptionId}
         isDisabled={option.props.isDisabled}
-        renderBeforeLabel={renderBeforeLabel}
-        renderAfterLabel={renderAfterLabel}
+        renderBeforeLabel={getRenderLabel(renderBeforeLabel)}
+        renderAfterLabel={getRenderLabel(renderAfterLabel)}
         {...passthroughProps(rest)}
       >
         {children}


### PR DESCRIPTION
Closes: INSTUI-2903

If a function is passed to `renderBeforeLabel` or `renderAfterLabel` prop, the function will have a
`props` parameter. This way the the properties of that `Option.Item` (e.g. the current `variant`) is
accessible in the render function, and can be used to set different colors to that icon for
different option state (variant).