### PR TITLE
INSTUI-3174 Refactor code, so propTypes is not used in code logic

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -64,8 +64,3 @@ Just add the `@instructure/ui` dependency as shown above and wrap the part of yo
 - To use a different theme or customize one read about [EmotionThemeProvider](#EmotionThemeProvider)
 - Make sure you read about [Accessibility](#accessibility) with InstUI.
 - [How to make your own component that uses InstUI's theming engine](#emotion)
-
-> Note: Do not use tools with Instructure UI that remove `PropTypes` (for example
-> [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)).
-> Instructure UI uses `PropTypes` for its internal functionality (e.g. in
-> `ui-react-utils/src/passtroughProps.js`), thus removing them will cause issues.

--- a/packages/__docs__/src/Figure/index.js
+++ b/packages/__docs__/src/Figure/index.js
@@ -77,6 +77,17 @@ class Figure extends Component {
     children: Children.oneOf(['FigureItem'])
   }
 
+  static allowedProps = [
+    'makeStyles',
+    'styles',
+    'title',
+    'caption',
+    'recommendation',
+    'iconTitle',
+    'float',
+    'children'
+  ]
+
   static defaultProps = {
     recommendation: 'none',
     float: 'none',
@@ -116,7 +127,7 @@ class Figure extends Component {
 
     return (
       <View
-        {...omitProps(mergedProps, Figure.propTypes, ['padding'])}
+        {...omitProps(mergedProps, Figure.allowedProps, ['padding'])}
         as="figure"
         css={styles.figure}
       >

--- a/packages/__docs__/src/Figure/index.js
+++ b/packages/__docs__/src/Figure/index.js
@@ -78,8 +78,6 @@ class Figure extends Component {
   }
 
   static allowedProps = [
-    'makeStyles',
-    'styles',
     'title',
     'caption',
     'recommendation',

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -153,9 +153,8 @@ const withStyle = decorator(
       )
     })
     hoistNonReactStatics(WithStyle, ComposedComponent)
-    // we have to pass these on, because sometimes we need to
+    // we have to pass these on, because sometimes users
     // access propTypes of the component in other components
-    // (mainly in the `omitProps` method)
     WithStyle.propTypes = ComposedComponent.propTypes
     WithStyle.defaultProps = ComposedComponent.defaultProps
     // @ts-expect-error These static fields exist on InstUI components

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -155,6 +155,7 @@ const withStyle = decorator(
     hoistNonReactStatics(WithStyle, ComposedComponent)
     // we have to pass these on, because sometimes users
     // access propTypes of the component in other components
+    // eslint-disable-next-line react/forbid-foreign-prop-types
     WithStyle.propTypes = ComposedComponent.propTypes
     WithStyle.defaultProps = ComposedComponent.defaultProps
     // @ts-expect-error These static fields exist on InstUI components

--- a/packages/ui-billboard/src/Billboard/index.tsx
+++ b/packages/ui-billboard/src/Billboard/index.tsx
@@ -145,10 +145,10 @@ class Billboard extends Component<BillboardProps> {
     return (
       <View as="div" margin={margin}>
         <View
-          {...omitProps(this.props, {
-            ...Billboard.propTypes,
+          {...omitProps(this.props, [
+            ...Billboard.allowedProps,
             ...View.allowedProps
-          })}
+          ])}
           type={Element === 'button' ? 'button' : undefined}
           as={Element}
           elementRef={elementRef}

--- a/packages/ui-billboard/src/Billboard/props.ts
+++ b/packages/ui-billboard/src/Billboard/props.ts
@@ -113,19 +113,19 @@ const propTypes: PropValidators<PropKeys> = {
 }
 
 const allowedProps: AllowedPropKeys = [
+  'hero',
+  'size',
   'as',
-  'disabled',
   'elementRef',
   'heading',
   'headingAs',
   'headingLevel',
-  'hero',
-  'href',
-  'margin',
   'message',
   'onClick',
+  'href',
+  'disabled',
   'readOnly',
-  'size'
+  'margin'
 ]
 
 export type { BillboardProps }

--- a/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
@@ -50,7 +50,7 @@ class BreadcrumbLink extends Component<BreadcrumbLinkProps> {
   render() {
     const { children, href, renderIcon, iconPlacement, onClick } = this.props
 
-    const props = omitProps(this.props, BreadcrumbLink.propTypes)
+    const props = omitProps(this.props, BreadcrumbLink.allowedProps)
 
     return (
       <Link

--- a/packages/ui-byline/src/Byline/index.tsx
+++ b/packages/ui-byline/src/Byline/index.tsx
@@ -65,7 +65,7 @@ class Byline extends Component<BylineProps> {
 
   render() {
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Byline.propTypes),
+      omitProps(this.props, Byline.allowedProps),
       Byline
     )
 

--- a/packages/ui-calendar/src/Calendar/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/Day/index.tsx
@@ -138,7 +138,7 @@ class Day extends Component<CalendarDayProps> {
     const { elementType, isDisabled } = this
 
     const passthroughProps = View.omitViewProps(
-      omitProps(props, Day.propTypes),
+      omitProps(props, Day.allowedProps),
       Day
     )
 

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -209,7 +209,7 @@ class Calendar extends Component<CalendarProps> {
 
   render() {
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Calendar.propTypes),
+      omitProps(this.props, Calendar.allowedProps),
       Calendar
     )
 

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -270,7 +270,7 @@ class Checkbox extends Component<CheckboxProps> {
       styles
     } = this.props
 
-    const props = omitProps(this.props, Checkbox.propTypes)
+    const props = omitProps(this.props, Checkbox.allowedProps)
 
     error(
       !(variant === 'toggle' && indeterminate),

--- a/packages/ui-checkbox/src/CheckboxGroup/index.tsx
+++ b/packages/ui-checkbox/src/CheckboxGroup/index.tsx
@@ -150,8 +150,8 @@ class CheckboxGroup extends Component<CheckboxGroupProps> {
     return (
       // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       <FormFieldGroup
-        {...omitProps(this.props, CheckboxGroup.propTypes)}
-        {...pickProps(this.props, FormFieldGroup.propTypes)}
+        {...omitProps(this.props, CheckboxGroup.allowedProps)}
+        {...pickProps(this.props, FormFieldGroup.allowedProps)}
         rowSpacing="small"
         vAlign="top"
         // @ts-expect-error ts-migrate(2339) FIXME: Property '_messagesId' does not exist on type 'Che... Remove this comment to see the full error message

--- a/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
@@ -115,6 +115,7 @@ describe('<Dialog />', async () => {
   describe('managed focus', async () => {
     class DialogExample extends React.Component {
       static propTypes = {
+        // eslint-disable-next-line react/forbid-foreign-prop-types
         ...Dialog.propTypes
       }
 
@@ -475,6 +476,7 @@ describe('<Dialog />', async () => {
       describe('when launching a dialog w/out focusable content from another dialog', () => {
         class NestedDialogExample extends React.Component {
           static propTypes = {
+            // eslint-disable-next-line react/forbid-foreign-prop-types
             ...Dialog.propTypes
           }
 

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -184,7 +184,7 @@ class Dialog extends Component<DialogProps & OtherHTMLAttributes<DialogProps>> {
     return this.props.open ? (
       <ElementType
         // @ts-expect-error TODO: `ref` prop causes: "Expression produces a union type that is too complex to represent.ts(2590)"
-        {...omitProps(this.props, Dialog.propTypes)}
+        {...omitProps(this.props, Dialog.allowedProps)}
         role={this.props.label ? 'dialog' : undefined}
         aria-label={this.props.label}
         className={this.props.className} // eslint-disable-line react/prop-types

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -148,7 +148,7 @@ class DrawerContent extends Component<
 
     return (
       <div
-        {...omitProps(this.props, DrawerContent.propTypes, [
+        {...omitProps(this.props, DrawerContent.allowedProps, [
           'shouldTransition'
         ])}
         role={role}

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -246,7 +246,7 @@ class DrawerTray extends Component<
               unmountOnExit
             >
               <div
-                {...omitProps(props, DrawerTray.propTypes)}
+                {...omitProps(props, DrawerTray.allowedProps)}
                 ref={this.handleContentRef}
                 css={trayStyles}
               >

--- a/packages/ui-eslint-config/lib/index.js
+++ b/packages/ui-eslint-config/lib/index.js
@@ -49,6 +49,7 @@ module.exports = {
   rules: {
     'react/no-deprecated': 0,
     'react/no-find-dom-node': 0,
+    'react/forbid-foreign-prop-types': 'error',
     'react/prop-types': ['error', { skipUndeclared: true }],
     'react/require-default-props': 'error',
     'react/no-typos': 'error',

--- a/packages/ui-flex/src/Flex/Item/index.tsx
+++ b/packages/ui-flex/src/Flex/Item/index.tsx
@@ -65,7 +65,7 @@ class Item extends Component<FlexItemProps> {
   }
 
   render() {
-    const props = omitProps(this.props, Item.propTypes)
+    const props = omitProps(this.props, Item.allowedProps)
 
     const {
       as,

--- a/packages/ui-form-field/src/FormField/index.tsx
+++ b/packages/ui-form-field/src/FormField/index.tsx
@@ -52,8 +52,8 @@ class FormField extends Component<FormFieldProps> {
   render() {
     return (
       <FormFieldLayout
-        {...omitProps(this.props, FormField.propTypes)}
-        {...pickProps(this.props, FormFieldLayout.propTypes)}
+        {...omitProps(this.props, FormField.allowedProps)}
+        {...pickProps(this.props, FormFieldLayout.allowedProps)}
         // @ts-expect-error ts-migrate(2322) FIXME: Remove this comment to see the full error message
         vAlign={this.props.vAlign}
         as="label"

--- a/packages/ui-form-field/src/FormFieldGroup/index.tsx
+++ b/packages/ui-form-field/src/FormFieldGroup/index.tsx
@@ -126,8 +126,8 @@ class FormFieldGroup extends Component<FormFieldGroupProps> {
 
     return (
       <FormFieldLayout
-        {...omitProps(props, FormFieldGroup.propTypes)}
-        {...pickProps(props, FormFieldLayout.propTypes)}
+        {...omitProps(props, FormFieldGroup.allowedProps)}
+        {...pickProps(props, FormFieldLayout.allowedProps)}
         // @ts-expect-error ts-migrate(2322) FIXME: Type '{ children: Element; vAlign: "top" | "middle... Remove this comment to see the full error message
         vAlign={props.vAlign}
         layout={props.layout === 'inline' ? 'inline' : 'stacked'}

--- a/packages/ui-form-field/src/FormFieldLabel/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLabel/index.tsx
@@ -78,7 +78,7 @@ class FormFieldLabel extends Component<FormFieldLabelProps> {
 
     return (
       <ElementType
-        {...omitProps(this.props, FormFieldLabel.propTypes)}
+        {...omitProps(this.props, FormFieldLabel.allowedProps)}
         css={styles?.formFieldLabel}
       >
         {children}

--- a/packages/ui-form-field/src/FormFieldLayout/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/index.tsx
@@ -175,13 +175,12 @@ class FormFieldLayout extends Component<FormFieldLayoutProps> {
     const { makeStyles, styles, ...props } = this.props
 
     const { width, layout, children } = props
-
     return (
       <ElementType
-        {...omitProps(props, {
-          ...FormFieldLayout.propTypes,
-          ...Grid.propTypes
-        })}
+        {...omitProps(props, [
+          ...FormFieldLayout.allowedProps,
+          ...Grid.allowedProps
+        ])}
         css={styles?.formFieldLayout}
         style={{ width }}
         // @ts-expect-error ts-migrate(2339) FIXME: Property '_messagesId' does not exist on type 'For... Remove this comment to see the full error message
@@ -194,7 +193,7 @@ class FormFieldLayout extends Component<FormFieldLayoutProps> {
           startAt={
             layout === 'inline' && this.hasVisibleLabel ? 'medium' : null
           }
-          {...pickProps(props, Grid.propTypes)}
+          {...pickProps(props, Grid.allowedProps)}
         >
           <Grid.Row>
             {this.renderLabel()}

--- a/packages/ui-form-field/src/FormFieldMessages/index.tsx
+++ b/packages/ui-form-field/src/FormFieldMessages/index.tsx
@@ -80,7 +80,7 @@ class FormFieldMessages extends Component<FormFieldMessagesProps> {
     return messages && messages.length > 0 ? (
       <span
         css={styles?.formFieldMessages}
-        {...omitProps(this.props, FormFieldMessages.propTypes)}
+        {...omitProps(this.props, FormFieldMessages.allowedProps)}
       >
         {messages.map((msg, i) => {
           return (

--- a/packages/ui-grid/src/Grid/index.tsx
+++ b/packages/ui-grid/src/Grid/index.tsx
@@ -85,7 +85,7 @@ class Grid extends Component<GridProps> {
     return children.map((child, index) => {
       if (matchComponentTypes(child, [GridRow])) {
         return safeCloneElement(child as ReactElement, {
-          ...pickProps(props, Grid.propTypes),
+          ...pickProps(props, Grid.allowedProps),
           // @ts-expect-error ts-migrate(2339) FIXME: Property 'props' does not exist on type 'string | ... Remove this comment to see the full error message
           ...child.props /* child props should override parent */,
           isLastRow: index + 1 === children.length
@@ -99,7 +99,7 @@ class Grid extends Component<GridProps> {
   render() {
     const { styles, ...restProps } = this.props
 
-    const props = omitProps(restProps, Grid.propTypes)
+    const props = omitProps(restProps, Grid.allowedProps)
 
     return (
       <span {...props} css={styles?.grid}>

--- a/packages/ui-grid/src/GridCol/index.tsx
+++ b/packages/ui-grid/src/GridCol/index.tsx
@@ -68,7 +68,7 @@ class GridCol extends Component<GridColProps> {
   render() {
     const { children, styles } = this.props
 
-    const props = omitProps(this.props, GridCol.propTypes)
+    const props = omitProps(this.props, GridCol.allowedProps)
 
     return (
       <span {...props} ref={this.props.elementRef} css={styles?.gridCol}>

--- a/packages/ui-grid/src/GridRow/index.tsx
+++ b/packages/ui-grid/src/GridRow/index.tsx
@@ -76,7 +76,7 @@ class GridRow extends Component<GridRowProps> {
     return Children.map(this.props.children, (child, index) => {
       if (matchComponentTypes(child, [GridCol])) {
         return safeCloneElement(child as ReactElement, {
-          ...pickProps(props, GridRow.propTypes),
+          ...pickProps(props, GridRow.allowedProps),
           // @ts-expect-error ts-migrate(2533) FIXME: Object is possibly 'null' or 'undefined'.
           ...child.props /* child props should override parent */,
           isLastRow: props.isLastRow,
@@ -91,7 +91,7 @@ class GridRow extends Component<GridRowProps> {
   render() {
     const { styles, ...restProps } = this.props
 
-    const props = omitProps(restProps, GridRow.propTypes)
+    const props = omitProps(restProps, GridRow.allowedProps)
 
     return (
       <span {...props} css={styles?.gridRow}>

--- a/packages/ui-i18n/src/bidirectional.tsx
+++ b/packages/ui-i18n/src/bidirectional.tsx
@@ -95,6 +95,7 @@ const bidirectional: BidirectionalType = decorator((ComposedComponent) => {
   }
   hoistNonReactStatics(BidirectionalForwardingRef, ComposedComponent)
   BidirectionalForwardingRef.defaultProps = ComposedComponent.defaultProps
+  // eslint-disable-next-line react/forbid-foreign-prop-types
   BidirectionalForwardingRef.propTypes = ComposedComponent.propTypes
   // @ts-expect-error These static fields exist on InstUI components
   BidirectionalForwardingRef.allowedProps = ComposedComponent.allowedProps

--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -227,7 +227,7 @@ class MenuItem extends Component<MenuItemProps> {
   render() {
     const { disabled, controls, onKeyDown, onKeyUp, type, href } = this.props
 
-    const props = omitProps(this.props, MenuItem.propTypes)
+    const props = omitProps(this.props, MenuItem.allowedProps)
     const ElementType = this.elementType
 
     return (

--- a/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
@@ -232,7 +232,7 @@ class MenuItemGroup extends Component<MenuGroupProps> {
   }
 
   render() {
-    const props = omitProps(this.props, MenuItemGroup.propTypes)
+    const props = omitProps(this.props, MenuItemGroup.allowedProps)
     return (
       <span
         {...props}

--- a/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemSeparator/index.tsx
@@ -61,7 +61,7 @@ class MenuItemSeparator extends Component<MenuSeparatorProps> {
   }
 
   render() {
-    const props = omitProps(this.props, MenuItemSeparator.propTypes)
+    const props = omitProps(this.props, MenuItemSeparator.allowedProps)
     return (
       <div
         {...props}

--- a/packages/ui-modal/src/Modal/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/index.tsx
@@ -79,7 +79,7 @@ class ModalBody extends Component<ModalBodyProps> {
     } = this.props
 
     const passthroughProps = View.omitViewProps(
-      omitProps(rest, ModalBody.propTypes),
+      omitProps(rest, ModalBody.allowedProps),
       ModalBody
     )
     const isFit = overflow === 'fit'

--- a/packages/ui-modal/src/Modal/__tests__/Modal.test.tsx
+++ b/packages/ui-modal/src/Modal/__tests__/Modal.test.tsx
@@ -373,6 +373,7 @@ describe('<Modal />', async () => {
   describe('managed focus', async () => {
     class ModalExample extends React.Component {
       static propTypes = {
+        // eslint-disable-next-line react/forbid-foreign-prop-types
         ...Modal.propTypes
       }
 

--- a/packages/ui-modal/src/Modal/props.ts
+++ b/packages/ui-modal/src/Modal/props.ts
@@ -29,7 +29,7 @@ import {
   element,
   Children as ChildrenPropTypes
 } from '@instructure/ui-prop-types'
-import { transitionTypes } from '@instructure/ui-motion'
+import { transitionTypePropType } from '@instructure/ui-motion'
 import { ModalHeader } from './ModalHeader'
 import { ModalBody } from './ModalBody'
 import { ModalFooter } from './ModalFooter'
@@ -169,7 +169,7 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.func
   ]),
 
-  transition: transitionTypes,
+  transition: transitionTypePropType,
 
   /**
    * Callback fired before the <Modal /> transitions in

--- a/packages/ui-modal/src/Modal/props.ts
+++ b/packages/ui-modal/src/Modal/props.ts
@@ -29,7 +29,7 @@ import {
   element,
   Children as ChildrenPropTypes
 } from '@instructure/ui-prop-types'
-import { Transition } from '@instructure/ui-motion'
+import { transitionTypes } from '@instructure/ui-motion'
 import { ModalHeader } from './ModalHeader'
 import { ModalBody } from './ModalBody'
 import { ModalFooter } from './ModalFooter'
@@ -169,7 +169,7 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.func
   ]),
 
-  transition: Transition.propTypes.type,
+  transition: transitionTypes,
 
   /**
    * Callback fired before the <Modal /> transitions in

--- a/packages/ui-motion/src/Transition/props.ts
+++ b/packages/ui-motion/src/Transition/props.ts
@@ -59,7 +59,7 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type TransitionProps = TransitionOwnProps & WithStyleProps
 
-const transitionTypes = PropTypes.oneOf([
+const transitionTypePropType = PropTypes.oneOf([
   'fade',
   'scale',
   'slide-down',
@@ -69,7 +69,7 @@ const transitionTypes = PropTypes.oneOf([
 ])
 
 const propTypes: PropValidators<PropKeys> = {
-  type: transitionTypes,
+  type: transitionTypePropType,
   /**
    * A single element to animate in and out
    */
@@ -143,4 +143,4 @@ const allowedProps: AllowedPropKeys = [
 ]
 
 export type { TransitionProps, TransitionType }
-export { propTypes, allowedProps, transitionTypes }
+export { propTypes, allowedProps, transitionTypePropType }

--- a/packages/ui-motion/src/Transition/props.ts
+++ b/packages/ui-motion/src/Transition/props.ts
@@ -59,15 +59,17 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type TransitionProps = TransitionOwnProps & WithStyleProps
 
+const transitionTypes = PropTypes.oneOf([
+  'fade',
+  'scale',
+  'slide-down',
+  'slide-up',
+  'slide-left',
+  'slide-right'
+])
+
 const propTypes: PropValidators<PropKeys> = {
-  type: PropTypes.oneOf([
-    'fade',
-    'scale',
-    'slide-down',
-    'slide-up',
-    'slide-left',
-    'slide-right'
-  ]),
+  type: transitionTypes,
   /**
    * A single element to animate in and out
    */
@@ -141,4 +143,4 @@ const allowedProps: AllowedPropKeys = [
 ]
 
 export type { TransitionProps, TransitionType }
-export { propTypes, allowedProps }
+export { propTypes, allowedProps, transitionTypes }

--- a/packages/ui-motion/src/index.ts
+++ b/packages/ui-motion/src/index.ts
@@ -23,4 +23,4 @@
  */
 export { Transition } from './Transition'
 export type { TransitionProps, TransitionType } from './Transition/props'
-export { transitionTypes } from './Transition/props'
+export { transitionTypePropType } from './Transition/props'

--- a/packages/ui-motion/src/index.ts
+++ b/packages/ui-motion/src/index.ts
@@ -23,3 +23,4 @@
  */
 export { Transition } from './Transition'
 export type { TransitionProps, TransitionType } from './Transition/props'
+export { transitionTypes } from './Transition/props'

--- a/packages/ui-navigation/src/AppNav/index.tsx
+++ b/packages/ui-navigation/src/AppNav/index.tsx
@@ -221,7 +221,7 @@ class AppNav extends Component<AppNavProps> {
     } = this.props
 
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, AppNav.propTypes),
+      omitProps(this.props, AppNav.allowedProps),
       AppNav
     )
 

--- a/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
+++ b/packages/ui-navigation/src/Navigation/NavigationItem/index.tsx
@@ -70,7 +70,7 @@ class NavigationItem extends Component<NavigationItemProps> {
 
     const { href, onClick, icon, label } = this.props
 
-    const props = omitProps(this.props, NavigationItem.propTypes)
+    const props = omitProps(this.props, NavigationItem.allowedProps)
 
     return (
       <ElementType

--- a/packages/ui-navigation/src/Navigation/index.tsx
+++ b/packages/ui-navigation/src/Navigation/index.tsx
@@ -124,7 +124,7 @@ class Navigation extends Component<NavigationProps, NavigationState> {
   render() {
     const { label } = this.props
 
-    const props = omitProps(this.props, Navigation.propTypes, ['minimized'])
+    const props = omitProps(this.props, Navigation.allowedProps, ['minimized'])
 
     return (
       <nav {...props} css={this.props.styles?.navigation} aria-label={label}>

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -239,7 +239,7 @@ class NumberInput extends Component<NumberInputProps, NumberInputState> {
 
     return (
       <FormField
-        {...pickProps(this.props, FormField.propTypes)}
+        {...pickProps(this.props, FormField.allowedProps)}
         label={callRenderProp(renderLabel)}
         inline={display === 'inline-block'}
         id={this.id}
@@ -250,10 +250,10 @@ class NumberInput extends Component<NumberInputProps, NumberInputState> {
         >
           <span css={this.props.styles?.inputContainer}>
             <input
-              {...omitProps(this.props, {
-                ...FormField.propTypes,
-                ...NumberInput.propTypes
-              })}
+              {...omitProps(this.props, [
+                ...FormField.allowedProps,
+                ...NumberInput.allowedProps
+              ])}
               css={this.props.styles?.input}
               aria-invalid={this.invalid ? 'true' : undefined}
               id={this.id}

--- a/packages/ui-options/src/Options/Item/index.tsx
+++ b/packages/ui-options/src/Options/Item/index.tsx
@@ -101,7 +101,7 @@ class Item extends Component<OptionsItemProps> {
     } = this.props
 
     const ElementType = getElementType(Item, this.props, () => as!)
-    const passthroughProps = omitProps(this.props, Item.propTypes)
+    const passthroughProps = omitProps(this.props, Item.allowedProps)
 
     return (
       <ElementType role="none" css={styles?.item}>

--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -129,7 +129,7 @@ class Options extends Component<OptionsProps> {
 
   render() {
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Options.propTypes),
+      omitProps(this.props, Options.allowedProps),
       Options
     )
 

--- a/packages/ui-overlays/src/Mask/index.tsx
+++ b/packages/ui-overlays/src/Mask/index.tsx
@@ -89,7 +89,7 @@ class Mask extends Component<MaskProps> {
     })
 
     const props = {
-      ...omitProps(this.props, Mask.propTypes),
+      ...omitProps(this.props, Mask.allowedProps),
       css: this.props.styles?.mask,
       ref: this.handleElementRef
     }

--- a/packages/ui-overlays/src/Overlay/index.tsx
+++ b/packages/ui-overlays/src/Overlay/index.tsx
@@ -143,7 +143,7 @@ class Overlay extends Component<OverlayProps> {
   renderTransition(content) {
     return (
       <Transition
-        {...pickProps(this.props, Transition.propTypes)}
+        {...pickProps(this.props, Transition.allowedProps)}
         in={this.props.open}
         transitionOnMount
         unmountOnExit
@@ -161,8 +161,8 @@ class Overlay extends Component<OverlayProps> {
   render() {
     let content = (
       <Dialog
-        {...omitProps(this.props, Overlay.propTypes)}
-        {...pickProps(this.props, Dialog.propTypes)}
+        {...omitProps(this.props, Overlay.allowedProps)}
+        {...pickProps(this.props, Dialog.allowedProps)}
         defaultFocusElement={this.props.defaultFocusElement}
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'open' does not exist on type 'Readonly<{... Remove this comment to see the full error message
         open={this.state.open}
@@ -177,7 +177,7 @@ class Overlay extends Component<OverlayProps> {
 
     return (
       <Portal
-        {...pickProps(this.props, Portal.propTypes)}
+        {...pickProps(this.props, Portal.allowedProps)}
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'transitioning' does not exist on type 'R... Remove this comment to see the full error message
         open={this.props.open || this.state.transitioning}
         onOpen={createChainedFunction(this.handlePortalOpen, this.props.onOpen)}

--- a/packages/ui-overlays/src/Overlay/props.ts
+++ b/packages/ui-overlays/src/Overlay/props.ts
@@ -26,7 +26,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { element } from '@instructure/ui-prop-types'
-import { transitionTypes } from '@instructure/ui-motion'
+import { transitionTypePropType } from '@instructure/ui-motion'
 
 import type { PortalNode } from '@instructure/ui-portal'
 import type { PositionMountNode } from '@instructure/ui-position'
@@ -127,7 +127,7 @@ const propTypes: PropValidators<PropKeys> = {
   /**
    * The type of `<Transition />` to use for animating in/out
    */
-  transition: transitionTypes,
+  transition: transitionTypePropType,
   /**
    * Show the component; triggers the enter or exit animation
    */

--- a/packages/ui-overlays/src/Overlay/props.ts
+++ b/packages/ui-overlays/src/Overlay/props.ts
@@ -26,7 +26,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { element } from '@instructure/ui-prop-types'
-import { Transition } from '@instructure/ui-motion'
+import { transitionTypes } from '@instructure/ui-motion'
 
 import type { PortalNode } from '@instructure/ui-portal'
 import type { PositionMountNode } from '@instructure/ui-position'
@@ -127,7 +127,7 @@ const propTypes: PropValidators<PropKeys> = {
   /**
    * The type of `<Transition />` to use for animating in/out
    */
-  transition: Transition.propTypes.type,
+  transition: transitionTypes,
   /**
    * Show the component; triggers the enter or exit animation
    */

--- a/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
@@ -50,7 +50,7 @@ class PaginationButton extends Component<PaginationPageProps> {
 
   render() {
     const exclude = this.props.current ? ['onClick', 'href'] : []
-    const props = omitProps(this.props, PaginationButton.propTypes, exclude)
+    const props = omitProps(this.props, PaginationButton.allowedProps, exclude)
     return (
       <BaseButton
         color="primary"

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -272,7 +272,7 @@ class Pagination extends Component<PaginationProps> {
     )
 
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Pagination.propTypes),
+      omitProps(this.props, Pagination.allowedProps),
       Pagination
     )
 

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -138,7 +138,7 @@ class RadioInput extends Component<RadioInputProps> {
   render() {
     const { disabled, readOnly, label, value, name, styles } = this.props
 
-    const props = omitProps(this.props, RadioInput.propTypes)
+    const props = omitProps(this.props, RadioInput.allowedProps)
 
     return (
       <div css={styles?.radioInput}>

--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -144,8 +144,8 @@ class RadioInputGroup extends Component<RadioInputGroupProps> {
     return (
       // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       <FormFieldGroup
-        {...omitProps(this.props, RadioInputGroup.propTypes)}
-        {...pickProps(this.props, FormFieldGroup.propTypes)}
+        {...omitProps(this.props, RadioInputGroup.allowedProps)}
+        {...pickProps(this.props, FormFieldGroup.allowedProps)}
         // TODO: split out toggle variant into its own component
         layout={
           layout === 'columns' && variant === 'toggle' ? 'stacked' : layout

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -175,12 +175,15 @@ class RangeInput extends Component<RangeInputProps> {
   render() {
     const { formatValue, disabled, readOnly } = this.props
 
-    const props = omitProps(this.props, RangeInput.propTypes)
+    const props = omitProps(this.props, RangeInput.allowedProps)
 
     /* eslint-disable jsx-a11y/no-redundant-roles */
     return (
       // @ts-expect-error ts-migrate(2554) FIXME: no overload..
-      <FormField {...pickProps(this.props, FormField.propTypes)} id={this.id}>
+      <FormField
+        {...pickProps(this.props, FormField.allowedProps)}
+        id={this.id}
+      >
         <div css={this.props.styles?.rangeInput}>
           <input
             css={this.props.styles?.rangeInputInput}

--- a/packages/ui-rating/src/Rating/index.tsx
+++ b/packages/ui-rating/src/Rating/index.tsx
@@ -105,7 +105,7 @@ class Rating extends Component<RatingProps> {
     const valueText = label + ' ' + formatValueText(this.filled, iconCount)
 
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Rating.propTypes),
+      omitProps(this.props, Rating.allowedProps),
       Rating
     )
 

--- a/packages/ui-react-utils/src/pickProps.ts
+++ b/packages/ui-react-utils/src/pickProps.ts
@@ -29,7 +29,7 @@
  * Return a props object with only specified propTypes.
  * @module pickProps
  * @param {Object} props React component props
- * @param {Object|Array<string>} propTypes React component propTypes or the list of allowed prop keys
+ * @param {Object|Array<string>} propTypesOrAllowedPropList React component propTypes or the list of allowed prop keys
  * @param {Array} include an optional array of prop names to include
  * @returns {Object} props object with only the included props
  * @module pickProps

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -381,10 +381,10 @@ class Select extends Component<SelectProps> {
 
     let optionProps = {
       // passthrough props
-      ...omitProps(option.props, {
-        ...Option.propTypes,
-        ...Options.Item.propTypes
-      }),
+      ...omitProps(option.props, [
+        ...Option.allowedProps,
+        ...Options.Item.allowedProps
+      ]),
       // props from selectable
       ...getOptionProps({ id }),
       // Options.Item props
@@ -434,10 +434,7 @@ class Select extends Component<SelectProps> {
         as="ul"
         role="group"
         renderLabel={renderLabel}
-        {...omitProps(rest, {
-          ...Options.propTypes,
-          ...Group.propTypes
-        })}
+        {...omitProps(rest, [...Options.allowedProps, ...Group.allowedProps])}
       >
         {Children.map(children, (child) => {
           return this.renderOption(child, {
@@ -554,7 +551,7 @@ class Select extends Component<SelectProps> {
     } = this.props
 
     const { interaction } = this
-    const passthroughProps = omitProps(rest, Select.propTypes)
+    const passthroughProps = omitProps(rest, Select.allowedProps)
     const { ref, ...triggerProps } = getTriggerProps({ ...passthroughProps })
     const isEditable = typeof onInputChange !== 'undefined'
     // props to ensure screen readers treat uneditable selects as accessible

--- a/packages/ui-spinner/src/Spinner/index.tsx
+++ b/packages/ui-spinner/src/Spinner/index.tsx
@@ -85,7 +85,7 @@ class Spinner extends Component<SpinnerProps> {
 
   render() {
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Spinner.propTypes),
+      omitProps(this.props, Spinner.allowedProps),
       Spinner
     )
 

--- a/packages/ui-svg-images/src/InlineSVG/index.tsx
+++ b/packages/ui-svg-images/src/InlineSVG/index.tsx
@@ -157,7 +157,7 @@ class InlineSVG extends Component<InlineSVGProps> {
     return (
       <svg
         {...parseAttributes(this.props.src)}
-        {...omitProps(this.props, InlineSVG.propTypes, ['inline'])}
+        {...omitProps(this.props, InlineSVG.allowedProps, ['inline'])}
         style={{
           ...style,
           width,

--- a/packages/ui-svg-images/src/SVGIcon/props.ts
+++ b/packages/ui-svg-images/src/SVGIcon/props.ts
@@ -43,6 +43,7 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 type SVGIconProps = SVGIconOwnProps & WithStyleProps
 
 const propTypes: PropValidators<PropKeys> = {
+  // eslint-disable-next-line react/forbid-foreign-prop-types
   ...InlineSVG.propTypes,
   rotate: PropTypes.oneOf(['0', '90', '180', '270']),
   size: PropTypes.oneOf(['x-small', 'small', 'medium', 'large', 'x-large']),

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -70,7 +70,7 @@ class Body extends Component<TableBodyProps> {
 
     return (
       <View
-        {...View.omitViewProps(omitProps(this.props, Body.propTypes), Body)}
+        {...View.omitViewProps(omitProps(this.props, Body.allowedProps), Body)}
         as={isStacked ? 'div' : 'tbody'}
         css={styles?.body}
         role={isStacked ? 'rowgroup' : undefined}

--- a/packages/ui-table/src/Table/Cell/index.tsx
+++ b/packages/ui-table/src/Table/Cell/index.tsx
@@ -66,7 +66,7 @@ class Cell extends Component<TableCellProps> {
 
     return (
       <View
-        {...View.omitViewProps(omitProps(this.props, Cell.propTypes), Cell)}
+        {...View.omitViewProps(omitProps(this.props, Cell.allowedProps), Cell)}
         as={isStacked ? 'div' : 'td'}
         css={styles?.cell}
         role={isStacked ? 'cell' : undefined}

--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -104,7 +104,7 @@ class ColHeader extends Component<TableColHeaderProps> {
 
     return (
       <th
-        {...omitProps(this.props, ColHeader.propTypes)}
+        {...omitProps(this.props, ColHeader.allowedProps)}
         css={styles?.colHeader}
         style={{
           width

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -182,7 +182,7 @@ class Head extends Component<TableHeadProps> {
     return isStacked ? (
       this.renderSelect()
     ) : (
-      <thead {...omitProps(this.props, Head.propTypes)} css={styles?.head}>
+      <thead {...omitProps(this.props, Head.allowedProps)} css={styles?.head}>
         {Children.map(children, (child) =>
           matchComponentTypes(child, [Row]) ? child : null
         )}

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -73,7 +73,7 @@ class Row extends Component<TableRowProps> {
 
     return (
       <View
-        {...View.omitViewProps(omitProps(this.props, Row.propTypes), Row)}
+        {...View.omitViewProps(omitProps(this.props, Row.allowedProps), Row)}
         as={isStacked ? 'div' : 'tr'}
         css={styles?.row}
         role={isStacked ? 'row' : undefined}

--- a/packages/ui-table/src/Table/RowHeader/index.tsx
+++ b/packages/ui-table/src/Table/RowHeader/index.tsx
@@ -67,7 +67,7 @@ class RowHeader extends Component<TableRowHeaderProps> {
     return (
       <View
         {...View.omitViewProps(
-          omitProps(this.props, RowHeader.propTypes),
+          omitProps(this.props, RowHeader.allowedProps),
           RowHeader
         )}
         as={isStacked ? 'div' : 'th'}

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -115,7 +115,10 @@ class Table extends Component<TableProps> {
 
     return (
       <View
-        {...View.omitViewProps(omitProps(this.props, Table.propTypes), Table)}
+        {...View.omitViewProps(
+          omitProps(this.props, Table.allowedProps),
+          Table
+        )}
         as={isStacked ? 'div' : 'table'}
         margin={margin}
         elementRef={elementRef}

--- a/packages/ui-tag/src/Tag/index.tsx
+++ b/packages/ui-tag/src/Tag/index.tsx
@@ -108,7 +108,7 @@ class Tag extends Component<TagProps> {
     } = this.props
 
     const passthroughProps = View.omitViewProps(
-      omitProps(this.props, Tag.propTypes),
+      omitProps(this.props, Tag.allowedProps),
       Tag
     )
 

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -304,7 +304,7 @@ class TextArea extends Component<TextAreaProps> {
       resize
     } = this.props
 
-    const props = omitProps(this.props, TextArea.propTypes)
+    const props = omitProps(this.props, TextArea.allowedProps)
 
     const style = {
       width,
@@ -341,7 +341,7 @@ class TextArea extends Component<TextAreaProps> {
     return (
       // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       <FormField
-        {...pickProps(this.props, FormField.propTypes)}
+        {...pickProps(this.props, FormField.allowedProps)}
         vAlign="top"
         id={this.id}
         ref={(el) => {

--- a/packages/ui-toggle-details/src/ToggleDetails/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/index.tsx
@@ -105,7 +105,7 @@ class ToggleDetails extends Component<ToggleDetailsProps> {
     const { variant } = this.props
 
     const props = {
-      ...omitProps(this.props, ToggleDetails.propTypes),
+      ...omitProps(this.props, ToggleDetails.allowedProps),
       ...toggleProps,
       // @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 0.
       children: this.renderSummary()
@@ -181,7 +181,7 @@ class ToggleDetails extends Component<ToggleDetailsProps> {
   render() {
     return (
       <Expandable
-        {...pickProps(this.props, Expandable.propTypes)}
+        {...pickProps(this.props, Expandable.allowedProps)}
         onToggle={this.handleToggle}
       >
         {({ expanded, getToggleProps, getDetailsProps }) => {

--- a/packages/ui-toggle-details/src/ToggleGroup/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleGroup/index.tsx
@@ -140,11 +140,11 @@ class ToggleGroup extends Component<ToggleGroupProps> {
     const Element = getElementType(ToggleGroup, this.props)
 
     return (
-      <Expandable {...pickProps(this.props, Expandable.propTypes)}>
+      <Expandable {...pickProps(this.props, Expandable.allowedProps)}>
         {({ expanded, getToggleProps, getDetailsProps }) => {
           return (
             <View
-              {...omitProps(this.props, ToggleGroup.propTypes)}
+              {...omitProps(this.props, ToggleGroup.allowedProps)}
               borderWidth={this.props.border ? 'small' : 'none'}
               as={Element}
               elementRef={this.props.elementRef}

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -100,7 +100,7 @@ class Tooltip extends Component<TooltipProps> {
 
     if (as) {
       const Trigger = getElementType(Tooltip, this.props)
-      const props = omitProps(this.props, Tooltip.propTypes)
+      const props = omitProps(this.props, Tooltip.allowedProps)
       return (
         <Trigger {...props} {...triggerProps}>
           {children}

--- a/packages/ui-tray/src/Tray/index.tsx
+++ b/packages/ui-tray/src/Tray/index.tsx
@@ -211,7 +211,7 @@ class Tray extends Component<TrayProps> {
             transitionExit
           >
             <span
-              {...omitProps(props, Tray.propTypes)}
+              {...omitProps(props, Tray.allowedProps)}
               css={this.props.styles?.tray}
               ref={contentRef}
             >

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -358,7 +358,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
       <TreeCollection
         key={i}
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.
-        {...pickProps(omitProps(this.props), TreeCollection.propTypes)}
+        {...pickProps(omitProps(this.props), TreeCollection.allowedProps)}
         {...this.getCollectionProps(collection)}
         // @ts-expect-error ts-migrate(2339) FIXME: Property 'selection' does not exist on type 'Reado... Remove this comment to see the full error message
         selection={this.state.selection}

--- a/packages/ui-view/src/ContextView/index.tsx
+++ b/packages/ui-view/src/ContextView/index.tsx
@@ -94,7 +94,7 @@ class ContextView extends Component<
 
     return (
       <View
-        {...omitProps(this.props, ContextView.propTypes)}
+        {...omitProps(this.props, ContextView.allowedProps)}
         css={styles?.contextView}
         style={style}
         borderWidth="none"


### PR DESCRIPTION
Now users can use tools like [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)  to make their bundle size smaller.
It also activates an ESLint rule that forbids the usage of `propTypes`

Note that while this PR allows prop type removers run, these will not actually shrink the bundle size by a significant amount because it only removes these lines: `static propTypes = propTypes`.  A further PR is needed, that moves back propTypes to the component itself.
