### PR TITLE
feat(ui-avatar): add `renderIcon` and `hasInverseColor` props to Avatar

### DIFF
--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "@instructure/console": "^7.12.0",
+    "@instructure/ui-icons": "^7.12.0",
     "@instructure/ui-react-utils": "^7.12.0",
     "@instructure/ui-testable": "^7.12.0",
     "@instructure/ui-themeable": "^7.12.0",

--- a/packages/ui-avatar/src/Avatar/README.md
+++ b/packages/ui-avatar/src/Avatar/README.md
@@ -15,7 +15,11 @@ guidelines: true
 </Guidelines>
 ```
 
-When an image src is not supplied the user's initials will display. The avatar can be `circle` _(default)_ or `rectangle`. Use the `margin` prop to add space between Avatar and other content.
+The avatar component can be used to display a user's avatar. When an image src is not supplied the user's initials will display.
+
+Instead of the initials, an SVG icon can be displayed with the `renderIcon` property.
+
+The avatar can be `circle` _(default)_ or `rectangle`. Use the `margin` prop to add space between Avatar and other content.
 
 ```js
 ---
@@ -24,8 +28,9 @@ example: true
 <div>
   <Avatar name="Sarah Robinson" src={avatarSquare} margin="0 small 0 0" />
   <Avatar name="Sarah Robinson" margin="0 small 0 0" />
-  <Avatar name="Kyle Montgomery" src={avatarSquare} shape="rectangle" margin="0 small 0 0" />
-  <Avatar name="Kyle Montgomery" shape="rectangle" />
+  <Avatar name="Sarah Robinson" renderIcon={<IconGroupLine />} margin="0 small 0 0" />
+  <Avatar name="Kyle Montgomery" src={avatarSquare} shape="rectangle" margin="0 small 0 0" />  <Avatar name="Kyle Montgomery" shape="rectangle" margin="0 small 0 0" />
+  <Avatar name="Kyle Montgomery" renderIcon={<IconGroupLine />} shape="rectangle" />
 </div>
 ```
 
@@ -56,25 +61,75 @@ example: true
     <Avatar name="David Herbert" size="x-large" margin="0 small 0 0"  src={avatarSquare} />
     <Avatar name="Isaac Asimov" size="xx-large"  src={avatarSquare} />
   </View>
+  <View display="block" padding="small medium">
+    <Avatar name="Arthur C. Clarke" renderIcon={<IconGroupLine />} size="xx-small" margin="0 small 0 0" />
+    <Avatar name="James Arias" renderIcon={<IconGroupLine />} size="x-small" margin="0 small 0 0" />
+    <Avatar name="Charles Kimball" renderIcon={<IconGroupLine />} size="small" margin="0 small 0 0" />
+    <Avatar name="Melissa Reed" renderIcon={<IconGroupLine />} size="medium" margin="0 small 0 0" />
+    <Avatar name="Heather Wheeler" renderIcon={<IconGroupLine />} size="large" margin="0 small 0 0" />
+    <Avatar name="David Herbert" renderIcon={<IconGroupLine />} size="x-large" margin="0 small 0 0" />
+    <Avatar name="Isaac Asimov" renderIcon={<IconGroupLine />} size="xx-large" />
+  </View>
 </div>
 ```
 
-### Color of the initials
+### Colors
 
