### PR TITLE
feat(ui-modal): add `spacing` prop to `Modal.Header`

### DIFF
--- a/packages/ui-modal/src/Modal/ModalHeader/__tests__/ModalHeader.test.js
+++ b/packages/ui-modal/src/Modal/ModalHeader/__tests__/ModalHeader.test.js
@@ -43,4 +43,27 @@ describe('<ModalHeader />', async () => {
     const header = within(subject.getDOMNode())
     expect(header).to.have.className(styles['inverse'])
   })
+
+  describe('spacing prop', async () => {
+    it('should be correct by default', async () => {
+      const subject = await mount(<ModalHeader />)
+
+      const header = within(subject.getDOMNode())
+      expect(header).to.have.className(styles['defaultSpacing'])
+    })
+
+    it('should correctly set default spacing', async () => {
+      const subject = await mount(<ModalHeader spacing="default" />)
+
+      const header = within(subject.getDOMNode())
+      expect(header).to.have.className(styles['defaultSpacing'])
+    })
+
+    it('should correctly set compact spacing', async () => {
+      const subject = await mount(<ModalHeader spacing="compact" />)
+
+      const header = within(subject.getDOMNode())
+      expect(header).to.have.className(styles['compactSpacing'])
+    })
+  })
 })

--- a/packages/ui-modal/src/Modal/ModalHeader/index.js
+++ b/packages/ui-modal/src/Modal/ModalHeader/index.js
@@ -48,16 +48,18 @@ id: Modal.Header
 class ModalHeader extends Component {
   static propTypes = {
     children: PropTypes.node,
-    variant: PropTypes.oneOf(['default', 'inverse'])
+    variant: PropTypes.oneOf(['default', 'inverse']),
+    spacing: PropTypes.oneOf(['default', 'compact'])
   }
 
   static defaultProps = {
     children: null,
-    variant: 'default'
+    variant: 'default',
+    spacing: 'default'
   }
 
   render() {
-    const { children, variant, ...rest } = this.props
+    const { children, variant, spacing, ...rest } = this.props
     let usesCloseButton = false
 
     React.Children.forEach(children, (child) => {
@@ -68,6 +70,7 @@ class ModalHeader extends Component {
 
     const classes = {
       [styles.root]: true,
+      [styles[`${spacing}Spacing`]]: true,
       [styles.inverse]: variant === 'inverse',
       [styles.withCloseButton]: usesCloseButton === true
     }

--- a/packages/ui-modal/src/Modal/ModalHeader/styles.css
+++ b/packages/ui-modal/src/Modal/ModalHeader/styles.css
@@ -1,8 +1,5 @@
 .root {
   box-sizing: border-box;
-  padding: var(--padding);
-  padding-inline-end: var(--padding);
-  padding-inline-start: var(--padding);
   flex: 0 0 auto;
   background: var(--background);
   border-bottom-width: 0.0625rem;
@@ -15,6 +12,22 @@
   border-bottom-color: var(--inverseBorderColor);
 }
 
-.withCloseButton {
-  padding-inline-end: calc(var(--padding) * 2 + 1em);
+.defaultSpacing {
+  padding: var(--padding);
+  padding-inline-end: var(--padding);
+  padding-inline-start: var(--padding);
+
+  &.withCloseButton {
+    padding-inline-end: calc(var(--padding) * 2 + 1em);
+  }
+}
+
+.compactSpacing {
+  padding: var(--paddingCompact);
+  padding-inline-end: var(--paddingCompact);
+  padding-inline-start: var(--paddingCompact);
+
+  &.withCloseButton {
+    padding-inline-end: calc(var(--paddingCompact) * 2 + 1em);
+  }
 }

--- a/packages/ui-modal/src/Modal/ModalHeader/theme.js
+++ b/packages/ui-modal/src/Modal/ModalHeader/theme.js
@@ -27,6 +27,7 @@ export default function ({ colors, spacing }) {
     background: colors.backgroundLightest,
     borderColor: colors.borderMedium,
     padding: spacing.medium,
+    paddingCompact: spacing.small,
 
     inverseBackground: colors.backgroundDarkest,
     inverseBorderColor: colors.backgroundDarkest

--- a/packages/ui-modal/src/Modal/README.md
+++ b/packages/ui-modal/src/Modal/README.md
@@ -198,9 +198,10 @@ class ModalAutoCompleteExample extends React.Component {
 
 render(<Example />)
 ```
+
 ### Media (images, etc.) inside Modals
 
-> Setting the `variant` prop to `"inverse"` will result in a dark version of Modal, useful for displaying media. *Note that the `inverse` Modal does not currently support text or form input content.*
+> Setting the `variant` prop to `"inverse"` will result in a dark version of Modal, useful for displaying media. _Note that the `inverse` Modal does not currently support text or form input content._
 
 **If you are displaying small, relatively uniform images or videos inside Modal, the default settings should work well.** Modal.Body will expand to the height of the media you're displaying. If there is overflow, scrollbars will be available.
 
@@ -407,6 +408,102 @@ class Example extends React.Component {
   }
 }
 
+render(<Example />)
+```
+
+### Small viewports
+
+On smaller viewports (like mobile devices or scaled-up UI), we don't want to lose space because of padding and margins. In order to achieve that, use `size="fullscreen"` on the Modal and set the `spacing` property of Modal.Header to `compact`.
+
+```js
+---
+render: false
+example: true
+---
+const fpo = lorem.paragraphs(1)
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      open: false,
+      smallViewport: true
+    }
+  }
+  toggleOpen = () => {
+    this.setState(function (state) {
+      return { open: !state.open }
+    })
+  }
+  toggleViewport = async () => {
+    await this.setState(function (state) {
+      return { smallViewport: !state.smallViewport }
+    })
+  }
+  renderCloseButton () {
+    return (
+      <CloseButton
+        placement="end"
+        offset="small"
+        onClick={this.toggleOpen}
+        screenReaderLabel="Close"
+      />
+    )
+  }
+  render () {
+    return (
+      <div>
+        <Button onClick={this.toggleOpen}>
+          {this.state.open ? 'Close' : 'Open'} the Modal
+        </Button>
+        <Button
+          onClick={this.toggleViewport}
+          margin='0 0 0 small'
+          id="toggleViewportButton"
+        >
+          Toggle viewport
+        </Button>
+        <Modal
+          open={this.state.open}
+          size={this.state.smallViewport ? 'fullscreen' : 'small'}
+          onDismiss={(event) => {
+            if (event.target.id !== 'toggleViewportButton') {
+              this.setState({ open: false })
+            }
+          }}
+          label="Modal Dialog: Hello World"
+          shouldCloseOnDocumentClick
+          mountNode={() => document.getElementById('viewportExample')}
+          constrain="parent"
+        >
+          <Modal.Header spacing={this.state.smallViewport ? 'compact' : 'default'}>
+            {this.renderCloseButton()}
+            {this.state.smallViewport
+              ? <Text size="large">This Modal is optimized for small viewport</Text>
+              : <Heading>This is a deafult size Modal</Heading>
+            }
+          </Modal.Header>
+          <Modal.Body>
+            <View as="p" margin="none none small"><Text>{fpo}</Text></View>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.handleButtonClick} margin="0 x-small 0 0">Close</Button>
+            <Button onClick={this.handleButtonClick} color="primary" type="submit">Submit</Button>
+          </Modal.Footer>
+        </Modal>
+        <View
+          background="primary-inverse"
+          margin="medium auto none"
+          display="block"
+          width={this.state.smallViewport ? '20rem' : '50rem'}
+          height="37.5rem"
+          borderWidth="large"
+          id="viewportExample"
+        >
+        </View>
+      </div>
+    )
+  }
+}
 render(<Example />)
 ```
 


### PR DESCRIPTION
Closes: INSTUI-3291

The new `spacing` prop allows setting a `compact` value to reduce the padding of the modal header.
This is used on smaller viewports. This feature backports the V8 version in INSTUI-3283.