### PR TITLE
INSTUI-3253 : fix shared-types TS errors

### DIFF
--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@emotion/react": "^11.4.1",
     "@instructure/console": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-decorator": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
     "@instructure/ui-themes": "8.8.0",
@@ -37,7 +38,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@types/lodash": "^4.14.171",

--- a/packages/ui-a11y-content/package.json
+++ b/packages/ui-a11y-content/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
   },

--- a/packages/ui-alerts/package.json
+++ b/packages/ui-alerts/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
@@ -33,6 +32,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-buttons": "8.8.0",
     "@instructure/ui-icons": "8.8.0",

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -27,13 +27,13 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-view": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-badge/package.json
+++ b/packages/ui-badge/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-position": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-billboard/package.json
+++ b/packages/ui-billboard/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-heading": "8.8.0",
     "@instructure/ui-img": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",

--- a/packages/ui-breadcrumb/package.json
+++ b/packages/ui-breadcrumb/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -37,6 +36,7 @@
     "@instructure/ui-link": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-truncate-text": "8.8.0",
     "@instructure/ui-utils": "8.8.0",

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-queries": "8.8.0",
@@ -42,6 +41,7 @@
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-position": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-tooltip": "8.8.0",
     "@instructure/ui-utils": "8.8.0",

--- a/packages/ui-byline/package.json
+++ b/packages/ui-byline/package.json
@@ -26,13 +26,13 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-view": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-calendar/package.json
+++ b/packages/ui-calendar/package.json
@@ -25,7 +25,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -36,6 +35,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -32,6 +32,7 @@
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-svg-images": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-utils": "8.8.0",
@@ -41,7 +42,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-code-editor/package.json
+++ b/packages/ui-code-editor/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@instructure/ui-themes": "8.8.0"
@@ -32,6 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -28,12 +28,12 @@
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
     "@instructure/console": "8.8.0",
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"

--- a/packages/ui-dom-utils/package.json
+++ b/packages/ui-dom-utils/package.json
@@ -23,11 +23,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
   },
   "dependencies": {
+    "@instructure/shared-types": "8.8.0",
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0"
   },

--- a/packages/ui-drawer-layout/package.json
+++ b/packages/ui-drawer-layout/package.json
@@ -28,6 +28,7 @@
     "@instructure/console": "8.8.0",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dialog": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
@@ -44,7 +45,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-themes": "8.8.0"

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
@@ -38,7 +39,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-flex/package.json
+++ b/packages/ui-flex/package.json
@@ -27,12 +27,12 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-view": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@instructure/ui-themes": "8.8.0"

--- a/packages/ui-form-field/package.json
+++ b/packages/ui-form-field/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@instructure/ui-themes": "8.8.0"
@@ -33,6 +32,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-grid": "8.8.0",

--- a/packages/ui-grid/package.json
+++ b/packages/ui-grid/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
@@ -34,7 +35,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-heading/package.json
+++ b/packages/ui-heading/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -34,7 +35,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-i18n/package.json
+++ b/packages/ui-i18n/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@types/hoist-non-react-statics": "^3.3.1"
@@ -35,6 +34,7 @@
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-utils": "8.8.0",
     "hoist-non-react-statics": "^3.3.2",
     "moment-timezone": "^0.5",

--- a/packages/ui-img/package.json
+++ b/packages/ui-img/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -34,7 +35,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"

--- a/packages/ui-link/package.json
+++ b/packages/ui-link/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
@@ -38,7 +39,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-queries": "8.8.0",

--- a/packages/ui-list/package.json
+++ b/packages/ui-list/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -34,7 +35,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -36,6 +35,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-icons": "8.8.0",

--- a/packages/ui-metric/package.json
+++ b/packages/ui-metric/package.json
@@ -27,13 +27,13 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-buttons": "8.8.0",
     "@instructure/ui-dialog": "8.8.0",
     "@instructure/ui-motion": "8.8.0",
@@ -43,7 +44,6 @@
     "react": ">=16.8 <=17"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-position": "8.8.0",

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -33,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",

--- a/packages/ui-navigation/package.json
+++ b/packages/ui-navigation/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -36,6 +35,7 @@
     "@instructure/console": "8.8.0",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-badge": "8.8.0",

--- a/packages/ui-number-input/package.json
+++ b/packages/ui-number-input/package.json
@@ -24,7 +24,6 @@
     "ts:check": "tsc -p tsconfig.build.json --noEmit --emitDeclarationOnly false"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -33,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",

--- a/packages/ui-overlays/package.json
+++ b/packages/ui-overlays/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-queries": "8.8.0",
@@ -35,6 +34,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-buttons": "8.8.0",
     "@instructure/ui-dialog": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",

