### PR TITLE
INSTUI - 3251 docs: delete broken build-status badges.

### DIFF
--- a/packages/babel-plugin-transform-imports/README.md
+++ b/packages/babel-plugin-transform-imports/README.md
@@ -22,7 +22,6 @@ import Text from '@instructure/ui-elements/lib/Text'
 ```
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/browserslist-config-instui/README.md
+++ b/packages/browserslist-config-instui/README.md
@@ -5,7 +5,6 @@ category: packages
 ## browserslist-config-instui
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/canvas-high-contrast-theme/README.md
+++ b/packages/canvas-high-contrast-theme/README.md
@@ -5,7 +5,6 @@ category: packages
 ## canvas-high-contrast-theme
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/canvas-theme/README.md
+++ b/packages/canvas-theme/README.md
@@ -5,7 +5,6 @@ category: packages
 ## canvas-theme
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/command-utils/README.md
+++ b/packages/command-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## command-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/config-loader/README.md
+++ b/packages/config-loader/README.md
@@ -5,7 +5,6 @@ category: packages
 ## config-loader
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -5,7 +5,6 @@ category: packages
 ## console
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/cz-lerna-changelog/README.md
+++ b/packages/cz-lerna-changelog/README.md
@@ -5,7 +5,6 @@ category: packages
 ## cz-lerna-changelog
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -7,7 +7,6 @@ title: debounce
 ## debounce
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/eslint-plugin-instructure-ui/README.md
+++ b/packages/eslint-plugin-instructure-ui/README.md
@@ -5,7 +5,6 @@ category: packages
 ## eslint-plugin-instructure-ui
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/instructure-theme/README.md
+++ b/packages/instructure-theme/README.md
@@ -5,7 +5,6 @@ category: packages
 ## instructure-theme
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/instui-config/README.md
+++ b/packages/instui-config/README.md
@@ -5,7 +5,6 @@ category: packages
 ## instui-config
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/pkg-utils/README.md
+++ b/packages/pkg-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## pkg-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/template-app/README.md
+++ b/packages/template-app/README.md
@@ -5,7 +5,6 @@ category: packages
 ## template-app
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/template-component/README.md
+++ b/packages/template-component/README.md
@@ -5,7 +5,6 @@ category: packages
 ## template-component
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/template-package/README.md
+++ b/packages/template-package/README.md
@@ -5,7 +5,6 @@ category: packages
 ## template-package
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-a11y-content/README.md
+++ b/packages/ui-a11y-content/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-a11y-content
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-a11y-utils/README.md
+++ b/packages/ui-a11y-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-a11y-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-alerts/README.md
+++ b/packages/ui-alerts/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-alerts
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-avatar/README.md
+++ b/packages/ui-avatar/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-avatar
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-axe-check/README.md
+++ b/packages/ui-axe-check/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-axe-check
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-babel-preset/README.md
+++ b/packages/ui-babel-preset/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-babel-preset
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-badge/README.md
+++ b/packages/ui-badge/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-badge
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-billboard/README.md
+++ b/packages/ui-billboard/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-billboard
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-breadcrumb/README.md
+++ b/packages/ui-breadcrumb/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-breadcrumb
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-buttons/README.md
+++ b/packages/ui-buttons/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-buttons
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-byline/README.md
+++ b/packages/ui-byline/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-byline
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-calendar/README.md
+++ b/packages/ui-calendar/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-calendar
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-checkbox/README.md
+++ b/packages/ui-checkbox/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-checkbox
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-code-editor/README.md
+++ b/packages/ui-code-editor/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-code-editor
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-codemods/README.md
+++ b/packages/ui-codemods/README.md
@@ -7,7 +7,6 @@ category: packages
 The ui-codemods should make it easier to deal with API changes when upgrading Instructure UI libraries.
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-color-utils/README.md
+++ b/packages/ui-color-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-color-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-date-input/README.md
+++ b/packages/ui-date-input/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-date-input
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-decorator/README.md
+++ b/packages/ui-decorator/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-decorator
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-dialog/README.md
+++ b/packages/ui-dialog/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-dialog
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-dom-utils/README.md
+++ b/packages/ui-dom-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-dom-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-drawer-layout/README.md
+++ b/packages/ui-drawer-layout/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-drawer-layout
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-editable/README.md
+++ b/packages/ui-editable/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-editable
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-eslint-config/README.md
+++ b/packages/ui-eslint-config/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-eslint-config
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-expandable/README.md
+++ b/packages/ui-expandable/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-expandable
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-file-drop/README.md
+++ b/packages/ui-file-drop/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-file-drop
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-flex/README.md
+++ b/packages/ui-flex/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-flex
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-focusable/README.md
+++ b/packages/ui-focusable/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-focusable
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-form-field/README.md
+++ b/packages/ui-form-field/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-form-field
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-grid/README.md
+++ b/packages/ui-grid/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-grid
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-heading/README.md
+++ b/packages/ui-heading/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-heading
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-i18n/README.md
+++ b/packages/ui-i18n/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-i18n
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-icons-build/README.md
+++ b/packages/ui-icons-build/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-icons-build
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-icons/README.md
+++ b/packages/ui-icons/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-icons
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-img/README.md
+++ b/packages/ui-img/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-img
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-karma-config/README.md
+++ b/packages/ui-karma-config/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-karma-config
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-link/README.md
+++ b/packages/ui-link/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-link
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-list/README.md
+++ b/packages/ui-list/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-list
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-menu/README.md
+++ b/packages/ui-menu/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-menu
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-metric/README.md
+++ b/packages/ui-metric/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-metric
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-modal/README.md
+++ b/packages/ui-modal/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-modal
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-motion/README.md
+++ b/packages/ui-motion/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-motion
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-navigation/README.md
+++ b/packages/ui-navigation/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-navigation
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-number-input/README.md
+++ b/packages/ui-number-input/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-number-input
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-options/README.md
+++ b/packages/ui-options/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-options
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-overlays/README.md
+++ b/packages/ui-overlays/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-overlays
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-pages/README.md
+++ b/packages/ui-pages/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-pages
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-pagination/README.md
+++ b/packages/ui-pagination/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-pagination
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-pill/README.md
+++ b/packages/ui-pill/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-pill
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-popover/README.md
+++ b/packages/ui-popover/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-popover
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-portal/README.md
+++ b/packages/ui-portal/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-portal
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-position/README.md
+++ b/packages/ui-position/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-position
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-progress/README.md
+++ b/packages/ui-progress/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-progress
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-prop-types/README.md
+++ b/packages/ui-prop-types/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-prop-types
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-radio-input/README.md
+++ b/packages/ui-radio-input/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-radio-input
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-range-input/README.md
+++ b/packages/ui-range-input/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-range-input
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-rating/README.md
+++ b/packages/ui-rating/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-rating
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-react-utils/README.md
+++ b/packages/ui-react-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-react-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-responsive/README.md
+++ b/packages/ui-responsive/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-responsive
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-scripts/README.md
+++ b/packages/ui-scripts/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-scripts
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-select/README.md
+++ b/packages/ui-select/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-select
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-selectable/README.md
+++ b/packages/ui-selectable/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-selectable
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-simple-select/README.md
+++ b/packages/ui-simple-select/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-simple-select
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-spinner/README.md
+++ b/packages/ui-spinner/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-spinner
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-stylelint-config/README.md
+++ b/packages/ui-stylelint-config/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-stylelint-config
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-svg-images/README.md
+++ b/packages/ui-svg-images/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-svg-images
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-table/README.md
+++ b/packages/ui-table/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-table
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-tabs/README.md
+++ b/packages/ui-tabs/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-tabs
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-tag/README.md
+++ b/packages/ui-tag/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-tag
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-template-scripts/README.md
+++ b/packages/ui-template-scripts/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-template-scripts
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-test-locator/README.md
+++ b/packages/ui-test-locator/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-test-locator
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-test-queries/README.md
+++ b/packages/ui-test-queries/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-test-queries
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-test-sandbox/README.md
+++ b/packages/ui-test-sandbox/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-test-sandbox
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-test-utils/README.md
+++ b/packages/ui-test-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-test-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-testable/README.md
+++ b/packages/ui-testable/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-testable
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-text-area/README.md
+++ b/packages/ui-text-area/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-text-area
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-text-input/README.md
+++ b/packages/ui-text-input/README.md
@@ -4,6 +4,7 @@ category: packages
 
 ## ui-text-input
 
+[![npm][npm]][npm-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-text-input/README.md
+++ b/packages/ui-text-input/README.md
@@ -4,8 +4,6 @@ category: packages
 
 ## ui-text-input
 
-[![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-text/README.md
+++ b/packages/ui-text/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-text
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-theme-tokens/README.md
+++ b/packages/ui-theme-tokens/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-theme-tokens
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-themes/README.md
+++ b/packages/ui-themes/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-themes
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-time-select/README.md
+++ b/packages/ui-time-select/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-time-select
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-toggle-details/README.md
+++ b/packages/ui-toggle-details/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-toggle-details
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-token-scripts/README.md
+++ b/packages/ui-token-scripts/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-token-scripts
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-tooltip/README.md
+++ b/packages/ui-tooltip/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-tooltip
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-tray/README.md
+++ b/packages/ui-tray/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-tray
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-tree-browser/README.md
+++ b/packages/ui-tree-browser/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-tree-browser
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-truncate-text/README.md
+++ b/packages/ui-truncate-text/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-truncate-text
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-upgrade-scripts/README.md
+++ b/packages/ui-upgrade-scripts/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-upgrade-scripts
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-utils/README.md
+++ b/packages/ui-utils/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-utils
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-view/README.md
+++ b/packages/ui-view/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-view
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui-webpack-config/README.md
+++ b/packages/ui-webpack-config/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui-webpack-config
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -5,7 +5,6 @@ category: packages
 ## ui
 
 [![npm][npm]][npm-url]
-[![build-status][build-status]][build-status-url]
 [![MIT License][license-badge]][license]
 [![Code of Conduct][coc-badge]][coc]
 

--- a/packages/uid/README.md
+++ b/packages/uid/README.md
@@ -7,7 +7,6 @@ title: uid
 ## uid
 
 [![npm][npm]][npm-url]&nbsp;
-[![build-status][build-status]][build-status-url]&nbsp;
 [![MIT License][license-badge]][license]&nbsp;
 [![Code of Conduct][coc-badge]][coc]
 


### PR DESCRIPTION
Our Readme.md files have a broken build-status badge, for example https://github.com/instructure/instructure-ui/blob/master/packages/ui-date-input/README.md
This pull request remove these badges from README.md files.