### PR TITLE
feat(ui-options): modify default nested Options padding to have no ex…

### DIFF
--- a/packages/ui-options/src/Options/Item/theme.ts
+++ b/packages/ui-options/src/Options/Item/theme.ts
@@ -55,7 +55,7 @@ const generateComponentTheme = (theme: Theme): OptionsItemTheme => {
 
     padding: `${spacing?.xSmall} ${spacing?.small}`,
     iconPadding: spacing?.small,
-    nestedPadding: spacing?.medium,
+    nestedPadding: spacing?.small,
 
     beforeLabelContentVOffset: '0.625rem',
     afterLabelContentVOffset: '0.625rem',


### PR DESCRIPTION
…tra padding

The nested Options used to have a little extra padding by default. It has been modified to have no
extra padding by default, but can still be set via the `nestedPadding` theme variable.

Closes: INSTUI-3444