### PR TITLE
Drilldown storybook examples

### DIFF
--- a/packages/__examples__/.storybook/stories/renderExample.tsx
+++ b/packages/__examples__/.storybook/stories/renderExample.tsx
@@ -28,6 +28,7 @@ import { Modal } from '@instructure/ui-modal'
 import { IconButton, CloseButton } from '@instructure/ui-buttons'
 import { IconInfoLine } from '@instructure/ui-icons'
 import { Example } from '@instructure/ui-test-utils'
+import { Heading } from '@instructure/ui-heading'
 
 export function renderExample({
   Component,
@@ -58,18 +59,20 @@ export function renderExample({
         size="small"
         renderIcon={IconInfoLine}
         screenReaderLabel="props"
-        // @ts-ignore FIXME when IconButton is typed
         onClick={toggleInfoModal}
       />
       <Modal
         open={isInfoOpen}
         onDismiss={toggleInfoModal}
-        size="auto"
+        size="large"
         label={`${Component.displayName} example`}
         shouldCloseOnDocumentClick
         variant="inverse"
       >
-        <Modal.Header>
+        <Modal.Header spacing="compact">
+          <Heading level="h3" margin="0 0 x-small">
+            {`${Component.displayName} example`}
+          </Heading>
           <CloseButton
             placement="end"
             offset="small"

--- a/packages/__examples__/.storybook/stories/stories.ts
+++ b/packages/__examples__/.storybook/stories/stories.ts
@@ -43,7 +43,7 @@ const examplesContext = require.context(
 )
 
 const componentsContext = require.context(
-  '../../../', // bug: This causes start:watch to recompile endlessly in SB 6.2+
+  '../../../',
   true,
   /ui-.*\/src\/.*\/index\.tsx$/,
   'sync'
@@ -66,8 +66,8 @@ console.log(
       const Component: ComponentType = componentsContext(
         exampleDir + '/index.tsx'
       ).default
-      const ExamplesModule: StoryConfig<any> = examplesContext(requirePath)
-        .default // xy.example.jsx
+      const ExamplesModule: StoryConfig<any> =
+        examplesContext(requirePath).default // xy.example.jsx
 
       // merge in generated prop values:
       ExamplesModule.propValues = Object.assign(

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -28,17 +28,15 @@ import type { StoryConfig } from '@instructure/ui-test-utils'
 
 import { Drilldown } from '../index'
 import type { DrilldownProps } from '../props'
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Button } from '@instructure/ui-buttons'
 
 export default {
   sectionProp: 'trigger',
   maxExamplesPerPage: 8,
   propValues: {
     trigger: [
-      <Button margin="medium" key={1}>
-        hello
-      </Button>,
+      <button key={1} style={{ margin: '5px' }}>
+        a drilldown trigger
+      </button>,
       undefined
     ],
     // these are non-existing props, we just pass them to getComponentProps()

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -32,8 +32,8 @@ import type { DrilldownProps } from '../props'
 import { Button } from '@instructure/ui-buttons'
 
 export default {
-  //sectionProp: '',
-  maxExamplesPerPage: 11,
+  sectionProp: 'trigger',
+  maxExamplesPerPage: 8,
   propValues: {
     trigger: [
       <Button margin="medium" key={1}>
@@ -42,41 +42,121 @@ export default {
       undefined
     ],
     // these are non-existing props, we just pass them to getComponentProps()
-    contentVAlign: ['start', 'center', 'end'],
-    group: [
-      { separator: true, disabled: true, renderGroupTitle: 'groupTitle' },
-      { separator: false, disabled: false, renderGroupTitle: undefined }
+    customProps: [
+      { text: 'all custom props are undefined' },
+      { text: 'disabled', defaultShow: false, disabled: true },
+      {
+        text: 'no overflow',
+        defaultShow: true,
+        disabled: false,
+        separator: true,
+        groupDisabled: true,
+        renderGroupTitle: 'groupTitle',
+        contentVAlign: 'start'
+      },
+      // overflowX tests
+      {
+        text: 'overflowX auto',
+        defaultShow: true,
+        width: '12rem',
+        overflowX: 'auto',
+        disabled: false,
+        separator: true,
+        groupDisabled: true,
+        renderGroupTitle: 'groupTitle',
+        contentVAlign: 'start'
+      },
+      {
+        text: 'overflowX hidden',
+        defaultShow: true,
+        width: '12rem',
+        overflowX: 'hidden',
+        disabled: true,
+        separator: false,
+        groupDisabled: false,
+        renderGroupTitle: undefined,
+        contentVAlign: 'center'
+      },
+      {
+        text: 'overflowX visible',
+        defaultShow: true,
+        width: '12rem',
+        overflowX: 'visible',
+        disabled: false,
+        separator: false,
+        groupDisabled: false,
+        renderGroupTitle: undefined,
+        contentVAlign: 'end'
+      },
+      // overflowY tests
+      {
+        text: 'overflowY auto',
+        defaultShow: true,
+        height: '20rem',
+        overflowY: 'auto',
+        disabled: false,
+        separator: true,
+        groupDisabled: true,
+        renderGroupTitle: 'groupTitle',
+        contentVAlign: 'start'
+      },
+      {
+        text: 'overflowY hidden',
+        defaultShow: true,
+        height: '20rem',
+        overflowY: 'hidden',
+        disabled: true,
+        separator: false,
+        groupDisabled: false,
+        renderGroupTitle: undefined,
+        contentVAlign: 'center'
+      },
+      {
+        text: 'overflowY visible',
+        defaultShow: true,
+        height: '20rem',
+        overflowY: 'visible',
+        disabled: false,
+        separator: false,
+        groupDisabled: false,
+        renderGroupTitle: undefined,
+        contentVAlign: 'end'
+      }
     ]
   },
   getExampleProps(props) {
     return {
-      height: props.defaultShow || !props.trigger ? '30rem' : '3rem',
+      height:
+        props.customProps.defaultShow || !props.trigger ? '35rem' : '3rem',
       width: '25rem',
       padding: '0 0 0 large'
     }
-  },
-  filter: () => {
-    return false
   },
   getComponentProps: (props) => {
     return {
       rootPageId: 'page0',
       children: [
-        <Drilldown.Page id="page0" key="0">
-          <Drilldown.Option id="o1">minimal</Drilldown.Option>
+        <Drilldown.Page id="page0" key="page0">
+          <Drilldown.Option id="otext">
+            {props.customProps.text}
+          </Drilldown.Option>
+          <Drilldown.Option id="o">
+            this should be an option with very very super very very long label
+          </Drilldown.Option>
+          <Drilldown.Option id="o1" href="#">
+            this is a link
+          </Drilldown.Option>
           <Drilldown.Group
             id="g1"
-            disabled={props.group.disabled}
-            renderGroupTitle={props.group.renderGroupTitle}
-            withoutSeparators={props.group.separator}
+            disabled={props.customProps.groupDisabled}
+            renderGroupTitle={props.customProps.renderGroupTitle}
+            withoutSeparators={props.customProps.separator}
             selectableType="multiple"
           >
             <Drilldown.Option id="o2" renderLabelInfo="li" defaultSelected>
               defaultSelected
             </Drilldown.Option>
-            <Drilldown.Option id="o3" href="#">
-              renders as link
-            </Drilldown.Option>
+            <Drilldown.Option id="o3">minimal</Drilldown.Option>
           </Drilldown.Group>
           <Drilldown.Option id="o4" disabled>
             disabled
@@ -89,12 +169,12 @@ export default {
           >
             extra labels
           </Drilldown.Option>
-          <Drilldown.Separator />
+          <Drilldown.Separator id="s1" />
           <Drilldown.Option
             id="o6"
-            beforeLabelContentVAlign={props.contentVAlign}
+            beforeLabelContentVAlign={props.customProps.contentVAlign}
             renderBeforeLabel="bef"
-            afterLabelContentVAlign={props.contentVAlign}
+            afterLabelContentVAlign={props.customProps.contentVAlign}
             renderAfterLabel="after"
           >
             <br />
@@ -108,8 +188,8 @@ export default {
         </Drilldown.Page>
       ],
       rotateFocus: true,
-      overflowX: 'auto',
-      overflowY: 'auto',
+      overflowX: props.customProps.overflowX,
+      overflowY: props.customProps.overflowY,
       placement: 'bottom center',
       shouldHideOnSelect: true,
       shouldFocusTriggerOnClose: true,
@@ -117,9 +197,14 @@ export default {
       shouldReturnFocus: true,
       offsetX: 0,
       offsetY: 0,
-      disabled: false, // TODO comment this out
-      withArrow: props.trigger && props.defaultShow ? props.withArrow : false,
-      defaultShow: props.trigger ? props.defaultShow : false
+      width: props.customProps.width,
+      height: props.customProps.height,
+      disabled: props.customProps.disabled,
+      withArrow:
+        props.trigger && props.customProps.defaultShow
+          ? props.withArrow
+          : false,
+      defaultShow: props.trigger ? props.customProps.defaultShow : false
     }
   }
 } as StoryConfig<DrilldownProps>

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -119,13 +119,16 @@ export default {
         groupDisabled: false,
         renderGroupTitle: undefined,
         contentVAlign: 'end'
-      }
+      },
+      // tests for Drilldown.Page
+      { page: 'pageWithSubpages' },
+      { page: 'pageWithSubpages2' }
     ]
   },
   getExampleProps(props) {
     return {
       height:
-        props.customProps.defaultShow || !props.trigger ? '35rem' : '3rem',
+        props.customProps.defaultShow || !props.trigger ? '27rem' : '3rem',
       width: '25rem',
       padding: '0 0 0 large'
     }
@@ -133,60 +136,7 @@ export default {
   getComponentProps: (props) => {
     return {
       rootPageId: 'page0',
-      children: [
-        <Drilldown.Page id="page0" key="page0">
-          <Drilldown.Option id="otext">
-            {props.customProps.text}
-          </Drilldown.Option>
-          <Drilldown.Option id="o">
-            <div style={{ whiteSpace: 'nowrap' }}>
-              this should be an option with very very super very very long label
-            </div>
-          </Drilldown.Option>
-          <Drilldown.Option id="o1" href="#">
-            this is a link
-          </Drilldown.Option>
-          <Drilldown.Group
-            id="g1"
-            disabled={props.customProps.groupDisabled}
-            renderGroupTitle={props.customProps.renderGroupTitle}
-            withoutSeparators={props.customProps.separator}
-            selectableType="multiple"
-          >
-            <Drilldown.Option id="o2" renderLabelInfo="li" defaultSelected>
-              defaultSelected
-            </Drilldown.Option>
-            <Drilldown.Option id="o3">minimal</Drilldown.Option>
-          </Drilldown.Group>
-          <Drilldown.Option id="o4" disabled>
-            disabled
-          </Drilldown.Option>
-          <Drilldown.Option
-            id="o5"
-            renderBeforeLabel="be"
-            renderAfterLabel="af"
-            renderLabelInfo="li"
-          >
-            extra labels
-          </Drilldown.Option>
-          <Drilldown.Separator id="s1" />
-          <Drilldown.Option
-            id="o6"
-            beforeLabelContentVAlign={props.customProps.contentVAlign}
-            renderBeforeLabel="bef"
-            afterLabelContentVAlign={props.customProps.contentVAlign}
-            renderAfterLabel="after"
-          >
-            <br />
-            valign settings
-            <br />
-            <br />
-          </Drilldown.Option>
-          <Drilldown.Option id="o7" description="the description">
-            has description
-          </Drilldown.Option>
-        </Drilldown.Page>
-      ],
+      children: generateDrilldownChildren(props, props.customProps.page),
       rotateFocus: true,
       overflowX: props.customProps.overflowX,
       overflowY: props.customProps.overflowY,
@@ -208,3 +158,94 @@ export default {
     }
   }
 } as StoryConfig<DrilldownProps>
+
+function generateDrilldownChildren(
+  props: Record<string, any>,
+  variant: string
+) {
+  if (variant == 'pageWithSubpages') {
+    return [
+      <Drilldown.Page id="page0" key="page0" renderTitle="pageWithSubpages">
+        <Drilldown.Option id="o1" subPageId="subpage">
+          has subpage
+        </Drilldown.Option>
+        <Drilldown.Separator id="s1" />
+        <Drilldown.Option id="o2">does not have subpage</Drilldown.Option>
+        <Drilldown.Option id="o3" href="#">
+          this is a link
+        </Drilldown.Option>
+      </Drilldown.Page>,
+      <Drilldown.Page id="subpage" renderTitle="aaa" key={1}>
+        <Drilldown.Option id="tmp">not shown</Drilldown.Option>
+      </Drilldown.Page>
+    ]
+  } else if (variant == 'pageWithSubpages2') {
+    return [
+      <Drilldown.Page
+        id="page0"
+        key="page0"
+        renderTitle="pageWithSubpages2"
+        renderActionLabel="action label"
+        withoutHeaderSeparator
+        renderBackButtonLabel="go back"
+      >
+        <Drilldown.Option id="o1" subPageId="subpage">
+          has subpage
+        </Drilldown.Option>
+        <Drilldown.Separator id="s1" />
+        <Drilldown.Option id="o2">does not have subpage</Drilldown.Option>
+      </Drilldown.Page>,
+      <Drilldown.Page id="subpage" renderTitle="aaa" key={1}>
+        <Drilldown.Option id="tmp">subpage option</Drilldown.Option>
+      </Drilldown.Page>
+    ]
+  }
+  return [
+    <Drilldown.Page id="page0" key="page0">
+      <Drilldown.Option id="otext">{props.customProps.text}</Drilldown.Option>
+      <Drilldown.Option id="o">
+        <div style={{ whiteSpace: 'nowrap' }}>
+          this should be an option with very very super very very long label
+        </div>
+      </Drilldown.Option>
+      <Drilldown.Group
+        id="g1"
+        disabled={props.customProps.groupDisabled}
+        renderGroupTitle={props.customProps.renderGroupTitle}
+        withoutSeparators={props.customProps.separator}
+        selectableType="multiple"
+      >
+        <Drilldown.Option id="o2" renderLabelInfo="li" defaultSelected>
+          defaultSelected
+        </Drilldown.Option>
+        <Drilldown.Option id="o3">minimal</Drilldown.Option>
+      </Drilldown.Group>
+      <Drilldown.Option id="o4" disabled>
+        disabled
+      </Drilldown.Option>
+      <Drilldown.Option
+        id="o5"
+        renderBeforeLabel="be"
+        renderAfterLabel="af"
+        renderLabelInfo="li"
+      >
+        extra labels
+      </Drilldown.Option>
+      <Drilldown.Option
+        id="o6"
+        beforeLabelContentVAlign={props.customProps.contentVAlign}
+        renderBeforeLabel="bef"
+        afterLabelContentVAlign={props.customProps.contentVAlign}
+        renderAfterLabel="after"
+      >
+        <br />
+        valign settings
+        <br />
+        <br />
+      </Drilldown.Option>
+      <Drilldown.Option id="o7" description="the description">
+        has description
+      </Drilldown.Option>
+    </Drilldown.Page>
+  ]
+}

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -44,7 +44,7 @@ export default {
       { text: 'all custom props are undefined' },
       { text: 'disabled', defaultShow: false, disabled: true },
       {
-        text: 'no overflow',
+        text: 'no overflow setting',
         defaultShow: true,
         disabled: false,
         separator: true,
@@ -139,7 +139,9 @@ export default {
             {props.customProps.text}
           </Drilldown.Option>
           <Drilldown.Option id="o">
-            this should be an option with very very super very very long label
+            <div style={{ whiteSpace: 'nowrap' }}>
+              this should be an option with very very super very very long label
+            </div>
           </Drilldown.Option>
           <Drilldown.Option id="o1" href="#">
             this is a link

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -28,10 +28,21 @@ import type { StoryConfig } from '@instructure/ui-test-utils'
 
 import { Drilldown } from '../index'
 import type { DrilldownProps } from '../props'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Button } from '@instructure/ui-buttons'
 
 export default {
   // sectionProp: 'shape',
-  propValues: {},
+  propValues: {
+    trigger: [<Button key={1}>hello</Button>],
+    defaultShow: [true, false]
+  },
+  getExampleProps(props) {
+    return {
+      height: props.defaultShow ? '12rem' : '3rem',
+      width: '6rem'
+    }
+  },
   filter: () => {
     return false
   },
@@ -41,15 +52,15 @@ export default {
       rootPageId: 'page0',
       children: [
         <Drilldown.Page id="page0" key="0">
-          <Drilldown.Option id="option1">Option 0</Drilldown.Option>
+          <Drilldown.Option id="option1">Option 1</Drilldown.Option>
+          <Drilldown.Option id="option2">Option 2</Drilldown.Option>
+          <Drilldown.Option id="option3">Option 3</Drilldown.Option>
         </Drilldown.Page>
       ],
-      disabled: false,
       rotateFocus: true,
       overflowX: 'auto',
       overflowY: 'auto',
       placement: 'bottom center',
-      defaultShow: false,
       shouldHideOnSelect: true,
       shouldFocusTriggerOnClose: true,
       shouldContainFocus: false,

--- a/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__examples__/Drilldown.examples.tsx
@@ -32,29 +32,79 @@ import type { DrilldownProps } from '../props'
 import { Button } from '@instructure/ui-buttons'
 
 export default {
-  // sectionProp: 'shape',
+  //sectionProp: '',
+  maxExamplesPerPage: 11,
   propValues: {
-    trigger: [<Button key={1}>hello</Button>],
-    defaultShow: [true, false]
+    trigger: [
+      <Button margin="medium" key={1}>
+        hello
+      </Button>,
+      undefined
+    ],
+    // these are non-existing props, we just pass them to getComponentProps()
+    contentVAlign: ['start', 'center', 'end'],
+    group: [
+      { separator: true, disabled: true, renderGroupTitle: 'groupTitle' },
+      { separator: false, disabled: false, renderGroupTitle: undefined }
+    ]
   },
   getExampleProps(props) {
     return {
-      height: props.defaultShow ? '12rem' : '3rem',
-      width: '6rem'
+      height: props.defaultShow || !props.trigger ? '30rem' : '3rem',
+      width: '25rem',
+      padding: '0 0 0 large'
     }
   },
   filter: () => {
     return false
   },
-  getComponentProps: () => {
-    // TODO: write examples, these defaults are just for the build to run
+  getComponentProps: (props) => {
     return {
       rootPageId: 'page0',
       children: [
         <Drilldown.Page id="page0" key="0">
-          <Drilldown.Option id="option1">Option 1</Drilldown.Option>
-          <Drilldown.Option id="option2">Option 2</Drilldown.Option>
-          <Drilldown.Option id="option3">Option 3</Drilldown.Option>
+          <Drilldown.Option id="o1">minimal</Drilldown.Option>
+          <Drilldown.Group
+            id="g1"
+            disabled={props.group.disabled}
+            renderGroupTitle={props.group.renderGroupTitle}
+            withoutSeparators={props.group.separator}
+            selectableType="multiple"
+          >
+            <Drilldown.Option id="o2" renderLabelInfo="li" defaultSelected>
+              defaultSelected
+            </Drilldown.Option>
+            <Drilldown.Option id="o3" href="#">
+              renders as link
+            </Drilldown.Option>
+          </Drilldown.Group>
+          <Drilldown.Option id="o4" disabled>
+            disabled
+          </Drilldown.Option>
+          <Drilldown.Option
+            id="o5"
+            renderBeforeLabel="be"
+            renderAfterLabel="af"
+            renderLabelInfo="li"
+          >
+            extra labels
+          </Drilldown.Option>
+          <Drilldown.Separator />
+          <Drilldown.Option
+            id="o6"
+            beforeLabelContentVAlign={props.contentVAlign}
+            renderBeforeLabel="bef"
+            afterLabelContentVAlign={props.contentVAlign}
+            renderAfterLabel="after"
+          >
+            <br />
+            valign settings
+            <br />
+            <br />
+          </Drilldown.Option>
+          <Drilldown.Option id="o7" description="the description">
+            has description
+          </Drilldown.Option>
         </Drilldown.Page>
       ],
       rotateFocus: true,
@@ -65,9 +115,11 @@ export default {
       shouldFocusTriggerOnClose: true,
       shouldContainFocus: false,
       shouldReturnFocus: true,
-      withArrow: true,
       offsetX: 0,
-      offsetY: 0
+      offsetY: 0,
+      disabled: false, // TODO comment this out
+      withArrow: props.trigger && props.defaultShow ? props.withArrow : false,
+      defaultShow: props.trigger ? props.defaultShow : false
     }
   }
 } as StoryConfig<DrilldownProps>

--- a/packages/ui-test-utils/src/utils/generateComponentExamples.ts
+++ b/packages/ui-test-utils/src/utils/generateComponentExamples.ts
@@ -26,7 +26,6 @@ import { nanoid } from 'nanoid'
 
 import { generatePropCombinations } from './generatePropCombinations'
 import React, { ComponentType, ReactNode } from 'react'
-import type { ViewProps } from '@instructure/ui-view'
 
 export type StoryConfig<Props> = {
   /**
@@ -66,7 +65,7 @@ export type StoryConfig<Props> = {
    * returns an object of props that will be passed into the `renderExample`
    * function as exampleProps.
    */
-  getExampleProps?: (props: Props) => Partial<ViewProps>
+  getExampleProps?: (props: Props) => Record<string, any>
   /**
    * A function called with the examples and index for the current page of
    * examples. It returns an object of parameters/metadata for that page of
@@ -97,7 +96,7 @@ export type ExamplesPage<Props> = {
 export type Example<Props> = {
   Component: ComponentType
   componentProps: Partial<Props>
-  exampleProps: Partial<ViewProps>
+  exampleProps: Record<string, any> // actually Partial<ViewProps>
   key: string
 }
 
@@ -158,7 +157,7 @@ export function generateComponentExamples<Props>(
   }
 
   const getExampleProps = (props: Props) => {
-    let exampleProps: Partial<ViewProps> = {}
+    let exampleProps: Record<string, any> = {}
     if (typeof config.getExampleProps === 'function') {
       exampleProps = {
         ...config.getExampleProps(props)


### PR DESCRIPTION
This PR takes a bit unusual approach to write Storybook tests for Drilldown. Since it has so many props and its sub-components should be tested too I've hand written most of the test cases. To do this I had to resort to a trick, I pass around fake props that specify the individual examples. This way almost every functionality is tested, the test cases are easy to identify, we dont have millions of examples.