### PR TITLE
docs(ui-modal): update Modal header spacing example - V7

### DIFF
--- a/packages/ui-modal/src/Modal/README.md
+++ b/packages/ui-modal/src/Modal/README.md
@@ -478,8 +478,8 @@ class Example extends React.Component {
           <Modal.Header spacing={this.state.smallViewport ? 'compact' : 'default'}>
             {this.renderCloseButton()}
             {this.state.smallViewport
-              ? <Text size="large">This Modal is optimized for small viewport</Text>
-              : <Heading>This is a deafult size Modal</Heading>
+              ? <Heading as="h2" level="h3" theme={{ h3FontWeight: 400 }}>This Modal is optimized for small viewport</Heading>
+              : <Heading as="h2">This is a deafult size Modal</Heading>
             }
           </Modal.Header>
           <Modal.Body>


### PR DESCRIPTION
Closes: INSTUI-3321

The title in the Modal.Header has to stay a h2 heading for a11y reasons.