### PR TITLE
Update github actions to Node 16

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,9 +8,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2
-        name: Install Node 15
+        name: Install Node 16
         with:
-          node-version: '15'
+          node-version: '16'
       - name: Install dependencies
         run: yarn install --check-files
       - name: Bootstrap project

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install Node 15
+      - name: Install Node 16
         uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
       - name: Install project dependencies
         run: yarn install --check-files
       - name: Bootstrap project


### PR DESCRIPTION
A dependency update does not work on Node 16, and Node 15 is end of life already. https://nodejs.org/en/about/releases/