### PR TITLE
fix(emotion): make theme componentOverrides apply to Buttons

### DIFF
--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -220,6 +220,10 @@ const withStyle = decorator(
           {...props}
           makeStyles={makeStyleHandler}
           styles={styles}
+          // passing themeOverrides is needed for components like Button
+          // that have no makeStyles of their own and only pass themeOverrides
+          // to the underlying component (e.g.: BaseButton)
+          themeOverride={themeOverride}
         />
       )
     })


### PR DESCRIPTION
The `componentOverrides` block of `InstUISettingsProvider` theme prop was not applying to Button and
other button subtypes. This happened because most of the Buttons don't have styling on their own and
just pass the themeOverrides to the underlying BaseButton component. This worked well with the local
`themeOverride={}` prop, but the `withStyle` decorator never passed them to the component. This
wasn't needed most of the components that use the theme in their style generation, but is needed for
components that just pass the themeOverrides on.