### PR TITLE
docs: add warning stripe on legacy doc pages

### DIFF
--- a/packages/__docs__/src/App/index.js
+++ b/packages/__docs__/src/App/index.js
@@ -42,6 +42,7 @@ import { Mask } from '@instructure/ui-overlays'
 import { Pill } from '@instructure/ui-pill'
 import { IconButton } from '@instructure/ui-buttons'
 import { Tray } from '@instructure/ui-tray'
+import { Link } from '@instructure/ui-link'
 import { addMediaQueryMatchListener } from '@instructure/ui-responsive'
 import {
   IconHamburgerSolid,
@@ -60,6 +61,8 @@ import { Select } from '../Select'
 import { Section } from '../Section'
 import { Icons } from '../Icons'
 import { compileMarkdown } from '../compileMarkdown'
+
+import { fetchVersionData, versionInPath } from '../versionData'
 
 import generateStyle from './styles'
 import generateComponentTheme from './theme'
@@ -143,17 +146,10 @@ class App extends Component {
         console.error('Unable to load docs data :(\n' + error)
       })
   }
+
   fetchVersionData = async () => {
-    // eslint-disable-next-line compat/compat
-    const isLocalHost = window.location.hostname === 'localhost'
-
-    if (!isLocalHost) {
-      // eslint-disable-next-line compat/compat
-      const result = await fetch(`${window.location.origin}/versions.json`)
-      const versionsData = await result.json()
-
-      return this.setState({ versionsData })
-    }
+    const versionsData = await fetchVersionData()
+    return this.setState({ versionsData })
   }
 
   /**
@@ -641,6 +637,51 @@ class App extends Component {
     )
   }
 
+  renderLegacyDocWarning() {
+    const { versionsData } = this.state
+
+    if (!versionsData) {
+      return null
+    }
+
+    // tf there is a version in the path, e.g. "/v6", then it is a legacy page
+    return versionInPath ? (
+      <div css={this.props.styles.legacyVersionAlert}>
+        <EmotionThemeProvider
+          theme={{
+            componentOverrides: {
+              BaseButton: {
+                secondaryGhostColor: 'white'
+              }
+            }
+          }}
+        >
+          <Alert
+            variant="warning"
+            transition="none"
+            margin="none"
+            renderCloseButtonLabel="Close"
+            themeOverride={{
+              background: '#BF32A4',
+              color: 'white',
+              borderRadius: '0rem',
+              warningBorderColor: '#BF32A4',
+              warningIconBackground: '#BF32A4',
+              boxShadow: 'none'
+            }}
+          >
+            You are currently viewing the documentation of an older version of
+            Instructure UI. For the latest version,{' '}
+            <Link color="link-inverse" href={`/${window.location.hash}`}>
+              click here
+            </Link>
+            .
+          </Alert>
+        </EmotionThemeProvider>
+      </div>
+    ) : null
+  }
+
   render() {
     const key = this.state.key
     const { showMenu, layout, docsData } = this.state
@@ -685,6 +726,7 @@ class App extends Component {
             {this.renderFooter()}
           </div>
         </div>
+        {this.renderLegacyDocWarning()}
       </AppContext.Provider>
     )
   }

--- a/packages/__docs__/src/App/styles.js
+++ b/packages/__docs__/src/App/styles.js
@@ -40,7 +40,10 @@ const generateStyle = (componentTheme, props, state) => {
       height: '100%',
       overflow: 'hidden',
       boxSizing: 'border-box',
-      display: 'flex'
+      display: 'flex',
+      position: 'relative',
+      flexShrink: 1,
+      flexGrow: 1
     },
     content: {
       label: 'app__content',
@@ -48,6 +51,11 @@ const generateStyle = (componentTheme, props, state) => {
       overflowY: 'auto',
       overflowX: 'hidden',
       width: '100%'
+    },
+    legacyVersionAlert: {
+      label: 'app__legacyVersionAlert',
+      flexShrink: 0,
+      flexGrow: 0
     },
     hamburger: {
       label: 'app__hamburger',
@@ -60,7 +68,7 @@ const generateStyle = (componentTheme, props, state) => {
       label: 'app__inlineNavigation',
       overflowY: 'auto',
       overflowX: 'hidden',
-      minHeight: '100vh',
+      minHeight: '100%',
       flexShrink: 0,
       borderInlineEndColor: componentTheme.navBorderColor,
       borderInlineEndWidth: componentTheme.navBorderWidth,

--- a/packages/__docs__/src/Header/index.js
+++ b/packages/__docs__/src/Header/index.js
@@ -34,6 +34,8 @@ import { IconMiniArrowDownLine } from '@instructure/ui-icons'
 import { Menu } from '@instructure/ui-menu'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 
+import { versionInPath } from '../versionData'
+
 import { Heading } from '../Heading'
 
 class Header extends Component {
@@ -55,9 +57,7 @@ class Header extends Component {
     const { versionsData } = this.props
     const { latestVersion } = versionsData
     const isSelectedLatestVersion = selectedVersion === latestVersion
-    const pathNameParts = window.location.pathname.split('/').filter(Boolean)
-    const [versionInPath] = pathNameParts
-    const isOnLatestVersion = pathNameParts.length === 0
+    const isOnLatestVersion = !versionInPath
 
     // Example scenarios:
     // 1: instructure.design, latest: v8, selected: v8 -> navigate to instructure.design/#index
@@ -82,8 +82,6 @@ class Header extends Component {
     const { versionsData } = this.props
     const { latestVersion, previousVersions } = versionsData
     const allVersions = [latestVersion, ...previousVersions]
-
-    const [versionInPath] = window.location.pathname.split('/').filter(Boolean)
 
     const currentVersion = versionInPath || latestVersion
 

--- a/packages/__docs__/src/index.html
+++ b/packages/__docs__/src/index.html
@@ -48,6 +48,8 @@
 
       #app {
         height: 100%;
+        display: flex;
+        flex-direction: column;
       }
 
       /* CSS for the loading animation */

--- a/packages/__docs__/src/versionData.js
+++ b/packages/__docs__/src/versionData.js
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Fetches version data from versions.json
+ * Returns null or an object:
+ * {
+ *   latestVersion: string, (e.g.: 'v8')
+ *   previousVersions: string[] (e.g.: ['v7', 'v6'])
+ * }
+ * @returns {Promise<null|object>}
+ */
+const fetchVersionData = async () => {
+  // eslint-disable-next-line compat/compat
+  const isLocalHost = window.location.hostname === 'localhost'
+
+  if (!isLocalHost) {
+    // eslint-disable-next-line compat/compat
+    const result = await fetch(`${window.location.origin}/versions.json`)
+    const versionsData = await result.json()
+
+    return versionsData
+  }
+
+  return null
+}
+
+/**
+ * if we are on the docs page of a legacy version,
+ * the path includes the version number, e.g. `/v7` or `/v8`
+ */
+const [versionInPath] = window.location.pathname.split('/').filter(Boolean)
+
+export default fetchVersionData
+export { fetchVersionData, versionInPath }


### PR DESCRIPTION
Closes: INSTUI-3148

If someone is viewing the docs page of a legacy version, we want to display a warning on the bottom of
the page.