### PR TITLE
feat(ui-select): add `optionsMaxHeight` prop to Select

### DIFF
--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -461,6 +461,41 @@ describe('<Select />', async () => {
         'rgb(3, 116, 181)'
       )
     })
+
+    it('should set maxHeight according to the visibleOptionsCount prop', async () => {
+      await mount(
+        <Select
+          renderLabel="Choose an option"
+          isShowingOptions
+          visibleOptionsCount={2}
+        >
+          {getOptions()}
+        </Select>
+      )
+      const select = await SelectLocator.find()
+      const list = await select.findOptionsList()
+      const listView = await list.getDOMNode().parentNode
+
+      expect(getComputedStyle(listView).height).to.equal('72px')
+    })
+
+    it('should override maxHeight with optionsMaxHeight, even if visibleOptionsCount is set', async () => {
+      await mount(
+        <Select
+          renderLabel="Choose an option"
+          isShowingOptions
+          visibleOptionsCount={2}
+          optionsMaxHeight="50px"
+        >
+          {getOptions()}
+        </Select>
+      )
+      const select = await SelectLocator.find()
+      const list = await select.findOptionsList()
+      const listView = await list.getDOMNode().parentNode
+
+      expect(getComputedStyle(listView).height).to.equal('50px')
+    })
   })
 
   describe('with callbacks', async () => {

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -459,8 +459,13 @@ class Select extends Component<SelectProps> {
     >
   ) {
     const { getListProps, getOptionProps, getDisabledOptionProps } = data
-    const { isShowingOptions, optionsMaxWidth, visibleOptionsCount, children } =
-      this.props
+    const {
+      isShowingOptions,
+      optionsMaxWidth,
+      optionsMaxHeight,
+      visibleOptionsCount,
+      children
+    } = this.props
 
     let lastWasGroup = false
 
@@ -468,7 +473,8 @@ class Select extends Component<SelectProps> {
       ? {
           display: 'block',
           overflowY: 'auto',
-          maxHeight: this._optionHeight * visibleOptionsCount!,
+          maxHeight:
+            optionsMaxHeight || this._optionHeight * visibleOptionsCount!,
           maxWidth: optionsMaxWidth || this.width,
           background: 'primary',
           elementRef: (node: Element | null) => (this._listView = node)

--- a/packages/ui-select/src/Select/props.ts
+++ b/packages/ui-select/src/Select/props.ts
@@ -72,15 +72,21 @@ type SelectOwnProps = {
   isInline?: boolean
 
   /**
+   * The number of options that should be visible before having to scroll. Works best when the options are the same height.
+   */
+  visibleOptionsCount?: number
+
+  /**
+   * The max height the options list can be before having to scroll. If
+   * set, it will __override__ the `visibleOptionsCount` prop.
+   */
+  optionsMaxHeight?: string
+
+  /**
    * The max width the options list can be before option text wraps. If not
    * set, the list will only display as wide as the text input.
    */
   optionsMaxWidth?: string
-
-  /**
-   * The number of options that should be visible before having to scroll.
-   */
-  visibleOptionsCount?: number
 
   // Passed directly to TextInput as `value`
   /**
@@ -270,8 +276,9 @@ const propTypes: PropValidators<PropKeys> = {
   isInline: PropTypes.bool,
   width: PropTypes.string,
   htmlSize: PropTypes.number,
-  optionsMaxWidth: PropTypes.string,
   visibleOptionsCount: PropTypes.number,
+  optionsMaxHeight: PropTypes.string,
+  optionsMaxWidth: PropTypes.string,
   messages: PropTypes.arrayOf(FormPropTypes.message),
   placement: PositionPropTypes.placement,
   constrain: PositionPropTypes.constrain,
@@ -305,8 +312,9 @@ const allowedProps: AllowedPropKeys = [
   'isInline',
   'width',
   'htmlSize',
-  'optionsMaxWidth',
   'visibleOptionsCount',
+  'optionsMaxHeight',
+  'optionsMaxWidth',
   'messages',
   'placement',
   'constrain',

--- a/packages/ui-simple-select/src/SimpleSelect/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/index.tsx
@@ -393,6 +393,7 @@ class SimpleSelect extends Component<SimpleSelectProps, SimpleSelectState> {
       isInline,
       width,
       optionsMaxWidth,
+      optionsMaxHeight,
       visibleOptionsCount,
       messages,
       placement,
@@ -425,6 +426,7 @@ class SimpleSelect extends Component<SimpleSelectProps, SimpleSelectState> {
         isInline={isInline}
         width={width}
         optionsMaxWidth={optionsMaxWidth}
+        optionsMaxHeight={optionsMaxHeight}
         visibleOptionsCount={visibleOptionsCount}
         messages={messages}
         placement={placement}

--- a/packages/ui-simple-select/src/SimpleSelect/props.ts
+++ b/packages/ui-simple-select/src/SimpleSelect/props.ts
@@ -144,15 +144,21 @@ type PropsPassedToSelect = {
   width?: string
 
   /**
+   * The number of options that should be visible before having to scroll. Works best when the options are the same height.
+   */
+  visibleOptionsCount?: number
+
+  /**
+   * The max height the options list can be before having to scroll. If
+   * set, it will __override__ the `visibleOptionsCount` prop.
+   */
+  optionsMaxHeight?: string
+
+  /**
    * The max width the options list can be before option text wraps. If not
    * set, the list will only display as wide as the text input.
    */
   optionsMaxWidth?: string
-
-  /**
-   * The number of options that should be visible before having to scroll.
-   */
-  visibleOptionsCount?: number
 
   /**
    * Displays messages and validation for the input. It should be an array of
@@ -253,8 +259,9 @@ const propTypes: PropValidators<PropKeys> = {
   isRequired: PropTypes.bool,
   isInline: PropTypes.bool,
   width: PropTypes.string,
-  optionsMaxWidth: PropTypes.string,
   visibleOptionsCount: PropTypes.number,
+  optionsMaxHeight: PropTypes.string,
+  optionsMaxWidth: PropTypes.string,
   messages: PropTypes.arrayOf(FormPropTypes.message),
   placement: PositionPropTypes.placement,
   constrain: PositionPropTypes.constrain,
@@ -284,8 +291,9 @@ const allowedProps: AllowedPropKeys = [
   'isRequired',
   'isInline',
   'width',
-  'optionsMaxWidth',
   'visibleOptionsCount',
+  'optionsMaxHeight',
+  'optionsMaxWidth',
   'messages',
   'placement',
   'constrain',


### PR DESCRIPTION
Closes: INSTUI-3404

The new prop controls the maxHeight of the options list and if set, overrides the `visibleOptionsCount` prop.