### PR TITLE
Fix rare race condition in mkdirSync code

### DIFF
--- a/packages/__docs__/buildScripts/build-docs.js
+++ b/packages/__docs__/buildScripts/build-docs.js
@@ -152,9 +152,7 @@ globby(files, { ignore })
     props.showMenu = options.showMenu ? 'true' : 'false'
     const everything = JSON.stringify(props)
     const buildDir = './__build__/'
-    if (!fs.existsSync(buildDir)) {
-      fs.mkdirSync(buildDir)
-    }
+    fs.mkdirSync(buildDir, { recursive: true })
     fs.writeFileSync(buildDir + DOCS_DATA_JSON, everything)
     // eslint-disable-next-line no-console
     console.log('Finished building documentation data')

--- a/packages/ui-scripts/bin/specify-commonjs-format.js
+++ b/packages/ui-scripts/bin/specify-commonjs-format.js
@@ -26,9 +26,8 @@
 
 const fs = require('fs')
 
-if (!fs.existsSync('lib')) {
-  fs.mkdirSync('lib')
-}
+// create if does not exist https://stackoverflow.com/a/24311711
+fs.mkdirSync('lib', { recursive: true })
 
 if (!fs.existsSync('lib/package.json')) {
   fs.writeFileSync('lib/package.json', '{"type":"commonjs"}\n', 'utf8')

--- a/packages/ui-template-scripts/lib/handlers/handleCreateFromTemplate.js
+++ b/packages/ui-template-scripts/lib/handlers/handleCreateFromTemplate.js
@@ -123,9 +123,7 @@ module.exports = async ({
 
 function copyFilesFromDependency(dependencyId, destPath, destFolder) {
   const fullDestPath = path.join(destPath, destFolder)
-  if (!fs.existsSync(fullDestPath)) {
-    fs.mkdirSync(fullDestPath)
-  }
+  fs.mkdirSync(fullDestPath, { recursive: true })
   // path to index.js in the dependency
   const dependencyPath = require.resolve(dependencyId)
   fse.copySync(path.dirname(dependencyPath), fullDestPath)


### PR DESCRIPTION
Fixes errors during build like:

```
@instructure/ui-form-field: [] internal/fs/utils.js:308
@instructure/ui-form-field: []     throw err;
@instructure/ui-form-field: []     ^
@instructure/ui-form-field: [] 
@instructure/ui-form-field: [] Error: EEXIST: file already exists, mkdir 'lib'
@instructure/ui-form-field: []     at Object.mkdirSync (fs.js:987:3)
@instructure/ui-form-field: []     at Object.<anonymous> (/instructure-ui/packages/ui-scripts/bin/specify-commonjs-format.js:30:6)
@instructure/ui-form-field: []     at Module._compile (internal/modules/cjs/loader.js:1063:30)
```