### PR TITLE
INSTUI-3402: Docs: Fix Codepen links

### DIFF
--- a/packages/__docs__/src/CodePenButton/index.tsx
+++ b/packages/__docs__/src/CodePenButton/index.tsx
@@ -47,21 +47,21 @@ class CodePenButton extends Component<CodePenButtonProps> {
       js: `const render = (el) => { ReactDOM.render(el, document.getElementById('app')) }\n\n${code}`,
       private: true,
       editors: '001',
-      html:
-        '<div id="app"></div><div id="flash-messages"></div><div id="nav"></div>',
-      layout: 'top',
+      html: '<div id="app"></div><div id="flash-messages"></div><div id="nav"></div>',
       css_prefix: 'autoprefixer',
       js_pre_processor: 'babel',
       ...this.props.options
     }
-
+    const JSONData = JSON.stringify(data)
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;')
     return (
       <form
         action="https://codepen.io/pen/define"
         method="POST"
         target="_blank"
       >
-        <input type="hidden" name="data" value={JSON.stringify(data)} />
+        <input type="hidden" name="data" value={JSONData} />
         <Tooltip renderTip="Edit in Codepen" placement="bottom">
           <IconButton
             type="submit"


### PR DESCRIPTION
The issue is that if we send layout="top" to Codepen it ignores every option and just shows an empty codepen. Remove this option and add escape quotes because Codepen docs recommend it.