### PR TITLE
chore(ui-scripts): use lerna's `--no-verify-access` flag for publishing snapshots

### DIFF
--- a/packages/ui-scripts/src/utils/npm.ts
+++ b/packages/ui-scripts/src/utils/npm.ts
@@ -65,7 +65,10 @@ export const publishPackages = async (
       '--yes',
       '--no-push',
       '--no-git-tag-version',
-      '--force-publish=*'
+      '--force-publish=*',
+      // lerna does not work with NPM automation tokens
+      // related: https://github.com/lerna/lerna/issues/2788
+      '--no-verify-access'
     ])
 
     publishedVersion = await syncRootPackageVersion()


### PR DESCRIPTION
`lerna`s publish command tries to verify whether the user who tries to publish packages to npm actually has valid access to push the package to the npm registry.

We use npm's automation tokens and for some reason those tokens can't be checked against npm's registry endpoints.

This is an old issue, I have no idea why we didn't encounter it before, something with the yarn upgrade might triggered it.

Relevant thread:
https://github.com/lerna/lerna/issues/2788