### PR TITLE
fix(ui-text-area): fix jumping scroll issue (INSTUI-3332)

### DIFF
--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -183,7 +183,7 @@ class TextArea extends Component<TextAreaProps> {
     let height = ''
 
     // Notes:
-    // 1. height has be reset to `auto` every time this method runs, or scrollHeight will not reset
+    // 1. height has to be reset to `auto` every time this method runs, or scrollHeight will not reset
     // 2. `this._textarea.scrollHeight` will not reset if assigned to a variable; it needs to be written out each time
     // @ts-expect-error ts-migrate(2339) FIXME: Property '_textarea' does not exist on type 'TextA... Remove this comment to see the full error message
     this._textarea.style.height = 'auto'
@@ -225,8 +225,6 @@ class TextArea extends Component<TextAreaProps> {
     this._height = height
     // @ts-expect-error ts-migrate(2339) FIXME: Property '_textarea' does not exist on type 'TextA... Remove this comment to see the full error message
     this._textarea.style.height = height
-    // @ts-expect-error ts-migrate(2339) FIXME: Property '_textarea' does not exist on type 'TextA... Remove this comment to see the full error message
-    this._textarea.scrollTop = this._textarea.scrollHeight
   }
 
   focus() {


### PR DESCRIPTION
Closes: INSTUI-3332, https://github.com/instructure/instructure-ui/issues/810

when textarea has maxhight set and there are enough lines to have a scrollbar,
if the component is
scrolled up and typed into, it will scroll down on every input.

removing the seemingly useless
scrollheight setter from the code fixes the issue