### PR TITLE
feat(shared-types,ui-range-input): add accessible variant for RangeIn…

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -962,6 +962,12 @@ export type RangeInputTheme = {
   minWidth: string | 0
   handleSize: string | 0
   handleBackground: Colors['backgroundBrand']
+  handleBorderColor: Colors['borderLightest']
+  handleBorderSize: Border['widthMedium']
+  handleShadow: string | 0
+  handleFocusInset: Border['widthSmall']
+  handleFocusRingSize: Border['widthMedium']
+  handleFocusRingColor: Colors['backgroundLightest']
   handleShadowColor: Colors['borderBrand']
   handleHoverBackground: Colors['backgroundBrand']
   handleFocusBackground: Colors['backgroundBrand']

--- a/packages/ui-range-input/src/RangeInput/README.md
+++ b/packages/ui-range-input/src/RangeInput/README.md
@@ -10,25 +10,67 @@ render: false
 example: true
 ---
 class Example extends React.Component {
-  state = { size: "small" }
-  handleModalSizeChange = (event, value) => {
+  state = {
+    size: "small",
+    thumbVariant: "accessible",
+  }
+
+  handleSizeChange = (event, value) => {
     this.setState({ size: value })
   }
+
+  handleThumbVariantChange = (event, value) => {
+    this.setState({ thumbVariant: value })
+  }
+
   render() {
     return (
       <div>
-        <RangeInput label="Grading range" defaultValue={30} max={100} min={0} size={this.state.size} />
-        <RadioInputGroup
-          onChange={this.handleModalSizeChange}
-          name="labelSize"
-          defaultValue="small"
-          description="Label size"
-          variant="toggle"
+        <View
+          as="div"
+          padding="medium"
+          background="primary"
         >
-          <RadioInput label="small" value="small" />
-          <RadioInput label="medium" value="medium" />
-          <RadioInput label="large" value="large" />
-        </RadioInputGroup>
+          <RangeInput
+            label="Grading range"
+            defaultValue={30}
+            max={100}
+            min={0}
+            size={this.state.size}
+            thumbVariant={this.state.thumbVariant}
+          />
+        </View>
+
+        <View as="div" margin='medium 0 0'>
+          <FormFieldGroup
+            description={
+              <ScreenReaderContent>RangeInput Example Settings</ScreenReaderContent>
+            }
+            layout='columns'
+            vAlign='top'
+          >
+            <RadioInputGroup
+              onChange={this.handleSizeChange}
+              name="labelSize"
+              value={this.state.size}
+              description="Label size"
+            >
+              <RadioInput label="small" value="small" />
+              <RadioInput label="medium" value="medium" />
+              <RadioInput label="large" value="large" />
+            </RadioInputGroup>
+
+            <RadioInputGroup
+              onChange={this.handleThumbVariantChange}
+              name="thumbVariant"
+              value={this.state.thumbVariant}
+              description="Thumb variant"
+            >
+              <RadioInput label="accessible" value="accessible" />
+              <RadioInput label="deprecated" value="deprecated" />
+            </RadioInputGroup>
+          </FormFieldGroup>
+        </View>
       </div>
     )
   }

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
@@ -30,6 +30,9 @@ import { RangeInputLocator } from '../RangeInputLocator'
 
 describe('<RangeInput />', async () => {
   it('renders an input with type "range"', async () => {
+    // TODO: remove console stubs after 'deprecated' thumbVariant is removed
+    stub(console, 'warn')
+
     await mount(<RangeInput label="Opacity" name="opacity" max={100} min={0} />)
     const rangeInput = await RangeInputLocator.find()
     const input = await rangeInput.findInput()
@@ -38,6 +41,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('displays the default value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -54,6 +58,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets input value to default value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -70,6 +75,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets input value to controlled value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -86,7 +92,61 @@ describe('<RangeInput />', async () => {
     expect(input).to.have.value('25')
   })
 
+  describe('thumbVariant prop', async () => {
+    it('should throw deprecation warning by default', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+        />
+      )
+
+      expect(consoleWarning).to.have.been.calledWith(
+        "Warning: [RangeInput] The 'deprecated' value for the `thumbVariant` prop is deprecated. The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant."
+      )
+    })
+
+    it('should throw deprecation warning when explicitly "deprecated"', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+          thumbVariant="deprecated"
+        />
+      )
+
+      expect(consoleWarning).to.have.been.calledWith(
+        "Warning: [RangeInput] The 'deprecated' value for the `thumbVariant` prop is deprecated. The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant."
+      )
+    })
+
+    it('should not throw deprecation warning when "accessible"', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+          thumbVariant="accessible"
+        />
+      )
+
+      expect(consoleWarning).to.not.have.been.called()
+    })
+  })
+
   it('sets min value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput label="Opacity" name="opacity" max={100} min={25} />
     )
