### PR TITLE
fix(ui-range-input): fixed empty label when `displayValue={true}` but…

### DIFF
--- a/packages/ui-range-input/src/RangeInput/__examples__/RangeInput.examples.ts
+++ b/packages/ui-range-input/src/RangeInput/__examples__/RangeInput.examples.ts
@@ -28,10 +28,44 @@ import type { RangeInputProps } from '../props'
 export default {
   sectionProp: 'layout',
   maxExamplesPerPage: 50,
+  propValues: {
+    value: [undefined, 20, 100],
+    defaultValue: [undefined, 88]
+  },
   getComponentProps: () => {
     return {
       label: 'Opacity',
-      onChange: () => {}
+      onChange: () => {},
+      min: 0,
+      max: 100
     }
+  },
+  filter: (props) => {
+    if (props.defaultValue && props.value) {
+      return true
+    }
+
+    if (
+      props.defaultValue &&
+      (props.size !== 'medium' ||
+        props.disabled ||
+        props.inline ||
+        props.readOnly)
+    ) {
+      return true
+    }
+
+    if (
+      !props.value &&
+      !props.defaultValue &&
+      (props.size !== 'medium' ||
+        props.disabled ||
+        props.inline ||
+        props.readOnly)
+    ) {
+      return true
+    }
+
+    return false
   }
 } as StoryConfig<RangeInputProps>

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -25,6 +25,7 @@
 /** @jsx jsx */
 import React, { Component } from 'react'
 
+import { warn } from '@instructure/console'
 import { ContextView } from '@instructure/ui-view'
 import { FormField } from '@instructure/ui-form-field'
 import { addEventListener } from '@instructure/ui-dom-utils'
@@ -139,7 +140,7 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
   get value() {
     const value =
       typeof this.props.value === 'undefined'
-        ? this.state.value!
+        ? this.state.value
         : this.props.value
 
     return typeof value === 'string' ? parseInt(value) : value
@@ -160,17 +161,21 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
 
   renderValue() {
     if (this.props.displayValue) {
+      if (!this.value) {
+        warn(
+          false,
+          'RangeInput should have a `value` or `defaultValue` set for the value to be displayed. If no value has to be displayed, set `displayValue={false}`.'
+        )
+
+        return null
+      }
+
       return (
         <ContextView background="inverse" placement="end center">
           <output
             htmlFor={this.id}
             css={this.props.styles?.rangeInputInputValue}
           >
-            {/**
-             * Value can be undefined when no value or defaultValue is given,
-             * and then it renders an empty ContextView
-             * TODO: Ask a designer what the intended behaviour is
-             */}
             {this.props.formatValue!(this.value, this.props.max)}
           </output>
         </ContextView>

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -57,8 +57,12 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
   static defaultProps = {
     step: 1,
     formatValue: (val?: number) => val,
+
+    // If min and max has default value, they don't give a warning if not set, even if they are required props.
+    // TODO: figure out if they don't need to be required or remove defaults in V9.
     max: 0,
     min: 0,
+
     inline: false,
     size: 'medium',
     layout: 'stacked',


### PR DESCRIPTION
… has no `value`/`defaultValue`

Closes: INSTUI-3356

If the `displayValue={true}` (by default) but no `value` or `defaultValue` was set, and empty value
label (ContextView) was displayed. Now it won't display the label and give a warning message.