### PR TITLE
INSTUI-3355 - deprecate warning text

### DIFF
--- a/docs/guides/v7-deprecated-props-and-components.md
+++ b/docs/guides/v7-deprecated-props-and-components.md
@@ -133,20 +133,21 @@ For more information, click the name of the component to see its full documentat
 
 \* CMA = Codemod available
 
-| Component          | Property    | Old value | New value       | CMA\* | Note                                                |
-| ------------------ | ----------- | --------- | --------------- | ----- | --------------------------------------------------- |
-| [List](#List)      | delimiter   | pipe      | -               | no    | will only be available when using [InlineList]      |
-|                    |             | slash     | -               | no    | will only be available when using [InlineList]      |
-|                    |             | arrow     | -               | no    | will only be available when using [InlineList]      |
-| [List.Item](#List) | delimiter   | pipe      | -               | no    | will only be available when using [InlineList.Item] |
-|                    |             | slash     | -               | no    | will only be available when using [InlineList.Item] |
-|                    |             | arrow     | -               | no    | will only be available when using [InlineList.Item] |
-| [Text](#Text)      | color       | error     | danger          | yes   |                                                     |
-| [View](#View)      | background  | default   | primary         | yes   |                                                     |
-|                    |             | light     | secondary       | yes   |                                                     |
-|                    |             | inverse   | primary-inverse | yes   |                                                     |
-|                    | borderColor | default   | primary         | yes   |                                                     |
-|                    |             | inverse   | transparent     | yes   |                                                     |
+| Component          | Property    | Old value | New value       | CMA\* | Note                                                                                                                                     |
+| ------------------ | ----------- | --------- | --------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [List](#List)      | delimiter   | pipe      | -               | no    | will only be available when using [InlineList]                                                                                           |
+|                    |             | slash     | -               | no    | will only be available when using [InlineList]                                                                                           |
+|                    |             | arrow     | -               | no    | will only be available when using [InlineList]                                                                                           |
+| [List.Item](#List) | delimiter   | pipe      | -               | no    | will only be available when using [InlineList.Item]                                                                                      |
+|                    |             | slash     | -               | no    | will only be available when using [InlineList.Item]                                                                                      |
+|                    |             | arrow     | -               | no    | will only be available when using [InlineList.Item]                                                                                      |
+| [Text](#Text)      | color       | error     | danger          | yes   |                                                                                                                                          |
+|                    | color       | warning   | -               | no    | The `warning` color variant doesn't have sufficient color contrast with the background (4.5:1) required for text. Will be removed in V9. |
+| [View](#View)      | background  | default   | primary         | yes   |                                                                                                                                          |
+|                    |             | light     | secondary       | yes   |                                                                                                                                          |
+|                    |             | inverse   | primary-inverse | yes   |                                                                                                                                          |
+|                    | borderColor | default   | primary         | yes   |                                                                                                                                          |
+|                    |             | inverse   | transparent     | yes   |                                                                                                                                          |
 
 ### Deprecated Theme Variables
 

--- a/packages/ui-text/src/Text/README.md
+++ b/packages/ui-text/src/Text/README.md
@@ -9,9 +9,10 @@ guidelines: true
 <Guidelines>
 <Figure title="Upgrade Notes for v8.0.0" recommendation="none">
 <Figure.Item>The color prop <code>error</code> has been updated to <code>danger</code> for component consistency</Figure.Item>
+<Figure.Item>The color prop <code>warning</code> is deprecated and will be removed in version 9.0.0, because it doesn't have sufficient color contrast with the background (4.5:1) required for text.</Figure.Item>
 </Figure>
 </Guidelines>
-````
+```
 
 A component for styling textual content
 
@@ -138,7 +139,6 @@ example: true
   <Text color="secondary">I&#39;m secondary text</Text><br/>
   <Text color="brand">I&#39;m brand text</Text><br />
   <Text color="success">I&#39;m success text</Text><br/>
-  <Text color="warning">I&#39;m warning text</Text><br/>
   <Text color="danger">I&#39;m danger text</Text><br />
   <Text color="alert">I&#39;m alert text</Text>
 </div>

--- a/packages/ui-text/src/Text/index.js
+++ b/packages/ui-text/src/Text/index.js
@@ -53,7 +53,7 @@ class Text extends Component {
     as: PropTypes.elementType,
     children: PropTypes.node,
     /**
-     * One of: primary, secondary, brand, success, warning, danger, alert, primary-inverse, secondary-inverse
+     * One of: primary, secondary, brand, success, danger, alert, primary-inverse, secondary-inverse
      */
     color: deprecated.deprecatePropValues(
       PropTypes.oneOf([
@@ -68,8 +68,8 @@ class Text extends Component {
         'primary-inverse',
         'secondary-inverse'
       ]),
-      ['error'],
-      'It will be removed in version 8.0.0. Use `danger` instead.'
+      ['error', 'warning'],
+      "The `error` value will be removed in version 8.0.0. Use `danger` instead. The `warning` value will be removed in version 9.0.0, because it doesn't have sufficient color contrast with the background (4.5:1) required for text."
     ),
     elementRef: PropTypes.func,
     fontStyle: PropTypes.oneOf(['italic', 'normal']),

--- a/packages/ui-text/src/Text/styles.css
+++ b/packages/ui-text/src/Text/styles.css
@@ -114,6 +114,7 @@ input.root[type] {
     color: var(--brandColor);
   }
 
+  /* deprecated, will be removed in v9. */
   &.color-warning {
     color: var(--warningColor);
   }

--- a/packages/ui-text/src/Text/theme.js
+++ b/packages/ui-text/src/Text/theme.js
@@ -34,12 +34,12 @@ export default function generator({ typography, colors, spacing }) {
     secondaryColor: colors.textDark,
     secondaryInverseColor: colors.textLight,
 
-    warningColor: colors.textWarning,
     brandColor: colors.textBrand,
     errorColor: colors.textDanger,
     dangerColor: colors.textDanger,
     successColor: colors.textSuccess,
     alertColor: colors.textAlert,
+    warningColor: colors.textWarning, // deprecated, will be removed in v9.
 
     paragraphMargin: `${spacing.medium} 0`
   }


### PR DESCRIPTION
Closes: INSTUI-3355

The `warning` color variant will be removed in version 9.0.0, because it doesn't have sufficient
color contrast with the background (4.5:1) required for text.

Backports PR #856 for ticket INSTUI-3352.