@@ -97,6 +157,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets max value', async () => {
+    stub(console, 'warn')
     await mount(<RangeInput label="Opacity" name="opacity" max={75} min={0} />)
     const rangeInput = await RangeInputLocator.find()
     const input = await rangeInput.findInput()
@@ -105,6 +166,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets step value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput label="Opacity" name="opacity" max={100} min={0} step={5} />
     )
@@ -115,6 +177,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('formats the value displayed', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -134,6 +197,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('hides the value when displayValue is false', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -152,6 +216,7 @@ describe('<RangeInput />', async () => {
   it('sets invalid when error messages are present', async () => {
     let ref: RangeInput | undefined
 
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -169,6 +234,7 @@ describe('<RangeInput />', async () => {
 
   describe('for a11y', async () => {
     it('should meet standards', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -183,6 +249,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the input role to "slider"', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -199,6 +266,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuenow attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -215,6 +283,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuemin attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput label="Opacity" name="opacity" max={100} min={20} />
       )
@@ -225,6 +294,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuemax attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput label="Opacity" name="opacity" max={80} min={0} />
       )
@@ -235,6 +305,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('formats the aria-valuetext attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -256,6 +327,7 @@ describe('<RangeInput />', async () => {
 
   describe('when the input value changes', async () => {
     it('should update the value displayed', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -278,6 +350,7 @@ describe('<RangeInput />', async () => {
     it('should call the onChange prop', async () => {
       const onChange = stub()
 
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -297,6 +370,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('should not update the input value when the value prop is set', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -72,7 +72,8 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
     layout: 'stacked',
     displayValue: true,
     disabled: false,
-    readOnly: false
+    readOnly: false,
+    thumbVariant: 'deprecated'
   }
 
   ref: Element | null = null

--- a/packages/ui-range-input/src/RangeInput/props.ts
+++ b/packages/ui-range-input/src/RangeInput/props.ts
@@ -26,6 +26,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { controllable } from '@instructure/ui-prop-types'
+import { deprecated } from '@instructure/ui-react-utils'
 import { FormPropTypes } from '@instructure/ui-form-field'
 
 import type {
@@ -89,6 +90,14 @@ type RangeInputOwnProps = {
   disabled?: boolean
 
   readOnly?: boolean
+
+  /**
+   * The "default" variant has an outer shadow on focus.
+   * The "accessible" variant has better color contrast, border and inset focus ring for better accessibility.
+   */
+  thumbVariant?:
+    | 'deprecated' // TODO: deprecated, remove in V9.
+    | 'accessible'
 }
 
 type PropKeys = keyof RangeInputOwnProps
@@ -101,12 +110,13 @@ type RangeInputProps =
     FormFieldOwnProps,
     'label' | 'inline' | 'id' | 'elementRef'
   > &
-  RangeInputOwnProps &
-  WithStyleProps<RangeInputTheme, RangeInputStyle> &
-  OtherHTMLAttributes<
-    RangeInputOwnProps,
-    InputHTMLAttributes<RangeInputOwnProps>
-  > & WithDeterministicIdProps
+    RangeInputOwnProps &
+    WithStyleProps<RangeInputTheme, RangeInputStyle> &
+    OtherHTMLAttributes<
+      RangeInputOwnProps,
+      InputHTMLAttributes<RangeInputOwnProps>
+    > &
+    WithDeterministicIdProps
 
 type RangeInputStyle = ComponentStyle<
   'rangeInput' | 'rangeInputInput' | 'rangeInputInputValue'
@@ -132,7 +142,12 @@ const propTypes: PropValidators<PropKeys> = {
   formatValue: PropTypes.func,
   inline: PropTypes.bool,
   disabled: PropTypes.bool,
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+  thumbVariant: deprecated.deprecatePropValues(
+    PropTypes.oneOf(['deprecated', 'accessible']),
+    ['deprecated'],
+    'The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant.'
+  )
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -151,7 +166,8 @@ const allowedProps: AllowedPropKeys = [
   'formatValue',
   'inline',
   'disabled',
-  'readOnly'
+  'readOnly',
+  'thumbVariant'
 ]
 
 export type { RangeInputProps, RangeInputState, RangeInputStyle }

--- a/packages/ui-range-input/src/RangeInput/styles.ts
+++ b/packages/ui-range-input/src/RangeInput/styles.ts
@@ -39,7 +39,7 @@ const generateStyle = (
   componentTheme: RangeInputTheme,
   props: RangeInputProps
 ): RangeInputStyle => {
-  const { size } = props
+  const { size, thumbVariant } = props
   const valueSizeVariants = {
     small: {
       fontSize: componentTheme.valueSmallFontSize,
@@ -57,6 +57,7 @@ const generateStyle = (
       lineHeight: componentTheme.valueLargeLineHeight
     }
   }
+
   const trackStyle = {
     borderRadius: '0.312em',
     borderColor: 'transparent',
@@ -65,21 +66,61 @@ const generateStyle = (
     background: componentTheme.trackBackground,
     height: `calc(${componentTheme.handleSize} / 2)`
   }
+
+  const borderedHandleSize = `calc(${componentTheme.handleSize} + (${componentTheme.handleBorderSize} * 2))`
+
+  const thumbVariantStyle = {
+    deprecated: {
+      width: componentTheme.handleSize,
+      height: componentTheme.handleSize,
+      boxShadow: `0 0.0625rem 0 ${componentTheme.handleShadowColor}`
+    },
+    accessible: {
+      width: borderedHandleSize,
+      height: borderedHandleSize,
+      borderWidth: componentTheme.handleBorderSize,
+      borderColor: componentTheme.handleBorderColor,
+      borderStyle: 'solid',
+      boxSizing: 'border-box',
+      boxShadow: componentTheme.handleShadow
+    }
+  }
+
   const thumbStyle = {
     appearance: 'none',
     borderRadius: '50%',
     cursor: 'pointer',
     transition: 'all 0.15s ease-in-out',
-    width: componentTheme.handleSize,
-    height: componentTheme.handleSize,
     background: componentTheme.handleBackground,
-    boxShadow: `0 0.0625rem 0 ${componentTheme.handleShadowColor}`,
+    ...thumbVariantStyle[thumbVariant!],
+
     '&:hover': {
       background: componentTheme.handleHoverBackground
     }
   }
+
+  const thumbPosition = {
+    deprecated: {
+      marginTop: `calc(-1 * ${componentTheme.handleSize} / 4)`
+    },
+    accessible: {
+      marginTop: `calc(-1 * ${borderedHandleSize} / 4)`
+    }
+  }
+
   const thumbFocusActiveStyle = {
-    boxShadow: `0 0.0625rem 0 ${componentTheme.handleShadowColor}, 0 0 0 ${componentTheme.handleFocusOutlineWidth} ${componentTheme.handleFocusOutlineColor}`
+    deprecated: {
+      background: componentTheme.handleFocusBackground,
+      boxShadow: `0 0.0625rem 0 ${componentTheme.handleShadowColor}, 0 0 0 ${componentTheme.handleFocusOutlineWidth} ${componentTheme.handleFocusOutlineColor}`
+    },
+    accessible: {
+      background: componentTheme.handleFocusBackground,
+      boxShadow:
+        componentTheme.handleShadow +
+        ', ' +
+        `inset 0 0 0 ${componentTheme.handleFocusInset} ${componentTheme.handleFocusBackground}, ` +
+        `inset 0 0 0 calc(${componentTheme.handleFocusInset} + ${componentTheme.handleFocusRingSize}) ${componentTheme.handleFocusRingColor}`
+    }
   }
 
   return {
@@ -99,15 +140,16 @@ const generateStyle = (
       width: '100%', // for Firefox
       outline: 'none',
       margin: 0,
+
       '&::-webkit-slider-thumb': {
         ...thumbStyle,
-        marginTop: `calc(-1 * ${componentTheme.handleSize} / 4)`
+        ...thumbPosition[thumbVariant!]
       },
       '&::-moz-range-thumb': thumbStyle,
       '&:focus, &:active': {
         outline: 'none',
-        '&::-webkit-slider-thumb': thumbFocusActiveStyle,
-        '&::-moz-range-thumb': thumbFocusActiveStyle
+        '&::-webkit-slider-thumb': thumbFocusActiveStyle[thumbVariant!],
+        '&::-moz-range-thumb': thumbFocusActiveStyle[thumbVariant!]
       },
       // remove outline in FF
       '&::-moz-focus-inner, &::-moz-focus-outer': {

--- a/packages/ui-range-input/src/RangeInput/theme.ts
+++ b/packages/ui-range-input/src/RangeInput/theme.ts
@@ -32,15 +32,17 @@ import { RangeInputTheme } from '@instructure/shared-types'
  * @return {Object} The final theme object with the overrides and component variables
  */
 const generateComponentTheme = (theme: Theme): RangeInputTheme => {
-  const { colors, typography, spacing, forms, key: themeName } = theme
+  const { colors, borders, typography, spacing, forms, key: themeName } = theme
 
   const themeSpecificStyle: ThemeSpecificStyle<RangeInputTheme> = {
     canvas: {
       handleBackground: theme['ic-brand-primary'],
-      handleShadowColor: darken(theme['ic-brand-primary'], 15),
-      handleFocusOutlineColor: alpha(theme['ic-brand-primary']!, 40),
       handleHoverBackground: theme['ic-brand-primary'],
-      handleFocusBackground: theme['ic-brand-primary']
+      handleFocusBackground: theme['ic-brand-primary'],
+
+      // Deprecated, remove with "deprecated" thumbVariant
+      handleShadowColor: darken(theme['ic-brand-primary'], 15),
+      handleFocusOutlineColor: alpha(theme['ic-brand-primary']!, 40)
     }
   }
 
@@ -49,11 +51,20 @@ const generateComponentTheme = (theme: Theme): RangeInputTheme => {
 
     handleSize: '1.5rem',
     handleBackground: colors?.backgroundBrand,
-    handleShadowColor: darken(colors?.borderBrand, 15),
+    handleBorderColor: colors?.borderLightest,
+    handleBorderSize: borders?.widthMedium,
+    handleShadow:
+      '0 0.0625rem 0.125rem rgba(0, 0, 0, .2), 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1)',
 
-    handleHoverBackground: colors?.backgroundBrand,
+    handleFocusInset: borders?.widthSmall,
+    handleFocusRingSize: borders?.widthMedium,
+    handleFocusRingColor: colors?.backgroundLightest,
 
     handleFocusBackground: colors?.backgroundBrand,
+    handleHoverBackground: colors?.backgroundBrand,
+
+    // Deprecated, remove with "deprecated" thumbVariant
+    handleShadowColor: darken(colors?.borderBrand, 15),
     handleFocusOutlineColor: alpha(colors?.borderBrand, 40),
     handleFocusOutlineWidth: '0.75em',
 


### PR DESCRIPTION
…put handle

Closes: INSTUI-3458

The previous thumb design is not fully accessible (doesn't have sufficiant color contrast and focus
indication), so it has become deprecated. For this feature to be non-breaking, we indtroduced a new
`thumbVariant` prop on the component. The `deprecated` variant (and connected theme variables) will
be removed in V9, please use the `accessible` variant.