### PR TITLE
INSTUI-3271 - feat(ui-view): vendor prefix all view style props

### DIFF
--- a/packages/ui-modal/src/Modal/ModalBody/__tests__/ModalBody.test.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/__tests__/ModalBody.test.tsx
@@ -51,13 +51,17 @@ describe('<ModalBody />', async () => {
     )
   })
 
-  it('should set 100% width and height when overflow is set to fit', async () => {
-    await mount(<ModalBody overflow="fit" />)
+  it('should set the same width and height as the parent when overflow is set to fit', async () => {
+    await mount(
+      <div style={{ width: '500px', height: '600px' }}>
+        <ModalBody overflow="fit" />
+      </div>
+    )
 
     const body = await ModalBodyLocator.find()
 
-    expect((body.getDOMNode() as HTMLElement).style.width).to.equal('100%')
-    expect((body.getDOMNode() as HTMLElement).style.height).to.equal('100%')
+    expect(window.getComputedStyle(body.getDOMNode()).width).to.equal('500px')
+    expect(window.getComputedStyle(body.getDOMNode()).height).to.equal('600px')
   })
 
   describe('when passing down props to View', async () => {

--- a/packages/ui-view/src/View/__tests__/View.test.tsx
+++ b/packages/ui-view/src/View/__tests__/View.test.tsx
@@ -26,6 +26,9 @@ import React, { CSSProperties } from 'react'
 
 import { expect, mount, stub, wait, within } from '@instructure/ui-test-utils'
 import { View } from '../../index'
+import generateStyle from '../styles'
+import generateComponentTheme from '../theme'
+import { canvas } from '@instructure/ui-themes'
 
 describe('<View />', async () => {
   it('should render', async () => {
@@ -217,6 +220,28 @@ describe('<View />', async () => {
     await subject.setProps({ maxWidth: '200px' })
 
     expect(view.getComputedStyle().maxWidth).to.equal('200px')
+  })
+
+  describe('generateStyle', () => {
+    it('decoreates inlineStyle props with !important', () => {
+      const styles = generateStyle(generateComponentTheme(canvas), {
+        width: 'fit-content',
+        padding: 'xxx-small',
+        display: 'auto',
+        overflowX: 'auto',
+        overflowY: 'auto',
+        borderColor: 'primary',
+        position: 'absolute',
+        focusPosition: 'offset',
+        focusColor: 'info',
+        shouldAnimateFocus: false
+      }) as Record<string, string>
+
+      Object.entries(styles?.inlineStyles).forEach((style) => {
+        const css = style[1].split(' ')
+        return expect(css[css.length - 1]).to.equal('!important')
+      })
+    })
   })
 
   describe('withFocusOutline', async () => {

--- a/packages/ui-view/src/View/__tests__/View.test.tsx
+++ b/packages/ui-view/src/View/__tests__/View.test.tsx
@@ -222,28 +222,6 @@ describe('<View />', async () => {
     expect(view.getComputedStyle().maxWidth).to.equal('200px')
   })
 
-  describe('generateStyle', () => {
-    it('decoreates inlineStyle props with !important', () => {
-      const styles = generateStyle(generateComponentTheme(canvas), {
-        width: 'fit-content',
-        padding: 'xxx-small',
-        display: 'auto',
-        overflowX: 'auto',
-        overflowY: 'auto',
-        borderColor: 'primary',
-        position: 'absolute',
-        focusPosition: 'offset',
-        focusColor: 'info',
-        shouldAnimateFocus: false
-      }) as Record<string, string>
-
-      Object.entries(styles?.inlineStyles).forEach((style) => {
-        const css = style[1].split(' ')
-        return expect(css[css.length - 1]).to.equal('!important')
-      })
-    })
-  })
-
   describe('withFocusOutline', async () => {
     it('should warn when withFocusOutline is true without position=relative', async () => {
       const consoleError = stub(console, 'error')

--- a/packages/ui-view/src/View/__tests__/View.test.tsx
+++ b/packages/ui-view/src/View/__tests__/View.test.tsx
@@ -26,9 +26,6 @@ import React, { CSSProperties } from 'react'
 
 import { expect, mount, stub, wait, within } from '@instructure/ui-test-utils'
 import { View } from '../../index'
-import generateStyle from '../styles'
-import generateComponentTheme from '../theme'
-import { canvas } from '@instructure/ui-themes'
 
 describe('<View />', async () => {
   it('should render', async () => {

--- a/packages/ui-view/src/View/index.tsx
+++ b/packages/ui-view/src/View/index.tsx
@@ -218,8 +218,7 @@ class View extends Component<ViewProps> {
         //@ts-expect-error TODO: `ref` prop causes: "Expression produces a union type that is too complex to represent.ts(2590)"
         {...passthroughProps(props)}
         className={className}
-        css={styles?.view}
-        style={styles?.inlineStyles}
+        css={[styles?.view, styles?.inlineStyles]}
         ref={this.handleElementRef}
       >
         {children}

--- a/packages/ui-view/src/View/styles.ts
+++ b/packages/ui-view/src/View/styles.ts
@@ -571,6 +571,15 @@ const generateStyle = (
 
   const focusStyles = getFocusStyles(props, componentTheme)
 
+  const important = (styles: any) =>
+    Object.entries(styles).reduce(
+      (acc, entry) =>
+        entry[1] === undefined
+          ? acc
+          : { ...acc, [entry[0]]: `${entry[1]} !important` },
+      {}
+    )
+
   return {
     view: {
       label: 'view',
@@ -600,16 +609,16 @@ const generateStyle = (
       ...(shouldUseFocusStyles ? focusStyles : {})
     },
     inlineStyles: {
-      ...spacingStyle,
-      ...borderStyle,
-      ...offsetStyle,
-      width,
-      height,
-      minWidth,
-      minHeight,
-      maxWidth,
-      maxHeight,
-      ...getStyleProps(props)
+      ...important(spacingStyle),
+      ...important(borderStyle),
+      ...important(offsetStyle),
+      width: `${width} !important`,
+      height: `${height} !important`,
+      minWidth: `${minWidth} !important`,
+      minHeight: `${minHeight} !important`,
+      maxWidth: `${maxWidth} !important`,
+      maxHeight: `${maxHeight} !important`,
+      ...important(getStyleProps(props))
     }
   }
 }

--- a/packages/ui-view/src/View/styles.ts
+++ b/packages/ui-view/src/View/styles.ts
@@ -600,6 +600,8 @@ const generateStyle = (
       ...(shouldUseFocusStyles ? focusStyles : {})
     },
     inlineStyles: {
+      //every '&' symbol will add another class to the rule, so it will be stronger
+      //making an accidental override less likely
       '&&&&&&&&&&': {
         ...spacingStyle,
         ...borderStyle,

--- a/packages/ui-view/src/View/styles.ts
+++ b/packages/ui-view/src/View/styles.ts
@@ -571,15 +571,6 @@ const generateStyle = (
 
   const focusStyles = getFocusStyles(props, componentTheme)
 
-  const important = (styles: Record<string, string | number | undefined>) =>
-    Object.entries(styles).reduce(
-      (acc, entry) =>
-        entry[1] === undefined
-          ? acc
-          : { ...acc, [entry[0]]: `${entry[1]} !important` },
-      {}
-    )
-
   return {
     view: {
       label: 'view',
@@ -608,18 +599,20 @@ const generateStyle = (
         : {}),
       ...(shouldUseFocusStyles ? focusStyles : {})
     },
-    inlineStyles: important({
-      ...spacingStyle,
-      ...borderStyle,
-      ...offsetStyle,
-      width,
-      height,
-      minWidth,
-      minHeight,
-      maxWidth,
-      maxHeight,
-      ...getStyleProps(props)
-    })
+    inlineStyles: {
+      '&&&&&&&&&&': {
+        ...spacingStyle,
+        ...borderStyle,
+        ...offsetStyle,
+        width,
+        height,
+        minWidth,
+        minHeight,
+        maxWidth,
+        maxHeight,
+        ...getStyleProps(props)
+      }
+    }
   }
 }
 export default generateStyle

--- a/packages/ui-view/src/View/styles.ts
+++ b/packages/ui-view/src/View/styles.ts
@@ -571,7 +571,7 @@ const generateStyle = (
 
   const focusStyles = getFocusStyles(props, componentTheme)
 
-  const important = (styles: any) =>
+  const important = (styles: Record<string, string | number | undefined>) =>
     Object.entries(styles).reduce(
       (acc, entry) =>
         entry[1] === undefined

--- a/packages/ui-view/src/View/styles.ts
+++ b/packages/ui-view/src/View/styles.ts
@@ -608,18 +608,18 @@ const generateStyle = (
         : {}),
       ...(shouldUseFocusStyles ? focusStyles : {})
     },
-    inlineStyles: {
-      ...important(spacingStyle),
-      ...important(borderStyle),
-      ...important(offsetStyle),
-      width: `${width} !important`,
-      height: `${height} !important`,
-      minWidth: `${minWidth} !important`,
-      minHeight: `${minHeight} !important`,
-      maxWidth: `${maxWidth} !important`,
-      maxHeight: `${maxHeight} !important`,
-      ...important(getStyleProps(props))
-    }
+    inlineStyles: important({
+      ...spacingStyle,
+      ...borderStyle,
+      ...offsetStyle,
+      width,
+      height,
+      minWidth,
+      minHeight,
+      maxWidth,
+      maxHeight,
+      ...getStyleProps(props)
+    })
   }
 }
 export default generateStyle


### PR DESCRIPTION
Closes: INSTUI-3271

Adding prop-based styling had no vendor prefixing.
Added inline styles to emotion's css prop and
added !important to every rule in it.

closes https://github.com/instructure/instructure-ui/issues/729