### PR TITLE
fix(emotion): fix EmotionThemeProvider falling back to using Canvas t…

### DIFF
--- a/packages/emotion/src/useTheme.ts
+++ b/packages/emotion/src/useTheme.ts
@@ -38,8 +38,7 @@ import type { ThemeOrOverride } from './EmotionTypes'
  */
 const useTheme = () => {
   let theme = useEmotionTheme() as ThemeOrOverride
-  // TODO type theme properly, then this cast might not be needed.
-  if (isEmpty(theme as Record<string, unknown>)) {
+  if (isEmpty(theme)) {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(
         `No theme provided for [EmotionThemeProvider], using default <canvas> theme.`

--- a/packages/shared-types/src/BaseTheme.ts
+++ b/packages/shared-types/src/BaseTheme.ts
@@ -133,6 +133,19 @@ type BaseThemeVariables = {
   typography: Typography
 }
 
+type BaseThemeVariableKeys = [
+  'borders',
+  'breakpoints',
+  'colors',
+  'forms',
+  'media',
+  'shadows',
+  'spacing',
+  'stacking',
+  'transitions',
+  'typography'
+]
+
 type BaseTheme = {
   key: string
   description?: string
@@ -140,6 +153,7 @@ type BaseTheme = {
 
 export type {
   BaseTheme,
+  BaseThemeVariableKeys,
   BaseThemeVariables,
   Shadows,
   Border,


### PR DESCRIPTION
…heme

Closes: INSTUI-3288

The `theme` prop is now correctly optional. If no theme is provided, or an invalid theme is provided
on the root level, we fall back to using Canvas an throw a warning.