### PR TITLE
Fix small typo in ui-tabs readme

### DIFF
--- a/packages/ui-tabs/src/Tabs/README.md
+++ b/packages/ui-tabs/src/Tabs/README.md
@@ -33,7 +33,7 @@ class Example extends React.Component {
           renderTitle="Tab A"
           textAlign="center"
           padding="large"
-          iSelected={selectedIndex === 0}
+          isSelected={selectedIndex === 0}
         >
           <Button>Focus Me</Button>
         </Tabs.Panel>


### PR DESCRIPTION
Just a small correction to the first tab panel's `isSelected` prop name. Thanks!