### PR TITLE
chore(ui-options): make new props optional

### DIFF
--- a/packages/ui-options/src/Options/Item/props.ts
+++ b/packages/ui-options/src/Options/Item/props.ts
@@ -63,11 +63,11 @@ type OptionsItemOwnProps = ItemProps & {
   /**
    * Sets the vAlign of renderBeforeLabel content
    */
-  beforeLabelContentVAlign: 'start' | 'center' | 'end'
+  beforeLabelContentVAlign?: 'start' | 'center' | 'end'
   /**
    * Sets the vAlign of renderAfterLabel content
    */
-  afterLabelContentVAlign: 'start' | 'center' | 'end'
+  afterLabelContentVAlign?: 'start' | 'center' | 'end'
   /**
    * Additional "secondary" description text
    */

--- a/packages/ui-options/src/Options/Item/styles.ts
+++ b/packages/ui-options/src/Options/Item/styles.ts
@@ -89,7 +89,7 @@ const generateStyle = (
         alignItems: 'flex-end',
         paddingBlockEnd: vOffset
       }
-    }[vAlign]
+    }[vAlign!]
   }
 
   const transition = 'background 200ms'


### PR DESCRIPTION
Accidentally added the new props `beforeLabelContentVAlign` and `afterLabelContentVAlign` as
required types, changed it to optional.