### PR TITLE
INSTUI-3235: fix missing docs pages; deprecate elementMatches

### DIFF
--- a/docs/guides/v9-upgrade-guide.md
+++ b/docs/guides/v9-upgrade-guide.md
@@ -17,5 +17,5 @@ We recommend upgrading your application for each major version gradually, e.g. i
 The following deprecated components are removed in v9:
 
 - [ComponentIdentifier](#ComponentIdentifier), [DateTime](#DateTime): These components have been removed because they are not used by InstUI and other Instructure projects. If you need it, just copy & paste their code.
-
+- [elementMatches](#elementMatches) This polyfill is only needed for old, unsupported browsers.
 - InstUI-CLI's `create-app`, `create-component` and `create-package` commands: Just follow the instructions in the [usage](#usage) docs. Also, the `template-component`, `template-app` and `template-app` packages have been removed.

--- a/packages/__docs__/buildScripts/processFile.js
+++ b/packages/__docs__/buildScripts/processFile.js
@@ -42,7 +42,8 @@ module.exports = function processFile(fullPath, loaderOptions) {
     console.warn(
       '\x1b[33m%s\x1b[0m',
       '[docgen-loader]: Error when parsing ',
-      this.request
+      this.request,
+      fullPath
     )
     console.warn(err.toString())
   })
@@ -50,7 +51,6 @@ module.exports = function processFile(fullPath, loaderOptions) {
     ...doc,
     ...pathInfo
   }
-
   doc.id = getDocId(doc, context, fullPath)
   if (!doc.title && doc.id) {
     doc.title = doc.id
@@ -65,7 +65,6 @@ module.exports = function processFile(fullPath, loaderOptions) {
 function getDocId(docData, context, fullPath) {
   const { relativePath, id, describes } = docData
   let docId
-
   const lowerPath = relativePath.toLowerCase()
   if (id) {
     // exist if it was in the description at the top
@@ -81,13 +80,13 @@ function getDocId(docData, context, fullPath) {
   } else {
     docId = path.parse(fullPath).name // filename without extension
   }
-
   if (DOCS[docId] && DOCS[docId] !== docData.relativePath) {
     console.warn(
       '\x1b[33m%s\x1b[0m',
       `[${docId}] is a duplicate id: ${docData.relativePath}, ${DOCS[docId]}`
     )
   }
+
   DOCS[docId] = docData.relativePath
   return docId
 }

--- a/packages/__docs__/buildScripts/utils/getReactDoc.js
+++ b/packages/__docs__/buildScripts/utils/getReactDoc.js
@@ -23,12 +23,12 @@
  */
 
 const reactDocgen = require('react-docgen')
+const path = require('path')
 
 const ERROR_MISSING_DEFINITION = 'No suitable component definition found.'
 
 module.exports = function getReactDoc(source, fileName, error) {
   let doc = {}
-
   try {
     doc = reactDocgen.parse(
       source,
@@ -40,13 +40,24 @@ module.exports = function getReactDoc(source, fileName, error) {
       }
     )
     if (Array.isArray(doc)) {
-      doc = doc.pop()
+      if (doc.length > 1) {
+        // If a file has multiple exports this will choose the one that has the
+        // same name in its path.
+        for (const docExport of doc) {
+          const filePathArray = fileName.split(path.sep)
+          if (filePathArray.includes(docExport.displayName)) {
+            doc = docExport
+            break
+          }
+        }
+      } else {
+        doc = doc.pop()
+      }
     }
   } catch (err) {
     if (err.message !== ERROR_MISSING_DEFINITION) {
       error(err)
     }
   }
-
   return doc
 }

--- a/packages/ui-dom-utils/src/elementMatches.ts
+++ b/packages/ui-dom-utils/src/elementMatches.ts
@@ -31,15 +31,18 @@ import { UIElement } from '@instructure/shared-types'
  * ---
  *
  * Polyfill for Element.matches (https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)
+ * DEPRECATED This polyfill is only needed for old browsers and will be removed in InstUI v9
  * @module elementMatches
- * @param { Node | Window | React.ReactElement | function } el - component or DOM node
- * @param { string } selectorString - a string representing the selector to test
- * @returns { boolean } if the element would be selected by the specified selector string
+ * @param el - component or DOM node
+ * @param selectorString - a string representing the selector to test
+ * @returns if the element would be selected by the specified selector string
  */
 function elementMatches(el: UIElement, selectorString: string) {
   const node = el && findDOMNode(el)
   if (!node) return false
-  return (node as Element).matches(selectorString)
+  // this cast is in a separate line to circumvent a react-docgen bug
+  const elem: Element = node as Element
+  return elem.matches(selectorString)
 }
 
 export default elementMatches


### PR DESCRIPTION
Some docs pages were not generated because with the new importer param react-docgen returned an array of objects for files with multiple exports, and the code just took the last one.

Now it uses the one that has the same name in its path as the exported displayName.

Also one component could not be parsed due to some bug in react-docgen, it got a bit refactored. And deprecated because its only needed for old IEs