### PR TITLE
fix(ui-billboard): fix heading margin when `size` is `small`

### DIFF
--- a/packages/ui-billboard/src/Billboard/styles.ts
+++ b/packages/ui-billboard/src/Billboard/styles.ts
@@ -43,7 +43,7 @@ const generateStyle = (componentTheme, props, state) => {
       billboard: { padding: componentTheme.paddingSmall },
       hero: { fontSize: '3rem' },
       message: { fontSize: componentTheme.messageFontSizeSmall },
-      heading: { ...(hero && { margin: `${componentTheme.largeMargin} 0 0` }) }
+      heading: { ...(hero && { margin: `${componentTheme.mediumMargin} 0 0` }) }
     },
     medium: {
       billboard: { padding: componentTheme.paddingMedium },


### PR DESCRIPTION
Changed margin-top for heading when `size` property is set to `small`. Now it's
`componentTheme.mediumMargin` instead of `componentTheme.largeMargin`
TEST PLAN:
Open documentation for the Billboard component. Check that margin is correct in the example with
`size` set to `small`