--- a/packages/ui-pages/package.json
+++ b/packages/ui-pages/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -34,6 +33,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",

--- a/packages/ui-pagination/package.json
+++ b/packages/ui-pagination/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-queries": "8.8.0",
@@ -33,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-a11y-utils": "8.8.0",
     "@instructure/ui-buttons": "8.8.0",

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-tooltip": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -24,12 +24,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",

--- a/packages/ui-position/package.json
+++ b/packages/ui-position/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-portal": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
@@ -37,7 +38,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-progress/package.json
+++ b/packages/ui-progress/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
@@ -35,7 +36,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-radio-input/package.json
+++ b/packages/ui-radio-input/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
@@ -35,7 +36,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-range-input/package.json
+++ b/packages/ui-range-input/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
@@ -40,7 +41,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-rating/package.json
+++ b/packages/ui-rating/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
@@ -37,7 +38,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-react-utils/package.json
+++ b/packages/ui-react-utils/package.json
@@ -23,7 +23,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
   },
@@ -31,6 +30,7 @@
     "@babel/runtime": "^7.13.10",
     "@emotion/is-prop-valid": "^1",
     "@instructure/console": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-decorator": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-utils": "8.8.0",

--- a/packages/ui-responsive/package.json
+++ b/packages/ui-responsive/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/debounce": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -34,7 +35,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-icons": "8.8.0",

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-svg-images/package.json
+++ b/packages/ui-svg-images/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -33,6 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
     "@instructure/ui-utils": "8.8.0",

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
@@ -34,6 +33,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-a11y-content": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",

--- a/packages/ui-tabs/package.json
+++ b/packages/ui-tabs/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -36,6 +35,7 @@
     "@instructure/console": "8.8.0",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-focusable": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",

--- a/packages/ui-tag/package.json
+++ b/packages/ui-tag/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-text-area/package.json
+++ b/packages/ui-text-area/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
@@ -37,7 +38,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-text-input/package.json
+++ b/packages/ui-text-input/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-badge": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-form-field": "8.8.0",
     "@instructure/ui-icons": "8.8.0",

--- a/packages/ui-text/package.json
+++ b/packages/ui-text/package.json
@@ -27,11 +27,11 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@instructure/ui-themes": "8.8.0"

--- a/packages/ui-theme-tokens/package.json
+++ b/packages/ui-theme-tokens/package.json
@@ -23,12 +23,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0"
   },
   "dependencies": {
+    "@instructure/shared-types": "8.8.0",
     "@babel/runtime": "^7.13.10"
   },
   "publishConfig": {

--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -23,14 +23,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-theme-tokens": "8.8.0"
   },
   "dependencies": {
     "@instructure/canvas-high-contrast-theme": "8.8.0",
     "@instructure/canvas-theme": "8.8.0",
-    "@instructure/instructure-theme": "8.8.0"
+    "@instructure/instructure-theme": "8.8.0",
+    "@instructure/shared-types": "8.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-toggle-details/package.json
+++ b/packages/ui-toggle-details/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-queries": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-buttons": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-expandable": "8.8.0",

--- a/packages/ui-tooltip/package.json
+++ b/packages/ui-tooltip/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-popover": "8.8.0",
     "@instructure/ui-position": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",
@@ -35,7 +36,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",

--- a/packages/ui-tray/package.json
+++ b/packages/ui-tray/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dialog": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
     "@instructure/ui-motion": "8.8.0",
@@ -39,7 +40,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-locator": "8.8.0",
@@ -34,6 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-icons": "8.8.0",
     "@instructure/ui-img": "8.8.0",
     "@instructure/ui-prop-types": "8.8.0",

--- a/packages/ui-truncate-text/package.json
+++ b/packages/ui-truncate-text/package.json
@@ -28,6 +28,7 @@
     "@instructure/console": "8.8.0",
     "@instructure/debounce": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-react-utils": "8.8.0",
     "@instructure/ui-testable": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",

--- a/packages/ui-view/package.json
+++ b/packages/ui-view/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.13.10",
     "@instructure/console": "8.8.0",
     "@instructure/emotion": "8.8.0",
+    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-color-utils": "8.8.0",
     "@instructure/ui-dom-utils": "8.8.0",
     "@instructure/ui-i18n": "8.8.0",
@@ -36,7 +37,6 @@
     "prop-types": "^15"
   },
   "devDependencies": {
-    "@instructure/shared-types": "8.8.0",
     "@instructure/ui-babel-preset": "8.8.0",
     "@instructure/ui-test-utils": "8.8.0",
     "@instructure/ui-themes": "8.8.0"


### PR DESCRIPTION
Closes: INSTUI-3253

The shared-types package was added as a devDependency causing TypeScript errors in some components.
This commit moves them to the normal dependencies.