### PR TITLE
INSTUI-3304 ui-tree-browser: add 'sortOrder' property to TreeBrowser component

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -383,7 +383,7 @@ render(<Example/>)
 
 ### Change the order of appearance of items and collection
 
-By default, the order of collections and items depends on the order of `collections` and `items` array. We can override it by add new `sortOrder` comparision function.
+By default, the order of collections and items depend on the order of `collections` and `items` array. We can override it by providing a `sortOrder` comparison function.
 
 ---
 
@@ -402,29 +402,22 @@ class Example extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      size: 'medium'
+      size: 'medium',
+      sorted: false
     }
-
-    this.sizes = ['small', 'medium', 'large']
   }
-
-  handleSizeSelect = (e, size) => {
-    this.setState({ size })
-  };
-
+  toogleSort = (event)=>{ this.setState({sorted:!this.state.sorted}) }
   render () {
     return (
       <>
         <View display="block" margin="none none medium">
-          <RadioInputGroup
-            name="treeBrowserSize"
-            defaultValue="medium"
-            description={<ScreenReaderContent>TreeBrowser size selector</ScreenReaderContent>}
-            variant="toggle"
-            onChange={this.handleSizeSelect}
-          >
-            {this.sizes.map((size) => <RadioInput key={size} label={size} value={size} />)}
-          </RadioInputGroup>
+         <FormFieldGroup description="Turn of/off sorting">
+              <Checkbox
+                checked={this.state.sorted}
+                label="Sort"
+                onChange={this.toogleSort}
+              />
+               </FormFieldGroup>
         </View>
 
         <TreeBrowser
@@ -451,9 +444,7 @@ class Example extends React.Component {
           }}
           defaultExpanded={[1, 3]}
           rootId={1}
-         sortOrder={(a, b) => {
-            return a.name.localeCompare(b.name) // sort by alphabetical order
-          }}
+         sortOrder={this.state.sorted? (a,b)=>{return(a.name).localeCompare(b.name)}: (a,b)=>{return 0} }
         />
       </>
     )

--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -381,6 +381,89 @@ class Example extends React.Component {
 render(<Example/>)
 ```
 
+### Change the order of appearance of items and collection
+
+By default, the order of collections and items depends on the order of `collections` and `items` array. We can override it by add new `sortOrder` comparision function.
+
+---
+
+**NOTE**
+
+This works with all collections and items of the TreeBrowser.
+
+---
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      size: 'medium'
+    }
+
+    this.sizes = ['small', 'medium', 'large']
+  }
+
+  handleSizeSelect = (e, size) => {
+    this.setState({ size })
+  };
+
+  render () {
+    return (
+      <>
+        <View display="block" margin="none none medium">
+          <RadioInputGroup
+            name="treeBrowserSize"
+            defaultValue="medium"
+            description={<ScreenReaderContent>TreeBrowser size selector</ScreenReaderContent>}
+            variant="toggle"
+            onChange={this.handleSizeSelect}
+          >
+            {this.sizes.map((size) => <RadioInput key={size} label={size} value={size} />)}
+          </RadioInputGroup>
+        </View>
+
+        <TreeBrowser
+          size={this.state.size}
+          collections={{
+            1: {
+              id: 1,
+              name: "Assignments",
+              collections: [3,2],
+              items: [3],
+              descriptor: "Class Assignments"
+            },
+            2: { id: 2, name: "English Assignments", collections: [4], items: [] },
+            3: { id: 3, name: "Math Assignments", collections: [5], items: [2,1] },
+            4: { id: 4, name: "Reading Assignments", collections: [], items: [4] },
+            5: { id: 5, name: "Advanced Math Assignments", items: [5]}
+          }}
+          items={{
+            1: { id: 1, name: "Addition Worksheet" },
+            2: { id: 2, name: "Subtraction Worksheet" },
+            3: { id: 3, name: "General Questions" },
+            4: { id: 4, name: "Vogon Poetry" },
+            5: { id: 5, name: "Bistromath", descriptor: "Explain the Bistromathic Drive" }
+          }}
+          defaultExpanded={[1, 3]}
+          rootId={1}
+         sortOrder={(a, b) => {
+            return a.name.localeCompare(b.name) // sort by alphabetical order
+          }}
+        />
+      </>
+    )
+  }
+}
+
+render(<Example/>)
+
+```
+
 ### showRootCollection
 
 The `showRootCollection` prop sets whether the root collection (specified in `rootId` prop) is displayed or to begin with its immediate sub-collections and items instead. It defaults to `true`.

--- a/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.tsx
@@ -909,4 +909,63 @@ describe('<TreeBrowser />', async () => {
       expect((await tree.findAllItems()).length).to.equal(4)
     })
   })
