### PR TITLE
feat(ui-form-field): make FormField messages accept `ReactNode` text,…

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/props.ts
+++ b/packages/ui-checkbox/src/Checkbox/props.ts
@@ -74,7 +74,7 @@ const propTypes: PropValidators<PropKeys> = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-checkbox/src/CheckboxGroup/props.ts
+++ b/packages/ui-checkbox/src/CheckboxGroup/props.ts
@@ -75,7 +75,7 @@ const propTypes: PropValidators<PropKeys> = {
   readOnly: PropTypes.bool,
   /**
    * object with shape: `{
-    text: PropTypes.string,
+    text: PropTypes.node,
     type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
       }`
    */

--- a/packages/ui-date-input/src/DateInput/props.ts
+++ b/packages/ui-date-input/src/DateInput/props.ts
@@ -154,7 +154,7 @@ const propTypes: PropValidators<PropKeys> = {
    * Displays messages and validation for the input. It should be an object
    * with the following shape:
    * `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */

--- a/packages/ui-file-drop/src/FileDrop/props.ts
+++ b/packages/ui-file-drop/src/FileDrop/props.ts
@@ -110,7 +110,7 @@ const propTypes: PropValidators<PropKeys> = {
   ]),
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-form-field/src/FormField/props.ts
+++ b/packages/ui-form-field/src/FormField/props.ts
@@ -62,7 +62,7 @@ const propTypes: PropValidators<PropKeys> = {
   id: PropTypes.string.isRequired,
   /**
    * object with shape: `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */

--- a/packages/ui-form-field/src/FormFieldGroup/props.ts
+++ b/packages/ui-form-field/src/FormFieldGroup/props.ts
@@ -72,7 +72,7 @@ const propTypes: PropValidators<PropKeys> = {
   as: PropTypes.elementType,
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-form-field/src/FormFieldLayout/props.ts
+++ b/packages/ui-form-field/src/FormFieldLayout/props.ts
@@ -71,7 +71,7 @@ const propTypes: PropValidators<PropKeys> = {
   as: PropTypes.elementType,
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-form-field/src/FormFieldMessage/__tests__/FormFieldMessage.test.tsx
+++ b/packages/ui-form-field/src/FormFieldMessage/__tests__/FormFieldMessage.test.tsx
@@ -24,6 +24,7 @@
 
 import React from 'react'
 import { expect, mount, within } from '@instructure/ui-test-utils'
+import { IconWarningLine } from '@instructure/ui-icons'
 
 import { FormFieldMessage } from '../index'
 
@@ -35,6 +36,20 @@ describe('<FormFieldMessage />', async () => {
 
     const formFieldMessage = within(subject.getDOMNode())
     expect(await formFieldMessage.findWithText('hello world')).to.exist()
+  })
+
+  it('should render message if Node is passed', async () => {
+    const subject = await mount(
+      <FormFieldMessage>
+        <span>
+          <IconWarningLine /> Invalid name
+        </span>
+      </FormFieldMessage>
+    )
+
+    const formFieldMessage = within(subject.getDOMNode())
+    expect(await formFieldMessage.findWithText('Invalid name')).to.exist()
+    expect(await formFieldMessage.find('svg')).to.exist()
   })
 
   it('should meet a11y standards', async () => {

--- a/packages/ui-form-field/src/FormFieldMessage/props.ts
+++ b/packages/ui-form-field/src/FormFieldMessage/props.ts
@@ -22,18 +22,21 @@
  * SOFTWARE.
  */
 
-import PropTypes from 'prop-types'
+import {
+  formMessageTypePropType,
+  formMessageChildPropType
+} from '../FormPropTypes'
 
 import type {
   PropValidators,
   FormFieldMessageTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
-import type { FormMessageType } from '../FormPropTypes'
+import type { FormMessageType, FormMessageChild } from '../FormPropTypes'
 
 type FormFieldMessageOwnProps = {
   variant?: FormMessageType
-  children?: React.ReactNode
+  children?: FormMessageChild
 }
 
 type PropKeys = keyof FormFieldMessageOwnProps
@@ -46,8 +49,8 @@ type FormFieldMessageProps = FormFieldMessageOwnProps &
 type FormFieldMessageStyle = ComponentStyle<'formFieldMessage'>
 
 const propTypes: PropValidators<PropKeys> = {
-  variant: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only']),
-  children: PropTypes.node
+  variant: formMessageTypePropType,
+  children: formMessageChildPropType
 }
 
 const allowedProps: AllowedPropKeys = ['variant', 'children']

--- a/packages/ui-form-field/src/FormFieldMessages/__tests__/FormFieldMessages.test.tsx
+++ b/packages/ui-form-field/src/FormFieldMessages/__tests__/FormFieldMessages.test.tsx
@@ -24,6 +24,7 @@
 
 import React from 'react'
 import { expect, mount, within } from '@instructure/ui-test-utils'
+import { IconWarningLine } from '@instructure/ui-icons'
 
 import { FormFieldMessages } from '../index'
 import { FormMessage } from '../../FormPropTypes'
@@ -43,6 +44,26 @@ describe('<FormFieldMessages />', () => {
     expect(formFieldMessages.getTextContent()).to.equal(
       'Invalid nameGood job!Full name, first and last'
     )
+  })
+
+  it('should render if Node is passed as message text', async () => {
+    const messages: FormMessage[] = [
+      {
+        text: (
+          <span>
+            <IconWarningLine /> Invalid name
+          </span>
+        ),
+        type: 'error'
+      }
+    ]
+
+    const subject = await mount(<FormFieldMessages messages={messages} />)
+
+    const formFieldMessages = within(subject.getDOMNode())
+    expect(formFieldMessages).to.exist()
+    expect(formFieldMessages.getTextContent()).to.equal(' Invalid name')
+    expect(await formFieldMessages.find('svg')).to.exist()
   })
 
   it('should meet a11y standards', async () => {

--- a/packages/ui-form-field/src/FormFieldMessages/props.ts
+++ b/packages/ui-form-field/src/FormFieldMessages/props.ts
@@ -51,7 +51,7 @@ type FormFieldMessagesStyle = ComponentStyle<'formFieldMessages' | 'message'>
 const propTypes: PropValidators<PropKeys> = {
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-form-field/src/FormPropTypes.ts
+++ b/packages/ui-form-field/src/FormPropTypes.ts
@@ -22,7 +22,19 @@
  * SOFTWARE.
  */
 
+import React from 'react'
 import PropTypes from 'prop-types'
+
+const formMessageTypePropType = PropTypes.oneOf([
+  'error',
+  'hint',
+  'success',
+  'screenreader-only'
+])
+const formMessageChildPropType = PropTypes.node
+
+type FormMessageType = 'error' | 'hint' | 'success' | 'screenreader-only'
+type FormMessageChild = React.ReactNode
 
 /**
  * ---
@@ -33,17 +45,16 @@ import PropTypes from 'prop-types'
  */
 const FormPropTypes = {
   message: PropTypes.shape({
-    text: PropTypes.string,
-    type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
+    type: formMessageTypePropType,
+    text: formMessageChildPropType
   })
 }
 
-export type FormMessageType = 'error' | 'hint' | 'success' | 'screenreader-only'
-
-export type FormMessage = {
-  text: string
+type FormMessage = {
   type: FormMessageType
+  text: FormMessageChild
 }
 
 export default FormPropTypes
-export { FormPropTypes }
+export { FormPropTypes, formMessageTypePropType, formMessageChildPropType }
+export type { FormMessage, FormMessageType, FormMessageChild }

--- a/packages/ui-number-input/src/NumberInput/props.ts
+++ b/packages/ui-number-input/src/NumberInput/props.ts
@@ -104,7 +104,7 @@ const propTypes: PropValidators<PropKeys> = {
   interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
   /**
    * Object with shape: `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */

--- a/packages/ui-radio-input/src/RadioInputGroup/props.ts
+++ b/packages/ui-radio-input/src/RadioInputGroup/props.ts
@@ -78,7 +78,7 @@ const propTypes: PropValidators<PropKeys> = {
   readOnly: PropTypes.bool,
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-select/src/Select/props.ts
+++ b/packages/ui-select/src/Select/props.ts
@@ -158,7 +158,7 @@ const propTypes: PropValidators<PropKeys> = {
    * Displays messages and validation for the input. It should be an object
    * with the following shape:
    * `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */

--- a/packages/ui-simple-select/src/SimpleSelect/props.ts
+++ b/packages/ui-simple-select/src/SimpleSelect/props.ts
@@ -150,7 +150,7 @@ const propTypes: PropValidators<PropKeys> = {
    * Displays messages and validation for the input. It should be an object
    * with the following shape:
    * `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */

--- a/packages/ui-text-area/src/TextArea/props.ts
+++ b/packages/ui-text-area/src/TextArea/props.ts
@@ -105,7 +105,7 @@ const propTypes: PropValidators<PropKeys> = {
   maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-text-input/src/TextInput/props.ts
+++ b/packages/ui-text-input/src/TextInput/props.ts
@@ -112,7 +112,7 @@ const propTypes: PropValidators<PropKeys> = {
   interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
   /**
    * object with shape: `{
-   * text: PropTypes.string,
+   * text: PropTypes.node,
    * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    *   }`
    */

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -153,7 +153,7 @@ const propTypes: PropValidators<PropKeys> = {
    * Displays messages and validation for the input. It should be an object
    * with the following shape:
    * `{
-   *   text: PropTypes.string,
+   *   text: PropTypes.node,
    *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
    * }`
    */


### PR DESCRIPTION
… not just `string`

Closes: INSTUI-3333