-The color of the initials can be set with the `color` prop, and it allows you to select from `default`, `shamrock`, `barney`, `crimson`, `fire`, `licorice` and `ash`.
+The color of the initials and icons can be set with the `color` prop, and it allows you to select from `default`, `shamrock`, `barney`, `crimson`, `fire`, `licorice` and `ash`.
 
 ```js
 ---
 example: true
 ---
 <div>
-  <Avatar name="Arthur C. Clarke" margin="0 small 0 0" />
-  <Avatar name="James Arias" color="shamrock" margin="0 small 0 0" />
-  <Avatar name="Charles Kimball" color="barney" margin="0 small 0 0" />
-  <Avatar name="Melissa Reed" color="crimson" margin="0 small 0 0" />
-  <Avatar name="Heather Wheeler" color="fire" margin="0 small 0 0" />
-  <Avatar name="David Herbert" color="licorice" margin="0 small 0 0" />
-  <Avatar name="Isaac Asimov" color="ash" />
+  <View display="block" padding="small medium">
+    <Avatar name="Arthur C. Clarke" margin="0 small 0 0" />
+    <Avatar name="James Arias" color="shamrock" margin="0 small 0 0" />
+    <Avatar name="Charles Kimball" color="barney" margin="0 small 0 0" />
+    <Avatar name="Melissa Reed" color="crimson" margin="0 small 0 0" />
+    <Avatar name="Heather Wheeler" color="fire" margin="0 small 0 0" />
+    <Avatar name="David Herbert" color="licorice" margin="0 small 0 0" />
+    <Avatar name="Isaac Asimov" color="ash" />
+  </View>
+  <View display="block" padding="small medium">
+    <Avatar renderIcon={<IconGroupLine />} name="Arthur C. Clarke" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="James Arias" color="shamrock" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Charles Kimball" color="barney" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Melissa Reed" color="crimson" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Heather Wheeler" color="fire" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="David Herbert" color="licorice" margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Isaac Asimov" color="ash" />
+  </View>
+</div>
+```
+
+The `hasInverseColor` prop inverts the background color and the text/icon color.
+
+Inverted Avatars have **no border**.
+
+```js
+---
+example: true
+---
+<div>
+  <View display="block" padding="small medium" background="primary">
+    <Avatar name="Arthur C. Clarke" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="James Arias" color="shamrock" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="Charles Kimball" color="barney" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="Melissa Reed" color="crimson" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="Heather Wheeler" color="fire" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="David Herbert" color="licorice" hasInverseColor margin="0 small 0 0" />
+    <Avatar name="Isaac Asimov" color="ash" hasInverseColor />
+  </View>
+  <View display="block" padding="small medium" background="primary">
+    <Avatar renderIcon={<IconGroupLine />} name="Arthur C. Clarke" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="James Arias" color="shamrock" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Charles Kimball" color="barney" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Melissa Reed" color="crimson" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Heather Wheeler" color="fire" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="David Herbert" color="licorice" hasInverseColor margin="0 small 0 0" />
+    <Avatar renderIcon={<IconGroupLine />} name="Isaac Asimov" color="ash" hasInverseColor />
+  </View>
 </div>
 ```
 
@@ -85,8 +140,10 @@ In case you need more control over the color, feel free to use the `theme` prop,
 example: true
 ---
 <div>