+
+  describe('sorting', async () => {
+    it("should present collections and items in alphabetical order, in spite of the order of 'collections' and 'items' arrays", async () => {
+      await mount(
+        <TreeBrowser
+          collections={{
+            1: {
+              id: 1,
+              name: 'Assignments',
+              collections: [5, 3, 2, 4],
+              items: [3, 5, 2, 1, 4]
+            },
+            2: {
+              id: 2,
+              name: 'English Assignments',
+              collections: [],
+              items: []
+            },
+            3: { id: 3, name: 'Math Assignments', collections: [], items: [] },
+            4: {
+              id: 4,
+              name: 'Reading Assignments',
+              collections: [],
+              items: []
+            },
+            5: { id: 5, name: 'Advanced Math Assignments', items: [] }
+          }}
+          items={{
+            1: { id: 1, name: 'Addition Worksheet' },
+            2: { id: 2, name: 'Subtraction Worksheet' },
+            3: { id: 3, name: 'General Questions' },
+            4: { id: 4, name: 'Vogon Poetry' },
+            5: { id: 5, name: 'Bistromath' }
+          }}
+          rootId={1}
+          defaultExpanded={[1]}
+          sortOrder={(a, b) => {
+            return a.name.localeCompare(b.name)
+          }}
+        />
+      )
+      const tree = await TreeBrowserLocator.find()
+      const items = await tree.findAllItems()
+      const arr = items.map((item) => item.getDOMNode().textContent)
+      expect(arr.slice(1, 5)).deep.equal([
+        'Advanced Math Assignments',
+        'English Assignments',
+        'Math Assignments',
+        'Reading Assignments'
+      ])
+      expect(arr.slice(5)).deep.equal([
+        'Addition Worksheet',
+        'Bistromath',
+        'General Questions',
+        'Subtraction Worksheet',
+        'Vogon Poetry'
+      ])
+    })
+  })
 })

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -75,7 +75,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     // @ts-expect-error ts-migrate(6133) FIXME: 'collection' is declared but its value is never re... Remove this comment to see the full error message
     onCollectionToggle: function (collection) {},
     // @ts-expect-error ts-migrate(6133) FIXME: 'foo' and 'bar' are declared but their values are never read.
-    sortOrder: function (foo: any, bar: any) {
+    sortOrder: function (obj1, obj2) {
       return 0
     }
   }

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -176,9 +176,6 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     return this.getExpanded(this.state, this.props)
   }
 
-  get sortOrder() {
-    return this.props.sortOrder
-  }
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'state' implicitly has an 'any' type.
   getExpanded(state, props) {
     return typeof props.expanded === 'undefined'
@@ -316,7 +313,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     return collections
       .map((id) => this.getCollectionProps(this.props.collections[id]))
       .filter((collection) => collection != null)
-      .sort(this.sortOrder)
+      .sort(this.props.sortOrder)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'collection' implicitly has an 'any' typ... Remove this comment to see the full error message
@@ -329,7 +326,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
           return { ...this.props.items[id] }
         })
         .filter((item) => item != null)
-        .sort(this.sortOrder)
+        .sort(this.props.sortOrder)
     } else {
       return []
     }
