### PR TITLE
feat(ui-form-field): make FormField messages accept `node` text, not …

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/index.js
+++ b/packages/ui-checkbox/src/Checkbox/index.js
@@ -59,7 +59,7 @@ class Checkbox extends Component {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-checkbox/src/CheckboxGroup/index.js
+++ b/packages/ui-checkbox/src/CheckboxGroup/index.js
@@ -68,7 +68,7 @@ class CheckboxGroup extends Component {
     readOnly: PropTypes.bool,
     /**
     * object with shape: `{
-    text: PropTypes.string,
+    text: PropTypes.node,
     type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
       }`
     */

--- a/packages/ui-date-input/src/DateInput/index.js
+++ b/packages/ui-date-input/src/DateInput/index.js
@@ -134,7 +134,7 @@ class DateInput extends Component {
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
      * `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */

--- a/packages/ui-file-drop/src/FileDrop/index.js
+++ b/packages/ui-file-drop/src/FileDrop/index.js
@@ -96,7 +96,7 @@ class FileDrop extends Component {
     ]),
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-form-field/src/FormField/index.js
+++ b/packages/ui-form-field/src/FormField/index.js
@@ -44,7 +44,7 @@ class FormField extends Component {
     id: PropTypes.string.isRequired,
     /**
      * object with shape: `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */

--- a/packages/ui-form-field/src/FormFieldGroup/index.js
+++ b/packages/ui-form-field/src/FormFieldGroup/index.js
@@ -51,7 +51,7 @@ class FormFieldGroup extends Component {
     as: PropTypes.elementType,
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-form-field/src/FormFieldLayout/index.js
+++ b/packages/ui-form-field/src/FormFieldLayout/index.js
@@ -64,7 +64,7 @@ class FormFieldLayout extends Component {
     as: PropTypes.elementType,
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-form-field/src/FormFieldMessage/__tests__/FormFieldMessage.test.js
+++ b/packages/ui-form-field/src/FormFieldMessage/__tests__/FormFieldMessage.test.js
@@ -24,6 +24,7 @@
 
 import React from 'react'
 import { expect, mount, within } from '@instructure/ui-test-utils'
+import { IconWarningLine } from '@instructure/ui-icons'
 
 import { FormFieldMessage } from '../index'
 
@@ -35,6 +36,20 @@ describe('<FormFieldMessage />', async () => {
 
     const formFieldMessage = within(subject.getDOMNode())
     expect(await formFieldMessage.findWithText('hello world')).to.exist()
+  })
+
+  it('should render message if Node is passed', async () => {
+    const subject = await mount(
+      <FormFieldMessage>
+        <span>
+          <IconWarningLine /> Invalid name
+        </span>
+      </FormFieldMessage>
+    )
+
+    const formFieldMessage = within(subject.getDOMNode())
+    expect(await formFieldMessage.findWithText('Invalid name')).to.exist()
+    expect(await formFieldMessage.find('svg')).to.exist()
   })
 
   it('should meet a11y standards', async () => {

--- a/packages/ui-form-field/src/FormFieldMessage/index.js
+++ b/packages/ui-form-field/src/FormFieldMessage/index.js
@@ -23,11 +23,15 @@
  */
 
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import { themeable } from '@instructure/ui-themeable'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
+
+import {
+  formMessageChildPropType,
+  formMessageTypePropType
+} from '../FormPropTypes'
 
 import styles from './styles.css'
 import theme from './theme'
@@ -50,8 +54,8 @@ example: true
 @themeable(theme, styles)
 class FormFieldMessage extends Component {
   static propTypes = {
-    variant: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only']),
-    children: PropTypes.node
+    variant: formMessageTypePropType,
+    children: formMessageChildPropType
   }
 
   static defaultProps = {

--- a/packages/ui-form-field/src/FormFieldMessages/__tests__/FormFieldMessages.test.js
+++ b/packages/ui-form-field/src/FormFieldMessages/__tests__/FormFieldMessages.test.js
@@ -24,6 +24,7 @@
 
 import React from 'react'
 import { expect, mount, within } from '@instructure/ui-test-utils'
+import { IconWarningLine } from '@instructure/ui-icons'
 
 import { FormFieldMessages } from '../index'
 
@@ -42,6 +43,26 @@ describe('<FormFieldMessages />', () => {
     expect(formFieldMessages.getTextContent()).to.equal(
       'Invalid nameGood job!Full name, first and last'
     )
+  })
+
+  it('should render if Node is passed as message text', async () => {
+    const messages = [
+      {
+        text: (
+          <span>
+            <IconWarningLine /> Invalid name
+          </span>
+        ),
+        type: 'error'
+      }
+    ]
+
+    const subject = await mount(<FormFieldMessages messages={messages} />)
+
+    const formFieldMessages = within(subject.getDOMNode())
+    expect(formFieldMessages).to.exist()
+    expect(formFieldMessages.getTextContent()).to.equal(' Invalid name')
+    expect(await formFieldMessages.find('svg')).to.exist()
   })
 
   it('should meet a11y standards', async () => {

--- a/packages/ui-form-field/src/FormFieldMessages/index.js
+++ b/packages/ui-form-field/src/FormFieldMessages/index.js
@@ -57,7 +57,7 @@ class FormFieldMessages extends Component {
   static propTypes = {
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-form-field/src/FormPropTypes.js
+++ b/packages/ui-form-field/src/FormPropTypes.js
@@ -24,6 +24,14 @@
 
 import PropTypes from 'prop-types'
 
+const formMessageChildPropType = PropTypes.node
+const formMessageTypePropType = PropTypes.oneOf([
+  'error',
+  'hint',
+  'success',
+  'screenreader-only'
+])
+
 /**
  * ---
  * category: utilities/form
@@ -33,10 +41,10 @@ import PropTypes from 'prop-types'
  */
 const FormPropTypes = {
   message: PropTypes.shape({
-    text: PropTypes.string,
-    type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
+    text: formMessageChildPropType,
+    type: formMessageTypePropType
   })
 }
 
 export default FormPropTypes
-export { FormPropTypes }
+export { FormPropTypes, formMessageTypePropType, formMessageChildPropType }

--- a/packages/ui-number-input/src/NumberInput/index.js
+++ b/packages/ui-number-input/src/NumberInput/index.js
@@ -79,7 +79,7 @@ class NumberInput extends Component {
     interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
     /**
      * Object with shape: `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */

--- a/packages/ui-radio-input/src/RadioInputGroup/index.js
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.js
@@ -67,7 +67,7 @@ class RadioInputGroup extends Component {
     readOnly: PropTypes.bool,
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-select/src/Select/index.js
+++ b/packages/ui-select/src/Select/index.js
@@ -140,7 +140,7 @@ class Select extends Component {
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
      * `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */

--- a/packages/ui-simple-select/src/SimpleSelect/index.js
+++ b/packages/ui-simple-select/src/SimpleSelect/index.js
@@ -120,7 +120,7 @@ class SimpleSelect extends Component {
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
      * `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */

--- a/packages/ui-text-area/src/TextArea/index.js
+++ b/packages/ui-text-area/src/TextArea/index.js
@@ -83,7 +83,7 @@ class TextArea extends Component {
     maxHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-text-input/src/TextInput/index.js
+++ b/packages/ui-text-input/src/TextInput/index.js
@@ -92,7 +92,7 @@ class TextInput extends Component {
     interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
     /**
      * object with shape: `{
-     * text: PropTypes.string,
+     * text: PropTypes.node,
      * type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      *   }`
      */

--- a/packages/ui-time-select/src/TimeSelect/index.js
+++ b/packages/ui-time-select/src/TimeSelect/index.js
@@ -121,7 +121,7 @@ class TimeSelect extends Component {
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
      * `{
-     *   text: PropTypes.string,
+     *   text: PropTypes.node,
      *   type: PropTypes.oneOf(['error', 'hint', 'success', 'screenreader-only'])
      * }`
      */


### PR DESCRIPTION
…just `string`

Closes: INSTUI-3335

Backports V8 version from PR#819