### PR TITLE
fix(ui): delete `ui-code-editor` from `ui` meta package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,6 @@
     "@instructure/ui-byline": "8.17.0",
     "@instructure/ui-calendar": "8.17.0",
     "@instructure/ui-checkbox": "8.17.0",
-    "@instructure/ui-code-editor": "8.17.0",
     "@instructure/ui-date-input": "8.17.0",
     "@instructure/ui-date-time-input": "8.17.0",
     "@instructure/ui-dialog": "8.17.0",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,7 +54,6 @@ export {
   CheckboxFacade,
   ToggleFacade
 } from '@instructure/ui-checkbox'
-export { CodeEditor } from '@instructure/ui-code-editor'
 export { DateInput } from '@instructure/ui-date-input'
 export { DateTimeInput } from '@instructure/ui-date-time-input'
 export { Dialog } from '@instructure/ui-dialog'

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -18,7 +18,6 @@
     { "path": "../ui-byline/tsconfig.build.json" },
     { "path": "../ui-calendar/tsconfig.build.json" },
     { "path": "../ui-checkbox/tsconfig.build.json" },
-    { "path": "../ui-code-editor/tsconfig.build.json" },
     { "path": "../ui-date-input/tsconfig.build.json" },
     { "path": "../ui-dialog/tsconfig.build.json" },
     { "path": "../ui-drawer-layout/tsconfig.build.json" },


### PR DESCRIPTION
Now that the `CodeMirror` dependencies of our `CodeEditor` are imported statically another error introduced itself:
 You can't use the `@instructure/ui` meta package with `Next.js` because the `ui` package simply re-exports the `CodeEditor` component and that component has browser specific API's (via `CodeMirror`).

Technically this is a breaking change, but nobody - internally at least - uses `CodeEditor` from the `ui` meta package (you can check it with livegrep).