### PR TITLE
feat(ui-responsive): modify Responsive "props override" error to warning

### DIFF
--- a/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.js
+++ b/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.js
@@ -113,7 +113,7 @@ describe('<Responsive />', async () => {
   })
 
   it('should warn when more than one breakpoint is applied and a prop value is overwritten', async () => {
-    const consoleError = stub(console, 'error')
+    const consoleError = stub(console, 'warn')
     await mount(
       <div style={{ width: 200 }}>
         <Responsive

--- a/packages/ui-responsive/src/Responsive/index.js
+++ b/packages/ui-responsive/src/Responsive/index.js
@@ -26,7 +26,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import { deepEqual } from '@instructure/ui-utils'
-import { error } from '@instructure/console/macro'
+import { error, warn } from '@instructure/console/macro'
 
 import {
   addElementQueryMatchListener,
@@ -163,9 +163,9 @@ class Responsive extends Component {
       // Iterate over the props for the current match. If that the prop is
       // already in `mergedProps` that means that the prop was defined for
       // multiple breakpoints, and more than one of those breakpoints is being
-      // currently applied so we log an error.
+      // currently applied so we log a warning.
       Object.keys(matchProps).forEach((prop) => {
-        error(
+        warn(
           !(prop in mergedProps),
           [
             `[Responsive] The prop \`${prop}\` is defined at 2 or more breakpoints`,


### PR DESCRIPTION
Closes: INSTUI-3412

Changing the overriding prop error to a warning, since this is how it is intended to work: the props
should override each other when the viewport changes like how CSS media queries work. It is still
worth logging a warning about it, but it is not an error.