### PR TITLE
Fix clean if there is a file, fix yarn.lock

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -63,15 +63,16 @@ async function deleteDirs(dirs = []) {
 async function clean() {
   const packagesPath = path.resolve('./packages')
   const dir = await fsp.opendir(packagesPath)
-
   for await (const package of dir) {
-    const rmDirs = DIRS_TO_DELETE.map(
-      (dir) => `${packagesPath}/${package.name}/${dir}`
-    )
-    if (NODE_PACKAGES.includes(package.name)) {
-      deleteDirs(rmDirs)
-    } else {
-      deleteDirs([...rmDirs, `${packagesPath}/${package.name}/lib`])
+    if (package.isDirectory()) {
+      const rmDirs = DIRS_TO_DELETE.map(
+        (dir) => `${packagesPath}/${package.name}/${dir}`
+      )
+      if (NODE_PACKAGES.includes(package.name)) {
+        deleteDirs(rmDirs)
+      } else {
+        deleteDirs([...rmDirs, `${packagesPath}/${package.name}/lib`])
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,6 +5256,7 @@ __metadata:
     "@babel/runtime": ^7.13.10
     "@instructure/ui-babel-preset": 8.22.0
     "@instructure/ui-decorator": 8.22.0
+    "@instructure/ui-dom-utils": 8.22.0
     "@instructure/ui-test-utils": 8.22.0
     prop-types: ^15.6.2
   peerDependencies:


### PR DESCRIPTION
2 small fixes:
- yarn clean was failing if there is a file in `packages` (I had a .DS_store placed there is OSX, it loves to litter the hard drive with these)
- there was a small change in the yarn.lock after my ReactDOM.render PR, I think its needed so it works properly