### PR TITLE
feat(shared-types,ui-checkbox,ui-radio-input): make checkbox and radi…

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -906,6 +906,7 @@ export type RadioInputTheme = {
   labelFontWeight: Typography['fontWeightNormal']
   labelLineHeight: Typography['lineHeightCondensed']
   background: Colors['backgroundLightest']
+  borderWidth: Border['widthSmall']
   borderColor: Colors['borderDarkest']
   hoverBorderColor: Colors['borderDarkest']
   controlSize: string | 0

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
@@ -47,7 +47,7 @@ const generateComponentTheme = (theme: Theme): CheckboxFacadeTheme => {
   const componentVariables: CheckboxFacadeTheme = {
     color: colors?.textLightest,
     borderWidth: borders?.widthSmall,
-    borderColor: colors?.borderDark,
+    borderColor: colors?.borderMedium,
     borderRadius: borders?.radiusMedium,
     background: colors?.backgroundLightest,
     marginRight: spacing?.xSmall,

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
@@ -56,7 +56,7 @@ const generateComponentTheme = (theme: Theme): ToggleFacadeTheme => {
     color: colors?.textLightest,
     background: colors?.backgroundLight,
     borderColor: colors?.borderMedium,
-    borderWidth: borders?.widthMedium,
+    borderWidth: borders?.widthSmall,
     borderRadius: '4rem',
     marginEnd: spacing?.small,
     marginStart: spacing?.small,

--- a/packages/ui-radio-input/src/RadioInput/styles.ts
+++ b/packages/ui-radio-input/src/RadioInput/styles.ts
@@ -63,7 +63,7 @@ const generateStyle = (
         minWidth: '1rem',
         transition: 'all 0.2s ease-out',
         borderRadius: '100%',
-        border: `0.125rem solid ${componentTheme.borderColor}`,
+        border: `${componentTheme.borderWidth} solid ${componentTheme.borderColor}`,
         background: componentTheme.background,
 
         '&::before': {

--- a/packages/ui-radio-input/src/RadioInput/theme.ts
+++ b/packages/ui-radio-input/src/RadioInput/theme.ts
@@ -44,7 +44,6 @@ const generateComponentTheme = (theme: Theme): RadioInputTheme => {
   const themeSpecificStyle: ThemeSpecificStyle<RadioInputTheme> = {
     canvas: {
       focusBorderColor: theme['ic-brand-primary'],
-      borderColor: theme['ic-brand-font-color-dark'],
       hoverBorderColor: theme['ic-brand-font-color-dark'],
       labelColor: theme['ic-brand-font-color-dark']
     },
@@ -60,7 +59,8 @@ const generateComponentTheme = (theme: Theme): RadioInputTheme => {
     labelLineHeight: typography?.lineHeightCondensed,
 
     background: colors?.backgroundLightest,
-    borderColor: colors?.borderDarkest,
+    borderWidth: borders?.widthSmall,
+    borderColor: colors?.borderMedium,
     hoverBorderColor: colors?.borderDarkest,
     controlSize: '0.1875rem',
 


### PR DESCRIPTION
…o borders consistent

Closes: INSTUI-3318

Now both checkboxes and radio buttons have 1px wide, Tiara colored borders when unchecked. This
makes the look of the forms more consistent.