### PR TITLE
INSTUI-3339 - add sortOrder prop to TreeBrowser

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/README.md
@@ -338,6 +338,83 @@ class Example extends React.Component {
 render(<Example/>)
 ```
 
+### Change the order of appearance of items and collection
+
+By default, the order of collections and items depend on the order of `collections` and `items` array. We can override it by providing a `sortOrder` comparison function.
+
+---
+
+**NOTE**
+
+This works with all collections and items of the TreeBrowser.
+
+---
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      sorted: false
+    }
+  }
+
+  toogleSort = (event) => { this.setState({ sorted: !this.state.sorted }) }
+
+  render () {
+    return (
+      <>
+        <View display="block" margin="none none medium">
+          <FormFieldGroup description="Turn of/off sorting">
+            <Checkbox
+              checked={this.state.sorted}
+              label="Sort"
+              onChange={this.toogleSort}
+            />
+          </FormFieldGroup>
+        </View>
+        <TreeBrowser
+          size="medium"
+          collections={{
+            1: {
+              id: 1,
+              name: "Assignments",
+              collections: [3,2],
+              items: [3],
+              descriptor: "Class Assignments"
+            },
+            2: { id: 2, name: "English Assignments", collections: [4], items: [] },
+            3: { id: 3, name: "Math Assignments", collections: [5], items: [2,1] },
+            4: { id: 4, name: "Reading Assignments", collections: [], items: [4] },
+            5: { id: 5, name: "Advanced Math Assignments", items: [5]}
+          }}
+          items={{
+            1: { id: 1, name: "Addition Worksheet" },
+            2: { id: 2, name: "Subtraction Worksheet" },
+            3: { id: 3, name: "General Questions" },
+            4: { id: 4, name: "Vogon Poetry" },
+            5: { id: 5, name: "Bistromath", descriptor: "Explain the Bistromathic Drive" }
+          }}
+          defaultExpanded={[1, 3]}
+          rootId={1}
+          sortOrder={
+            this.state.sorted
+              ? (a,b)=>{ return (a.name).localeCompare(b.name) }
+              : (a,b) => { return 0 }
+          }
+        />
+      </>
+    )
+  }
+}
+render(<Example/>)
+```
+
 ### showRootCollection
 
 The `showRootCollection` prop sets whether the root collection (specified in `rootId` prop) is displayed or to begin with its immediate sub-collections and items instead. It defaults to `true`.

--- a/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/__tests__/TreeBrowser.test.js
@@ -905,4 +905,63 @@ describe('<TreeBrowser />', async () => {
       expect((await tree.findAllItems()).length).to.equal(4)
     })
   })
+
+  describe('sorting', async () => {
+    it("should present collections and items in alphabetical order, in spite of the order of 'collections' and 'items' arrays", async () => {
+      await mount(
+        <TreeBrowser
+          collections={{
+            1: {
+              id: 1,
+              name: 'Assignments',
+              collections: [5, 3, 2, 4],
+              items: [3, 5, 2, 1, 4]
+            },
+            2: {
+              id: 2,
+              name: 'English Assignments',
+              collections: [],
+              items: []
+            },
+            3: { id: 3, name: 'Math Assignments', collections: [], items: [] },
+            4: {
+              id: 4,
+              name: 'Reading Assignments',
+              collections: [],
+              items: []
+            },
+            5: { id: 5, name: 'Advanced Math Assignments', items: [] }
+          }}
+          items={{
+            1: { id: 1, name: 'Addition Worksheet' },
+            2: { id: 2, name: 'Subtraction Worksheet' },
+            3: { id: 3, name: 'General Questions' },
+            4: { id: 4, name: 'Vogon Poetry' },
+            5: { id: 5, name: 'Bistromath' }
+          }}
+          rootId={1}
+          defaultExpanded={[1]}
+          sortOrder={(a, b) => {
+            return a.name.localeCompare(b.name)
+          }}
+        />
+      )
+      const tree = await TreeBrowserLocator.find()
+      const items = await tree.findAllItems()
+      const arr = items.map((item) => item.getDOMNode().textContent)
+      expect(arr.slice(1, 5)).deep.equal([
+        'Advanced Math Assignments',
+        'English Assignments',
+        'Math Assignments',
+        'Reading Assignments'
+      ])
+      expect(arr.slice(5)).deep.equal([
+        'Addition Worksheet',
+        'Bistromath',
+        'General Questions',
+        'Subtraction Worksheet',
+        'Vogon Poetry'
+      ])
+    })
+  })
 })

--- a/packages/ui-tree-browser/src/TreeBrowser/index.js
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.js
@@ -111,7 +111,11 @@ class TreeBrowser extends Component {
     /**
      * An optional label to assist visually impaired users
      */
-    treeLabel: PropTypes.string
+    treeLabel: PropTypes.string,
+    /**
+     * An optional compare function to specify order of the collections and the items
+     */
+    sortOrder: PropTypes.func
   }
 
   static defaultProps = {
@@ -127,6 +131,9 @@ class TreeBrowser extends Component {
     onItemClick: function (item) {},
     onCollectionClick: function (id, collection) {},
     onCollectionToggle: function (collection) {},
+    sortOrder: function (obj1, obj2) {
+      return 0
+    },
     rootId: undefined,
     expanded: undefined,
     treeLabel: undefined
@@ -326,6 +333,7 @@ class TreeBrowser extends Component {
     return collections
       .map((id) => this.getCollectionProps(this.props.collections[id]))
       .filter((collection) => collection != null)
+      .sort(this.props.sortOrder)
   }
 
   getItems(collection) {
@@ -337,6 +345,7 @@ class TreeBrowser extends Component {
           return { ...this.props.items[id] }
         })
         .filter((item) => item != null)
+        .sort(this.props.sortOrder)
     } else {
       return []
     }
@@ -371,20 +380,22 @@ class TreeBrowser extends Component {
   }
 
   renderRoot() {
-    return this.collections.map((collection, i) => (
-      <TreeCollection
-        key={i}
-        {...pickProps(this.props, TreeCollection.propTypes)}
-        {...this.getCollectionProps(collection)}
-        selection={this.state.selection}
-        onItemClick={this.handleItemClick}
-        onCollectionClick={this.handleCollectionClick}
-        onKeyDown={this.handleKeyDown}
-        numChildren={this.collections.length}
-        level={1}
-        position={1}
-      />
-    ))
+    return this.collections
+      .sort(this.props.sortOrder)
+      .map((collection, i) => (
+        <TreeCollection
+          key={i}
+          {...pickProps(this.props, TreeCollection.propTypes)}
+          {...this.getCollectionProps(collection)}
+          selection={this.state.selection}
+          onItemClick={this.handleItemClick}
+          onCollectionClick={this.handleCollectionClick}
+          onKeyDown={this.handleKeyDown}
+          numChildren={this.collections.length}
+          level={1}
+          position={1}
+        />
+      ))
   }
 
   render() {


### PR DESCRIPTION
Closes: INSTUI-3339

The new `sortOrder` prop accepts an optional compare function to specify order of the collections
and the items.

Backports https://github.com/instructure/instructure-ui/pull/776
Original feature request: https://github.com/instructure/instructure-ui/issues/752