### PR TITLE
fix(ui-svg-images): fix icons getting cropped in zoomed windows

### DIFF
--- a/packages/ui-svg-images/src/InlineSVG/styles.css
+++ b/packages/ui-svg-images/src/InlineSVG/styles.css
@@ -1,5 +1,6 @@
 .root {
   fill: currentColor;
+  overflow: visible;
 }
 
 .inline {


### PR DESCRIPTION
Closes: INSTUI-3292

When applying zoom to the browser window, the edges of some icons could get chipped off due to the
fractional pixel size of the container. This happened because the user agent stylesheet applies
`svg:not(:root) { overflow: hidden }` on the SVG-s. We can allow overflow here, because all InstUI
icons are drawn to fit the square canvas, so there won't be any unwanted overflows, but lets the
cropped of edges to show in scaled windows. Backports the V8 version from INSTUI-3214, PR #746.