### PR TITLE
docs: add theme override info on component pages

### DIFF
--- a/packages/__docs__/src/ComponentTheme/index.tsx
+++ b/packages/__docs__/src/ComponentTheme/index.tsx
@@ -24,16 +24,19 @@
 
 /** @jsx jsx */
 import { Component } from 'react'
+
+import { withStyle, jsx } from '@instructure/emotion'
 import { Table } from '@instructure/ui-table'
 import { View } from '@instructure/ui-view'
 
+import type { BaseColors } from '@instructure/shared-types'
+
 import { ColorSwatch } from '../ColorSwatch'
 
-import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
-import type { ComponentThemeProps } from './props'
 import { propTypes, allowedProps } from './props'
-import type { BaseColors } from '@instructure/shared-types'
+import type { ComponentThemeProps } from './props'
+
 @withStyle(generateStyle, null)
 class ComponentTheme extends Component<ComponentThemeProps> {
   static propTypes = propTypes

--- a/packages/__docs__/src/Description/index.tsx
+++ b/packages/__docs__/src/Description/index.tsx
@@ -25,8 +25,10 @@
 import React, { Component } from 'react'
 
 import { compileMarkdown } from '../compileMarkdown'
-import type { DescriptionProps } from './props'
+
 import { propTypes, allowedProps } from './props'
+import type { DescriptionProps } from './props'
+
 class Description extends Component<DescriptionProps> {
   static propTypes = propTypes
   static allowedProps = allowedProps

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -107,7 +107,9 @@ class Document extends Component<
       typeof generateComponentTheme === 'function' &&
       generateComponentTheme(themeVariables)
 
-    return componentTheme && Object.keys(componentTheme).length > 0 ? (
+    const themeVariableKeys = Object.keys(componentTheme)
+
+    return componentTheme && themeVariableKeys.length > 0 ? (
       <View margin="x-large 0" display="block">
         <Heading level="h2" as="h3" id={`${doc.id}Theme`} margin="0 0 small 0">
           Default Theme Variables
@@ -116,6 +118,45 @@ class Document extends Component<
           componentTheme={componentTheme}
           themeVariables={themeVariables}
         />
+
+        <View margin="x-large 0 0" display="block">
+          <Heading
+            level="h4"
+            id={`${doc.id}ThemeOverrideExample`}
+            margin="0 0 small 0"
+          >
+            How to override the default theme
+          </Heading>
+
+          <View margin="small 0" display="block">
+            In case you need to change the appearance of the{' '}
+            <code>{doc.id}</code> component, you can override it&apos;s default
+            theme variables.
+          </View>
+          <View margin="small 0" display="block">
+            The easiest way to do this is to utilize the{' '}
+            <code>themeOverride</code> property. See the{' '}
+            <Link href="#using-theme-overrides">Using theme overrides</Link>{' '}
+            guide for more info and alternative methods.
+          </View>
+
+          <CodeEditor
+            label="Component theme override example"
+            language="js"
+            readOnly
+            value={`// theme override example
+
+<${doc.id}
+  {...props}
+  themeOverride={{
+    ${
+      // get random theme variable
+      themeVariableKeys[Math.floor(Math.random() * themeVariableKeys.length)]
+    }: 'custom value'
+  }}
+/>`}
+          />
+        </View>
       </View>
     ) : null
   }

--- a/packages/__docs__/src/Properties/index.tsx
+++ b/packages/__docs__/src/Properties/index.tsx
@@ -24,17 +24,18 @@
 
 /** @jsx jsx */
 import { Component } from 'react'
+
 import { Table } from '@instructure/ui-table'
 import { withStyle, jsx } from '@instructure/emotion'
+
 import generateStyle from './styles'
 import { compileMarkdown } from '../compileMarkdown'
+
 import type { PropertiesProps } from './props'
 import type {
   ElementsType,
   ObjectSignatureType,
-  PropDescriptor
-} from '../../buildScripts/DataTypes'
-import {
+  PropDescriptor,
   SimpleType,
   TSFunctionSignatureType,
   TypeDescriptor


### PR DESCRIPTION
Closes: INSTUI-2954

Adds info and example for themeOverride (and theme overrides in general) under the component Default
Theme Variable section.