### PR TITLE
refactor: multiple docs fixes

### DIFF
--- a/packages/__docs__/buildScripts/build-docs.ts
+++ b/packages/__docs__/buildScripts/build-docs.ts
@@ -195,7 +195,9 @@ function processSingleFile(fullPath: string) {
     // Components (e.g. Alert) store their descriptions in README.md files.
     // Add this to the final JSON if it's edited
     const readmeDesc = tryParseReadme(dirName)
-    docObject.description = readmeDesc ? readmeDesc : docObject.description
+    docObject.description = readmeDesc
+      ? docObject.description + readmeDesc
+      : docObject.description
   } else if (fileName === 'README') {
     // if we edit a README, we'll need to add the changes to the components JSON
     let componentIndexFile: string | undefined

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -147,9 +147,16 @@ class App extends Component<AppProps, AppState> {
   fetchDocumentData = async (docId: string) => {
     const result = await fetch('docs/' + docId + '.json')
     const docData: DocData = await result.json()
-    docData.componentInstance =
-      // eslint-disable-next-line import/namespace
-      EveryComponent[docId as keyof typeof EveryComponent]
+    if (docId.includes('.')) {
+      // e.g. 'Calendar.Day', first get 'Calendar' then 'Day'
+      const components = docId.split('.')
+      const everyComp = EveryComponent as Record<string, any>
+      docData.componentInstance = everyComp[components[0]][components[1]]
+    } else {
+      docData.componentInstance =
+        // eslint-disable-next-line import/namespace
+        EveryComponent[docId as keyof typeof EveryComponent]
+    }
     return docData
   }
 

--- a/packages/__docs__/src/Params/index.tsx
+++ b/packages/__docs__/src/Params/index.tsx
@@ -55,7 +55,7 @@ class Params extends Component<ParamsProps> {
   }
 
   renderType(type?: { names: string[] }) {
-    return type ? type.names : null
+    return type ? type.names.join(' | ') : null
   }
 
   renderDescription(description: string) {

--- a/packages/__docs__/src/Properties/index.tsx
+++ b/packages/__docs__/src/Properties/index.tsx
@@ -175,9 +175,7 @@ class Properties extends Component<PropertiesProps> {
     if (prop.required) {
       return <span css={styles?.required}>Required</span>
     } else if (prop.defaultValue) {
-      let defaultValue: string | React.ReactNode = this.unquote(
-        prop.defaultValue.value
-      )
+      let defaultValue: string | React.ReactNode = prop.defaultValue.value
       if (defaultValue === '() => {}') {
         defaultValue = <span css={styles?.noWrap}>{defaultValue}</span>
       }


### PR DESCRIPTION
- docs was not showing TS type descriptions
- theme info was not showing for subcomponents
- if amethod could have multiple param types these were written without space in one large string
- default value for method params was removing quote characters in a buggy way