### PR TITLE
feat(ui-modal): add `spacing` prop to `Modal.Header`

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -636,6 +636,7 @@ export type ModalHeaderTheme = {
   background: Colors['backgroundLightest']
   borderColor: Colors['borderMedium']
   padding: Spacing['medium']
+  paddingCompact: Spacing['small']
   inverseBackground: Colors['backgroundDarkest']
   inverseBorderColor: Colors['backgroundDarkest']
 }

--- a/packages/ui-modal/src/Modal/ModalHeader/__tests__/ModalHeader.test.tsx
+++ b/packages/ui-modal/src/Modal/ModalHeader/__tests__/ModalHeader.test.tsx
@@ -23,11 +23,14 @@
  */
 
 import React from 'react'
+
 import { expect, mount, within } from '@instructure/ui-test-utils'
-import { ModalHeader } from '../index'
-import generateComponentTheme from '../theme'
 import { canvas } from '@instructure/ui-themes'
 import { color2hex } from '@instructure/ui-color-utils'
+import { px } from '@instructure/ui-utils'
+
+import { ModalHeader } from '../index'
+import generateComponentTheme from '../theme'
 
 describe('<ModalHeader />', async () => {
   it('should render', async () => {
@@ -49,5 +52,43 @@ describe('<ModalHeader />', async () => {
     expect(variables.inverseBorderColor).to.equal(
       color2hex(cssStyleDeclaration.getPropertyValue('border-bottom-color'))
     )
+  })
+
+  describe('spacing prop', async () => {
+    it('should be correct by default', async () => {
+      const variables = generateComponentTheme(canvas)
+
+      const subject = await mount(<ModalHeader />)
+      const header = within(subject.getDOMNode())
+
+      const cssStyleDeclaration = header.getComputedStyle() // CSSStyleDeclaration type
+      expect(cssStyleDeclaration.getPropertyValue('padding')).to.equal(
+        `${px(variables.padding)}px`
+      )
+    })
+
+    it('should correctly set default spacing', async () => {
+      const variables = generateComponentTheme(canvas)
+
+      const subject = await mount(<ModalHeader spacing="default" />)
+      const header = within(subject.getDOMNode())
+
+      const cssStyleDeclaration = header.getComputedStyle() // CSSStyleDeclaration type
+      expect(cssStyleDeclaration.getPropertyValue('padding')).to.equal(
+        `${px(variables.padding)}px`
+      )
+    })
+
+    it('should correctly set compact spacing', async () => {
+      const variables = generateComponentTheme(canvas)
+
+      const subject = await mount(<ModalHeader spacing="compact" />)
+      const header = within(subject.getDOMNode())
+
+      const cssStyleDeclaration = header.getComputedStyle() // CSSStyleDeclaration type
+      expect(cssStyleDeclaration.getPropertyValue('padding')).to.equal(
+        `${px(variables.paddingCompact)}px`
+      )
+    })
   })
 })

--- a/packages/ui-modal/src/Modal/ModalHeader/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalHeader/index.tsx
@@ -54,7 +54,8 @@ class ModalHeader extends Component<ModalHeaderProps> {
   static allowedProps = allowedProps
   static defaultProps = {
     children: null,
-    variant: 'default'
+    variant: 'default',
+    spacing: 'default'
   }
 
   ref: Element | null = null

--- a/packages/ui-modal/src/Modal/ModalHeader/props.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/props.ts
@@ -34,6 +34,7 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 type ModalHeaderOwnProps = {
   children?: React.ReactNode
   variant?: 'default' | 'inverse'
+  spacing?: 'default' | 'compact'
 }
 
 type ModalHeaderStyleProps = {
@@ -51,10 +52,11 @@ type ModalHeaderStyle = ComponentStyle<'modalHeader'>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node,
-  variant: PropTypes.oneOf(['default', 'inverse'])
+  variant: PropTypes.oneOf(['default', 'inverse']),
+  spacing: PropTypes.oneOf(['default', 'compact'])
 }
 
-const allowedProps: AllowedPropKeys = ['children', 'variant']
+const allowedProps: AllowedPropKeys = ['children', 'variant', 'spacing']
 
 export type { ModalHeaderProps, ModalHeaderStyleProps, ModalHeaderStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-modal/src/Modal/ModalHeader/styles.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/styles.ts
@@ -44,8 +44,25 @@ const generateStyle = (
   props: ModalHeaderProps,
   state: ModalHeaderStyleProps
 ): ModalHeaderStyle => {
-  const { variant } = props
+  const { variant, spacing } = props
   const { withCloseButton } = state
+
+  const sizeVariants = {
+    default: {
+      padding: componentTheme.padding,
+      paddingInlineStart: componentTheme.padding,
+      paddingInlineEnd: withCloseButton
+        ? `calc(${componentTheme.padding} * 2 + 1em)`
+        : componentTheme.padding
+    },
+    compact: {
+      padding: componentTheme.paddingCompact,
+      paddingInlineStart: componentTheme.paddingCompact,
+      paddingInlineEnd: withCloseButton
+        ? `calc(${componentTheme.paddingCompact} * 2 + 1em)`
+        : componentTheme.paddingCompact
+    }
+  }
 
   const inverseStyle =
     variant === 'inverse'
@@ -55,27 +72,17 @@ const generateStyle = (
         }
       : {}
 
-  const closeButtonStyle = withCloseButton
-    ? {
-        paddingInlineEnd: `calc(${componentTheme.padding} * 2 + 1em)`
-      }
-    : {
-        paddingInlineEnd: componentTheme.padding
-      }
-
   return {
     modalHeader: {
       label: 'modalHeader',
       boxSizing: 'border-box',
-      padding: componentTheme.padding,
-      paddingInlineStart: componentTheme.padding,
       flex: '0 0 auto',
       background: componentTheme.background,
       borderBottomWidth: '0.0625rem',
       borderBottomStyle: 'solid',
       borderBottomColor: componentTheme.borderColor,
-      ...inverseStyle,
-      ...closeButtonStyle
+      ...sizeVariants[spacing!],
+      ...inverseStyle
     }
   }
 }

--- a/packages/ui-modal/src/Modal/ModalHeader/theme.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/theme.ts
@@ -37,6 +37,7 @@ const generateComponentTheme = (theme: Theme): ModalHeaderTheme => {
     background: colors?.backgroundLightest,
     borderColor: colors?.borderMedium,
     padding: spacing?.medium,
+    paddingCompact: spacing?.small,
 
     inverseBackground: colors?.backgroundDarkest,
     inverseBorderColor: colors?.backgroundDarkest

--- a/packages/ui-modal/src/Modal/README.md
+++ b/packages/ui-modal/src/Modal/README.md
@@ -427,12 +427,19 @@ class Example extends React.Component {
 
     this.state = {
       open: false,
+      smallViewport: true
     }
   }
 
-  handleButtonClick = () => {
+  toggleOpen = () => {
     this.setState(function (state) {
       return { open: !state.open }
+    })
+  }
+
+  toggleViewport = async () => {
+    await this.setState(function (state) {
+      return { smallViewport: !state.smallViewport }
     })
   }
 
@@ -441,7 +448,7 @@ class Example extends React.Component {
       <CloseButton
         placement="end"
         offset="small"
-        onClick={this.handleButtonClick}
+        onClick={this.toggleOpen}
         screenReaderLabel="Close"
       />
     )
@@ -450,21 +457,35 @@ class Example extends React.Component {
   render () {
     return (
       <div>
-        <Button onClick={this.handleButtonClick}>
+        <Button onClick={this.toggleOpen}>
           {this.state.open ? 'Close' : 'Open'} the Modal
+        </Button>
+        <Button
+          onClick={this.toggleViewport}
+          margin='0 0 0 small'
+          id="toggleViewportButton"
+        >
+          Toggle viewport
         </Button>
         <Modal
           open={this.state.open}
-          onDismiss={() => { this.setState({ open: false }) }}
-          size="fullscreen"
+          size={this.state.smallViewport ? 'fullscreen' : 'small'}
+          onDismiss={(event) => {
+            if (event.target.id !== 'toggleViewportButton') {
+              this.setState({ open: false })
+            }
+          }}
           label="Modal Dialog: Hello World"
           shouldCloseOnDocumentClick
-          mountNode={() => document.getElementById('mobilePhoneExample')}
+          mountNode={() => document.getElementById('viewportExample')}
           constrain="parent"
         >
-          <Modal.Header spacing="compact">
+          <Modal.Header spacing={this.state.smallViewport ? 'compact' : 'default'}>
             {this.renderCloseButton()}
-            <Text size="large">This Modal is optmized for small viewport</Text>
+            {this.state.smallViewport
+              ? <Text size="large">This Modal is optimized for small viewport</Text>
+              : <Heading>This is a deafult size Modal</Heading>
+            }
           </Modal.Header>
           <Modal.Body>
             <View as="p" margin="none none small"><Text>{fpo}</Text></View>
@@ -474,24 +495,17 @@ class Example extends React.Component {
             <Button onClick={this.handleButtonClick} color="primary" type="submit">Submit</Button>
           </Modal.Footer>
         </Modal>
-        <div style={{
-          boxSizing: "border-box",
-          width: "20rem",
-          height: "37.5rem",
-          borderRadius: "16px",
-          padding: "32px 8px",
-          background: "#C7CDD1",
-          margin: "16px auto 0"
-        }}>
-          <View
-            background="primary-inverse"
-            display="block"
-            width="100%"
-            height="100%"
-            id="mobilePhoneExample"
-          >
-          </View>
-        </div>
+
+        <View
+          background="primary-inverse"
+          margin="medium auto none"
+          display="block"
+          width={this.state.smallViewport ? '20rem' : '50rem'}
+          height="37.5rem"
+          borderWidth="large"
+          id="viewportExample"
+        >
+        </View>
       </div>
     )
   }

--- a/packages/ui-modal/src/Modal/README.md
+++ b/packages/ui-modal/src/Modal/README.md
@@ -198,9 +198,10 @@ class ModalAutoCompleteExample extends React.Component {
 
 render(<Example />)
 ```
+
 ### Media (images, etc.) inside Modals
 
-> Setting the `variant` prop to `"inverse"` will result in a dark version of Modal, useful for displaying media. *Note that the `inverse` Modal does not currently support text or form input content.*
+> Setting the `variant` prop to `"inverse"` will result in a dark version of Modal, useful for displaying media. _Note that the `inverse` Modal does not currently support text or form input content._
 
 **If you are displaying small, relatively uniform images or videos inside Modal, the default settings should work well.** Modal.Body will expand to the height of the media you're displaying. If there is overflow, scrollbars will be available.
 
@@ -402,6 +403,95 @@ class Example extends React.Component {
             <Button onClick={this.handleButtonClick} withBackground={false} color="primary-inverse" type="submit">Close</Button>
           </Modal.Footer>
         </Modal>
+      </div>
+    )
+  }
+}
+
+render(<Example />)
+```
+
+### Small viewports
+
+On smaller viewports (like mobile devices or scaled-up UI), we don't want to lose space because of padding and margins. In order to achieve that, use `size="fullscreen"` on the Modal and set the `spacing` property of Modal.Header to `compact`.
+
+```js
+---
+render: false
+example: true
+---
+const fpo = lorem.paragraphs(1)
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      open: false,
+    }
+  }
+
+  handleButtonClick = () => {
+    this.setState(function (state) {
+      return { open: !state.open }
+    })
+  }
+
+  renderCloseButton () {
+    return (
+      <CloseButton
+        placement="end"
+        offset="small"
+        onClick={this.handleButtonClick}
+        screenReaderLabel="Close"
+      />
+    )
+  }
+
+  render () {
+    return (
+      <div>
+        <Button onClick={this.handleButtonClick}>
+          {this.state.open ? 'Close' : 'Open'} the Modal
+        </Button>
+        <Modal
+          open={this.state.open}
+          onDismiss={() => { this.setState({ open: false }) }}
+          size="fullscreen"
+          label="Modal Dialog: Hello World"
+          shouldCloseOnDocumentClick
+          mountNode={() => document.getElementById('mobilePhoneExample')}
+          constrain="parent"
+        >
+          <Modal.Header spacing="compact">
+            {this.renderCloseButton()}
+            <Text size="large">This Modal is optmized for small viewport</Text>
+          </Modal.Header>
+          <Modal.Body>
+            <View as="p" margin="none none small"><Text>{fpo}</Text></View>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.handleButtonClick} margin="0 x-small 0 0">Close</Button>
+            <Button onClick={this.handleButtonClick} color="primary" type="submit">Submit</Button>
+          </Modal.Footer>
+        </Modal>
+        <div style={{
+          boxSizing: "border-box",
+          width: "20rem",
+          height: "37.5rem",
+          borderRadius: "16px",
+          padding: "32px 8px",
+          background: "#C7CDD1",
+          margin: "16px auto 0"
+        }}>
+          <View
+            background="primary-inverse"
+            display="block"
+            width="100%"
+            height="100%"
+            id="mobilePhoneExample"
+          >
+          </View>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Closes: INSTUI-3283

The new `spacing` prop allows setting a `compact` value to reduce the padding of the modal header.
This is used on smaller viewports.