### PR TITLE
chore(ui-tabs): add 'fixHeight' prop to Tabs

### DIFF
--- a/packages/__examples__/buildScripts/parsePropValues.js
+++ b/packages/__examples__/buildScripts/parsePropValues.js
@@ -70,7 +70,7 @@ module.exports = function parsePropValues(fileSource, fileName) {
       }
     )
     if (Array.isArray(parsedSrc)) {
-      parsedSrc = parsedSrc.pop()
+      parsedSrc = parsedSrc.shift()
     }
   } catch (error) {
     throw new Error(

--- a/packages/ui-tabs/src/Tabs/Panel/styles.ts
+++ b/packages/ui-tabs/src/Tabs/Panel/styles.ts
@@ -39,21 +39,28 @@ const generateStyle = (
   componentTheme: TabsPanelTheme,
   props: TabsPanelProps
 ): TabsPanelStyle => {
-  const { maxHeight } = props
+  const { maxHeight, isSelected } = props
 
   return {
     panel: {
       label: 'panel',
       boxSizing: 'border-box',
+      flexShrink: 0,
+      flexGrow: 0,
       fontFamily: componentTheme.fontFamily,
       fontWeight: componentTheme.fontWeight,
       lineHeight: componentTheme.lineHeight,
-      fontSize: componentTheme.fontSize
+      fontSize: componentTheme.fontSize,
+      ...(isSelected && {
+        flexGrow: 1,
+        height: '100%'
+      })
     },
     content: {
       label: 'panel__content',
       boxSizing: 'border-box',
       width: '100%',
+      height: '100%',
       borderWidth: componentTheme.borderWidth,
       borderStyle: componentTheme.borderStyle,
       background: componentTheme.background,
@@ -62,6 +69,7 @@ const generateStyle = (
       borderLeft: 'none',
       borderRight: 'none',
       borderBottom: 'none',
+      overflowY: 'auto',
       ...(maxHeight && { overflow: 'auto' })
     }
   }

--- a/packages/ui-tabs/src/Tabs/README.md
+++ b/packages/ui-tabs/src/Tabs/README.md
@@ -4,8 +4,6 @@ describes: Tabs
 
 `<Tabs />` is an accessible tabbed navigation component. Use the TAB key to focus the component and arrow keys to navigate between panels of content. To set a default panel that should be selected on initial render, set the `selected` prop on that `<Tabs.Panel>`.
 
-To restrict the width of `<Tabs />`, use the `maxWidth` prop. Add space around the entire component using the `margin` prop. Adjust the padding around the panel content via `padding` (default is `small`) on each `<Tabs.Panel>`. Restrict the height of the panel using `minHeight` or `maxHeight`. Finally, switch the text alignment of the panel content with `textAlign`.
-
 ```js
 ---
 example: true
@@ -151,6 +149,106 @@ class Example extends React.Component {
           {lorem.sentence()}
         </Tabs.Panel>
       </Tabs>
+    )
+  }
+}
+
+render(<Example />)
+```
+
+### Controlling the size and the spacing
+
+To restrict the width of `<Tabs />`, use the `maxWidth` prop. Add space around the entire component using the `margin` prop. Adjust the padding around the panel content via `padding` (default is `small`) on each `<Tabs.Panel>`.
+
+Set the height of the Tabs component with the `fixHeight` property (set to '100%' to fill out it's parent element). You can also restrict the height of the **panels** using the `minHeight` and `maxHeight` properties (they don't work if you set `fixHeight` on the whole Tabs component).
+
+Finally, switch the text alignment of the panel content with `textAlign`.
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      selectedIndex: 0,
+      heightOption: 'fixHeight: 100%'
+    }
+
+    this.heightOptions = {
+      ['fixHeight: 100%']: { fixHeight: '100%' },
+      ['fixHeight: 15rem']: { fixHeight: '15rem' },
+      ['minHeight: 17rem']: { minHeight: '17rem' },
+      ['maxHeight: 10rem']: { maxHeight: '10rem' }
+    }
+  }
+
+  handleTabChange = (event, { index, id }) => {
+    this.setState({
+      selectedIndex: index
+    })
+  }
+
+  handleHeightOptionSelect = (e, heightOption) => {
+    this.setState({ heightOption })
+  }
+
+  render () {
+    const { selectedIndex, heightOption } = this.state
+    const { heightOptions } = this
+
+    const containerProps = {
+      as: 'div',
+      ...(heightOption.includes('fixHeight') && {
+        height: "22rem",
+        withVisualDebug: true
+      })
+    }
+
+    return (
+      <>
+        <View display="block" margin="none none medium">
+          <RadioInputGroup
+            name="tabsHeightOptions"
+            defaultValue="fixHeight: 100%"
+            description={<ScreenReaderContent>Tabs height selector</ScreenReaderContent>}
+            variant="toggle"
+            onChange={this.handleHeightOptionSelect}
+          >
+            {Object.keys(heightOptions).map((heightOption) => <RadioInput key={heightOption} label={heightOption} value={heightOption} />)}
+          </RadioInputGroup>
+        </View>
+
+        <View {...containerProps}>
+          <Tabs
+            margin="large auto"
+            padding="medium"
+            onRequestTabChange={this.handleTabChange}
+            {...heightOptions[heightOption]}
+          >
+            <Tabs.Panel
+              id="tabA"
+              renderTitle="Tab A"
+              textAlign="center"
+              padding="large"
+              iSelected={selectedIndex === 0}
+            >
+              <Button>Focus Me</Button>
+            </Tabs.Panel>
+            <Tabs.Panel id="tabB" renderTitle="Disabled Tab" isDisabled>
+              {lorem.paragraphs()}
+            </Tabs.Panel>
+            <Tabs.Panel id="tabC" renderTitle="Tab C" isSelected={selectedIndex === 2}>
+              {lorem.paragraphs()}
+            </Tabs.Panel>
+            <Tabs.Panel id="tabD" renderTitle="Tab D" isSelected={selectedIndex === 3}>
+              {lorem.paragraphs()}
+            </Tabs.Panel>
+          </Tabs>
+        </View>
+      </>
     )
   }
 }

--- a/packages/ui-tabs/src/Tabs/__examples__/Tabs.examples.tsx
+++ b/packages/ui-tabs/src/Tabs/__examples__/Tabs.examples.tsx
@@ -31,14 +31,30 @@ const contentLong =
 
 export default {
   propValues: {
-    dir: ['ltr']
+    dir: ['ltr'],
+    minHeight: [undefined, 400],
+    fixHeight: [undefined, 200],
+    maxHeight: [undefined, 200],
+    maxWidth: [undefined, 200]
   },
   sectionProp: 'variant',
-  excludeProps: ['focus'],
+  excludeProps: [
+    // TODO: textAlign doesn't seem to do anything when passed on Tabs
+    'textAlign'
+  ],
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'props' implicitly has an 'any' type.
   filter: (props) => {
-    if (props.tabOverflow === 'scroll' && props.variant === 'secondary')
+    if (props.tabOverflow === 'scroll' && props.variant === 'secondary') {
       return true
+    }
+
+    if (
+      props.shouldFocusOnRender &&
+      (props.maxWidth || props.maxHeight || props.fixHeight || props.minHeight)
+    ) {
+      return true
+    }
+
     return false
   },
   // @ts-expect-error ts-migrate(6133) FIXME: 'props' is declared but its value is never read.

--- a/packages/ui-tabs/src/Tabs/index.tsx
+++ b/packages/ui-tabs/src/Tabs/index.tsx
@@ -365,6 +365,9 @@ class Tabs extends Component<TabsProps> {
   clonePanel(index, generatedId, selected, panel) {
     const id = panel.props.id || generatedId
 
+    // fixHeight can be 0, so simply `fixheight` could return falsy value
+    const hasFixedHeight = typeof this.props.fixHeight !== 'undefined'
+
     return safeCloneElement(panel, {
       id: panel.props.id || `panel-${id}`,
       labelledBy: `tab-${id}`,
@@ -373,8 +376,10 @@ class Tabs extends Component<TabsProps> {
       variant: this.props.variant,
       padding: panel.props.padding || this.props.padding,
       textAlign: panel.props.textAlign || this.props.textAlign,
-      maxHeight: panel.maxHeight || this.props.maxHeight,
-      minHeight: panel.minHeight || this.props.minHeight
+      maxHeight:
+        panel.maxHeight || (!hasFixedHeight ? this.props.maxHeight : undefined),
+      minHeight:
+        panel.minHeight || (!hasFixedHeight ? this.props.minHeight : '100%')
     })
   }
 
@@ -492,8 +497,11 @@ class Tabs extends Component<TabsProps> {
             </View>
           )}
         </Focusable>
-        {/* @ts-expect-error ts-migrate(7005) FIXME: Variable 'panels' implicitly has an 'any[]' type. */}
-        {panels}
+
+        <div css={styles?.panelsContainer}>
+          {/* @ts-expect-error ts-migrate(7005) FIXME: Variable 'panels' implicitly has an 'any[]' type. */}
+          {panels}
+        </div>
       </View>
     )
   }

--- a/packages/ui-tabs/src/Tabs/props.ts
+++ b/packages/ui-tabs/src/Tabs/props.ts
@@ -44,6 +44,7 @@ type TabsOwnProps = {
   maxWidth?: string | number
   maxHeight?: string | number
   minHeight?: string | number
+  fixHeight?: string | number
   margin?: Spacing
   padding?: Spacing
   textAlign?: 'start' | 'center' | 'end'
@@ -65,6 +66,7 @@ type TabsStyle = ComponentStyle<
   | 'tabs'
   | 'container'
   | 'tabList'
+  | 'panelsContainer'
   | 'scrollOverlay'
   | 'scrollSpacer'
   | 'scrollOverlayWidthDefault'
@@ -88,6 +90,7 @@ const propTypes: PropValidators<PropKeys> = {
   maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   minHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  fixHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
    * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
    * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
@@ -118,6 +121,7 @@ const allowedProps: AllowedPropKeys = [
   'maxWidth',
   'maxHeight',
   'minHeight',
+  'fixHeight',
   'margin',
   'padding',
   'textAlign',

--- a/packages/ui-tabs/src/Tabs/styles.ts
+++ b/packages/ui-tabs/src/Tabs/styles.ts
@@ -39,7 +39,10 @@ const generateStyle = (
   componentTheme: TabsTheme,
   props: TabsProps
 ): TabsStyle => {
-  const { variant, tabOverflow } = props
+  const { variant, tabOverflow, fixHeight } = props
+
+  // fixHeight can be 0, so simply `fixheight` could return falsy value
+  const hasFixedHeight = typeof fixHeight !== 'undefined'
 
   const variants = {
     default: {
@@ -82,11 +85,16 @@ const generateStyle = (
   return {
     tabs: {
       label: 'tabs',
+      flexShrink: 0,
+      flexGrow: 0,
       ...variants[variant!].tabs
     },
 
     container: {
       label: 'tabs__container',
+      display: 'flex',
+      flexDirection: 'column',
+      height: fixHeight,
       ...variants[variant!].container
     },
 
@@ -95,6 +103,17 @@ const generateStyle = (
       display: 'flex',
       width: '100%',
       ...tabOverflowVariants[tabOverflow!]
+    },
+
+    panelsContainer: {
+      label: 'tabs__panelsContainer',
+      flexShrink: 1,
+      flexGrow: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      ...(hasFixedHeight && {
+        overflowY: 'hidden'
+      })
     },
 
     scrollOverlay: {


### PR DESCRIPTION
Closes: INSTUI-3258

Refactored the DOM structure and CSS of Tabs component to have an extra wrapper for panels and use
flex layout under the hood. This makes it easier to handle the fix, min and max heights of the
component. Added a `fixHeight` prop to set a fix height, which can be set to `100%` now to fill the
parent element. Also added a few new examples.