### PR TITLE
fix(ui-options): add aria-hidden to Options label span

### DIFF
--- a/packages/ui-options/src/Options/index.js
+++ b/packages/ui-options/src/Options/index.js
@@ -99,6 +99,7 @@ class Options extends Component {
       <span
         id={this._labelId}
         role="presentation"
+        aria-hidden="true"
         className={classnames({
           [styles.label]: true
         })}


### PR DESCRIPTION
Closes: INSTUI-3204

Fixes the bug where `Select.Group` labels counted as "groups" when VoiceOver announced select groups
(e.g. 2 groups counted as 4), even if you couldn't select it.