### PR TITLE
fix(ui-options): add aria-hidden to Options label span

### DIFF
--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -126,7 +126,12 @@ class Options extends Component<Props> {
   renderLabel() {
     const { renderLabel, styles } = this.props
     return (
-      <span id={this._labelId} role="presentation" css={styles.label}>
+      <span
+        id={this._labelId}
+        role="presentation"
+        aria-hidden="true"
+        css={styles.label}
+      >
         {callRenderProp(renderLabel)}
       </span>
     )


### PR DESCRIPTION
Closes: INSTUI-3203

Fixes the bug where `Select.Group` labels counted as "groups" when VoiceOver announced select groups
(e.g. 2 groups counted as 4), even if you couldn't select t..