### PR TITLE
INSTUI-3300 - drawer tray role prop not applying correctly

### DIFF
--- a/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.js
+++ b/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.js
@@ -68,6 +68,19 @@ describe('<Dialog />', async () => {
     expect(await dialog.find('[aria-label="Dialog Example"]')).to.exist()
   })
 
+  it('should apply the role attributes, if explicitly passed', async () => {
+    const subject = await mount(
+      <Dialog open label="Dialog Example" role="region">
+        <button>Hello World</button>
+      </Dialog>
+    )
+
+    const dialog = within(subject.getDOMNode())
+
+    expect(await dialog.find('[role="region"]')).to.exist()
+    expect(await dialog.find('[aria-label="Dialog Example"]')).to.exist()
+  })
+
   it('should call onDismiss prop when Esc key pressed', async () => {
     const onDismiss = stub()
     const subject = await mount(

--- a/packages/ui-dialog/src/Dialog/index.js
+++ b/packages/ui-dialog/src/Dialog/index.js
@@ -220,11 +220,15 @@ class Dialog extends Component {
 
   render() {
     const ElementType = getElementType(Dialog, this.props)
+
+    // In case the HTML role attribute is explicitly passed, use props.role
+    const role = this.props.role || (this.props.label ? 'dialog' : undefined) // eslint-disable-line react/prop-types
+
     return this.props.open ? (
       <ElementType
         {...omitProps(this.props, Dialog.propTypes)}
         ref={this.getRef}
-        role={this.props.label ? 'dialog' : null}
+        role={role}
         aria-label={this.props.label}
         className={this.props.className} // eslint-disable-line react/prop-types
       >

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.js
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/__tests__/DrawerTray.test.js
@@ -222,20 +222,44 @@ describe('<DrawerTray />', async () => {
     })
   })
 
-  it('should apply the a11y attributes', async () => {
-    await mount(
-      <DrawerTray
-        label="a tray test"
-        open={true}
-        render={() => {
-          return 'Hello from layout tray'
-        }}
-      />
-    )
-    const drawerTray = await DrawerTrayLocator.find()
-    const dialog = await drawerTray.find(':label(a tray test)')
+  describe('should apply the a11y attributes', async () => {
+    it("when it doesn't overlay the content", async () => {
+      await mount(
+        <DrawerTray
+          label="a tray test"
+          open={true}
+          render={() => {
+            return 'Hello from layout tray'
+          }}
+        />
+      )
+      const drawerTray = await DrawerTrayLocator.find()
+      const dialog = await drawerTray.find(':label(a tray test)')
 
-    expect(dialog).to.exist()
-    expect(dialog.getAttribute('role')).to.equal('dialog')
+      expect(dialog).to.exist()
+      expect(dialog.getAttribute('role')).to.equal('region')
+    })
+
+    it('when it overlays the content', async () => {
+      const subject = await mount(
+        <DrawerTray
+          label="a tray test"
+          open={true}
+          render={() => {
+            return 'Hello from layout tray'
+          }}
+        />
+      )
+
+      subject.setContext({
+        shouldOverlayTray: true
+      })
+
+      const drawerTray = await DrawerTrayLocator.find()
+      const dialog = await drawerTray.find(':label(a tray test)')
+
+      expect(dialog).to.exist()
+      expect(dialog.getAttribute('role')).to.equal('dialog')
+    })
   })
 })


### PR DESCRIPTION
If the role aria attribute is explicitly passed to the Dialog, it should use it. This caused an a11y
issue in DrawerTray where the passed role "region" never applied to the Dialog. Backports PR #765.

Closes: INSTUI-3300