-  <Avatar name="Isaac Asimov" theme={{ color: '#efb410' }} margin="0 small 0 0" />
-  <Avatar name="Heather Wheeler" color="fire" theme={{ colorFire: 'magenta' }} />
+  <Avatar name="Isaac Asimov" renderIcon={<IconGroupLine />} theme={{ color: '#efb410' }} margin="0 small 0 0" />
+  <Avatar name="Heather Wheeler" color="fire" theme={{ colorFire: 'magenta' }} margin="0 small 0 0" />
+  <Avatar name="Charles Kimball" renderIcon={<IconGroupLine />} hasInverseColor theme={{ color: 'lightblue', background: 'black' }} margin="0 small 0 0" />
+  <Avatar name="David Herbert" hasInverseColor color="fire" theme={{ colorFire: '#efb410' }} />
 </div>
 ```
 

--- a/packages/ui-avatar/src/Avatar/__examples__/Avatar.examples.js
+++ b/packages/ui-avatar/src/Avatar/__examples__/Avatar.examples.js
@@ -21,13 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+import React from 'react'
+
+import { IconGroupLine } from '@instructure/ui-icons'
+
 export default {
   excludeProps: ['inline', 'variant'],
   sectionProp: 'shape',
   propValues: {
-    src: [null, require('./testImage.jpg')]
+    src: [null, require('./testImage.jpg')],
+    renderIcon: [undefined, <IconGroupLine key="icon" />]
   },
-  getComponentProps: (props) => {
+  filter: (props) => {
+    if (props.color !== 'default' && props.size !== 'medium') {
+      return true
+    }
+
+    if (props.renderIcon && props.src) {
+      return true
+    }
+
+    if (props.src && props.color !== 'default') {
+      return true
+    }
+
+    if (
+      props.hasInverseColor &&
+      (props.size !== 'medium' || props.display !== 'block')
+    ) {
+      return true
+    }
+
+    return false
+  },
+  getComponentProps: () => {
     return {
       name: 'Kyle Montgomery'
     }

--- a/packages/ui-avatar/src/Avatar/__tests__/Avatar.test.js
+++ b/packages/ui-avatar/src/Avatar/__tests__/Avatar.test.js
@@ -25,6 +25,8 @@
 import React from 'react'
 import { expect, mount, stub } from '@instructure/ui-test-utils'
 
+import { IconGroupLine } from '@instructure/ui-icons'
+
 import { Avatar } from '../index'
 import { AvatarLocator } from '../AvatarLocator'
 
@@ -85,6 +87,44 @@ describe('<Avatar />', async () => {
     })
   })
 
+  describe('when the renderIcon prop is provided', async () => {
+    it('should display an svg passed', async () => {
+      const SomeIcon = () => (
+        <svg>
+          <circle cx="25" cy="75" r="20" />
+        </svg>
+      )
+
+      await mount(
+        <Avatar name="Jessica Jones" renderIcon={SomeIcon}>
+          Hello World
+        </Avatar>
+      )
+      const avatar = await AvatarLocator.find()
+      expect(await avatar.find('svg')).to.exist()
+    })
+
+    it('should display an InstUI icon passed', async () => {
+      await mount(
+        <Avatar name="Jessica Jones" renderIcon={<IconGroupLine />}>
+          Hello World
+        </Avatar>
+      )
+      const avatar = await AvatarLocator.find()
+      expect(await avatar.find('svg')).to.exist()
+    })
+
+    it('should display correctly when an icon renderer is passed', async () => {
+      await mount(
+        <Avatar name="Jessica Jones" renderIcon={() => <IconGroupLine />}>
+          Hello World
+        </Avatar>
+      )
+      const avatar = await AvatarLocator.find()
+      expect(await avatar.find('svg')).to.exist()
+    })
+  })
+
   describe('when an image src url is provided', async () => {
     // eslint-disable-next-line max-len
     const src =
@@ -99,6 +139,19 @@ describe('<Avatar />', async () => {
       await image.load()
 
       expect(avatar.getDOMNode().style.backgroundImage).to.contain(src)
+    })
+
+    it('should display the image even if an icon is provided', async () => {
+      await mount(
+        <Avatar name="Foo bar" src={src} renderIcon={<IconGroupLine />} />
+      )
+
+      const avatar = await AvatarLocator.find()
+      const image = await avatar.find('img')
+
+      await image.load()
+
+      expect(avatar.getAttribute('src')).to.contain(src)
     })
 
     it('should call onImageLoaded once the image loads', async () => {
@@ -152,6 +205,91 @@ describe('<Avatar />', async () => {
       expect(getComputedStyle(initials.getDOMNode()).color).to.equal(
         'rgb(0, 172, 24)'
       )
+    })
+
+    it('should display the icon in green (shamrock)', async () => {
+      await mount(
+        <Avatar
+          name="Jessica Jones"
+          renderIcon={<IconGroupLine />}
+          color="shamrock"
+        >
+          Hello World
+        </Avatar>
+      )
+
+      const avatar = await AvatarLocator.find()
+      const svg = await avatar.find('svg')
+
+      expect(getComputedStyle(svg.getDOMNode()).fill).to.equal(
+        'rgb(0, 172, 24)'
+      )
+    })
+  })
+
+  describe('when "hasInverseColor" is set', async () => {
+    describe('with initials', async () => {
+      it('should display the background in the color', async () => {
+        await mount(
+          <Avatar name="Jessica Jones" color="shamrock" hasInverseColor />
+        )
+
+        const avatar = await AvatarLocator.find()
+
+        expect(getComputedStyle(avatar.getDOMNode()).backgroundColor).to.equal(
+          'rgb(0, 172, 24)'
+        )
+      })
+
+      it('should display the initials in white', async () => {
+        await mount(
+          <Avatar name="Jessica Jones" color="shamrock" hasInverseColor />
+        )
+
+        const avatar = await AvatarLocator.find()
+        const initials = await avatar.findWithText('JJ')
+
+        expect(getComputedStyle(initials.getDOMNode()).color).to.equal(
+          'rgb(255, 255, 255)'
+        )
+      })
+    })
+
+    describe('with icon', async () => {
+      it('should display the background in the color', async () => {
+        await mount(
+          <Avatar
+            name="Jessica Jones"
+            color="shamrock"
+            hasInverseColor
+            renderIcon={<IconGroupLine />}
+          />
+        )
+
+        const avatar = await AvatarLocator.find()
+
+        expect(getComputedStyle(avatar.getDOMNode()).backgroundColor).to.equal(
+          'rgb(0, 172, 24)'
+        )
+      })
+
+      it('should display the icon in white', async () => {
+        await mount(
+          <Avatar
+            name="Jessica Jones"
+            color="shamrock"
+            hasInverseColor
+            renderIcon={<IconGroupLine />}
+          />
+        )
+
+        const avatar = await AvatarLocator.find()
+        const svg = await avatar.find('svg')
+
+        expect(getComputedStyle(svg.getDOMNode()).fill).to.equal(
+          'rgb(255, 255, 255)'
+        )
+      })
     })
   })
 

--- a/packages/ui-avatar/src/Avatar/__tests__/theme.test.js
+++ b/packages/ui-avatar/src/Avatar/__tests__/theme.test.js
@@ -31,9 +31,57 @@ describe('Avatar.theme', () => {
   describe('with the default theme', () => {
     const variables = Avatar.generateTheme()
 
-    describe('default', () => {
+    describe('default color', () => {
       it('should ensure background color and text color meet 3:1 contrast', () => {
         expect(contrast(variables.background, variables.color)).to.be.above(3)
+      })
+    })
+
+    describe('colorShamrock', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorShamrock)
+        ).to.be.above(3)
+      })
+    })
+
+    describe('colorBarney', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorBarney)
+        ).to.be.above(3)
+      })
+    })
+
+    describe('colorCrimson', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorCrimson)
+        ).to.be.above(3)
+      })
+    })
+
+    describe('colorFire', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(contrast(variables.background, variables.colorFire)).to.be.above(
+          3
+        )
+      })
+    })
+
+    describe('colorLicorice', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorLicorice)
+        ).to.be.above(3)
+      })
+    })
+
+    describe('colorAsh', () => {
+      it('should ensure background color and text color meet 3:1 contrast', () => {
+        expect(contrast(variables.background, variables.colorAsh)).to.be.above(
+          3
+        )
       })
     })
   })
@@ -41,9 +89,57 @@ describe('Avatar.theme', () => {
   describe('with the "canvas-high-contrast" theme', () => {
     const variables = Avatar.generateTheme('canvas-high-contrast')
 
-    describe('default', () => {
+    describe('default color', () => {
       it('should ensure background color and text color meet 4.5:1 contrast', () => {
         expect(contrast(variables.background, variables.color)).to.be.above(4.5)
+      })
+    })
+
+    describe('colorShamrock', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorShamrock)
+        ).to.be.above(4.5)
+      })
+    })
+
+    describe('colorBarney', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorBarney)
+        ).to.be.above(4.5)
+      })
+    })
+
+    describe('colorCrimson', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorCrimson)
+        ).to.be.above(4.5)
+      })
+    })
+
+    describe('colorFire', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(contrast(variables.background, variables.colorFire)).to.be.above(
+          4.5
+        )
+      })
+    })
+
+    describe('colorLicorice', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(
+          contrast(variables.background, variables.colorLicorice)
+        ).to.be.above(4.5)
+      })
+    })
+
+    describe('colorAsh', () => {
+      it('should ensure background color and text color meet 4.5:1 contrast', () => {
+        expect(contrast(variables.background, variables.colorAsh)).to.be.above(
+          4.5
+        )
       })
     })
   })

--- a/packages/ui-avatar/src/Avatar/styles.css
+++ b/packages/ui-avatar/src/Avatar/styles.css
@@ -79,44 +79,118 @@
     box-shadow: inset 0 0 var(--boxShadowBlur) 0 var(--boxShadowColor);
   }
 
+  /* stylelint-disable max-nesting-depth, selector-max-class */
+
   &:not(.loaded) {
     border-style: solid;
     border-color: var(--borderColor);
+
+    &.hasInverseColor {
+      border: 0;
+      padding: 0;
+      background-clip: border-box;
+
+      &.auto {
+        padding: var(--borderWidthSmall);
+      }
+
+      &.xx-small {
+        padding: var(--borderWidthSmall);
+      }
+
+      &.x-small {
+        padding: var(--borderWidthSmall);
+      }
+
+      &.small {
+        padding: var(--borderWidthSmall);
+      }
+
+      &.medium {
+        padding: var(--borderWidthMedium);
+      }
+
+      &.large {
+        padding: var(--borderWidthMedium);
+      }
+
+      &.x-large {
+        padding: var(--borderWidthMedium);
+      }
+
+      &.xx-large {
+        padding: var(--borderWidthMedium);
+      }
+    }
   }
 }
+
+/* stylelint-enable max-nesting-depth, selector-max-class */
 
 .initials {
   line-height: 2.375em;
   font-family: var(--fontFamily);
   font-weight: var(--fontWeight);
   letter-spacing: 0.0313em;
+}
 
-  .default & {
-    color: var(--color);
+.default {
+  color: var(--color);
+}
+
+.shamrock {
+  color: var(--colorShamrock);
+}
+
+.barney {
+  color: var(--colorBarney);
+}
+
+.crimson {
+  color: var(--colorCrimson);
+}
+
+.fire {
+  color: var(--colorFire);
+}
+
+.licorice {
+  color: var(--colorLicorice);
+}
+
+.ash {
+  color: var(--colorAsh);
+}
+
+.hasInverseColor {
+  color: var(--background);
+
+  &.default {
+    background-color: var(--color);
   }
 
-  .shamrock & {
-    color: var(--colorShamrock);
+  &.shamrock {
+    background-color: var(--colorShamrock);
   }
 
-  .barney & {
-    color: var(--colorBarney);
+  &.barney {
+    background-color: var(--colorBarney);
   }
 
-  .crimson & {
-    color: var(--colorCrimson);
+  &.crimson {
+    background-color: var(--colorCrimson);
   }
 
-  .fire & {
-    color: var(--colorFire);
+  &.fire {
+    background-color: var(--colorFire);
   }
 
-  .licorice & {
-    color: var(--colorLicorice);
+  &.licorice {
+    background-color: var(--colorLicorice);
   }
 
-  .ash & {
-    color: var(--colorAsh);
+  &.ash {
+    background-color: var(--colorAsh);
   }
 }
 
@@ -133,4 +207,19 @@
 
 .rectangle {
   width: 3em;
+}
+
+.iconSVG {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+
+  /* stylelint-disable-next-line selector-max-type */
+  svg {
+    fill: currentColor;
+    height: 1em;
+    width: 1em;
+  }
 }


### PR DESCRIPTION
Closes: INSTUI-3330

Instead of the initials, an icon can be displayed inside the Avatar with the new `renderIcon`
property. It worls with the `color` and `size` properties as well.
The `hasInverseColor` prop
inverts the background color and the text/icon color. Inverted Avatars have no border.
Add logic
that in case the image is unset in an update, show icons/initials again.
Backports PR #781