### PR TITLE
fix(ui-popover): recalculate offset and position on prop change

### DIFF
--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -466,6 +466,18 @@ class Popover extends Component<Props> {
         this._focusRegion.deactivate()
       }
     }
+
+    // if the props the state is based on change,
+    // we need to recalculate the offset and placement
+    if (
+      this.props.offsetX !== prevProps.offsetX ||
+      this.props.offsetY !== prevProps.offsetY ||
+      this.props.placement !== prevProps.placement
+    ) {
+      this.setState({
+        ...this.computeOffsets(this.placement)
+      })
+    }
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'placement' implicitly has an 'any' type... Remove this comment to see the full error message

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -467,8 +467,9 @@ class Popover extends Component<Props> {
       }
     }
 
-    // if the props the state is based on change,
-    // we need to recalculate the offset and placement
+    // since `offsetX`, `offsetY` and `placement` are saved into the state
+    // in the constructor and used from the state later,
+    // we need to update the state if these props change
     if (
       this.props.offsetX !== prevProps.offsetX ||
       this.props.offsetY !== prevProps.offsetY ||


### PR DESCRIPTION
Closes: INSTUI-3157

The 3 props, `offsetX`, `offsetY` and `placement` were used from the state, and didn't update if any
of these 3 props changed (e.g. when set from the `Responsive` component). They only updated if the
position of the `Popover` changed, now it updates and recalculates correctly on prop change as well.