### PR TITLE
fix(ui-portal): fix `Portal` not being SSR-able

### DIFF
--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -32,6 +32,7 @@
     "@instructure/ui-i18n": "8.17.0",
     "@instructure/ui-prop-types": "8.17.0",
     "@instructure/ui-react-utils": "8.17.0",
+    "@instructure/ui-dom-utils": "8.17.0",
     "prop-types": "^15"
   },
   "peerDependencies": {

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -33,6 +33,7 @@
     "@instructure/ui-prop-types": "8.17.0",
     "@instructure/ui-react-utils": "8.17.0",
     "@instructure/ui-dom-utils": "8.17.0",
+    "@instructure/console": "8.17.0",
     "prop-types": "^15"
   },
   "peerDependencies": {

--- a/packages/ui-portal/src/Portal/index.tsx
+++ b/packages/ui-portal/src/Portal/index.tsx
@@ -27,6 +27,7 @@ import ReactDOM from 'react-dom'
 
 import { passthroughProps } from '@instructure/ui-react-utils'
 import { textDirectionContextConsumer } from '@instructure/ui-i18n'
+import { canUseDOM } from '@instructure/ui-dom-utils'
 
 import { propTypes, allowedProps } from './props'
 import type { PortalNode, PortalProps, PortalState } from './props'
@@ -55,6 +56,10 @@ class Portal extends Component<PortalProps, PortalState> {
   constructor(props: PortalProps) {
     super(props)
 
+    if (!canUseDOM) {
+      return
+    }
+
     this.state = {
       mountNode: this.findMountNode(props)
     }
@@ -63,6 +68,9 @@ class Portal extends Component<PortalProps, PortalState> {
   DOMNode: PortalNode = null
 
   componentDidMount() {
+    if (!canUseDOM) {
+      return
+    }
     // If Portal is mounting in an open condition fire onOpen handler
     if (this.props.open && typeof this.props.onOpen === 'function') {
       this.props.onOpen(this.DOMNode)
@@ -70,6 +78,9 @@ class Portal extends Component<PortalProps, PortalState> {
   }
 
   componentDidUpdate(prevProps: PortalProps) {
+    if (!canUseDOM) {
+      return
+    }
     const mountNode = this.findMountNode(this.props)
 
     if (mountNode !== this.state.mountNode) {
@@ -97,6 +108,9 @@ class Portal extends Component<PortalProps, PortalState> {
   }
 
   componentWillUnmount() {
+    if (!canUseDOM) {
+      return
+    }
     this.removeNode()
 
     // If Portal was open fire onClose handler
@@ -188,6 +202,10 @@ class Portal extends Component<PortalProps, PortalState> {
   }
 
   render(): React.ReactPortal | null {
+    if (!canUseDOM) {
+      return null
+    }
+
     const { children } = this.props
 
     return this.props.open && React.Children.count(children) > 0

--- a/packages/ui-portal/src/Portal/index.tsx
+++ b/packages/ui-portal/src/Portal/index.tsx
@@ -28,6 +28,7 @@ import ReactDOM from 'react-dom'
 import { passthroughProps } from '@instructure/ui-react-utils'
 import { textDirectionContextConsumer } from '@instructure/ui-i18n'
 import { canUseDOM } from '@instructure/ui-dom-utils'
+import { warn } from '@instructure/console'
 
 import { propTypes, allowedProps } from './props'
 import type { PortalNode, PortalProps, PortalState } from './props'
@@ -203,6 +204,12 @@ class Portal extends Component<PortalProps, PortalState> {
 
   render(): React.ReactPortal | null {
     if (!canUseDOM) {
+      warn(
+        false,
+        `It looks like you are trying to render <Portal> on the server side, which is not supported!
+         Please be aware that this will result in a no-op!
+         Read more about it here: https://instructure.design/#server-side-rendering`
+      )
       return null
     }
 

--- a/packages/ui-portal/tsconfig.build.json
+++ b/packages/ui-portal/tsconfig.build.json
@@ -10,23 +10,23 @@
     {
       "path": "../ui-babel-preset/tsconfig.build.json"
     },
-
     {
       "path": "../ui-test-utils/tsconfig.build.json"
     },
     {
       "path": "../shared-types/tsconfig.build.json"
     },
-
     {
       "path": "../ui-i18n/tsconfig.build.json"
     },
     {
       "path": "../ui-prop-types/tsconfig.build.json"
     },
-
     {
       "path": "../ui-react-utils/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-dom-utils/tsconfig.build.json"
     }
   ]
 }

--- a/packages/ui-portal/tsconfig.build.json
+++ b/packages/ui-portal/tsconfig.build.json
@@ -27,6 +27,9 @@
     },
     {
       "path": "../ui-dom-utils/tsconfig.build.json"
+    },
+    {
+      "path": "../console/tsconfig.build.json"
     }
   ]
 }


### PR DESCRIPTION
`Portal` tried to access the `document` in its lifecylce methods, which is not suitalbe in SSR, so I
added a check in every lifecycle to bail out if we are in a server environment.