### PR TITLE
feat(ui-options): remove nested paddin from option groups

### DIFF
--- a/packages/ui-options/src/Options/Item/theme.js
+++ b/packages/ui-options/src/Options/Item/theme.js
@@ -38,7 +38,7 @@ export default function generator({ colors, typography, spacing }) {
 
     padding: `${spacing.xSmall} ${spacing.small}`,
     iconPadding: spacing.small,
-    nestedPadding: spacing.medium
+    nestedPadding: spacing.small
   }
 }
 


### PR DESCRIPTION
Closes: INSTUI-3445

The nested Options used to have a little extra padding by default. It has been modified to have no
extra padding by default, but can still be set via the `nestedPadding` theme variable.