### PR TITLE
Fix emotion examples

### DIFF
--- a/packages/__docs__/components.js
+++ b/packages/__docs__/components.js
@@ -117,3 +117,4 @@ export { Figure } from './src/Figure'
 // eslint-disable-next-line no-restricted-imports
 export { ToggleBlockquote } from './src/ToggleBlockquote'
 export { EmotionThemeProvider } from '@instructure/emotion'
+export { canvas, canvasHighContrast, instructure } from '@instructure/ui-themes'

--- a/packages/emotion/src/EmotionThemeProvider/README.md
+++ b/packages/emotion/src/EmotionThemeProvider/README.md
@@ -50,17 +50,19 @@ ReactDOM.render(
 ---
 example: true
 ---
-<div>
-  <Heading level="h3" margin="small small medium">I should have default font family.</Heading>
+<EmotionThemeProvider theme={canvas}>
+  <div>
+    <Heading level="h3" margin="small small medium">I should have default font family.</Heading>
 
-  <EmotionThemeProvider
-    theme={{
-      typography: { fontFamily: 'monospace' }
-    }}
-  >
-    <Heading level="h3" margin="small small">I should have monospace font family.</Heading>
-  </EmotionThemeProvider>
-</div>
+    <EmotionThemeProvider
+      theme={{
+        typography: { fontFamily: 'monospace' }
+      }}
+    >
+      <Heading level="h3" margin="small small">I should have monospace font family.</Heading>
+    </EmotionThemeProvider>
+  </div>
+</EmotionThemeProvider>
 ```
 
 ### Theme overrides
@@ -71,7 +73,8 @@ In case you are using multiple themes in your app, you can target a specific the
 ---
   example: true
 ---
-<div>
+<EmotionThemeProvider theme={canvas}>
+  <div>
   <Alert variant="info" margin="small">
     I am a default style Alert.
   </Alert>
@@ -101,6 +104,7 @@ In case you are using multiple themes in your app, you can target a specific the
     </Alert>
   </EmotionThemeProvider>
 </div>
+</EmotionThemeProvider>
 ```
 
 ### Global component theme overrides
@@ -118,6 +122,7 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
 ---
   example: true
 ---
+<EmotionThemeProvider theme={canvas}>
   <div>
     <Alert variant="info" margin="small">
       I am a default style Alert.
@@ -178,4 +183,5 @@ The `componentOverrides` can also be nested inside `themeOverrides`.
       </div>
     </EmotionThemeProvider>
   </div>
+</EmotionThemeProvider>
 ```


### PR DESCRIPTION
Import our themes for the docs app so it can be used in example codes
Wrap EmotionThemeProvider examples `<EmotionThemeProvider>` tags, so its clear that they are needed and users can easily edit the code to change its values.
This makes the whole page more clear, helping with issues like https://github.com/instructure/instructure-ui/issues/612