### PR TITLE
fix(ui-options,ui-select,ui-simple-select): fix icon positioning

### DIFF
--- a/packages/ui-options/src/Options/Item/styles.ts
+++ b/packages/ui-options/src/Options/Item/styles.ts
@@ -89,7 +89,7 @@ const generateStyle = (
             paddingInlineStart: componentTheme.nestedPadding
           },
           '[class$=-optionItem__content--before]': {
-            offsetInlineStart: componentTheme.nestedPadding
+            insetInlineStart: componentTheme.nestedPadding
           }
         })
       }
@@ -124,13 +124,13 @@ const generateStyle = (
     },
     contentBefore: {
       label: 'optionItem__content--before',
-      offsetInlineEnd: 'auto',
-      offsetInlineStart: componentTheme.iconPadding
+      insetInlineEnd: 'auto',
+      insetInlineStart: componentTheme.iconPadding
     },
     contentAfter: {
       label: 'optionItem__content--after',
-      offsetInlineEnd: componentTheme.iconPadding,
-      offsetInlineStart: 'auto'
+      insetInlineEnd: componentTheme.iconPadding,
+      insetInlineStart: 'auto'
     }
   }
 }


### PR DESCRIPTION
Closes: INSTUI-3297

After the removal of the bidirectional polyfill, the `offset-inline` CSS props were not working
anymore, had to change it to `inset-inline`.