### PR TITLE
docs: removing 'firefox only' note for JAWS in docs (INSTUI-3244)

### DIFF
--- a/packages/__docs__/src/Hero/index.js
+++ b/packages/__docs__/src/Hero/index.js
@@ -222,7 +222,7 @@ class Hero extends Component {
             <Flex>
               <Flex.Item padding="none small none none">{checkmark}</Flex.Item>
               <Flex.Item>
-                Leading screen readers: VoiceOver, NVDA, and JAWS (Firefox only)
+                Leading screen readers: VoiceOver, NVDA, and JAWS
               </Flex.Item>
             </Flex>
           </List.Item>


### PR DESCRIPTION
Closes: INSTUI-3244

The A11y team's audit concluded, that JAWS in other browsers works well as well