### PR TITLE
feat(ui-tabs): update Tabs focus styles to inset focus ring

### DIFF
--- a/packages/ui-tabs/src/Tabs/Tab/index.js
+++ b/packages/ui-tabs/src/Tabs/Tab/index.js
@@ -130,6 +130,8 @@ class Tab extends Component {
         aria-disabled={isDisabled ? 'true' : null}
         aria-controls={controls}
         tabIndex={isSelected && !isDisabled ? '0' : null}
+        position="relative"
+        focusPosition="inset"
       >
         {callRenderProp(children)}
       </View>

--- a/packages/ui-tabs/src/Tabs/Tab/styles.css
+++ b/packages/ui-tabs/src/Tabs/Tab/styles.css
@@ -1,4 +1,4 @@
-/* stylelint-disable no-descending-specificity */
+/* stylelint-disable no-descending-specificity, declaration-no-important, comment-empty-line-before */
 
 .root {
   font-family: var(--fontFamily);
@@ -17,9 +17,20 @@
     opacity: 0.5;
   }
 
-  &:focus {
-    outline: none;
+  /* START hacky override for focus state
+   * backporting INSTUI-3317, it is done correctly in V8
+   */
+  &::before {
+    inset: 0.5rem !important;
+    border-radius: 0.25rem !important;
   }
+
+  &:focus {
+    &::before {
+      inset: 0.375rem !important;
+    }
+  }
+  /* END hacky override for focus state */
 }
 
 .default,
@@ -113,4 +124,4 @@
   }
 }
 
-/* stylelint-enable no-descending-specificity */
+/* stylelint-enable no-descending-specificity, declaration-no-important, comment-empty-line-before */

--- a/packages/ui-tabs/src/Tabs/index.js
+++ b/packages/ui-tabs/src/Tabs/index.js
@@ -479,12 +479,11 @@ class Tabs extends Component {
         })}
       >
         <Focusable ref={this.handleFocusableRef}>
-          {({ focusVisible }) => (
+          {() => (
             <View
               as="div"
               position="relative"
               borderRadius="medium"
-              withFocusOutline={focusVisible}
               shouldAnimateFocus={false}
               className={styles.tabs}
             >


### PR DESCRIPTION
Closes: INSTUI-3326

Needed to change the focus indication to display inside of the active tab instead of having a focus
ring around the whole Tab list. This way the Tabs component can be used in tight spaces whithout the
focus ring getting cut off.

Backports PR #782