### PR TITLE
fix(ui-time-select): fix timeselect highlight behaviour (INSTUI-3308)

### DIFF
--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -340,7 +340,10 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
   }
 
   handleShowOptions = (event: SyntheticEvent) => {
-    this.setState({ isShowingOptions: true })
+    this.setState({
+      isShowingOptions: true,
+      highlightedOptionId: this.state.selectedOptionId
+    })
     this.props.onShowOptions?.(event)
   }
 
@@ -417,11 +420,8 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
   }
 
   renderOptions() {
-    const {
-      filteredOptions,
-      highlightedOptionId,
-      selectedOptionId
-    } = this.state
+    const { filteredOptions, highlightedOptionId, selectedOptionId } =
+      this.state
 
     if (filteredOptions.length < 1) {
       return this.renderEmptyOption()


### PR DESCRIPTION
Closes: INSTUI-3308

Sometimes when there is a selected time and the select reopens, the
highlight not starts from the
selection, but rather from the first element
TEST PLAN:

- Pick a time
- set the focus to somewhere above the component
- with keyboard, navigate to the select
- open it
- navigate with arrows and see if the highlight starts from the selected element or not