### PR TITLE
fix(ui-code-editor): change dynamically imported `CodeMirror` language modes

### DIFF
--- a/packages/ui-code-editor/src/CodeEditor/README.md
+++ b/packages/ui-code-editor/src/CodeEditor/README.md
@@ -4,6 +4,43 @@ describes: CodeEditor
 
 A wrapper around the popular [CodeMirror](https://codemirror.net/) text editor.
 
+### Note!
+
+If you are testing a component that utilizes `CodeEditor` as a sub component with `jest`, then from version _8.15.0_ and upwards those test might start to **fail**. This is because the `CodeMirror` language options - which depend on browser API's - are now being statically imported instead of dynamically imported when the browser is available.
+
+`CodeMirror` depends on specific browser API - `document.createRange` -, and since `document.createRange` is not defined in `jsdom`, we have to mock it in order to fix the failing test(s):
+
+```js
+...
+// yourFailingComponent.test.js
+beforeAll(() => {
+  // CodeMirror langague options depend on createRange function
+  // which is not defined in jsdom environments
+  Document.prototype.createRange = function () {
+    return {
+      setEnd: function () {},
+      setStart: function () {},
+      getBoundingClientRect: function () {
+        return { right: 0 }
+      },
+      getClientRects: function () {
+        return {
+          length: 0,
+          left: 0,
+          right: 0
+        }
+      }
+    }
+  }
+})
+test('should render', () => {
+  // YourComponent uses InstUI's CodeEditor under the hood
+  const { container } = render(<YourComponent />)
+
+  expect(container).toBeInTheDocument()
+})
+```
+
 ### Code layout
 
 The CodeEditor component can be used to display code via the `defaultValue` prop.

--- a/packages/ui-code-editor/src/CodeEditor/codemirror.ts
+++ b/packages/ui-code-editor/src/CodeEditor/codemirror.ts
@@ -21,16 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { canUseDOM } from '@instructure/ui-dom-utils'
 import { Controlled as CodeMirror } from 'react-codemirror2'
-
-if (canUseDOM) {
-  require('codemirror/mode/jsx/jsx')
-  require('codemirror/mode/shell/shell')
-  require('codemirror/mode/css/css')
-  require('codemirror/mode/htmlmixed/htmlmixed')
-  require('codemirror/mode/markdown/markdown')
-  require('codemirror/mode/yaml/yaml')
-}
-
+import 'codemirror/mode/jsx/jsx'
+import 'codemirror/mode/shell/shell'
+import 'codemirror/mode/css/css'
+import 'codemirror/mode/htmlmixed/htmlmixed'
+import 'codemirror/mode/markdown/markdown'
+import 'codemirror/mode/yaml/yaml'
 export default CodeMirror


### PR DESCRIPTION
Closes: INSTUI-3394

our `CodeEditor` component dynamically imported `CodeMirror` language options
which was not
transpiled at all by `babel` which ment that we shipped
code that is not usable in browser
environments out of the box.
this change removes those dynamic `require`s and instead statically
imports them.
this might cause issues for users that uses this component and use jest in order to
test their components
I added notes on how to fix those jest related issues