### PR TITLE
docs(ui-modal): update Modal Header spacing example

### DIFF
--- a/packages/ui-modal/src/Modal/README.md
+++ b/packages/ui-modal/src/Modal/README.md
@@ -483,8 +483,8 @@ class Example extends React.Component {
           <Modal.Header spacing={this.state.smallViewport ? 'compact' : 'default'}>
             {this.renderCloseButton()}
             {this.state.smallViewport
-              ? <Text size="large">This Modal is optimized for small viewport</Text>
-              : <Heading>This is a deafult size Modal</Heading>
+              ? <Heading as="h2" level="h3" themeOverride={{ h3FontWeight: 400 }}>This Modal is optimized for small viewport</Heading>
+              : <Heading as="h2">This is a deafult size Modal</Heading>
             }
           </Modal.Header>
           <Modal.Body>


### PR DESCRIPTION
Closes: INSTUI-3320

The title in the Modal.Header has to remain a h2 heading for a11y reasons.