### PR TITLE
V7: fix(ui-popover): inverse color Popover without arrow shouldn't have light border

### DIFF
--- a/packages/ui-popover/src/Popover/index.js
+++ b/packages/ui-popover/src/Popover/index.js
@@ -787,7 +787,8 @@ class Popover extends Component {
         viewProps = {
           ...viewProps,
           borderWidth: 'small',
-          borderRadius: 'medium'
+          borderRadius: 'medium',
+          ...(color === 'primary-inverse' && { borderColor: 'transparent' })
         }
       }
 


### PR DESCRIPTION
Closes: INSTUI-3156