### PR TITLE
chore: remove bundle analysis from comment, put it inside job console

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,8 +37,9 @@ jobs:
         # only run this step if the previous step has not failed
         # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
         if: ${{ steps.deploy_to_netlify.outcome == 'success' }}
-        uses: actions-cool/maintain-one-comment@v2.0.0
+        uses: mshick/add-pr-comment@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'
+          message: |
             Preview URL: ${{ steps.deploy_to_netlify.outputs.preview_url }}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -28,7 +28,7 @@ const path = require('path')
 const { esBuild, gzip } = require('./scripts/calculateBundleSize')
 
 const META_FILE = path.resolve('./packages/ui/src/index.ts')
-const SIZE_DIFF_TRESHOLD = process.env.SIZE_DIFF_TRESHOLD || 3
+const SIZE_DIFF_THRESHOLD = process.env.SIZE_DIFF_THRESHOLD || 3
 
 const git = async (command: string) => {
   return new Promise((resolve, reject) => {
@@ -102,11 +102,11 @@ const calculateSizeDiff = ({ base, head }: { base: number; head: number }) => {
 
   if (diff < 0) {
     return `:white_check_mark: ${diff}% decrease in bundle size.`
-  } else if (diff >= SIZE_DIFF_TRESHOLD) {
+  } else if (diff >= SIZE_DIFF_THRESHOLD) {
     return `:warning: +${diff}% increase in bundle size.`
   }
 
-  return `Bundle size difference is lower than the specified treshold (diff=${diff}%, treshold=${SIZE_DIFF_TRESHOLD}%).`
+  return `Bundle size difference is lower than the specified threshold (diff=${diff}%, threshold=${SIZE_DIFF_THRESHOLD}%).`
 }
 
 calculateSizes()

--- a/scripts/calculateBundleSize.js
+++ b/scripts/calculateBundleSize.js
@@ -46,7 +46,7 @@ const esBuild = async (entryPoint, sha) => {
 }
 const gzip = async (fileName) => {
   const file = path.resolve(fileName)
-  await execAsync(`gzip -k ${file}`)
+  await execAsync(`gzip ${file}`)
 
   const stats = await fsp.stat(path.resolve(`${file}.gz`))
 


### PR DESCRIPTION
This PR fixes a couple of things:
- comments by github bot being overridden by the `maintain-one` github action, now instead the `pr-validation` workflow uses an another github action to post bot comments which enables multiple bot comments
- bundle size analysis will not be included in the comment, instead it will be logged out inside the `Calculate bundle size` step
- added threshold variable