### PR TITLE
fix(emotion,ui-i18n): decorator adds allowedProps property

### DIFF
--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -158,6 +158,8 @@ const withStyle = decorator(
     // (mainly in the `omitProps` method)
     WithStyle.propTypes = ComposedComponent.propTypes
     WithStyle.defaultProps = ComposedComponent.defaultProps
+    // @ts-expect-error These static fields exist on InstUI components
+    WithStyle.allowedProps = ComposedComponent.allowedProps
     // we are exposing the theme generator for the docs generation
     ;(WithStyle as any).generateComponentTheme = generateComponentTheme
     // we have to add defaults to makeStyles and styles added by this decorator

--- a/packages/ui-i18n/src/bidirectional.tsx
+++ b/packages/ui-i18n/src/bidirectional.tsx
@@ -96,6 +96,8 @@ const bidirectional: BidirectionalType = decorator((ComposedComponent) => {
   hoistNonReactStatics(BidirectionalForwardingRef, ComposedComponent)
   BidirectionalForwardingRef.defaultProps = ComposedComponent.defaultProps
   BidirectionalForwardingRef.propTypes = ComposedComponent.propTypes
+  // @ts-expect-error These static fields exist on InstUI components
+  BidirectionalForwardingRef.allowedProps = ComposedComponent.allowedProps
   return BidirectionalForwardingRef
 }) as BidirectionalType
 


### PR DESCRIPTION
When using the decorator the decorated method did not have the "allowedProps" static property, this
fix adds them back.