### PR TITLE
feat(ui-responsive): modify Responsive "props override" error to warning

### DIFF
--- a/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
+++ b/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
@@ -113,7 +113,7 @@ describe('<Responsive />', async () => {
   })
 
   it('should warn when more than one breakpoint is applied and a prop value is overwritten', async () => {
-    const consoleError = stub(console, 'error')
+    const consoleError = stub(console, 'warn')
     await mount(
       <div style={{ width: 200 }}>
         <Responsive

--- a/packages/ui-responsive/src/Responsive/index.tsx
+++ b/packages/ui-responsive/src/Responsive/index.tsx
@@ -25,7 +25,7 @@
 import React, { Component, createRef } from 'react'
 
 import { deepEqual } from '@instructure/ui-utils'
-import { logError as error } from '@instructure/console'
+import { logError as error, warn } from '@instructure/console'
 
 import {
   addElementQueryMatchListener,
@@ -147,11 +147,11 @@ class Responsive extends Component<ResponsiveProps> {
       // Iterate over the props for the current match. If that the prop is
       // already in `mergedProps` that means that the prop was defined for
       // multiple breakpoints, and more than one of those breakpoints is being
-      // currently applied so we log an error.
+      // currently applied so we log a warning.
       Object.keys(matchProps).forEach((prop) => {
         const currentValue = mergedProps[prop]
 
-        error(
+        warn(
           !(prop in mergedProps),
           [
             `[Responsive] The prop \`${prop}\` is defined at 2 or more breakpoints`,


### PR DESCRIPTION
Closes: INSTUI-3413

Changing the overriding prop error to a warning, since this is how it is intended to work: the props
should override each other when the viewport changes like how CSS media queries work. It is still
worth logging a warning about it, but it is not an error.