### PR TITLE
INSTUI-3216 Clean up defaultprops in all components

### DIFF
--- a/packages/ui-a11y-content/src/AccessibleContent/__tests__/AccessibleContent.test.tsx
+++ b/packages/ui-a11y-content/src/AccessibleContent/__tests__/AccessibleContent.test.tsx
@@ -53,7 +53,7 @@ describe('<AccessibleContent />', async () => {
   })
 
   it('should render with the specified tag when `as` prop is set', async () => {
-    const subject = await mount(<AccessibleContent as="div" />)
+    const subject = await mount(<AccessibleContent as="div" alt="abc" />)
     const accessibleContent = within(subject.getDOMNode())
 
     expect(accessibleContent).to.have.tagName('div')

--- a/packages/ui-a11y-content/src/AccessibleContent/index.tsx
+++ b/packages/ui-a11y-content/src/AccessibleContent/index.tsx
@@ -33,12 +33,12 @@ import { PresentationContent } from '../PresentationContent'
 import { ScreenReaderContent } from '../ScreenReaderContent'
 
 type OwnProps = {
-  alt?: string
+  alt: string
   /**
    * the element type to render the screen reader content as
    */
   as: AsElementType
-  children: ReactNode
+  children?: ReactNode
 }
 
 type Props = OwnProps & OtherHTMLAttributes<OwnProps>
@@ -52,15 +52,13 @@ category: components/utilities
 **/
 class AccessibleContent extends Component<Props> {
   static propTypes = {
-    alt: PropTypes.string,
+    alt: PropTypes.string.isRequired,
     as: PropTypes.elementType,
     children: PropTypes.node
   }
 
   static defaultProps = {
-    alt: undefined,
-    as: 'span',
-    children: null
+    as: 'span'
   }
 
   render() {

--- a/packages/ui-a11y-content/src/PresentationContent/index.tsx
+++ b/packages/ui-a11y-content/src/PresentationContent/index.tsx
@@ -34,7 +34,7 @@ type OwnProps = {
    * the element type to render as
    */
   as: AsElementType
-  children: ReactNode
+  children?: ReactNode
 }
 
 type Props = OwnProps & OtherHTMLAttributes<OwnProps>
@@ -53,8 +53,7 @@ class PresentationContent extends Component<Props> {
   }
 
   static defaultProps = {
-    as: 'span',
-    children: null
+    as: 'span'
   }
 
   render() {

--- a/packages/ui-a11y-content/src/ScreenReaderContent/index.tsx
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/index.tsx
@@ -44,7 +44,7 @@ type OwnProps = {
   /**
    * content meant for screen readers only
    */
-  children: ReactNode
+  children?: ReactNode
 }
 
 type Props = OwnProps & OtherHTMLAttributes<OwnProps>
@@ -70,8 +70,7 @@ class ScreenReaderContent extends Component<Props> {
   }
 
   static defaultProps = {
-    as: 'span',
-    children: null
+    as: 'span'
   }
 
   componentDidMount() {

--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -153,10 +153,6 @@ class Alert extends Component<Props> {
     screenReaderOnly: false,
     liveRegionPoliteness: 'assertive',
     isLiveRegionAtomic: false,
-    onDismiss: undefined,
-    liveRegion: undefined,
-    renderCloseButtonLabel: undefined,
-    children: null,
     hasShadow: true
   }
 

--- a/packages/ui-avatar/src/Avatar/index.tsx
+++ b/packages/ui-avatar/src/Avatar/index.tsx
@@ -56,7 +56,7 @@ type Props = {
    * Accessible label
    */
   alt?: string
-  size:
+  size?:
     | 'auto'
     | 'xx-small'
     | 'x-small'
@@ -65,7 +65,7 @@ type Props = {
     | 'large'
     | 'x-large'
     | 'xx-large'
-  color:
+  color?:
     | 'default' // = brand
     | 'shamrock'
     | 'barney'
@@ -73,8 +73,8 @@ type Props = {
     | 'fire'
     | 'licorice'
     | 'ash'
-  shape: 'circle' | 'rectangle'
-  display: 'inline-block' | 'block'
+  shape?: 'circle' | 'rectangle'
+  display?: 'inline-block' | 'block'
   /**
    * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
    * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
@@ -84,7 +84,7 @@ type Props = {
   /**
    * Callback fired when the avatar image has loaded
    */
-  onImageLoaded: (event: SyntheticEvent) => void
+  onImageLoaded?: (event: SyntheticEvent) => void
   /**
    * The element type to render as
    */
@@ -142,15 +142,10 @@ class Avatar extends Component<Props> {
   }
 
   static defaultProps = {
-    src: undefined,
-    alt: undefined,
-    margin: undefined,
-    elementRef: undefined,
     size: 'medium',
     color: 'default',
     shape: 'circle',
-    display: 'inline-block',
-    onImageLoaded: (_event: SyntheticEvent) => {}
+    display: 'inline-block'
   }
 
   state = { loaded: false }
@@ -186,7 +181,7 @@ class Avatar extends Component<Props> {
 
   handleImageLoaded = (event: SyntheticEvent) => {
     this.setState({ loaded: true })
-    this.props.onImageLoaded(event)
+    this.props.onImageLoaded?.(event)
   }
 
   renderInitials() {
@@ -198,7 +193,7 @@ class Avatar extends Component<Props> {
   }
 
   render() {
-    const { onImageLoaded, styles, ...props } = this.props
+    const { styles, ...props } = this.props
 
     return (
       <View

--- a/packages/ui-badge/src/Badge/index.tsx
+++ b/packages/ui-badge/src/Badge/index.tsx
@@ -59,8 +59,8 @@ type Props = {
   formatOverflowText?: (...args: any[]) => any
   formatOutput?: (...args: any[]) => any
   as?: AsElementType
-  margin: Spacing
-  placement: PlacementPropValues
+  margin?: Spacing
+  placement?: PlacementPropValues
 }
 
 /**
@@ -68,7 +68,6 @@ type Props = {
 category: components
 ---
 **/
-
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Badge extends Component<Props> {
@@ -123,17 +122,11 @@ class Badge extends Component<Props> {
   }
 
   static defaultProps = {
-    count: undefined,
-    children: null,
-    countUntil: undefined,
-    margin: undefined,
-    formatOutput: undefined,
     standalone: false,
     type: 'count',
     variant: 'primary',
     pulse: false,
     placement: 'top end',
-    elementRef: () => {},
     formatOverflowText: (_count: number, countUntil: number) =>
       `${countUntil - 1} +`
   }

--- a/packages/ui-billboard/src/Billboard/index.tsx
+++ b/packages/ui-billboard/src/Billboard/index.tsx
@@ -138,19 +138,12 @@ class Billboard extends Component<Props> {
   }
 
   static defaultProps = {
-    margin: undefined,
     disabled: false,
     readOnly: false,
-    href: undefined,
-    message: undefined,
-    onClick: undefined,
-    heading: undefined,
-    hero: undefined,
     size: 'medium',
     headingAs: 'span',
     headingLevel: 'h1',
-    as: 'span',
-    elementRef: () => {}
+    as: 'span'
   }
 
   componentDidMount() {

--- a/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/index.tsx
@@ -87,9 +87,7 @@ class Breadcrumb extends Component<Props> {
   }
 
   static defaultProps = {
-    size: 'medium',
-    children: null,
-    margin: undefined
+    size: 'medium'
   }
 
   componentDidMount() {

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -57,6 +57,7 @@ type Props = {
   size?: 'small' | 'medium' | 'large'
   elementRef?: (...args: any[]) => any
   as?: AsElementType
+  // interaction is by default undefined so that `disabled` and `readOnly` can also be supplied
   interaction?: InteractionType
   color?: 'primary' | 'primary-inverse' | 'secondary' | 'success' | 'danger'
   focusColor?: 'info' | 'inverse'
@@ -189,16 +190,12 @@ class BaseButton extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     type: 'button',
     size: 'medium',
     // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
     elementRef: (el) => {},
     as: 'button',
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     color: 'secondary',
-    focusColor: undefined,
     shape: 'rectangle',
     display: 'inline-block',
     textAlign: 'start',
@@ -206,13 +203,7 @@ class BaseButton extends Component<Props> {
     withBorder: true,
     isCondensed: false,
     margin: '0',
-    cursor: 'pointer',
-    href: undefined,
-    onClick: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyDown: (event) => {},
-    renderIcon: undefined,
-    tabIndex: undefined
+    cursor: 'pointer'
   }
 
   _rootElement = null
@@ -317,8 +308,7 @@ class BaseButton extends Component<Props> {
     const { onClick, onKeyDown, href } = this.props
     const { interaction } = this
 
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onKeyDown(event)
+    onKeyDown?.(event)
 
     // behave like a button when space key is pressed
     const { space, enter } = keycode.codes

--- a/packages/ui-buttons/src/Button/index.tsx
+++ b/packages/ui-buttons/src/Button/index.tsx
@@ -136,23 +136,15 @@ class Button extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     type: 'button',
     size: 'medium',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     as: 'button',
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     color: 'secondary',
-    focusColor: undefined,
     display: 'inline-block',
     textAlign: 'center',
     withBackground: true,
     margin: '0',
-    cursor: 'pointer',
-    href: undefined,
-    renderIcon: undefined
+    cursor: 'pointer'
   }
 
   _buttonComponent = null
@@ -170,9 +162,7 @@ class Button extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
   handleElementRef = (el) => {
     const { elementRef } = this.props
-
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    elementRef(el)
+    elementRef?.(el)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'component' implicitly has an 'any' type... Remove this comment to see the full error message

--- a/packages/ui-buttons/src/CloseButton/index.tsx
+++ b/packages/ui-buttons/src/CloseButton/index.tsx
@@ -142,24 +142,13 @@ class CloseButton extends Component<Props> {
   }
 
   static defaultProps = {
-    screenReaderLabel: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClick: (event) => {},
-    elementRef: undefined,
-    color: undefined,
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
-    disabled: undefined,
-    readOnly: undefined,
     type: 'button',
     placement: 'static',
     offset: 'x-small',
     size: 'small',
     margin: '0',
     as: 'button',
-    href: undefined,
-    cursor: 'pointer',
-    tabIndex: undefined
+    cursor: 'pointer'
   }
 
   componentDidMount() {

--- a/packages/ui-buttons/src/CondensedButton/index.tsx
+++ b/packages/ui-buttons/src/CondensedButton/index.tsx
@@ -109,19 +109,12 @@ class CondensedButton extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     type: 'button',
     size: 'medium',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     as: 'button',
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     color: 'primary',
     margin: '0',
-    cursor: 'pointer',
-    href: undefined,
-    renderIcon: undefined
+    cursor: 'pointer'
   }
 
   _baseButton = null

--- a/packages/ui-buttons/src/IconButton/index.tsx
+++ b/packages/ui-buttons/src/IconButton/index.tsx
@@ -195,6 +195,7 @@ class IconButton extends Component<Props> {
         {...passthroughProps(props)}
         type={type}
         size={size}
+        elementRef={elementRef}
         as={as}
         interaction={interaction}
         color={color}

--- a/packages/ui-buttons/src/IconButton/index.tsx
+++ b/packages/ui-buttons/src/IconButton/index.tsx
@@ -142,23 +142,15 @@ class IconButton extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    renderIcon: undefined,
     type: 'button',
     size: 'medium',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     as: 'button',
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     color: 'secondary',
-    focusColor: undefined,
     shape: 'rectangle',
     withBackground: true,
     withBorder: true,
     margin: '0',
-    cursor: 'pointer',
-    href: undefined
+    cursor: 'pointer'
   }
 
   _baseButton = null
@@ -203,7 +195,6 @@ class IconButton extends Component<Props> {
         {...passthroughProps(props)}
         type={type}
         size={size}
-        elementRef={elementRef}
         as={as}
         interaction={interaction}
         color={color}

--- a/packages/ui-buttons/src/ToggleButton/index.tsx
+++ b/packages/ui-buttons/src/ToggleButton/index.tsx
@@ -132,15 +132,9 @@ class ToggleButton extends Component<Props> {
   static defaultProps = {
     size: 'medium',
     as: 'button',
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
-    renderIcon: () => {},
-    onClick: () => {},
-    mountNode: null,
+    renderIcon: () => {}, // TODO check if its OK if this line is removed
+    onClick: () => {}, // TODO check if its OK if this line is removed
     color: 'secondary',
-    isShowingTooltip: undefined,
     placement: 'top center',
     constrain: 'window'
   }

--- a/packages/ui-byline/src/Byline/index.tsx
+++ b/packages/ui-byline/src/Byline/index.tsx
@@ -91,12 +91,7 @@ class Byline extends Component<Props> {
   }
 
   static defaultProps = {
-    alignContent: 'center',
-    elementRef: undefined,
-    margin: undefined,
-    title: undefined,
-    size: undefined,
-    description: undefined
+    alignContent: 'center'
   }
 
   componentDidMount() {

--- a/packages/ui-calendar/src/Calendar/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/Day/index.tsx
@@ -134,12 +134,7 @@ class Day extends Component<Props> {
     interaction: 'enabled',
     isSelected: false,
     isToday: false,
-    isOutsideMonth: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
-    onClick: undefined,
-    onKeyDown: undefined,
-    children: null
+    isOutsideMonth: false
   }
 
   componentDidMount() {
@@ -192,8 +187,7 @@ class Day extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
   handleElementRef = (el) => {
     const { elementRef } = this.props
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    elementRef(el)
+    elementRef?.(el)
   }
 
   render() {

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -145,12 +145,8 @@ class Calendar extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    renderNextMonthButton: undefined,
-    renderPrevMonthButton: undefined,
-    renderNavigationLabel: undefined,
-    onRequestRenderNextMonth: () => {},
-    onRequestRenderPrevMonth: () => {},
+    onRequestRenderNextMonth: () => {}, // TODO check if its OK if this is removed
+    onRequestRenderPrevMonth: () => {}, // TODO check if its OK if this is removed
     as: 'span',
     role: 'table'
   }

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -139,17 +139,6 @@ class Checkbox extends Component<Props> {
     inline: false,
     indeterminate: false,
     readOnly: false,
-    onChange: undefined,
-    onKeyDown: undefined,
-    onFocus: undefined,
-    onBlur: undefined,
-    onMouseOut: undefined,
-    onMouseOver: undefined,
-    checked: undefined,
-    defaultChecked: undefined,
-    messages: undefined,
-    id: undefined,
-    value: undefined,
     labelPlacement: 'end'
   }
 

--- a/packages/ui-code-editor/src/CodeEditor/index.tsx
+++ b/packages/ui-code-editor/src/CodeEditor/index.tsx
@@ -107,10 +107,7 @@ class CodeEditor extends Component<Props> {
     readOnly: false,
     options: {
       styleActiveLine: true
-    },
-    onChange: () => {},
-    attachment: undefined,
-    value: undefined
+    }
   }
 
   // @ts-expect-error ts-migrate(6133) FIXME: 'props' is declared but its value is never read.
@@ -190,8 +187,7 @@ class CodeEditor extends Component<Props> {
             value={value}
             // @ts-expect-error ts-migrate(6133) FIXME: 'editor' is declared but its value is never read.
             onBeforeChange={(editor, data, value) => {
-              // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-              onChange(value)
+              onChange?.(value)
             }}
             ref={(el) => {
               // @ts-expect-error ts-migrate(2339) FIXME: Property 'codeMirror' does not exist on type 'Code... Remove this comment to see the full error message

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -62,6 +62,7 @@ type Props = {
   placeholder?: string
   onChange?: (...args: any[]) => any
   onBlur?: (...args: any[]) => any
+  // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
   interaction?: 'enabled' | 'disabled' | 'readonly'
   isRequired?: boolean
   isInline?: boolean
@@ -266,39 +267,13 @@ class DateInput extends Component<Props> {
     size: 'medium',
     placeholder: null,
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
+    onBlur: (event) => {}, // TODO check if its OK if this line is removed
     isRequired: false,
     isInline: false,
-    assistiveText: undefined,
     layout: 'stacked',
     width: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    inputRef: (el) => {},
-    messages: undefined,
     placement: 'bottom center',
-    isShowingCalendar: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestValidateDate: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestShowCalendar: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestHideCalendar: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestSelectNextDay: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestSelectPrevDay: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestRenderNextMonth: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestRenderPrevMonth: (event) => {},
-    renderNavigationLabel: null,
-    renderNextMonthButton: null,
-    renderPrevMonthButton: null,
-    children: null
+    isShowingCalendar: false
   }
 
   componentDidMount() {
@@ -353,15 +328,13 @@ class DateInput extends Component<Props> {
     }
 
     this._input = el
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    inputRef(el)
+    inputRef?.(el)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleInputChange = (event, value) => {
     const { onChange } = this.props
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onChange(event, { value })
+    onChange?.(event, { value })
     this.handleShowCalendar(event)
   }
 
@@ -371,18 +344,15 @@ class DateInput extends Component<Props> {
     const { interaction } = this
 
     if (interaction === 'enabled') {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      onRequestShowCalendar(event)
+      onRequestShowCalendar?.(event)
     }
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleHideCalendar = (event) => {
     const { onRequestHideCalendar, onRequestValidateDate } = this.props
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onRequestValidateDate(event)
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onRequestHideCalendar(event)
+    onRequestValidateDate?.(event)
+    onRequestHideCalendar?.(event)
   }
 
   handleHighlightOption = (
@@ -390,10 +360,8 @@ class DateInput extends Component<Props> {
     { direction }: { direction?: number }
   ) => {
     const { onRequestSelectNextDay, onRequestSelectPrevDay } = this.props
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    if (direction === -1) onRequestSelectPrevDay(event)
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    if (direction === 1) onRequestSelectNextDay(event)
+    if (direction === -1) onRequestSelectPrevDay?.(event)
+    if (direction === 1) onRequestSelectNextDay?.(event)
   }
 
   renderMonthNavigationButton(type = 'prev') {

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -128,22 +128,12 @@ class Dialog extends Component<Props & OtherHTMLAttributes<Props>> {
   }
 
   static defaultProps = {
-    children: null,
-    display: undefined,
-    label: undefined,
     open: false,
     shouldFocusOnOpen: true,
     shouldContainFocus: false,
     shouldReturnFocus: false,
     shouldCloseOnDocumentClick: true,
-    shouldCloseOnEscape: true,
-    defaultFocusElement: null,
-    contentElement: null,
-    liveRegion: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onDismiss: (event) => {}
+    shouldCloseOnEscape: true
   }
 
   _timeouts: ReturnType<typeof setTimeout>[] = []

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -73,7 +73,11 @@ class DrawerContent extends Component<Props> {
   }
 
   static defaultProps = {
-    role: 'region'
+    role: 'region',
+    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
+    contentRef: (el: any) => {}, // TODO if this is set to undefined _content is never set
+    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
+    onSizeChange: (node: any) => {} // TODO this should not need a default value
   }
 
   state = {
@@ -92,15 +96,14 @@ class DrawerContent extends Component<Props> {
       width: rect.width
     }
     // set initial size
-    if (this.props.onSizeChange) {
-      this.props.onSizeChange({ width: rect.width, height: rect.height })
-      // listen for changes to size
-      // @ts-expect-error ts-migrate(2322) FIXME: Type 'Function' is not assignable to type 'null'.
-      this._debounced = debounce(this.props.onSizeChange, 100, {
-        leading: false,
-        trailing: true
-      })
-    }
+    // @ts-expect-error ts-migrate(2322) FIXME: Type 'onSizeChange' is possibly undefined
+    this.props.onSizeChange({ width: rect.width, height: rect.height })
+    // listen for changes to size
+    // @ts-expect-error ts-migrate(2322) FIXME: Type 'Function' is not assignable to type 'null'.
+    this._debounced = debounce(this.props.onSizeChange, 100, {
+      leading: false,
+      trailing: true
+    })
 
     // @ts-expect-error ts-migrate(2322) FIXME: Type 'ResizeObserver' is not assignable to type 'n... Remove this comment to see the full error message
     this._resizeListener = new ResizeObserver((entries) => {

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -73,11 +73,6 @@ class DrawerContent extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    contentRef: (el: any) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    onSizeChange: (node: any) => {},
     role: 'region'
   }
 
@@ -97,14 +92,16 @@ class DrawerContent extends Component<Props> {
       width: rect.width
     }
     // set initial size
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefined'.
-    this.props.onSizeChange({ width: rect.width, height: rect.height })
-    // listen for changes to size
-    // @ts-expect-error ts-migrate(2322) FIXME: Type 'Function' is not assignable to type 'null'.
-    this._debounced = debounce(this.props.onSizeChange, 100, {
-      leading: false,
-      trailing: true
-    })
+    if (this.props.onSizeChange) {
+      this.props.onSizeChange({ width: rect.width, height: rect.height })
+      // listen for changes to size
+      // @ts-expect-error ts-migrate(2322) FIXME: Type 'Function' is not assignable to type 'null'.
+      this._debounced = debounce(this.props.onSizeChange, 100, {
+        leading: false,
+        trailing: true
+      })
+    }
+
     // @ts-expect-error ts-migrate(2322) FIXME: Type 'ResizeObserver' is not assignable to type 'n... Remove this comment to see the full error message
     this._resizeListener = new ResizeObserver((entries) => {
       for (const entry of entries) {

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -180,37 +180,26 @@ class DrawerTray extends Component<Props & BidirectionalProps> {
     dir: PropTypes.oneOf(Object.values(bidirectional.DIRECTION))
   }
   static defaultProps = {
-    children: null,
-    render: undefined,
     shouldContainFocus: true,
     shouldCloseOnEscape: true,
     shouldCloseOnDocumentClick: true,
     shouldReturnFocus: true,
     open: false,
-    onOpen: () => {},
+    onOpen: () => {}, // TODO check if its OK if this line is removed
     shadow: true,
     border: true,
     placement: 'start',
-    mountNode: null,
-    onEnter: () => {},
-    onEntering: () => {},
-    onEntered: () => {},
-    onExit: () => {},
-    onExiting: () => {},
-    onExited: () => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    contentRef: (node: any) => {},
-    onClose: undefined,
-    onDismiss: undefined,
-    defaultFocusElement: undefined,
-    liveRegion: undefined,
-    onTransition: undefined
+    onEntered: () => {}, // TODO check if its OK if this line is removed
+    onExited: () => {} // TODO check if its OK if this line is removed
   }
+
   state = {
     transitioning: false,
     portalOpen: false
   }
+
   _DOMNode?: PortalNode = null
+
   componentDidMount() {
     ;(this.props as any).makeStyles(this.makeStyleProps())
   }

--- a/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/index.tsx
@@ -88,10 +88,7 @@ class DrawerLayout extends Component<Props & BidirectionalProps> {
   }
 
   static defaultProps = {
-    children: null,
-    minWidth: '30rem',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'shouldOverlayTray' is declared but its value is n... Remove this comment to see the full error message
-    onOverlayTrayChange: (shouldOverlayTray) => {}
+    minWidth: '30rem'
   }
 
   static Content = DrawerContent

--- a/packages/ui-editable/src/Editable/index.tsx
+++ b/packages/ui-editable/src/Editable/index.tsx
@@ -87,11 +87,7 @@ class Editable extends Component<Props> {
   }
 
   static defaultProps = {
-    readOnly: false,
-    onChange: undefined,
-    value: undefined,
-    render: undefined,
-    children: null
+    readOnly: false
   }
 
   state = {

--- a/packages/ui-editable/src/InPlaceEdit/index.tsx
+++ b/packages/ui-editable/src/InPlaceEdit/index.tsx
@@ -144,9 +144,7 @@ class InPlaceEdit extends Component<Props> {
     readOnly: false,
     showFocusRing: true,
     inline: true,
-    value: undefined,
-    editButtonPlacement: 'end',
-    onChange: undefined
+    editButtonPlacement: 'end'
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.

--- a/packages/ui-eslint-config/lib/index.js
+++ b/packages/ui-eslint-config/lib/index.js
@@ -50,7 +50,6 @@ module.exports = {
     'react/no-deprecated': 0,
     'react/no-find-dom-node': 0,
     'react/prop-types': ['error', { skipUndeclared: true }],
-    'react/require-default-props': 'error',
     'react/no-typos': 'error',
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-unused-vars': [

--- a/packages/ui-expandable/src/Expandable/index.tsx
+++ b/packages/ui-expandable/src/Expandable/index.tsx
@@ -64,7 +64,7 @@ type ExpandableProps = {
    */
   defaultExpanded: boolean
 
-  onToggle: (event: Event, expanded: boolean) => void
+  onToggle?: (event: Event, expanded: boolean) => void
 
   /**
    * @param {Object} renderProps
@@ -97,11 +97,7 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
   }
 
   static defaultProps = {
-    defaultExpanded: false,
-    onToggle: function () {},
-    expanded: undefined,
-    children: null,
-    render: undefined
+    defaultExpanded: false
   }
 
   _contentId: string
@@ -148,7 +144,7 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
     if (!this.isControlled()) {
       this.setState(toggleExpanded)
     }
-    this.props.onToggle(event, !this.expanded)
+    this.props.onToggle?.(event, !this.expanded)
   }
 
   render() {

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -80,6 +80,7 @@ type Props = {
   shouldAllowRepeats?: boolean
   maxSize?: number
   minSize?: number
+  // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
   interaction?: 'enabled' | 'disabled' | 'readonly'
   display?: 'block' | 'inline-block'
   height?: string | number
@@ -212,38 +213,16 @@ class FileDrop extends Component<Props, State> {
     // eslint-disable-next-line react/require-default-props
     styles: PropTypes.object
   }
+
   static defaultProps = {
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onClick: function (e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'accepted' is declared but its value is never read... Remove this comment to see the full error message
-    onDrop: function (accepted: any, rejected: any, e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'accepted' is declared but its value is never read... Remove this comment to see the full error message
-    onDropAccepted: function (accepted: any, e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'rejected' is declared but its value is never read... Remove this comment to see the full error message
-    onDropRejected: function (rejected: any, e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onDragEnter: function (e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onDragOver: function (e: any) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onDragLeave: function (e: any) {},
     shouldEnablePreview: false,
     shouldAllowMultiple: false,
     shouldAllowRepeats: true,
     maxSize: Infinity,
     minSize: 0,
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
-    messages: [],
-    id: undefined,
-    accept: undefined,
-    display: 'block',
-    height: undefined,
-    width: undefined,
-    minWidth: undefined,
-    maxWidth: undefined,
-    margin: undefined
+    display: 'block'
   }
+
   constructor(props: Props) {
     super(props)
     // @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'null'.
@@ -265,30 +244,32 @@ class FileDrop extends Component<Props, State> {
       dragAccepted: this.state.isDragAccepted
     }
   }
+
   state = {
     isDragAccepted: false,
     isDragRejected: false,
     isFocused: false,
     isFileBrowserDisplayed: false
   }
+
   enterCounter = 0
   fileInputEl = null
   defaultId = null
   get functionallyDisabled() {
     return this.interaction === 'disabled' || this.interaction === 'readonly'
   }
+
   get hasMessages() {
-    return (
-      (this.props as any).messages && (this.props as any).messages.length > 0
-    )
+    return this.props.messages && this.props.messages.length > 0
   }
+
   get interaction() {
     return getInteraction({ props: this.props })
   }
   get invalid() {
     return (
       this.hasMessages &&
-      (this.props as any).messages.findIndex((message: any) => {
+      this.props.messages!.findIndex((message: any) => {
         return message.type === 'error'
       }) >= 0
     )
@@ -319,7 +300,7 @@ class FileDrop extends Component<Props, State> {
       isDragAccepted: allFilesAccepted,
       isDragRejected: !allFilesAccepted
     })
-    ;(this.props as any).onDragEnter(e)
+    this.props.onDragEnter?.(e)
   }
   handleDragOver = (e: any) => {
     e.preventDefault()
@@ -330,7 +311,7 @@ class FileDrop extends Component<Props, State> {
     } catch (err) {
       // continue regardless of error
     }
-    ;(this.props as any).onDragOver(e)
+    this.props.onDragOver?.(e)
     return false
   }
   handleDragLeave = (e: any) => {
@@ -344,7 +325,7 @@ class FileDrop extends Component<Props, State> {
       isDragAccepted: false,
       isDragRejected: false
     })
-    ;(this.props as any).onDragLeave(e)
+    this.props.onDragLeave?.(e)
   }
   parseFiles(fileList: any) {
     const accepted: any = []
@@ -369,15 +350,12 @@ class FileDrop extends Component<Props, State> {
     const [accepted, rejected] = this.parseFiles(fileList)
     e.preventDefault()
     this.enterCounter = 0
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefined'.
-    onDrop(accepted, rejected, e)
+    onDrop?.(accepted, rejected, e)
     if (rejected.length > 0) {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefined'.
-      onDropRejected(rejected, e)
+      onDropRejected?.(rejected, e)
     }
     if (accepted.length > 0) {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefined'.
-      onDropAccepted(accepted, e)
+      onDropAccepted?.(accepted, e)
     }
     this.setState({
       isDragAccepted: false,
@@ -433,7 +411,7 @@ class FileDrop extends Component<Props, State> {
     // focus the input (because FF won't)
     // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
     this.fileInputEl.focus()
-    ;(this.props as any).onClick(e)
+    this.props.onClick?.(e)
     this.setState({
       isFileBrowserDisplayed: true
     })
@@ -536,7 +514,7 @@ class FileDrop extends Component<Props, State> {
             <FormFieldMessages
               // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
               id={(this as any).messagesId}
-              messages={(this.props as any).messages}
+              messages={this.props.messages}
             />
           </View>
         ) : null}

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -220,6 +220,7 @@ class FileDrop extends Component<Props, State> {
     shouldAllowRepeats: true,
     maxSize: Infinity,
     minSize: 0,
+    messages: [],
     display: 'block'
   }
 

--- a/packages/ui-flex/src/Flex/Item/index.tsx
+++ b/packages/ui-flex/src/Flex/Item/index.tsx
@@ -147,8 +147,6 @@ class Item extends Component<Props> {
 
   static defaultProps = {
     as: 'span',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el: any) => {},
     shouldGrow: false,
     shouldShrink: false
   }

--- a/packages/ui-flex/src/Flex/index.tsx
+++ b/packages/ui-flex/src/Flex/index.tsx
@@ -171,21 +171,12 @@ class Flex extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     as: 'span',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el: any) => {},
     direction: 'row',
     justifyItems: 'start',
     display: 'flex',
     withVisualDebug: false,
-    wrap: 'no-wrap',
-    width: undefined,
-    height: undefined,
-    padding: undefined,
-    margin: undefined,
-    alignItems: undefined,
-    textAlign: undefined
+    wrap: 'no-wrap'
   }
 
   renderChildren(children: any) {

--- a/packages/ui-focusable/src/Focusable/index.tsx
+++ b/packages/ui-focusable/src/Focusable/index.tsx
@@ -57,11 +57,6 @@ class Focusable extends Component<Props> {
     render: PropTypes.func
   }
 
-  static defaultProps = {
-    children: null,
-    render: undefined
-  }
-
   static inputTypes = {
     text: true,
     search: true,
@@ -80,8 +75,10 @@ class Focusable extends Component<Props> {
 
   _focusListener: { remove(): void } | null = null
   _blurListener: { remove(): void } | null = null
-  _inputModeListener: { isKeyboardMode(): boolean; remove(): void } | null =
-    null
+  _inputModeListener: {
+    isKeyboardMode(): boolean
+    remove(): void
+  } | null = null
 
   state = {
     focused: false,

--- a/packages/ui-form-field/src/FormField/index.tsx
+++ b/packages/ui-form-field/src/FormField/index.tsx
@@ -78,12 +78,7 @@ class FormField extends Component<Props> {
     inline: false,
     layout: 'stacked',
     labelAlign: 'end',
-    vAlign: 'middle',
-    messages: undefined,
-    messagesId: undefined,
-    children: null,
-    width: undefined,
-    inputContainerRef: undefined
+    vAlign: 'middle'
   }
 
   render() {

--- a/packages/ui-form-field/src/FormFieldGroup/index.tsx
+++ b/packages/ui-form-field/src/FormFieldGroup/index.tsx
@@ -92,11 +92,6 @@ class FormFieldGroup extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    layout: undefined,
-    startAt: undefined,
-    messages: undefined,
-    messagesId: undefined,
     as: 'fieldset',
     disabled: false,
     rowSpacing: 'medium',

--- a/packages/ui-form-field/src/FormFieldLayout/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/index.tsx
@@ -104,16 +104,10 @@ class FormFieldLayout extends Component<Props> {
   }
 
   static defaultProps = {
-    id: undefined,
-    width: undefined,
-    messages: undefined,
-    messagesId: undefined,
-    children: null,
     inline: false,
     layout: 'stacked',
     as: 'label',
-    labelAlign: 'end',
-    inputContainerRef: undefined
+    labelAlign: 'end'
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.

--- a/packages/ui-form-field/src/FormFieldMessage/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessage/index.tsx
@@ -69,8 +69,7 @@ class FormFieldMessage extends Component<Props> {
   }
 
   static defaultProps = {
-    variant: 'hint',
-    children: null
+    variant: 'hint'
   }
 
   componentDidMount() {

--- a/packages/ui-form-field/src/FormFieldMessages/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessages/index.tsx
@@ -78,10 +78,6 @@ class FormFieldMessages extends Component<Props> {
     messages: PropTypes.arrayOf(FormPropTypes.message)
   }
 
-  static defaultProps = {
-    messages: undefined
-  }
-
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
     this.props.makeStyles()

--- a/packages/ui-grid/src/Grid/index.tsx
+++ b/packages/ui-grid/src/Grid/index.tsx
@@ -89,8 +89,7 @@ class Grid extends Component<Props> {
     hAlign: 'start',
     startAt: 'small',
     vAlign: 'top',
-    visualDebug: false,
-    children: null
+    visualDebug: false
   }
 
   static Row = GridRow

--- a/packages/ui-grid/src/GridCol/index.tsx
+++ b/packages/ui-grid/src/GridCol/index.tsx
@@ -123,10 +123,8 @@ class GridCol extends Component<Props> {
 
   static defaultProps = {
     textAlign: 'inherit',
-    children: null,
     isLastCol: false,
-    isLastRow: false,
-    elementRef: undefined
+    isLastRow: false
   }
 
   componentDidMount() {

--- a/packages/ui-grid/src/GridRow/index.tsx
+++ b/packages/ui-grid/src/GridRow/index.tsx
@@ -88,7 +88,6 @@ class GridRow extends Component<Props> {
   /* eslint-enable react/require-default-props */
 
   static defaultProps = {
-    children: null,
     isLastRow: false
   }
 

--- a/packages/ui-heading/src/Heading/index.tsx
+++ b/packages/ui-heading/src/Heading/index.tsx
@@ -114,9 +114,6 @@ class Heading extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    margin: undefined,
-    elementRef: undefined,
     border: 'none',
     color: 'inherit',
     level: 'h2'

--- a/packages/ui-i18n/src/ApplyLocale/index.tsx
+++ b/packages/ui-i18n/src/ApplyLocale/index.tsx
@@ -47,10 +47,4 @@ export const ApplyLocale = ({ children, locale, timezone }: Props) => {
   )
 }
 
-ApplyLocale.defaultProps = {
-  locale: undefined,
-  timezone: undefined,
-  children: undefined
-}
-
 export default ApplyLocale

--- a/packages/ui-i18n/src/ApplyTextDirection/index.tsx
+++ b/packages/ui-i18n/src/ApplyTextDirection/index.tsx
@@ -59,9 +59,7 @@ const ApplyTextDirection = (props: ApplyTextDirectionProps) => {
 }
 
 ApplyTextDirection.defaultProps = {
-  dir: undefined,
-  as: 'span',
-  children: null
+  as: 'span'
 }
 
 ApplyTextDirection.DIRECTION = DIRECTION

--- a/packages/ui-img/src/Img/index.tsx
+++ b/packages/ui-img/src/Img/index.tsx
@@ -107,13 +107,6 @@ class Img extends Component<Props> {
   }
 
   static defaultProps = {
-    margin: undefined,
-    overlay: undefined,
-    constrain: undefined,
-    elementRef: undefined,
-    height: undefined,
-    width: undefined,
-    alt: '',
     display: 'inline-block',
     withGrayscale: false,
     withBlur: false

--- a/packages/ui-link/src/Link/index.tsx
+++ b/packages/ui-link/src/Link/index.tsx
@@ -151,20 +151,9 @@ class Link extends Component<Props> {
   }
 
   static defaultProps = {
-    href: undefined,
-    elementRef: undefined,
-    // Leave interaction default undefined so that `disabled` can also be supplied
-    interaction: undefined,
-    margin: undefined,
-    renderIcon: undefined,
-    display: undefined,
     color: 'link',
-    as: undefined,
     iconPlacement: 'start',
-    isWithinText: true,
-    onClick: undefined,
-    onFocus: undefined,
-    onBlur: undefined
+    isWithinText: true
   }
 
   state = { hasFocus: false }

--- a/packages/ui-list/src/InlineList/InlineListItem/index.tsx
+++ b/packages/ui-list/src/InlineList/InlineListItem/index.tsx
@@ -112,12 +112,9 @@ class InlineListItem extends Component<Props> {
 
   static defaultProps = {
     padding: 'none',
-    margin: undefined,
     spacing: 'none',
     delimiter: 'none',
-    size: 'medium',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {}
+    size: 'medium'
   }
 
   componentDidMount() {

--- a/packages/ui-list/src/InlineList/index.tsx
+++ b/packages/ui-list/src/InlineList/index.tsx
@@ -89,10 +89,7 @@ class InlineList extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     itemSpacing: 'none',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     as: 'ul',
     margin: 'none',
     delimiter: 'none',

--- a/packages/ui-list/src/List/ListItem/index.tsx
+++ b/packages/ui-list/src/List/ListItem/index.tsx
@@ -113,12 +113,9 @@ class ListItem extends Component<Props> {
 
   static defaultProps = {
     padding: 'none',
-    margin: undefined,
     spacing: 'none',
     delimiter: 'none',
-    size: 'medium',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {}
+    size: 'medium'
   }
 
   componentDidMount() {

--- a/packages/ui-list/src/List/index.tsx
+++ b/packages/ui-list/src/List/index.tsx
@@ -117,15 +117,11 @@ class List extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     as: 'ul',
     delimiter: 'none',
     isUnstyled: false,
-    margin: undefined,
     size: 'medium',
-    itemSpacing: 'none',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {}
+    itemSpacing: 'none'
   }
 
   static Item = ListItem

--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -107,18 +107,7 @@ class MenuItem extends Component<Props> {
 
   static defaultProps = {
     type: 'button',
-    disabled: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onSelect: function (e, value, selected, item) {},
-    defaultSelected: undefined,
-    selected: undefined,
-    onClick: undefined,
-    onKeyDown: undefined,
-    onKeyUp: undefined,
-    onMouseOver: undefined,
-    controls: undefined,
-    value: undefined,
-    href: undefined
+    disabled: false
   }
 
   static contextType = MenuContext

--- a/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
@@ -114,19 +114,10 @@ class MenuItemGroup extends Component<Props> {
   }
 
   static defaultProps = {
-    onMouseOver: undefined,
     disabled: false,
-    controls: undefined,
-    onKeyDown: undefined,
-    selected: undefined,
-    children: null,
     isTabbable: false,
     allowMultiple: false,
-    defaultSelected: [],
-    // @ts-expect-error ts-migrate(6133) FIXME: 'item' is declared but its value is never read.
-    itemRef: function (item) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onSelect: function (e, value, selected, item) {}
+    defaultSelected: []
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.

--- a/packages/ui-menu/src/Menu/index.tsx
+++ b/packages/ui-menu/src/Menu/index.tsx
@@ -228,40 +228,12 @@ class Menu extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    label: null,
     disabled: false,
-    trigger: null,
     placement: 'bottom center',
     defaultShow: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'shown' is declared but its value is never read.
-    onToggle: (shown, menu) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onSelect: (event, value, selected, item) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onDismiss: (event, documentClick) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onMouseOver: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyDown: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyUp: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    menuRef: (el) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    popoverRef: (el) => {},
-    mountNode: null,
     constrain: 'window',
-    liveRegion: null,
     shouldHideOnSelect: true,
     shouldFocusTriggerOnClose: true,
-    show: undefined,
-    id: undefined,
-    type: undefined,
     withArrow: true,
     offsetX: 0,
     offsetY: 0
@@ -679,8 +651,7 @@ class Menu extends Component<Props> {
         isShowingContent={show}
         defaultIsShowingContent={defaultShow}
         onHideContent={(event, { documentClick }) => {
-          // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-          onDismiss(event, documentClick)
+          onDismiss?.(event, documentClick)
           this.handleToggle(false)
         }}
         onShowContent={() => this.handleToggle(true)}

--- a/packages/ui-metric/src/Metric/index.tsx
+++ b/packages/ui-metric/src/Metric/index.tsx
@@ -36,14 +36,14 @@ import { OtherHTMLAttributes } from '@instructure/ui-prop-types'
 type Props = {
   makeStyles?: (...args: any[]) => any
   styles?: any
-  textAlign: 'start' | 'center' | 'end'
+  textAlign?: 'start' | 'center' | 'end'
   renderLabel?: ((props?: any) => ReactNode) | ReactNode
   renderValue?: ((props?: any) => ReactNode) | ReactNode
   /**
    * Set to true when a child of MetricGroup so the appropriate
    * aria labels get set
    */
-  isGroupChild: boolean
+  isGroupChild?: boolean
 }
 
 /**
@@ -70,8 +70,6 @@ class Metric extends Component<Props & OtherHTMLAttributes<Props>> {
 
   static defaultProps = {
     textAlign: 'center',
-    renderLabel: undefined,
-    renderValue: undefined,
     isGroupChild: false
   }
 

--- a/packages/ui-metric/src/MetricGroup/index.tsx
+++ b/packages/ui-metric/src/MetricGroup/index.tsx
@@ -64,10 +64,6 @@ class MetricGroup extends Component<Props & OtherHTMLAttributes<Props>> {
     children: ChildrenPropTypes.oneOf([Metric])
   }
 
-  static defaultProps = {
-    children: null
-  }
-
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
     this.props.makeStyles()

--- a/packages/ui-modal/src/Modal/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/index.tsx
@@ -78,10 +78,7 @@ class ModalBody extends Component<Props> {
   static defaultProps = {
     padding: 'medium',
     as: 'div',
-    variant: 'default',
-    children: null,
-    elementRef: undefined,
-    overflow: undefined
+    variant: 'default'
   }
 
   componentDidMount() {

--- a/packages/ui-modal/src/Modal/ModalFooter/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalFooter/index.tsx
@@ -60,8 +60,7 @@ class ModalFooter extends Component<Props> {
   }
 
   static defaultProps = {
-    variant: 'default',
-    children: null
+    variant: 'default'
   }
 
   componentDidMount() {

--- a/packages/ui-modal/src/Modal/ModalHeader/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalHeader/index.tsx
@@ -65,7 +65,6 @@ class ModalHeader extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     variant: 'default'
   }
 

--- a/packages/ui-modal/src/Modal/index.tsx
+++ b/packages/ui-modal/src/Modal/index.tsx
@@ -237,27 +237,11 @@ class Modal extends Component<Props> {
     variant: 'default',
     transition: 'fade',
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onOpen: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClose: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onDismiss: (event) => {},
-    onEnter: () => {},
-    onEntering: () => {},
-    onEntered: () => {},
-    onExit: () => {},
-    onExiting: () => {},
-    onExited: () => {},
-    as: undefined,
-    mountNode: null,
+    onOpen: (_event) => {}, // TODO check if its OK if this line is removed
+    onExited: () => {}, // TODO check if its OK if this line is removed
     insertAt: 'bottom',
-    liveRegion: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    contentRef: (el) => {},
     shouldCloseOnDocumentClick: true,
     shouldReturnFocus: true,
-    defaultFocusElement: null,
-    children: null,
     constrain: 'window',
     overflow: 'scroll'
   }

--- a/packages/ui-motion/src/Transition/BaseTransition.ts
+++ b/packages/ui-motion/src/Transition/BaseTransition.ts
@@ -38,6 +38,29 @@ const STATES = {
   ENTERED: 2
 }
 
+type Props = {
+  in?: boolean
+  unmountOnExit?: boolean
+  transitionOnMount?: boolean
+  transitionEnter?: boolean
+  transitionExit?: boolean
+  enterDelay?: number
+  exitDelay?: number
+  transitionClassName?: string
+  exitedClassName?: string
+  exitingClassName?: string
+  enteredClassName?: string
+  enteringClassName?: string
+  onTransition?: (...args: any[]) => any
+  onEnter?: (...args: any[]) => any
+  onEntering?: (...args: any[]) => any
+  onEntered?: (...args: any[]) => any
+  onExit?: (...args: any[]) => any
+  onExiting?: (...args: any[]) => any
+  onExited?: (...args: any[]) => any
+  children?: any
+  className?: string
+}
 /**
 ---
 private: true
@@ -45,7 +68,7 @@ private: true
   Note: this is forked from https://github.com/react-bootstrap/react-overlays/blob/master/src/Transition.js
   so that it works with css modules. The internals are pretty different now, but it has roughly the same api.
 **/
-class BaseTransition extends React.Component {
+class BaseTransition extends React.Component<Props> {
   static propTypes = {
     /**
      * Show the component? Triggers the enter or exit animation.
@@ -157,25 +180,7 @@ class BaseTransition extends React.Component {
     transitionExit: true,
 
     enterDelay: 300,
-    exitDelay: 300,
-
-    onEnter: function () {},
-    onEntering: function () {},
-    onEntered: function () {},
-
-    onExit: function () {},
-    onExiting: function () {},
-    onExited: function () {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'toState' is declared but its value is never read.
-    onTransition: function (toState, fromState) {},
-
-    className: undefined,
-    children: null,
-    transitionClassName: undefined,
-    exitedClassName: undefined,
-    exitingClassName: undefined,
-    enteredClassName: undefined,
-    enteringClassName: undefined
+    exitDelay: 300
   }
 
   static states = STATES
@@ -187,13 +192,11 @@ class BaseTransition extends React.Component {
   }
 
   componentDidMount() {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
     this.startTransition(this.props.in, this.props.transitionOnMount)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'prevProps' implicitly has an 'any' type... Remove this comment to see the full error message
   getSnapshotBeforeUpdate(prevProps, prevState) {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
     if (this.props.in !== prevProps.in && prevState.transitioning) {
       // direction changed before previous transition finished
       return true
@@ -207,14 +210,11 @@ class BaseTransition extends React.Component {
       this.clearTransition(prevProps.transitionClassName)
     }
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionClassName' does not exist on t... Remove this comment to see the full error message
     if (this.props.transitionClassName !== prevProps.transitionClassName) {
       this.clearTransition(prevProps.transitionClassName)
     }
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
     if (prevProps.in !== this.props.in) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
       this.startTransition(this.props.in, true)
     }
   }
@@ -229,7 +229,6 @@ class BaseTransition extends React.Component {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'transitionIn' implicitly has an 'any' t... Remove this comment to see the full error message
   startTransition = (transitionIn, transitionOnStart) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionEnter' does not exist on type ... Remove this comment to see the full error message
     const { transitionEnter, transitionExit } = this.props
     if (transitionIn) {
       this.enter(transitionEnter && transitionOnStart ? STATES.EXITED : null)
@@ -254,13 +253,12 @@ class BaseTransition extends React.Component {
 
     const transitionClassName = this.getTransitionClassName(toState)
     const prevTransitionClassName = this.getTransitionClassName(fromState)
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionClassName' does not exist on t... Remove this comment to see the full error message
     const baseTransitionClassName = this.props.transitionClassName
 
     if (fromState && transitionDuration && this.transitionEnabled(toState)) {
-      classList.add(baseTransitionClassName)
+      classList.add(baseTransitionClassName!)
     } else {
-      classList.remove(baseTransitionClassName)
+      classList.remove(baseTransitionClassName!)
     }
 
     if (prevTransitionClassName) {
@@ -272,8 +270,7 @@ class BaseTransition extends React.Component {
     }
 
     if (toState && fromState) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'onTransition' does not exist on type 'Re... Remove this comment to see the full error message
-      this.props.onTransition(toState, fromState)
+      this.props.onTransition?.(toState, fromState)
     }
 
     this._timeouts.push(
@@ -301,7 +298,7 @@ class BaseTransition extends React.Component {
       const classList = getClassList(this)
 
       Object.keys(STATES).forEach((state) => {
-        classList.remove(this.getTransitionClassName(state))
+        classList.remove(this.getTransitionClassName(state)!)
       })
 
       classList.remove(transitionClassName)
@@ -314,19 +311,15 @@ class BaseTransition extends React.Component {
     if (this.state.transitioning || this._unmounted) return
 
     const { props } = this
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'onEnter' does not exist on type 'Readonl... Remove this comment to see the full error message
-    props.onEnter()
+    props.onEnter?.()
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionEnter' does not exist on type ... Remove this comment to see the full error message
     if (props.transitionEnter) {
       this.setState({ transitioning: true }, () => {
         const enter = () => {
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'onEntering' does not exist on type 'Read... Remove this comment to see the full error message
-          props.onEntering()
+          props.onEntering?.()
           this.transition(STATES.ENTERED, STATES.ENTERING, () => {
             this.setState({ transitioning: false }, () => {
-              // @ts-expect-error ts-migrate(2339) FIXME: Property 'onEntered' does not exist on type 'Reado... Remove this comment to see the full error message
-              props.onEntered()
+              props.onEntered?.()
             })
           })
         }
@@ -336,7 +329,6 @@ class BaseTransition extends React.Component {
               STATES.ENTERING,
               initialState,
               enter,
-              // @ts-expect-error ts-migrate(2339) FIXME: Property 'enterDelay' does not exist on type 'Read... Remove this comment to see the full error message
               props.enterDelay
             )
           })
@@ -348,8 +340,7 @@ class BaseTransition extends React.Component {
       this.setState({ transitioning: false }, () => {
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 3-4 arguments, but got 2.
         this.transition(STATES.ENTERED, STATES.EXITED)
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'onEntered' does not exist on type 'Reado... Remove this comment to see the full error message
-        props.onEntered()
+        props.onEntered?.()
       })
     }
   }
@@ -359,25 +350,20 @@ class BaseTransition extends React.Component {
     if (this.state.transitioning) return
 
     const { props } = this
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'onExit' does not exist on type 'Readonly... Remove this comment to see the full error message
-    props.onExit()
+    props.onExit?.()
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionExit' does not exist on type '... Remove this comment to see the full error message
     if (props.transitionExit) {
       this.setState({ transitioning: true }, () => {
         const exit = () => {
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'onExiting' does not exist on type 'Reado... Remove this comment to see the full error message
-          props.onExiting()
+          props.onExiting?.()
           this.transition(STATES.EXITED, STATES.EXITING, () => {
             this.setState({ transitioning: false }, () => {
-              // @ts-expect-error ts-migrate(2339) FIXME: Property 'onExited' does not exist on type 'Readon... Remove this comment to see the full error message
-              props.onExited()
+              props.onExited?.()
             })
           })
         }
         if (initialState) {
           this.transition(initialState, null, () => {
-            // @ts-expect-error ts-migrate(2339) FIXME: Property 'exitDelay' does not exist on type 'Reado... Remove this comment to see the full error message
             this.transition(STATES.EXITING, initialState, exit, props.exitDelay)
           })
         } else {
@@ -388,8 +374,7 @@ class BaseTransition extends React.Component {
       this.setState({ transitioning: false }, () => {
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 3-4 arguments, but got 2.
         this.transition(STATES.EXITED, STATES.ENTERED)
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'onExited' does not exist on type 'Readon... Remove this comment to see the full error message
-        props.onExited()
+        props.onExited?.()
       })
     }
   }
@@ -401,11 +386,9 @@ class BaseTransition extends React.Component {
     switch (toState) {
       case STATES.EXITED:
       case STATES.EXITING:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionExit' does not exist on type '... Remove this comment to see the full error message
         return props.transitionExit
       case STATES.ENTERED:
       case STATES.ENTERING:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitionEnter' does not exist on type ... Remove this comment to see the full error message
         return props.transitionEnter
       default:
         return false
@@ -417,16 +400,12 @@ class BaseTransition extends React.Component {
     const { props } = this
     switch (transitionState) {
       case STATES.EXITED:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'exitedClassName' does not exist on type ... Remove this comment to see the full error message
         return props.exitedClassName
       case STATES.ENTERING:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'enteringClassName' does not exist on typ... Remove this comment to see the full error message
         return props.enteringClassName
       case STATES.ENTERED:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'enteredClassName' does not exist on type... Remove this comment to see the full error message
         return props.enteredClassName
       case STATES.EXITING:
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'exitingClassName' does not exist on type... Remove this comment to see the full error message
         return props.exitingClassName
       default:
         return null
@@ -435,16 +414,13 @@ class BaseTransition extends React.Component {
 
   renderChildren() {
     return safeCloneElement(ensureSingleChild(this.props.children)!, {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
       'aria-hidden': !this.props.in ? true : null
     })
   }
 
   render() {
     if (
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'in' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
       !this.props.in &&
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'unmountOnExit' does not exist on type 'R... Remove this comment to see the full error message
       this.props.unmountOnExit &&
       !this.state.transitioning
     ) {

--- a/packages/ui-motion/src/Transition/index.tsx
+++ b/packages/ui-motion/src/Transition/index.tsx
@@ -149,17 +149,7 @@ class Transition extends Component<Props> {
     unmountOnExit: false,
     transitionOnMount: false,
     transitionEnter: true,
-    transitionExit: true,
-
-    onEnter: function () {},
-    onEntering: function () {},
-    onEntered: function () {},
-    onExit: function () {},
-    onExiting: function () {},
-    onExited: function () {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'toState' is declared but its value is never read.
-    onTransition: function (toState, fromState) {},
-    children: null
+    transitionExit: true
   }
 
   static states = BaseTransition.states

--- a/packages/ui-navigation/src/AppNav/Item/index.tsx
+++ b/packages/ui-navigation/src/AppNav/Item/index.tsx
@@ -120,15 +120,7 @@ class Item extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClick: function (event) {},
     isSelected: false,
-    href: undefined,
-    elementRef: undefined,
-    renderIcon: undefined,
-    renderAfter: undefined,
-    as: undefined,
     cursor: 'pointer',
     isDisabled: false
   }

--- a/packages/ui-navigation/src/AppNav/index.tsx
+++ b/packages/ui-navigation/src/AppNav/index.tsx
@@ -126,15 +126,9 @@ class AppNav extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     debounce: 300,
     margin: '0',
-    renderBeforeItems: undefined,
-    renderAfterItems: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     renderTruncateLabel: () => 'More',
-    onUpdate: () => {},
     visibleItemsCount: 0
   }
 
@@ -228,9 +222,7 @@ class AppNav extends Component<Props> {
   handleResize = () => {
     this.setState({ isMeasuring: true }, () => {
       const { visibleItemsCount } = this.measureItems()
-
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      this.props.onUpdate({ visibleItemsCount })
+      this.props.onUpdate?.({ visibleItemsCount })
       this.setState({ isMeasuring: false })
     })
   }

--- a/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
@@ -95,11 +95,8 @@ class NavigationItem extends Component<Props> {
 
   static defaultProps = {
     as: 'a',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onClick: function (e, selected) {},
     selected: false,
-    minimized: false,
-    href: undefined
+    minimized: false
   }
 
   componentDidMount() {

--- a/packages/ui-navigation/src/Navigation/index.tsx
+++ b/packages/ui-navigation/src/Navigation/index.tsx
@@ -108,14 +108,7 @@ class Navigation extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    defaultMinimized: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onMinimized: function (event, minimized) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'e' is declared but its value is never read.
-    onClick: function (e) {},
-    href: undefined,
-    minimized: undefined
+    defaultMinimized: false
   }
 
   static Item = NavigationItem
@@ -159,9 +152,7 @@ class Navigation extends Component<Props> {
     if (!this.isControlled()) {
       this.setState(navMinimized)
     }
-
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onMinimized(event, !this.minimized)
+    this.props.onMinimized?.(event, !this.minimized)
   }
 
   renderChildren() {

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -180,33 +180,11 @@ class NumberInput extends Component<Props> {
   }
 
   static defaultProps = {
-    id: null,
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     messages: [],
-    placeholder: null,
     isRequired: false,
     showArrows: true,
     size: 'medium',
-    value: undefined,
-    width: undefined,
     display: 'block',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    inputRef: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: (event, value) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onDecrement: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onIncrement: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyDown: (event) => {},
-    disabled: undefined,
-    readOnly: undefined,
     inputMode: 'numeric'
   }
 
@@ -258,43 +236,36 @@ class NumberInput extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'element' implicitly has an 'any' type.
   handleRef = (element) => {
     this._input = element
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.inputRef(element)
+    this.props.inputRef?.(element)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleFocus = (event) => {
     this.setState({ hasFocus: true })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onFocus(event)
+    this.props.onFocus?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleBlur = (event) => {
     this.setState({ hasFocus: false })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onBlur(event)
+    this.props.onBlur?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleChange = (event) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onChange(event, event.target.value)
+    this.props.onChange?.(event, event.target.value)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleKeyDown = (event) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onKeyDown(event)
+    this.props.onKeyDown?.(event)
 
     if (event.keyCode === keycode.codes.down) {
       event.preventDefault()
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      this.props.onDecrement(event)
+      this.props.onDecrement?.(event)
     } else if (event.keyCode === keycode.codes.up) {
       event.preventDefault()
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      this.props.onIncrement(event)
+      this.props.onIncrement?.(event)
     }
   }
 
@@ -316,7 +287,7 @@ class NumberInput extends Component<Props> {
     if (interaction === 'enabled') {
       // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
       this._input.focus()
-      callback(event)
+      callback?.(event)
     }
   }
 

--- a/packages/ui-options/src/Options/Item/index.tsx
+++ b/packages/ui-options/src/Options/Item/index.tsx
@@ -98,10 +98,7 @@ class Item extends Component<Props> {
   static defaultProps = {
     as: 'span',
     variant: 'default',
-    role: 'listitem',
-    renderBeforeLabel: null,
-    renderAfterLabel: null,
-    children: null
+    role: 'listitem'
   }
 
   componentDidMount() {

--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -92,11 +92,7 @@ class Options extends Component<Props> {
 
   static defaultProps = {
     as: 'span',
-    role: 'list',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    elementRef: (node) => {},
-    renderLabel: null,
-    children: null
+    role: 'list'
   }
 
   static Item = Item

--- a/packages/ui-overlays/src/Mask/index.tsx
+++ b/packages/ui-overlays/src/Mask/index.tsx
@@ -67,12 +67,7 @@ class Mask extends Component<Props> {
 
   static defaultProps = {
     placement: 'center',
-    fullscreen: false,
-    onDismiss: undefined,
-    children: null,
-    onClick: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {}
+    fullscreen: false
   }
 
   componentDidMount() {
@@ -97,8 +92,7 @@ class Mask extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
   handleElementRef = (el) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.elementRef(el)
+    this.props.elementRef?.(el)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.

--- a/packages/ui-overlays/src/Overlay/index.tsx
+++ b/packages/ui-overlays/src/Overlay/index.tsx
@@ -181,32 +181,19 @@ class Overlay extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     open: false,
     insertAt: 'bottom',
-    onOpen: () => {},
-    onClose: () => {},
-    mountNode: null,
+    onOpen: () => {}, // TODO check if this line can be deleted
     shouldContainFocus: false,
     shouldReturnFocus: false,
     shouldCloseOnDocumentClick: false,
     shouldCloseOnEscape: true,
-    applicationElement: null,
-    defaultFocusElement: null,
-    contentElement: null,
-    onDismiss: () => {},
-    transition: null,
     in: false,
     unmountOnExit: false,
     transitionOnMount: false,
     transitionEnter: true,
     transitionExit: true,
-    onEnter: function () {},
-    onEntering: function () {},
-    onEntered: function () {},
-    onExit: function () {},
-    onExiting: function () {},
-    onExited: function () {}
+    onExited: function () {} // TODO check if this line can be deleted
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -232,7 +219,7 @@ class Overlay extends Component<Props> {
     if (prevProps.open && !this.props.open) {
       // closing
       this.setState({
-        transitioning: prevProps.transition !== null
+        transitioning: !!prevProps.transition
       })
     }
   }

--- a/packages/ui-pages/src/Pages/Page/index.tsx
+++ b/packages/ui-pages/src/Pages/Page/index.tsx
@@ -69,10 +69,8 @@ class Page extends Component<Props> {
   }
 
   static defaultProps = {
-    defaultFocusElement: null,
     padding: 'small',
-    textAlign: 'start',
-    children: null
+    textAlign: 'start'
   }
 
   static contextTypes = {

--- a/packages/ui-pages/src/Pages/index.tsx
+++ b/packages/ui-pages/src/Pages/index.tsx
@@ -100,11 +100,7 @@ class Pages extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    defaultPageIndex: null,
-    activePageIndex: 0,
-    onPageIndexChange: function () {},
-    margin: undefined
+    activePageIndex: 0
   }
 
   static Page = Page
@@ -136,8 +132,7 @@ class Pages extends Component<Props> {
     const oldPageIndex = this._history.pop()
     // @ts-expect-error ts-migrate(2339) FIXME: Property '_history' does not exist on type 'Pages'... Remove this comment to see the full error message
     const newPageIndex = this._history[this._history.length - 1]
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onPageIndexChange(newPageIndex || 0, oldPageIndex)
+    this.props.onPageIndexChange?.(newPageIndex || 0, oldPageIndex)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'nextProps' implicitly has an 'any' type... Remove this comment to see the full error message

--- a/packages/ui-pagination/src/Pagination/PaginationArrowButton/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationArrowButton/index.tsx
@@ -56,12 +56,6 @@ class PaginationArrowButton extends Component<Props> {
     buttonRef: PropTypes.func
   }
 
-  static defaultProps = {
-    direction: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    buttonRef: (el) => {}
-  }
-
   render() {
     const { label, direction, buttonRef, ...props } = this.props
     const Icon =

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -146,16 +146,9 @@ class Pagination extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    label: undefined,
-    labelNext: undefined,
-    labelPrev: undefined,
-    margin: undefined,
     disabled: false,
     variant: 'full',
     as: 'div',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     shouldHandleFocus: true
   }
 

--- a/packages/ui-pill/src/Pill/index.tsx
+++ b/packages/ui-pill/src/Pill/index.tsx
@@ -87,9 +87,6 @@ class Pill extends Component<Props> {
   }
 
   static defaultProps = {
-    children: undefined,
-    margin: undefined,
-    elementRef: undefined,
     color: 'primary'
   }
 

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -296,7 +296,6 @@ class Popover extends Component<Props & BidirectionalProps> {
   }
 
   static defaultProps = {
-    isShowingContent: undefined,
     defaultIsShowingContent: false,
     placement: 'bottom center',
     stacking: 'topmost',
@@ -305,17 +304,9 @@ class Popover extends Component<Props & BidirectionalProps> {
     offsetY: 0,
     color: 'primary',
     on: ['hover', 'focus'],
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    contentRef: (el) => {},
     withArrow: true,
     constrain: 'window',
-    defaultFocusElement: undefined,
-    screenReaderLabel: undefined,
-    mountNode: undefined,
     insertAt: 'bottom',
-    liveRegion: undefined,
-    positionTarget: undefined,
-    id: undefined,
     shouldAlignArrow: false,
     shouldTrackPosition: true,
     shouldRenderOffscreen: false,
@@ -324,10 +315,6 @@ class Popover extends Component<Props & BidirectionalProps> {
     shouldCloseOnDocumentClick: true,
     shouldFocusContentOnTriggerBlur: false,
     shouldCloseOnEscape: true,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onShowContent: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onHideContent: (event, { documentClick }) => {},
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
     onClick: (event) => {},
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
@@ -341,13 +328,7 @@ class Popover extends Component<Props & BidirectionalProps> {
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
     onKeyDown: (event) => {},
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyUp: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'position' is declared but its value is never read... Remove this comment to see the full error message
-    onPositioned: (position) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'position' is declared but its value is never read... Remove this comment to see the full error message
-    onPositionChanged: (position) => {},
-    renderTrigger: null,
-    children: null
+    onKeyUp: (event) => {}
   }
 
   _handleMouseOver: (...args: any[]) => any | undefined
@@ -559,8 +540,7 @@ class Popover extends Component<Props & BidirectionalProps> {
     if (typeof this.props.isShowingContent === 'undefined') {
       this.setState({ isShowingContent: true })
     }
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onShowContent(event)
+    this.props.onShowContent?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -572,15 +552,13 @@ class Popover extends Component<Props & BidirectionalProps> {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'isShowingContent' does not exist on type... Remove this comment to see the full error message
       this.setState(({ isShowingContent }) => {
         if (isShowingContent) {
-          // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-          onHideContent(event, { documentClick })
+          onHideContent?.(event, { documentClick })
         }
         return { isShowingContent: false }
       })
     } else if (isShowingContent) {
       // controlled, fire callback
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      onHideContent(event, { documentClick })
+      onHideContent?.(event, { documentClick })
     }
   }
 
@@ -671,8 +649,7 @@ class Popover extends Component<Props & BidirectionalProps> {
       placement,
       ...this.computeOffsets(placement)
     })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onPositioned(position)
+    this.props.onPositioned?.(position)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'position' implicitly has an 'any' type.
@@ -682,8 +659,7 @@ class Popover extends Component<Props & BidirectionalProps> {
       placement,
       ...this.computeOffsets(placement)
     })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onPositionChanged(position)
+    this.props.onPositionChanged?.(position)
   }
 
   renderTrigger() {
@@ -798,8 +774,7 @@ class Popover extends Component<Props & BidirectionalProps> {
         elementRef: (el) => {
           // @ts-expect-error ts-migrate(2339) FIXME: Property '_contentElement' does not exist on type ... Remove this comment to see the full error message
           this._contentElement = el
-          // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-          this.props.contentRef(el)
+          this.props.contentRef?.(el)
         },
         background: color,
         stacking: this.props.stacking,

--- a/packages/ui-portal/src/Portal/index.tsx
+++ b/packages/ui-portal/src/Portal/index.tsx
@@ -101,12 +101,7 @@ class Portal extends Component<Props, State> {
 
   static defaultProps = {
     open: false,
-    insertAt: 'bottom',
-    onOpen: () => {},
-    onClose: () => {},
-    mountNode: null,
-    children: null,
-    elementRef: () => {}
+    insertAt: 'bottom'
   }
 
   constructor(props: Props) {

--- a/packages/ui-position/src/Position/index.tsx
+++ b/packages/ui-position/src/Position/index.tsx
@@ -85,21 +85,14 @@ class Position extends Component<Props, State> {
     children: PropTypes.node
   }
 
-  static defaultProps: Props = {
-    renderTarget: undefined,
-    target: undefined,
+  static defaultProps = {
     placement: 'bottom center',
-    mountNode: null,
     insertAt: 'bottom',
     constrain: 'window',
     offsetX: 0,
     offsetY: 0,
-    id: undefined,
     shouldTrackPosition: true,
-    shouldPositionOverTarget: false,
-    onPositioned: () => {},
-    onPositionChanged: () => {},
-    children: null
+    shouldPositionOverTarget: false
   }
 
   static locatorAttribute = 'data-position'
@@ -160,7 +153,7 @@ class Position extends Component<Props, State> {
         style.top !== prevState.style.top ||
         style.left !== prevState.style.left)
     ) {
-      this.props.onPositionChanged({
+      this.props.onPositionChanged?.({
         top: style.top,
         left: style.left,
         placement

--- a/packages/ui-position/src/Position/types.ts
+++ b/packages/ui-position/src/Position/types.ts
@@ -53,29 +53,29 @@ type Props = {
    * An element or a function returning an element to use as the mount node
    * for the `<Position />` (defaults to `document.body`)
    */
-  mountNode: PositionMountNode
+  mountNode?: PositionMountNode
 
   /**
    * Insert the element at the 'top' of the mountNode or at the 'bottom'
    */
-  insertAt: 'bottom' | 'top'
+  insertAt?: 'bottom' | 'top'
 
   /**
    * The parent in which to constrain the placement.
    * One of: 'window', 'scroll-parent', 'parent', 'none', an element,
    * or a function returning an element
    */
-  constrain: PositionConstraint
+  constrain?: PositionConstraint
 
   /**
    * The horizontal offset for the positioned content
    */
-  offsetX: string | number
+  offsetX?: string | number
 
   /**
    * The vertical offset for the positioned content
    */
-  offsetY: string | number
+  offsetY?: string | number
 
   /**
    * An id will be generated if not provided
@@ -85,27 +85,27 @@ type Props = {
   /**
    * Whether or not position of the target should be tracked or just set statically on render
    */
-  shouldTrackPosition: boolean
+  shouldTrackPosition?: boolean
 
   /**
    * Whether or not you want the content to position over the target
    */
-  shouldPositionOverTarget: boolean
+  shouldPositionOverTarget?: boolean
 
   /**
    * Callback fired when the position changes
    */
-  onPositionChanged: (position: Position) => any
+  onPositionChanged?: (position: Position) => any
 
   /**
    * Callback fired when `<Position />` content has been mounted and is initially positioned
    */
-  onPositioned: (position: Position) => any
+  onPositioned?: (position: Position) => any
 
   /**
    * The content to be positioned
    */
-  children: React.ReactNode
+  children?: React.ReactNode
 } & WithStyleProps
 
 type State = {

--- a/packages/ui-progress/src/ProgressBar/index.tsx
+++ b/packages/ui-progress/src/ProgressBar/index.tsx
@@ -141,11 +141,7 @@ class ProgressBar extends Component<Props> {
     valueMax: 100,
     valueNow: 0,
     as: 'div',
-    renderValue: undefined,
-    margin: undefined,
-    elementRef: undefined,
     color: 'primary',
-
     // default to showing `success` color on completion
     // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'valueNow' implicitly has an 'any'... Remove this comment to see the full error message
     meterColor: ({ valueNow, valueMax }) =>

--- a/packages/ui-progress/src/ProgressCircle/index.tsx
+++ b/packages/ui-progress/src/ProgressCircle/index.tsx
@@ -153,13 +153,8 @@ class ProgressCircle extends Component<Props> {
     valueMax: 100,
     valueNow: 0,
     as: 'div',
-    renderValue: undefined,
-    margin: undefined,
-    elementRef: undefined,
     color: 'primary',
     shouldAnimateOnMount: false,
-    animationDelay: undefined,
-
     // default to showing `success` color on completion
     // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'valueNow' implicitly has an 'any'... Remove this comment to see the full error message
     meterColor: ({ valueNow, valueMax }) =>

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -90,20 +90,12 @@ class RadioInput extends Component<Props> {
   }
 
   static defaultProps = {
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClick: function (event) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: function (event) {},
     variant: 'simple',
     size: 'medium',
     disabled: false,
     inline: false,
     context: 'success',
-    readOnly: false,
-    checked: undefined,
-    id: undefined,
-    name: undefined,
-    value: undefined
+    readOnly: false
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -139,8 +131,7 @@ class RadioInput extends Component<Props> {
       return
     }
 
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onClick(e)
+    this.props.onClick?.(e)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'e' implicitly has an 'any' type.
@@ -149,14 +140,11 @@ class RadioInput extends Component<Props> {
       e.preventDefault()
       return
     }
-
     if (typeof this.props.checked === 'undefined') {
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'checked' does not exist on type 'Readonl... Remove this comment to see the full error message
       this.setState({ checked: !this.state.checked })
     }
-
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onChange(e)
+    this.props.onChange?.(e)
   }
 
   focus() {

--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -106,12 +106,7 @@ class RadioInputGroup extends Component<Props> {
     variant: 'simple',
     size: 'medium',
     layout: 'stacked',
-    readOnly: false,
-    defaultValue: undefined,
-    value: undefined,
-    children: null,
-    messages: undefined,
-    onChange: undefined
+    readOnly: false
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -126,12 +126,7 @@ class RangeInput extends Component<Props> {
     layout: 'stacked',
     displayValue: true,
     disabled: false,
-    readOnly: false,
-    id: undefined,
-    defaultValue: undefined,
-    value: undefined,
-    onChange: undefined,
-    messages: undefined
+    readOnly: false
   }
 
   _input: HTMLInputElement | null = null

--- a/packages/ui-rating/src/Rating/index.tsx
+++ b/packages/ui-rating/src/Rating/index.tsx
@@ -110,9 +110,7 @@ class Rating extends Component<Props> {
     formatValueText: (filled, iconCount) => `${filled} / ${iconCount}`,
     iconCount: 3,
     size: 'medium',
-    valueNow: 0,
-    margin: undefined,
-    valueMax: undefined
+    valueNow: 0
   }
 
   static Icon = RatingIcon

--- a/packages/ui-react-utils/src/ComponentIdentifier.ts
+++ b/packages/ui-react-utils/src/ComponentIdentifier.ts
@@ -76,10 +76,6 @@ class ComponentIdentifier<P> extends Component<P> {
     children: PropTypes.node
   }
 
-  static defaultProps = {
-    children: null
-  }
-
   static pick = (component: ComponentType, children: ReactNode) => {
     let result
 

--- a/packages/ui-react-utils/src/__tests__/ComponentIdentifier.test.tsx
+++ b/packages/ui-react-utils/src/__tests__/ComponentIdentifier.test.tsx
@@ -37,10 +37,6 @@ describe('ComponentIdentifier', async () => {
       children: PropTypes.node
     }
 
-    static defaultProps = {
-      children: null
-    }
-
     render() {
       const trigger = ComponentIdentifier.pick(Trigger, this.props.children)
 

--- a/packages/ui-responsive/src/Responsive/index.tsx
+++ b/packages/ui-responsive/src/Responsive/index.tsx
@@ -98,10 +98,7 @@ class Responsive extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    render: undefined,
-    match: 'element',
-    props: null
+    match: 'element'
   }
 
   _matchListener: { remove(): void } | null = null

--- a/packages/ui-select/src/Select/Group/index.tsx
+++ b/packages/ui-select/src/Select/Group/index.tsx
@@ -55,10 +55,6 @@ class Group extends Component<Props> {
     children: ChildrenPropTypes.oneOf([Option])
   }
 
-  static defaultProps = {
-    children: null
-  }
-
   /* istanbul ignore next */
   render() {
     // this component is only used for prop validation. Select.Group children

--- a/packages/ui-select/src/Select/Option/index.tsx
+++ b/packages/ui-select/src/Select/Option/index.tsx
@@ -78,10 +78,7 @@ class Option extends Component<Props> {
   static defaultProps = {
     isHighlighted: false,
     isSelected: false,
-    isDisabled: false,
-    renderBeforeLabel: undefined,
-    renderAfterLabel: undefined,
-    children: null
+    isDisabled: false
   }
 
   /* istanbul ignore next */

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -263,42 +263,14 @@ class Select extends Component<Props> {
   static defaultProps = {
     inputValue: '',
     isShowingOptions: false,
-    id: undefined,
     size: 'medium',
-    assistiveText: undefined,
-    placeholder: null,
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     isRequired: false,
     isInline: false,
-    width: undefined,
-    htmlSize: undefined,
-    optionsMaxWidth: undefined,
     visibleOptionsCount: 8,
-    messages: undefined,
     placement: 'bottom stretch',
     constrain: 'window',
-    mountNode: undefined,
     // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    onInputChange: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestShowOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestHideOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestHighlightOption: (event, data) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestSelectOption: (event, data) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    inputRef: (node) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    listRef: (node) => {},
-    renderBeforeInput: null,
-    renderAfterInput: null,
-    children: null,
+    onBlur: (event) => {}, // TODO check if this line can be removed
     shouldNotWrap: false
   }
 
@@ -422,15 +394,13 @@ class Select extends Component<Props> {
     }
 
     this._input = node
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.inputRef(node)
+    this.props.inputRef?.(node)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'node' implicitly has an 'any' type.
   handleListRef = (node) => {
     this._list = node
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.listRef(node)
+    this.props.listRef?.(node)
 
     // store option height to calculate list maxHeight
     if (node && node.querySelector('[role="option"]')) {
@@ -473,8 +443,7 @@ class Select extends Component<Props> {
   highlightOption(event, id) {
     const { onRequestHighlightOption } = this.props
     if (id) {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      onRequestHighlightOption(event, { id })
+      onRequestHighlightOption?.(event, { id })
     }
   }
 
@@ -493,8 +462,7 @@ class Select extends Component<Props> {
       ? {
           // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
           onRequestShowOptions: (event) => {
-            // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-            onRequestShowOptions(event)
+            onRequestShowOptions?.(event)
             if (selectedOptionId && !Array.isArray(selectedOptionId)) {
               // highlight selected option on show
               this.highlightOption(event, selectedOptionId)
@@ -502,8 +470,7 @@ class Select extends Component<Props> {
           },
           // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
           onRequestHideOptions: (event) => {
-            // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-            onRequestHideOptions(event)
+            onRequestHideOptions?.(event)
           },
           onRequestHighlightOption: (
             event: Event,
@@ -545,8 +512,7 @@ class Select extends Component<Props> {
             // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'any' is not assignable to parame... Remove this comment to see the full error message
             if (id && this._optionIds.indexOf(id) !== -1) {
               // only select if id exists as a valid option
-              // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-              onRequestSelectOption(event, { id })
+              onRequestSelectOption?.(event, { id })
             }
           }
         }

--- a/packages/ui-selectable/src/Selectable/index.tsx
+++ b/packages/ui-selectable/src/Selectable/index.tsx
@@ -52,31 +52,31 @@ type Props = {
   /**
    * Callback fired when the options want to become visible
    */
-  onRequestShowOptions: (event: Event) => void
+  onRequestShowOptions?: (event: Event) => void
   /**
    * Callback fired when the options no longer want to be visible
    */
-  onRequestHideOptions: (event: Event) => void
+  onRequestHideOptions?: (event: Event) => void
   /**
    * Callback fired when option is hovered or highlighted via keyboard.
    * Either the `id` or the `direction` parameter is supplied
    */
-  onRequestHighlightOption: (
+  onRequestHighlightOption?: (
     event: Event,
     data: { id?: string; direction?: 1 | -1 }
   ) => void
   /**
    * Callback fired when first option should be highlighted
    */
-  onRequestHighlightFirstOption: (event: Event) => void
+  onRequestHighlightFirstOption?: (event: Event) => void
   /**
    * Callback fired when last option should be highlighted
    */
-  onRequestHighlightLastOption: (event: Event) => void
+  onRequestHighlightLastOption?: (event: Event) => void
   /**
    * Callback fired when option clicked or selected via keyboard
    */
-  onRequestSelectOption: (event: Event, data: { id?: string }) => void
+  onRequestSelectOption?: (event: Event, data: { id?: string }) => void
   /**
    * A function with prop getters
    */
@@ -84,7 +84,7 @@ type Props = {
   /**
    * A function with prop getters
    */
-  children: (propGetters: SelectableRender) => ReactNode
+  children?: (propGetters: SelectableRender) => ReactNode
 }
 
 type MouseEventFunction = (event: MouseEvent) => void
@@ -169,24 +169,7 @@ class Selectable extends Component<Props> {
   }
 
   static defaultProps = {
-    id: null,
-    highlightedOptionId: null,
-    selectedOptionId: null,
-    isShowingOptions: false,
-    onRequestShowOptions: (_event: Event) => {},
-    onRequestHideOptions: (_event: Event) => {},
-    onRequestHighlightOption: (
-      _event: Event,
-      _data: { id?: string; direction?: 1 | -1 }
-    ) => {},
-    onRequestHighlightFirstOption: (_event: Event) => {},
-    onRequestHighlightLastOption: (_event: Event) => {},
-    onRequestSelectOption: (
-      _event: Event,
-      _data: Record<string, unknown>
-    ) => {},
-    children: null,
-    render: undefined
+    isShowingOptions: false
   }
 
   _id = this.props.id || uid('Selectable')
@@ -213,12 +196,12 @@ class Selectable extends Component<Props> {
     event.preventDefault()
 
     if (isShowingOptions) {
-      onRequestHideOptions(event)
+      onRequestHideOptions?.(event)
     } else {
       if (!isActiveElement(this._trigger)) {
         this._trigger!.focus()
       }
-      onRequestShowOptions(event)
+      onRequestShowOptions?.(event)
     }
   }
 
@@ -245,14 +228,14 @@ class Selectable extends Component<Props> {
         if (highlightedOptionId) {
           // select highlighted option
           event.preventDefault()
-          onRequestSelectOption(event, { id: highlightedOptionId })
+          onRequestSelectOption?.(event, { id: highlightedOptionId })
         }
         break
       case 'down':
         event.preventDefault()
         if (isShowingOptions) {
           // if options showing, change highlight
-          onRequestHighlightOption(event, { direction: 1 })
+          onRequestHighlightOption?.(event, { direction: 1 })
         } else {
           // otherwise, show options
           this.handleOpenClose(event)
@@ -262,7 +245,7 @@ class Selectable extends Component<Props> {
         event.preventDefault()
         if (isShowingOptions) {
           // if options showing, change highlight
-          onRequestHighlightOption(event, { direction: -1 })
+          onRequestHighlightOption?.(event, { direction: -1 })
         } else {
           // otherwise, show options
           this.handleOpenClose(event)
@@ -272,14 +255,14 @@ class Selectable extends Component<Props> {
         if (isShowingOptions) {
           // if options showing, highlight first option
           event.preventDefault()
-          onRequestHighlightFirstOption(event)
+          onRequestHighlightFirstOption?.(event)
         }
         break
       case 'end':
         if (isShowingOptions) {
           // if options showing, highlight last option
           event.preventDefault()
-          onRequestHighlightLastOption(event)
+          onRequestHighlightLastOption?.(event)
         }
         break
     }
@@ -383,10 +366,10 @@ class Selectable extends Component<Props> {
             role: 'option',
             'aria-selected': this.isSelectedOption(id!) ? 'true' : 'false',
             onClick: createChainedFunction((event) => {
-              onRequestSelectOption(event, { id })
+              onRequestSelectOption?.(event, { id })
             }, onClick),
             onMouseOver: createChainedFunction((event) => {
-              onRequestHighlightOption(event, { id })
+              onRequestHighlightOption?.(event, { id })
             }, onMouseOver),
             ...rest
           }

--- a/packages/ui-simple-select/src/SimpleSelect/Group/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/Group/index.tsx
@@ -53,10 +53,6 @@ class Group extends Component<Props> {
     children: ChildrenPropTypes.oneOf([Option])
   }
 
-  static defaultProps = {
-    children: null
-  }
-
   /* istanbul ignore next */
   render() {
     // this component is only used for prop validation. Select.Group children

--- a/packages/ui-simple-select/src/SimpleSelect/Option/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/Option/index.tsx
@@ -70,10 +70,7 @@ class Option extends Component<Props> {
   }
 
   static defaultProps = {
-    isDisabled: false,
-    renderBeforeLabel: undefined,
-    renderAfterLabel: undefined,
-    children: null
+    isDisabled: false
   }
 
   /* istanbul ignore next */

--- a/packages/ui-simple-select/src/SimpleSelect/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/index.tsx
@@ -225,40 +225,13 @@ class SimpleSelect extends Component<Props> {
   }
 
   static defaultProps = {
-    value: undefined,
-    defaultValue: undefined,
-    id: undefined,
     size: 'medium',
-    assistiveText: undefined,
-    placeholder: null,
-    interaction: undefined,
     isRequired: false,
     isInline: false,
-    width: undefined,
-    optionsMaxWidth: undefined,
     visibleOptionsCount: 8,
-    messages: undefined,
     placement: 'bottom stretch',
-    mountNode: undefined,
     constrain: 'window',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: (event, data) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onShowOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onHideOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    inputRef: (node) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    listRef: (node) => {},
-    renderEmptyOption: '---',
-    renderBeforeInput: null,
-    renderAfterInput: null,
-    children: null
+    renderEmptyOption: '---'
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -398,15 +371,13 @@ class SimpleSelect extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleBlur = (event) => {
     this.setState({ highlightedOptionId: null })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onBlur(event)
+    this.props.onBlur?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleShowOptions = (event) => {
     this.setState({ isShowingOptions: true })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onShowOptions(event)
+    this.props.onShowOptions?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -421,8 +392,7 @@ class SimpleSelect extends Component<Props> {
         inputValue: option ? option.props.children : ''
       }
     })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onHideOptions(event)
+    this.props.onHideOptions?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -464,11 +434,9 @@ class SimpleSelect extends Component<Props> {
       }))
     }
     // fire onChange if selected option changed
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    option && this.props.onChange(event, { value, id })
+    option && this.props.onChange?.(event, { value, id })
     // hide options list whenever selection is made
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onHideOptions(event)
+    this.props.onHideOptions?.(event)
   }
 
   renderChildren() {

--- a/packages/ui-spinner/src/Spinner/index.tsx
+++ b/packages/ui-spinner/src/Spinner/index.tsx
@@ -91,12 +91,9 @@ class Spinner extends Component<Props> {
   }
 
   static defaultProps = {
-    renderTitle: undefined,
     as: 'div',
     size: 'medium',
-    variant: 'default',
-    margin: undefined,
-    elementRef: undefined
+    variant: 'default'
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.

--- a/packages/ui-svg-images/src/InlineSVG/index.tsx
+++ b/packages/ui-svg-images/src/InlineSVG/index.tsx
@@ -109,7 +109,6 @@ class InlineSVG extends Component<Props> {
     title: '',
     description: '',
     inline: true,
-    children: null,
     width: '1em',
     height: '1em',
     color: 'inherit'

--- a/packages/ui-svg-images/src/SVGIcon/index.tsx
+++ b/packages/ui-svg-images/src/SVGIcon/index.tsx
@@ -69,8 +69,7 @@ class SVGIcon extends Component<Props> {
 
   static defaultProps = {
     rotate: '0',
-    bidirectional: false,
-    size: undefined
+    bidirectional: false
   }
 
   componentDidMount() {

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -73,11 +73,6 @@ class Body extends Component<Props> {
       PropTypes.oneOfType([PropTypes.node, PropTypes.func])
     )
   }
-  /* eslint-enable react/require-default-props */
-
-  static defaultProps = {
-    children: null
-  }
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message

--- a/packages/ui-table/src/Table/Cell/index.tsx
+++ b/packages/ui-table/src/Table/Cell/index.tsx
@@ -69,8 +69,7 @@ class Cell extends Component<Props> {
   /* eslint-enable react/require-default-props */
 
   static defaultProps = {
-    textAlign: 'start',
-    children: null
+    textAlign: 'start'
   }
 
   componentDidMount() {

--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -41,7 +41,7 @@ type Props = {
   makeStyles?: (...args: any[]) => any
   styles?: any
   id: string
-  stackedSortByLabel: string
+  stackedSortByLabel?: string
   width?: string | number
   textAlign?: 'start' | 'center' | 'end'
   sortDirection?: 'none' | 'ascending' | 'descending'
@@ -103,8 +103,6 @@ class ColHeader extends Component<Props> {
   static defaultProps = {
     textAlign: 'start',
     sortDirection: 'none',
-    stackedSortByLabel: undefined,
-    children: null,
     scope: 'col'
   }
 

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -75,11 +75,6 @@ class Head extends Component<Props> {
     isStacked: PropTypes.bool,
     renderSortLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
   }
-  /* eslint-enable react/require-default-props */
-
-  static defaultProps = {
-    children: null
-  }
 
   get isSortable() {
     const [row] = Children.toArray(this.props.children)

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -77,11 +77,6 @@ class Row extends Component<Props> {
       PropTypes.oneOfType([PropTypes.node, PropTypes.func])
     )
   }
-  /* eslint-enable react/require-default-props */
-
-  static defaultProps = {
-    children: null
-  }
 
   componentDidMount() {
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message

--- a/packages/ui-table/src/Table/RowHeader/index.tsx
+++ b/packages/ui-table/src/Table/RowHeader/index.tsx
@@ -64,11 +64,9 @@ class RowHeader extends Component<Props> {
      */
     textAlign: PropTypes.oneOf(['start', 'center', 'end'])
   }
-  /* eslint-enable react/require-default-props */
 
   static defaultProps = {
-    textAlign: 'start',
-    children: null
+    textAlign: 'start'
   }
 
   componentDidMount() {

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -108,11 +108,8 @@ class Table extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     hover: false,
-    layout: 'auto',
-    margin: undefined,
-    elementRef: undefined
+    layout: 'auto'
   }
 
   static Head = Head

--- a/packages/ui-tabs/src/Tabs/Panel/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Panel/index.tsx
@@ -91,18 +91,11 @@ class Panel extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
-    id: undefined,
     isDisabled: false,
-    maxHeight: undefined,
-    minHeight: undefined,
     textAlign: 'start',
     variant: 'default',
-    labelledBy: null,
     isSelected: false,
-    padding: 'small',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {}
+    padding: 'small'
   }
 
   componentDidMount() {

--- a/packages/ui-tabs/src/Tabs/Tab/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Tab/index.tsx
@@ -74,14 +74,9 @@ class Tab extends Component<Props> {
   }
 
   static defaultProps = {
-    children: null,
     variant: 'default',
     isDisabled: false,
-    isSelected: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClick: (event, { index, id }) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onKeyDown: (event, { index, id }) => {}
+    isSelected: false
   }
 
   componentDidMount() {
@@ -98,25 +93,19 @@ class Tab extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleClick = (event) => {
     const { onClick, index, id, isDisabled } = this.props
-
     if (isDisabled) {
       return
     }
-
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onClick(event, { index, id })
+    onClick?.(event, { index, id })
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleKeyDown = (event) => {
     const { onKeyDown, index, id, isDisabled } = this.props
-
     if (isDisabled) {
       return
     }
-
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onKeyDown(event, { index, id })
+    onKeyDown?.(event, { index, id })
   }
 
   render() {

--- a/packages/ui-tabs/src/Tabs/index.tsx
+++ b/packages/ui-tabs/src/Tabs/index.tsx
@@ -132,17 +132,6 @@ class Tabs extends Component<Props & BidirectionalProps> {
 
   static defaultProps = {
     variant: 'default',
-    padding: undefined,
-    textAlign: undefined,
-    maxWidth: undefined,
-    maxHeight: undefined,
-    minHeight: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onRequestTabChange: (event, { index, id }) => {},
-    margin: undefined,
-    children: null,
-    elementRef: () => {},
-    screenReaderLabel: undefined,
     shouldFocusOnRender: false,
     tabOverflow: 'stack'
   }

--- a/packages/ui-tag/src/Tag/index.tsx
+++ b/packages/ui-tag/src/Tag/index.tsx
@@ -106,13 +106,8 @@ class Tag extends Component<Props> {
     size: 'medium',
     dismissible: false,
     variant: 'default',
-    elementRef: undefined,
-    className: undefined,
-    title: undefined,
     disabled: false,
-    readOnly: false,
-    margin: undefined,
-    onClick: undefined
+    readOnly: false
   }
 
   componentDidMount() {

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -168,18 +168,8 @@ class TextArea extends Component<Props> {
     messages: [],
     disabled: false,
     readOnly: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'textarea' is declared but its value is never read... Remove this comment to see the full error message
-    textareaRef: function (textarea) {},
     layout: 'stacked',
-    id: undefined,
-    value: undefined,
-    defaultValue: undefined,
-    onChange: undefined,
-    required: false,
-    placeholder: undefined,
-    width: undefined,
-    height: undefined,
-    maxHeight: undefined
+    required: false
   }
 
   _listener: { remove(): void } | null = null
@@ -435,8 +425,7 @@ class TextArea extends Component<Props> {
         ref={(textarea, ...args) => {
           // @ts-expect-error ts-migrate(2339) FIXME: Property '_textarea' does not exist on type 'TextA... Remove this comment to see the full error message
           this._textarea = textarea
-          // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-          textareaRef.apply(this, [textarea].concat(args))
+          textareaRef?.apply(this, [textarea].concat(args))
         }}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '{ width: string | undefined; resize: "none" ... Remove this comment to see the full error message
         style={style}

--- a/packages/ui-text-input/src/TextInput/index.tsx
+++ b/packages/ui-text-input/src/TextInput/index.tsx
@@ -202,34 +202,13 @@ class TextInput extends Component<Props> {
   }
 
   static defaultProps = {
-    renderLabel: undefined,
     type: 'text',
-    id: undefined,
-    // Leave interaction default undefined so that `disabled` and `readOnly` can also be supplied
-    interaction: undefined,
     isRequired: false,
-    value: undefined,
-    defaultValue: undefined,
     display: 'block',
     shouldNotWrap: false,
-    placeholder: undefined,
-    width: undefined,
     size: 'medium',
-    htmlSize: undefined,
     textAlign: 'start',
-    messages: [],
-    // @ts-expect-error ts-migrate(6133) FIXME: 'input' is declared but its value is never read.
-    inputRef: function (input) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'container' is declared but its value is never rea... Remove this comment to see the full error message
-    inputContainerRef: function (container) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: function (event, value) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: function (event) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: function (event) {},
-    renderBeforeInput: undefined,
-    renderAfterInput: undefined
+    messages: []
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -304,20 +283,17 @@ class TextInput extends Component<Props> {
   handleInputRef = (node) => {
     // @ts-expect-error ts-migrate(2339) FIXME: Property '_input' does not exist on type 'TextInpu... Remove this comment to see the full error message
     this._input = node
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.inputRef(node)
+    this.props.inputRef?.(node)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleChange = (event) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onChange(event, event.target.value)
+    this.props.onChange?.(event, event.target.value)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleBlur = (event) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onBlur(event)
+    this.props.onBlur?.(event)
     this.setState({
       hasFocus: false
     })
@@ -325,8 +301,7 @@ class TextInput extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleFocus = (event) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onFocus(event)
+    this.props.onFocus?.(event)
     this.setState({
       hasFocus: true
     })

--- a/packages/ui-text/src/Text/index.tsx
+++ b/packages/ui-text/src/Text/index.tsx
@@ -118,14 +118,7 @@ class Text extends Component<Props> {
     as: 'span',
     wrap: 'normal',
     size: 'medium',
-    letterSpacing: 'normal',
-    children: null,
-    elementRef: undefined,
-    color: undefined,
-    transform: undefined,
-    lineHeight: undefined,
-    fontStyle: undefined,
-    weight: undefined
+    letterSpacing: 'normal'
   }
 
   componentDidMount() {

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -254,39 +254,15 @@ class TimeSelect extends Component<Props> {
   }
 
   static defaultProps = {
-    value: undefined,
-    defaultValue: undefined,
     defaultToFirstOption: false,
-    id: undefined,
     format: 'LT',
     step: 30,
-    interaction: undefined,
-    placeholder: undefined,
     isRequired: false,
     isInline: false,
-    width: undefined,
-    optionsMaxWidth: undefined,
     visibleOptionsCount: 8,
-    messages: undefined,
     placement: 'bottom stretch',
     constrain: 'window',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onChange: (event, data) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onFocus: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onBlur: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onShowOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onHideOptions: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    inputRef: (node) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'node' is declared but its value is never read.
-    listRef: (node) => {},
-    renderEmptyOption: '---',
-    renderBeforeInput: null,
-    renderAfterInput: null
+    renderEmptyOption: '---'
   }
 
   static contextType = ApplyLocaleContext
@@ -517,8 +493,7 @@ class TimeSelect extends Component<Props> {
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleBlur = (event) => {
     this.setState({ highlightedOptionId: null })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onBlur(event)
+    this.props.onBlur?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -536,16 +511,14 @@ class TimeSelect extends Component<Props> {
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'isShowingOptions' does not exist on type... Remove this comment to see the full error message
     if (!this.state.isShowingOptions) {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      this.props.onShowOptions(event)
+      this.props.onShowOptions?.(event)
     }
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleShowOptions = (event) => {
     this.setState({ isShowingOptions: true })
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onShowOptions(event)
+    this.props.onShowOptions?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -571,8 +544,7 @@ class TimeSelect extends Component<Props> {
       filteredOptions: this.filterOptions(''),
       ...this.matchValue()
     }))
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onHideOptions(event)
+    this.props.onHideOptions?.(event)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
@@ -615,11 +587,9 @@ class TimeSelect extends Component<Props> {
 
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'selectedOptionId' does not exist on type... Remove this comment to see the full error message
     if (id !== this.state.selectedOptionId) {
-      // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-      this.props.onChange(event, { value: option.value })
+      this.props.onChange?.(event, { value: option.value })
     }
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onHideOptions(event)
+    this.props.onHideOptions?.(event)
   }
 
   renderOptions() {

--- a/packages/ui-toggle-details/src/ToggleDetails/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/index.tsx
@@ -118,11 +118,7 @@ class ToggleDetails extends Component<Props> {
     icon: IconArrowOpenEndSolid,
     iconExpanded: IconArrowOpenDownSolid,
     iconPosition: 'start',
-    defaultExpanded: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onToggle: function (event, expanded) {},
-    children: null,
-    expanded: undefined
+    defaultExpanded: false
   }
 
   get focused() {
@@ -234,8 +230,7 @@ class ToggleDetails extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'event' implicitly has an 'any' type.
   handleToggle = (event, expanded) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onToggle(event, expanded)
+    this.props.onToggle?.(event, expanded)
     // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
     this.props.makeStyles({ animate: true })
   }

--- a/packages/ui-toggle-details/src/ToggleGroup/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleGroup/index.tsx
@@ -123,17 +123,12 @@ class ToggleGroup extends Component<Props> {
   }
 
   static defaultProps = {
-    expanded: undefined,
     size: 'medium',
     icon: IconArrowOpenEndSolid,
     iconExpanded: IconArrowOpenDownSolid,
     defaultExpanded: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onToggle: function (event, expanded) {},
     transition: true,
     as: 'span',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    elementRef: (el) => {},
     border: true
   }
 

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -159,20 +159,12 @@ class Tooltip extends Component<Props> {
   }
 
   static defaultProps = {
-    isShowingContent: undefined,
     defaultIsShowingContent: false,
-    on: undefined,
     color: 'primary',
     placement: 'top',
-    mountNode: null,
     constrain: 'window',
     offsetX: 0,
-    offsetY: 0,
-    positionTarget: undefined,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onShowContent: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onHideContent: (event, { documentClick }) => {}
+    offsetY: 0
   }
 
   _id = uid('Tooltip')

--- a/packages/ui-tray/src/Tray/index.tsx
+++ b/packages/ui-tray/src/Tray/index.tsx
@@ -213,33 +213,14 @@ class Tray extends Component<Props & BidirectionalProps> {
 
   static defaultProps = {
     open: false,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onOpen: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onClose: (event) => {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'event' is declared but its value is never read.
-    onDismiss: (event) => {},
-    onEnter: () => {},
-    onEntering: () => {},
-    onEntered: () => {},
-    onExit: () => {},
-    onExiting: () => {},
-    onExited: () => {},
-    mountNode: null,
     insertAt: 'bottom',
-    liveRegion: null,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'el' is declared but its value is never read.
-    contentRef: (el) => {},
     shouldCloseOnDocumentClick: false,
     shouldContainFocus: true,
     shouldReturnFocus: true,
-    defaultFocusElement: null,
     size: 'small',
     placement: 'start',
     shadow: true,
-    border: false,
-    children: null,
-    onTransition: undefined
+    border: false
   }
 
   state = {

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeButton/index.tsx
@@ -103,18 +103,7 @@ class TreeButton extends Component<Props> {
     variant: 'folderTree',
     selected: false,
     focused: false,
-    onClick: function () {},
-    id: undefined,
-    name: undefined,
-    collectionIcon: undefined,
-    collectionIconExpanded: undefined,
-    itemIcon: undefined,
-    thumbnail: undefined,
-    expanded: false,
-    descriptor: undefined,
-    level: undefined,
-    containerRef: function () {},
-    renderContent: undefined
+    expanded: false
   }
 
   componentDidMount() {
@@ -194,8 +183,7 @@ class TreeButton extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
   handleRef = (el) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    el && this.props.containerRef(el.parentElement)
+    el && this.props.containerRef?.(el.parentElement)
   }
 
   render() {

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
@@ -129,27 +129,13 @@ class TreeCollection extends Component<Props> {
     selection: '',
     size: 'medium',
     variant: 'folderTree',
-    onItemClick: function () {},
-    onCollectionClick: function () {},
-    onKeyDown: function () {},
-    id: undefined,
-    name: undefined,
-    descriptor: undefined,
-    collectionIconExpanded: undefined,
-    collectionIcon: undefined,
-    itemIcon: undefined,
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
     getItemProps: (props) => props,
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
     getCollectionProps: (props) => props,
-    numChildren: undefined,
-    level: undefined,
-    position: undefined,
     renderBeforeItems: null,
     renderAfterItems: null,
-    containerRef: function () {},
-    isCollectionFlattened: false,
-    renderContent: undefined
+    isCollectionFlattened: false
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -283,8 +269,7 @@ class TreeCollection extends Component<Props> {
 
     const itemHash = { id: key, type: 'child' }
 
-    // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-    const itemProps = getItemProps({
+    const itemProps = getItemProps?.({
       key: key,
       selected: selection === `child_${key}`,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'focused' does not exist on type 'Readonl... Remove this comment to see the full error message
@@ -319,8 +304,7 @@ class TreeCollection extends Component<Props> {
           if (typeof child.props.onKeyDown === 'function') {
             child.props.onKeyDown(e, n)
           } else {
-            // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-            onKeyDown(e, itemHash)
+            onKeyDown?.(e, itemHash)
           }
         }}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => void' is not assignable ... Remove this comment to see the full error message
@@ -373,8 +357,7 @@ class TreeCollection extends Component<Props> {
 
     const itemHash = { id: item.id, type: 'item' }
 
-    // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-    const itemProps = getItemProps({
+    const itemProps = getItemProps?.({
       ...this.getCommonButtonProps(),
       id: item.id,
       name: item.name,
@@ -398,9 +381,9 @@ class TreeCollection extends Component<Props> {
         aria-posinset={position}
         aria-setsize={this.childCount}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => any' is not assignable t... Remove this comment to see the full error message
-        onClick={(e, n) => onItemClick(e, itemHash)}
+        onClick={(e, n) => onItemClick?.(e, itemHash)}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => any' is not assignable t... Remove this comment to see the full error message
-        onKeyDown={(e, n) => onKeyDown(e, itemHash)}
+        onKeyDown={(e, n) => onKeyDown?.(e, itemHash)}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => void' is not assignable ... Remove this comment to see the full error message
         onFocus={(e, n) => this.handleFocus(e, itemHash)}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => void' is not assignable ... Remove this comment to see the full error message

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeNode/index.tsx
@@ -93,19 +93,10 @@ class TreeNode extends Component<Props> {
   }
 
   static defaultProps = {
-    id: undefined,
     size: 'medium',
     variant: 'folderTree',
     selected: false,
-    focused: false,
-    children: undefined,
-    itemIcon: undefined,
-    thumbnail: undefined,
-    level: undefined,
-    containerRef: function () {},
-    parentRef: undefined,
-    onKeyDown: undefined,
-    onClick: undefined
+    focused: false
   }
 
   componentDidMount() {
@@ -119,8 +110,7 @@ class TreeNode extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'el' implicitly has an 'any' type.
   handleRef = (el) => {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    el && this.props.containerRef(el.parentElement)
+    el && this.props.containerRef?.(el.parentElement)
   }
 
   // @ts-expect-error ts-migrate(7030) FIXME: Not all code paths return a value.

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -172,17 +172,7 @@ class TreeBrowser extends Component<Props> {
     // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
     getCollectionProps: (props) => props,
     defaultExpanded: [],
-    selectionType: 'none',
-    // @ts-expect-error ts-migrate(6133) FIXME: 'item' is declared but its value is never read.
-    onItemClick: function (item) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'id' is declared but its value is never read.
-    onCollectionClick: function (id, collection) {},
-    // @ts-expect-error ts-migrate(6133) FIXME: 'collection' is declared but its value is never re... Remove this comment to see the full error message
-    onCollectionToggle: function (collection) {},
-    rootId: undefined,
-    expanded: undefined,
-    treeLabel: undefined,
-    renderContent: undefined
+    selectionType: 'none'
   }
 
   static Node = TreeNode
@@ -215,8 +205,7 @@ class TreeBrowser extends Component<Props> {
     const { onCollectionClick } = this.props
 
     if (expand) this.expandOrCollapseNode(collection)
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onCollectionClick(collection.id, collection) // TODO: this should pass the event as the first arg
+    onCollectionClick?.(collection.id, collection) // TODO: this should pass the event as the first arg
     this.handleSelection(collection.id, 'collection')
   }
 
@@ -224,8 +213,7 @@ class TreeBrowser extends Component<Props> {
   handleItemClick = (e, item) => {
     e.stopPropagation()
     const { onItemClick } = this.props
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    onItemClick(item)
+    onItemClick?.(item)
     this.handleSelection(item.id, 'item') // TODO: this should pass the event as the first arg
   }
 
@@ -284,8 +272,7 @@ class TreeBrowser extends Component<Props> {
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'collection' implicitly has an 'any' typ... Remove this comment to see the full error message
   expandOrCollapseNode(collection) {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.onCollectionToggle(collection)
+    this.props.onCollectionToggle?.(collection)
     if (typeof this.props.expanded === 'undefined') {
       this.setState((state, props) => {
         const expanded = [].concat(this.getExpanded(state, props))

--- a/packages/ui-truncate-text/src/TruncateText/index.tsx
+++ b/packages/ui-truncate-text/src/TruncateText/index.tsx
@@ -116,9 +116,7 @@ class TruncateText extends Component<Props> {
     truncate: 'character',
     position: 'end',
     ignore: [' ', '.', ','],
-    debounce: 0,
-    // @ts-expect-error ts-migrate(6133) FIXME: 'truncated' is declared but its value is never rea... Remove this comment to see the full error message
-    onUpdate: (truncated, text) => {}
+    debounce: 0
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
@@ -218,8 +216,7 @@ class TruncateText extends Component<Props> {
 
       // @ts-expect-error ts-migrate(2339) FIXME: Property '_wasTruncated' does not exist on type 'T... Remove this comment to see the full error message
       if (!needsSecondRender && (isTruncated || this._wasTruncated)) {
-        // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-        onUpdate(isTruncated, truncatedText)
+        onUpdate?.(isTruncated, truncatedText)
         // @ts-expect-error ts-migrate(2339) FIXME: Property '_wasTruncated' does not exist on type 'T... Remove this comment to see the full error message
         this._wasTruncated = isTruncated
       } else {

--- a/packages/ui-utils/src/createChainedFunction.ts
+++ b/packages/ui-utils/src/createChainedFunction.ts
@@ -34,10 +34,9 @@ type GenericFunction = (...args: any[]) => any
  *
  * Forked from: https://github.com/react-bootstrap/react-overlays/blob/master/src/utils/createChainedFunction.js
  * @module createChainedFunction
- * @param {function} funcs to chain
- * @returns {function|null}
+ * @param funcs to chain
+ * @returns A single function that executes every input function.
  */
-
 function createChainedFunction(
   ...funcs: (null | undefined | GenericFunction)[]
 ) {
@@ -56,11 +55,11 @@ function createChainedFunction(
           'Invalid Argument Type, must only provide functions, undefined, or null.'
         )
       }
-      if (acc === null) {
+      if (acc == null) {
         return f
       }
-      return function chainedFunction(this: any, ...args) {
-        acc!.apply(this, args)
+      return function chainedFunction(this: unknown, ...args) {
+        acc.apply(this, args)
         f.apply(this, args)
       }
       // TODO I think it can return null too
@@ -70,9 +69,9 @@ function createChainedFunction(
 /**
  * Find all indexes for a value in an Array
  *
- * @param {array} arr The Array to search for val
- * @param {*} val The value to find indexes for
- * @return {array} All the indexes of the Array matching val
+ * @param arr The Array to search for val
+ * @param val The value to find indexes for
+ * @returns All the indexes of the Array matching val
  */
 function getAllIndexes(arr: unknown[], val: unknown): number[] {
   const indexes: number[] = []

--- a/packages/ui-view/src/ContextView/index.tsx
+++ b/packages/ui-view/src/ContextView/index.tsx
@@ -57,10 +57,10 @@ type Props = {
   debug?: boolean
   makeStyles?: (...args: any[]) => any
   styles?: CSSObject
-  margin: Spacing
-  padding: Spacing
-  shadow: Shadow
-  stacking: Stacking
+  margin?: Spacing
+  padding?: Spacing
+  shadow?: Shadow
+  stacking?: Stacking
   placement: unknown //TODO: fix this
 }
 
@@ -150,22 +150,13 @@ class ContextView extends Component<Props & OtherHTMLAttributes<Props>> {
 
   static defaultProps = {
     as: 'span',
-    elementRef: () => {},
     debug: false,
     width: 'auto',
     height: 'auto',
-    children: null,
     textAlign: 'start',
     background: 'default',
     shadow: 'resting',
-    placement: 'center end',
-    margin: undefined,
-    padding: undefined,
-    stacking: undefined,
-    maxWidth: undefined,
-    minWidth: undefined,
-    maxHeight: undefined,
-    minHeight: undefined
+    placement: 'center end'
   }
 
   componentDidMount() {


### PR DESCRIPTION
Remove any `undefined`, `null` and empty function (e.g. `()=>{}`)
Add null checks where needed.
There should be no functional difference.