@@ -368,7 +365,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
   }
 
   renderRoot() {
-    return this.collections.sort(this.sortOrder).map((collection, i) => (
+    return this.collections.sort(this.props.sortOrder).map((collection, i) => (
       <TreeCollection
         key={i}
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.

--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -73,7 +73,11 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     // @ts-expect-error ts-migrate(6133) FIXME: 'id' is declared but its value is never read.
     onCollectionClick: function (id, collection) {},
     // @ts-expect-error ts-migrate(6133) FIXME: 'collection' is declared but its value is never re... Remove this comment to see the full error message
-    onCollectionToggle: function (collection) {}
+    onCollectionToggle: function (collection) {},
+    // @ts-expect-error ts-migrate(6133) FIXME: 'foo' and 'bar' are declared but their values are never read.
+    sortOrder: function (foo: any, bar: any) {
+      return 0
+    }
   }
 
   static Node = TreeNode
@@ -172,6 +176,9 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     return this.getExpanded(this.state, this.props)
   }
 
+  get sortOrder() {
+    return this.props.sortOrder
+  }
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'state' implicitly has an 'any' type.
   getExpanded(state, props) {
     return typeof props.expanded === 'undefined'
@@ -309,6 +316,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
     return collections
       .map((id) => this.getCollectionProps(this.props.collections[id]))
       .filter((collection) => collection != null)
+      .sort(this.sortOrder)
   }
 
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'collection' implicitly has an 'any' typ... Remove this comment to see the full error message
@@ -321,6 +329,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
           return { ...this.props.items[id] }
         })
         .filter((item) => item != null)
+        .sort(this.sortOrder)
     } else {
       return []
     }
@@ -359,7 +368,7 @@ class TreeBrowser extends Component<TreeBrowserProps> {
   }
 
   renderRoot() {
-    return this.collections.map((collection, i) => (
+    return this.collections.sort(this.sortOrder).map((collection, i) => (
       <TreeCollection
         key={i}
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.

--- a/packages/ui-tree-browser/src/TreeBrowser/props.ts
+++ b/packages/ui-tree-browser/src/TreeBrowser/props.ts
@@ -52,7 +52,7 @@ type TreeBrowserOwnProps = {
   onItemClick?: (...args: any[]) => any
   treeLabel?: string
   renderContent?: (...args: any[]) => any
-  sortOrder?: (arg1: any, arg2: any) => number
+  sortOrder?: (obj1: any, obj2: any) => number
 }
 
 type PropKeys = keyof TreeBrowserOwnProps

--- a/packages/ui-tree-browser/src/TreeBrowser/props.ts
+++ b/packages/ui-tree-browser/src/TreeBrowser/props.ts
@@ -52,6 +52,7 @@ type TreeBrowserOwnProps = {
   onItemClick?: (...args: any[]) => any
   treeLabel?: string
   renderContent?: (...args: any[]) => any
+  sortOrder?: (arg1: any, arg2: any) => number
 }
 
 type PropKeys = keyof TreeBrowserOwnProps
@@ -134,7 +135,11 @@ const propTypes: PropValidators<PropKeys> = {
    * An optional label to assist visually impaired users
    */
   treeLabel: PropTypes.string,
-  renderContent: PropTypes.func
+  renderContent: PropTypes.func,
+  /**
+   * An optional compare function to specify order of the collections and the items
+   */
+  sortOrder: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -156,7 +161,8 @@ const allowedProps: AllowedPropKeys = [
   'onCollectionToggle',
   'onItemClick',
   'treeLabel',
-  'renderContent'
+  'renderContent',
+  'sortOrder'
 ]
 
 export type { TreeBrowserProps, TreeBrowserStyle }


### PR DESCRIPTION
According to [this issue](https://github.com/instructure/instructure-ui/issues/752), I have implemented a 'sortOrder' property to rearranged the appearance order of collections and items base on users' need. Closes https://github.com/instructure/instructure-ui/issues/752