### PR TITLE
refactor(ui-docs-client): fix Codepen button for v6 docs

### DIFF
--- a/packages/ui-docs-client/src/CodePenButton/index.js
+++ b/packages/ui-docs-client/src/CodePenButton/index.js
@@ -54,15 +54,16 @@ class CodePenButton extends Component {
       private: true,
       editors: '001',
       html: '<div id="app"></div><div id="flash-messages"></div><div id="nav"></div>',
-      layout: 'top',
       css_prefix: 'autoprefixer',
       js_pre_processor: 'babel',
       ...this.props.options
     }
-
+    const JSONData = JSON.stringify(data)
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;')
     return (
       <form action="https://codepen.io/pen/define" method="POST" target="_blank">
-        <input type="hidden" name="data" value={JSON.stringify(data)} />
+        <input type="hidden" name="data" value={JSONData} />
         <Tooltip renderTip="Edit in Codepen" placement="bottom">
           <IconButton
             type="submit"


### PR DESCRIPTION
there was some undocumented change that broke it. Backport of https://github.com/instructure/instructure-ui/pull/896