### PR TITLE
feat(ui-select): add `optionsMaxHeight` prop to Select

### DIFF
--- a/packages/ui-select/src/Select/__tests__/Select.test.js
+++ b/packages/ui-select/src/Select/__tests__/Select.test.js
@@ -416,6 +416,41 @@ describe('<Select />', async () => {
 
       expect(listRef).to.have.been.calledWith(listbox.getDOMNode())
     })
+
+    it('should set maxHeight according to the visibleOptionsCount prop', async () => {
+      await mount(
+        <Select
+          renderLabel="Choose an option"
+          isShowingOptions
+          visibleOptionsCount={2}
+        >
+          {getOptions()}
+        </Select>
+      )
+      const select = await SelectLocator.find()
+      const list = await select.findOptionsList()
+      const listView = await list.getDOMNode().parentNode
+
+      expect(getComputedStyle(listView).height).to.equal('72px')
+    })
+
+    it('should override maxHeight with optionsMaxHeight, even if visibleOptionsCount is set', async () => {
+      await mount(
+        <Select
+          renderLabel="Choose an option"
+          isShowingOptions
+          visibleOptionsCount={2}
+          optionsMaxHeight="50px"
+        >
+          {getOptions()}
+        </Select>
+      )
+      const select = await SelectLocator.find()
+      const list = await select.findOptionsList()
+      const listView = await list.getDOMNode().parentNode
+
+      expect(getComputedStyle(listView).height).to.equal('50px')
+    })
   })
 
   describe('with callbacks', async () => {

--- a/packages/ui-select/src/Select/index.js
+++ b/packages/ui-select/src/Select/index.js
@@ -128,14 +128,19 @@ class Select extends Component {
      */
     htmlSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
+     * The number of options that should be visible before having to scroll. Works best when the options are the same height.
+     */
+    visibleOptionsCount: PropTypes.number,
+    /**
+     * The max height the options list can be before having to scroll. If
+     * set, it will __override__ the `visibleOptionsCount` prop.
+     */
+    optionsMaxHeight: PropTypes.string,
+    /**
      * The max width the options list can be before option text wraps. If not
      * set, the list will only display as wide as the text input.
      */
     optionsMaxWidth: PropTypes.string,
-    /**
-     * The number of options that should be visible before having to scroll.
-     */
-    visibleOptionsCount: PropTypes.number,
     /**
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
@@ -228,8 +233,9 @@ class Select extends Component {
     isInline: false,
     width: undefined,
     htmlSize: undefined,
-    optionsMaxWidth: undefined,
     visibleOptionsCount: 8,
+    optionsMaxHeight: undefined,
+    optionsMaxWidth: undefined,
     messages: undefined,
     placement: 'bottom stretch',
     constrain: 'window',
@@ -535,6 +541,7 @@ class Select extends Component {
     const {
       isShowingOptions,
       optionsMaxWidth,
+      optionsMaxHeight,
       visibleOptionsCount,
       children
     } = this.props
@@ -544,7 +551,8 @@ class Select extends Component {
       ? {
           display: 'block',
           overflowY: 'auto',
-          maxHeight: this._optionHeight * visibleOptionsCount,
+          maxHeight:
+            optionsMaxHeight || this._optionHeight * visibleOptionsCount,
           maxWidth: optionsMaxWidth || this.width,
           background: 'primary',
           elementRef: (node) => (this._listView = node)

--- a/packages/ui-simple-select/src/SimpleSelect/index.js
+++ b/packages/ui-simple-select/src/SimpleSelect/index.js
@@ -108,14 +108,19 @@ class SimpleSelect extends Component {
      */
     width: PropTypes.string,
     /**
+     * The number of options that should be visible before having to scroll. Works best when the options are the same height.
+     */
+    visibleOptionsCount: PropTypes.number,
+    /**
+     * The max height the options list can be before having to scroll. If
+     * set, it will __override__ the `visibleOptionsCount` prop.
+     */
+    optionsMaxHeight: PropTypes.string,
+    /**
      * The max width the options list can be before option text wraps. If not
      * set, the list will only display as wide as the text input.
      */
     optionsMaxWidth: PropTypes.string,
-    /**
-     * The number of options that should be visible before having to scroll.
-     */
-    visibleOptionsCount: PropTypes.number,
     /**
      * Displays messages and validation for the input. It should be an object
      * with the following shape:
@@ -201,6 +206,7 @@ class SimpleSelect extends Component {
     isInline: false,
     width: undefined,
     optionsMaxWidth: undefined,
+    optionsMaxHeight: undefined,
     visibleOptionsCount: 8,
     messages: undefined,
     placement: 'bottom stretch',
@@ -477,6 +483,7 @@ class SimpleSelect extends Component {
       isInline,
       width,
       optionsMaxWidth,
+      optionsMaxHeight,
       visibleOptionsCount,
       messages,
       placement,
@@ -509,6 +516,7 @@ class SimpleSelect extends Component {
         isInline={isInline}
         width={width}
         optionsMaxWidth={optionsMaxWidth}
+        optionsMaxHeight={optionsMaxHeight}
         visibleOptionsCount={visibleOptionsCount}
         messages={messages}
         placement={placement}


### PR DESCRIPTION
The new prop controls the maxHeight of the options list and if set, overrides the
`visibleOptionsCount` prop.

Closes: INSTUI-3405