### PR TITLE
fix(ui-dialog,ui-drawer-layout): fix Dialog role attribute

### DIFF
--- a/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
@@ -68,6 +68,19 @@ describe('<Dialog />', async () => {
     expect(await dialog.find('[aria-label="Dialog Example"]')).to.exist()
   })
 
+  it('should apply the role attributes, if explicitly passed', async () => {
+    const subject = await mount(
+      <Dialog open label="Dialog Example" role="region">
+        <button>Hello World</button>
+      </Dialog>
+    )
+
+    const dialog = within(subject.getDOMNode())
+
+    expect(await dialog.find('[role="region"]')).to.exist()
+    expect(await dialog.find('[aria-label="Dialog Example"]')).to.exist()
+  })
+
   it('should call onDismiss prop when Esc key pressed', async () => {
     const onDismiss = stub()
 

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -188,11 +188,14 @@ class Dialog extends Component<DialogProps> {
   render() {
     const ElementType = getElementType(Dialog, this.props)
 
+    // In case the HTML role attribute is explicitly passed, use props.role
+    const role = this.props.role || (this.props.label ? 'dialog' : undefined)
+
     return this.props.open ? (
       <ElementType
         // @ts-expect-error TODO: `ref` prop causes: "Expression produces a union type that is too complex to represent.ts(2590)"
         {...omitProps(this.props, Dialog.allowedProps)}
-        role={this.props.label ? 'dialog' : undefined}
+        role={role}
         aria-label={this.props.label}
         className={this.props.className} // eslint-disable-line react/prop-types
         ref={this.getRef}

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.tsx
@@ -224,20 +224,43 @@ describe('<DrawerTray />', async () => {
     )
   })
 
-  it('should apply the a11y attributes', async () => {
-    await mount(
-      <DrawerTray
-        label="a tray test"
-        open={true}
-        render={() => {
-          return 'Hello from layout tray'
-        }}
-      />
-    )
-    const drawerTray = await DrawerTrayLocator.find()
-    const dialog = await drawerTray.find(':label(a tray test)')
+  describe('should apply the a11y attributes', async () => {
+    it("when it doesn't overlay the content", async () => {
+      await mount(
+        <DrawerLayoutContext.Provider value={false}>
+          <DrawerTray
+            label="a tray test"
+            open={true}
+            render={() => {
+              return 'Hello from layout tray'
+            }}
+          />
+        </DrawerLayoutContext.Provider>
+      )
+      const drawerTray = await DrawerTrayLocator.find()
+      const dialog = await drawerTray.find(':label(a tray test)')
 
-    expect(dialog).to.exist()
-    expect(dialog.getAttribute('role')).to.equal('dialog')
+      expect(dialog).to.exist()
+      expect(dialog.getAttribute('role')).to.equal('region')
+    })
+
+    it('when it overlays the content', async () => {
+      await mount(
+        <DrawerLayoutContext.Provider value={true}>
+          <DrawerTray
+            label="a tray test"
+            open={true}
+            render={() => {
+              return 'Hello from layout tray'
+            }}
+          />
+        </DrawerLayoutContext.Provider>
+      )
+      const drawerTray = await DrawerTrayLocator.find()
+      const dialog = await drawerTray.find(':label(a tray test)')
+
+      expect(dialog).to.exist()
+      expect(dialog.getAttribute('role')).to.equal('dialog')
+    })
   })
 })


### PR DESCRIPTION
Closes: INSTUI-3299

If the role aria attribute is explicitly passed to the Dialog, it should use it. This caused an a11y
issue in DrawerTray where the passed role "region"never applied to the Dialog.