### PR TITLE
chore: fix `deterministicId` being passed to html elements

### DIFF
--- a/packages/ui-code-editor/tsconfig.build.json
+++ b/packages/ui-code-editor/tsconfig.build.json
@@ -18,7 +18,6 @@
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../ui-utils/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" }
+    { "path": "../ui-utils/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-expandable/tsconfig.build.json
+++ b/packages/ui-expandable/tsconfig.build.json
@@ -14,6 +14,7 @@
     { "path": "../ui-babel-preset/tsconfig.build.json" },
     { "path": "../ui-color-utils/tsconfig.build.json" },
     { "path": "../ui-test-utils/tsconfig.build.json" },
-    { "path": "../ui-react-utils/tsconfig.build.json" }
+    { "path": "../ui-react-utils/tsconfig.build.json" },
+    { "path": "../shared-types/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-options/tsconfig.build.json
+++ b/packages/ui-options/tsconfig.build.json
@@ -18,7 +18,6 @@
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../ui-view/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" }
+    { "path": "../ui-view/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-pages/tsconfig.build.json
+++ b/packages/ui-pages/tsconfig.build.json
@@ -18,7 +18,6 @@
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-view/tsconfig.build.json" },
-    { "path": "../ui-utils/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" }
+    { "path": "../ui-utils/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-radio-input/tsconfig.build.json
+++ b/packages/ui-radio-input/tsconfig.build.json
@@ -14,7 +14,6 @@
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
     { "path": "../ui-color-utils/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },

--- a/packages/ui-react-utils/src/omitProps.ts
+++ b/packages/ui-react-utils/src/omitProps.ts
@@ -29,7 +29,7 @@
  * Return an object with the remaining props after the given props are omitted.
  *
  * Automatically excludes the following props:
- * 'theme', 'children', 'className', 'style', 'styles', 'makeStyles', 'themeOverride'
+ * 'theme', 'children', 'className', 'style', 'styles', 'makeStyles', 'themeOverride', 'deterministicId'
  * @module omitProps
  * @param props The object to process
  * @param propsToOmit list disallowed prop keys or an object whose
@@ -67,7 +67,7 @@ const omit = <T>(originalObject: T, keysToOmit: string[]) => {
       key === 'styles' ||
       key === 'makeStyles' ||
       key === 'themeOverride' ||
-      key === 'instanceCounterMap'
+      key === 'deterministicId'
     ) {
       continue
     }

--- a/packages/ui-react-utils/src/passthroughProps.ts
+++ b/packages/ui-react-utils/src/passthroughProps.ts
@@ -29,7 +29,7 @@ import isPropValid from '@emotion/is-prop-valid'
  * HTML or SVG elements (see https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid)
  *
  * Disallowed is anything else and 'style', 'styles', 'className', 'children',
- * 'makeStyles'
+ * 'makeStyles', 'deterministicId'
  * @param props The props to process
  */
 function passthroughProps<P>(props: P) {
@@ -45,7 +45,7 @@ function passthroughProps<P>(props: P) {
         propName !== 'children' &&
         propName !== 'styles' &&
         propName !== 'makeStyles' &&
-        propName !== 'instanceCounterMap'
+        propName !== 'deterministicId'
     )
     .forEach((propName) => {
       validProps[propName as keyof P] = props[propName as keyof P]

--- a/packages/ui-selectable/tsconfig.build.json
+++ b/packages/ui-selectable/tsconfig.build.json
@@ -14,6 +14,6 @@
     { "path": "../ui-testable/tsconfig.build.json" },
     { "path": "../ui-utils/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" }
+    { "path": "../shared-types/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-simple-select/tsconfig.build.json
+++ b/packages/ui-simple-select/tsconfig.build.json
@@ -14,11 +14,11 @@
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-select/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
     { "path": "../ui-color-utils/tsconfig.build.json" },
     { "path": "../ui-icons/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },
-    { "path": "../ui-test-utils/tsconfig.build.json" }
+    { "path": "../ui-test-utils/tsconfig.build.json" },
+    { "path": "../shared-types/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-text-input/tsconfig.build.json
+++ b/packages/ui-text-input/tsconfig.build.json
@@ -20,7 +20,6 @@
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-tag/tsconfig.build.json" },
-    { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" }
+    { "path": "../ui-testable/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-time-select/tsconfig.build.json
+++ b/packages/ui-time-select/tsconfig.build.json
@@ -7,7 +7,6 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../console/tsconfig.build.json" },
     { "path": "../ui-form-field/tsconfig.build.json" },
     { "path": "../ui-i18n/tsconfig.build.json" },
     { "path": "../ui-position/tsconfig.build.json" },
@@ -16,8 +15,8 @@
     { "path": "../ui-select/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
-    { "path": "../ui-test-utils/tsconfig.build.json" }
+    { "path": "../ui-test-utils/tsconfig.build.json" },
+    { "path": "../shared-types/tsconfig.build.json" }
   ]
 }

--- a/packages/ui-tooltip/tsconfig.build.json
+++ b/packages/ui-tooltip/tsconfig.build.json
@@ -14,7 +14,6 @@
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
-    { "path": "../uid/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
     { "path": "../ui-color-utils/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },


### PR DESCRIPTION
This PR also fixes the TS reference errors popped up on master.