### PR TITLE
fix(ui-a11y-utils,ui-drawer-layout): fix Drawer not opening on small …

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.js
+++ b/packages/ui-a11y-utils/src/FocusRegion.js
@@ -69,7 +69,9 @@ class FocusRegion {
   }
 
   handleDismiss = (event, documentClick) => {
-    this._options.onDismiss(event, documentClick)
+    if (this._contextElement) {
+      this._options.onDismiss(event, documentClick)
+    }
   }
 
   captureDocumentClick = (event) => {


### PR DESCRIPTION
…viewport

Closes: INSTUI-3341

This is a hotfix for an issue where sometimes the DrawerTray wouldn't open. It turned out to be a
FocusRegion problem where the region "got stuck" and was listening to all document clicks and
calling `onDismiss` for every page click (including to "open the drawer" button). Checking if there
is even a contextelement in the `handleDismiss` method gives a quick and dirty solution, but since
this problem is not present in V8, there was no need to do further lengthy investigation.