### PR TITLE
feat(ui-range-input): add accessible variant for RangeInput handle

### DIFF
--- a/packages/ui-range-input/src/RangeInput/README.md
+++ b/packages/ui-range-input/src/RangeInput/README.md
@@ -6,7 +6,74 @@ An html5 range input/slider component.
 
 ```js
 ---
+render: false
 example: true
 ---
-<RangeInput label="Grading range" defaultValue={50} max={100} min={0} />
+  class Example extends React.Component {
+    state = {
+      size: "small",
+      thumbVariant: "accessible",
+    }
+
+    handleSizeChange = (event, value) => {
+      this.setState({ size: value })
+    }
+
+    handleThumbVariantChange = (event, value) => {
+      this.setState({ thumbVariant: value })
+    }
+
+    render() {
+      return (
+        <div>
+          <View
+            as="div"
+            padding="medium"
+            background="primary"
+          >
+            <RangeInput
+              label="Grading range"
+              defaultValue={30}
+              max={100}
+              min={0}
+              size={this.state.size}
+              thumbVariant={this.state.thumbVariant}
+            />
+          </View>
+
+          <View as="div" margin='medium 0 0'>
+            <FormFieldGroup
+              description={
+                <ScreenReaderContent>RangeInput Example Settings</ScreenReaderContent>
+              }
+              layout='columns'
+              vAlign='top'
+            >
+              <RadioInputGroup
+                onChange={this.handleSizeChange}
+                name="labelSize"
+                value={this.state.size}
+                description="Label size"
+              >
+                <RadioInput label="small" value="small" />
+                <RadioInput label="medium" value="medium" />
+                <RadioInput label="large" value="large" />
+              </RadioInputGroup>
+
+              <RadioInputGroup
+                onChange={this.handleThumbVariantChange}
+                name="thumbVariant"
+                value={this.state.thumbVariant}
+                description="Thumb variant"
+              >
+                <RadioInput label="accessible" value="accessible" />
+                <RadioInput label="deprecated" value="deprecated" />
+              </RadioInputGroup>
+            </FormFieldGroup>
+          </View>
+        </div>
+      )
+    }
+  }
+render(<Example />)
 ```

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.js
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.js
@@ -30,6 +30,8 @@ import { RangeInputLocator } from '../RangeInputLocator'
 
 describe('<RangeInput />', async () => {
   it('renders an input with type "range"', async () => {
+    // TODO: remove console stubs after 'deprecated' thumbVariant is removed
+    stub(console, 'warn')
     await mount(<RangeInput label="Opacity" name="opacity" max={100} min={0} />)
     const rangeInput = await RangeInputLocator.find()
     const input = await rangeInput.findInput()
@@ -38,6 +40,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('displays the default value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -54,6 +57,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets input value to default value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -70,6 +74,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets input value to controlled value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -86,7 +91,61 @@ describe('<RangeInput />', async () => {
     expect(input).to.have.value('25')
   })
 
+  describe('thumbVariant prop', async () => {
+    it('should throw deprecation warning by default', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+        />
+      )
+
+      expect(consoleWarning).to.have.been.calledWith(
+        "Warning: [RangeInput] The 'deprecated' value for the `thumbVariant` prop is deprecated. The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant."
+      )
+    })
+
+    it('should throw deprecation warning when explicitly "deprecated"', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+          thumbVariant="deprecated"
+        />
+      )
+
+      expect(consoleWarning).to.have.been.calledWith(
+        "Warning: [RangeInput] The 'deprecated' value for the `thumbVariant` prop is deprecated. The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant."
+      )
+    })
+
+    it('should not throw deprecation warning when "accessible"', async () => {
+      const consoleWarning = stub(console, 'warn')
+      await mount(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={30}
+          thumbVariant="accessible"
+        />
+      )
+
+      expect(consoleWarning).to.not.have.been.called()
+    })
+  })
+
   it('sets min value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput label="Opacity" name="opacity" max={100} min={25} />
     )
@@ -97,6 +156,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets max value', async () => {
+    stub(console, 'warn')
     await mount(<RangeInput label="Opacity" name="opacity" max={75} min={0} />)
     const rangeInput = await RangeInputLocator.find()
     const input = await rangeInput.findInput()
@@ -105,6 +165,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('sets step value', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput label="Opacity" name="opacity" max={100} min={0} step={5} />
     )
@@ -116,6 +177,7 @@ describe('<RangeInput />', async () => {
 
   it('requires an `onChange` prop with a `value` prop', async () => {
     const consoleError = stub(console, 'error')
+    stub(console, 'warn')
     await mount(
       <RangeInput label="Opacity" name="opacity" max={100} min={0} value={50} />
     )
@@ -126,6 +188,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('formats the value displayed', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -145,6 +208,7 @@ describe('<RangeInput />', async () => {
   })
 
   it('hides the value when displayValue is false', async () => {
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -162,6 +226,7 @@ describe('<RangeInput />', async () => {
 
   it('sets invalid when error messages are present', async () => {
     let ref
+    stub(console, 'warn')
     await mount(
       <RangeInput
         label="Opacity"
@@ -178,6 +243,7 @@ describe('<RangeInput />', async () => {
 
   describe('for a11y', async () => {
     it('should meet standards', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -192,6 +258,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the input role to "slider"', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -208,6 +275,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuenow attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -224,6 +292,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuemin attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput label="Opacity" name="opacity" max={100} min={20} />
       )
@@ -234,6 +303,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('sets the aria-valuemax attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput label="Opacity" name="opacity" max={80} min={0} />
       )
@@ -244,6 +314,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('formats the aria-valuetext attribute', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -265,6 +336,7 @@ describe('<RangeInput />', async () => {
 
   describe('when the input value changes', async () => {
     it('should update the value displayed', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -286,6 +358,7 @@ describe('<RangeInput />', async () => {
 
     it('should call the onChange prop', async () => {
       const onChange = stub()
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"
@@ -305,6 +378,7 @@ describe('<RangeInput />', async () => {
     })
 
     it('should not update the input value when the value prop is set', async () => {
+      stub(console, 'warn')
       await mount(
         <RangeInput
           label="Opacity"

--- a/packages/ui-range-input/src/RangeInput/index.js
+++ b/packages/ui-range-input/src/RangeInput/index.js
@@ -33,7 +33,7 @@ import { addEventListener } from '@instructure/ui-dom-utils'
 import { uid } from '@instructure/uid'
 import { themeable } from '@instructure/ui-themeable'
 import { testable } from '@instructure/ui-testable'
-import { omitProps, pickProps } from '@instructure/ui-react-utils'
+import { omitProps, pickProps, deprecated } from '@instructure/ui-react-utils'
 import { isEdge } from '@instructure/ui-utils'
 
 import styles from './styles.css'
@@ -79,7 +79,15 @@ class RangeInput extends Component {
     formatValue: PropTypes.func,
     inline: PropTypes.bool,
     disabled: PropTypes.bool,
-    readOnly: PropTypes.bool
+    readOnly: PropTypes.bool,
+
+    // The thumbVariant prop got deprecated in V8, and is backported to V7.
+    // Will be removed in V9.
+    thumbVariant: deprecated.deprecatePropValues(
+      PropTypes.oneOf(['deprecated', 'accessible']),
+      ['deprecated'],
+      'The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant.'
+    )
   }
 
   static defaultProps = {
@@ -97,7 +105,11 @@ class RangeInput extends Component {
     defaultValue: undefined,
     value: undefined,
     onChange: undefined,
-    messages: undefined
+    messages: undefined,
+
+    // The thumbVariant prop got deprecated in V8, and is backported to V7.
+    // Will be removed in V9.
+    thumbVariant: 'deprecated'
   }
 
   constructor(props) {
@@ -186,13 +198,14 @@ class RangeInput extends Component {
   }
 
   render() {
-    const { formatValue, size, disabled, readOnly } = this.props
+    const { formatValue, size, disabled, readOnly, thumbVariant } = this.props
 
     const props = omitProps(this.props, RangeInput.propTypes)
 
     const classes = {
       [styles.root]: true,
       [styles[size]]: size,
+      [styles[`thumbVariant-${thumbVariant}`]]: thumbVariant,
       [styles.edge16Up]: isEdge
     }
 

--- a/packages/ui-range-input/src/RangeInput/styles.css
+++ b/packages/ui-range-input/src/RangeInput/styles.css
@@ -27,10 +27,25 @@
     border-radius: 50%;
     cursor: pointer;
     transition: all 0.15s ease-in-out;
-    width: var(--handleSize);
-    height: var(--handleSize);
     background: var(--handleBackground);
-    box-shadow: 0 0.0625rem 0 var(--handleShadowColor);
+
+    /* stylelint-disable max-nesting-depth */
+    .thumbVariant-deprecated & {
+      width: var(--handleSize);
+      height: var(--handleSize);
+      box-shadow: 0 0.0625rem 0 var(--handleShadowColor);
+    }
+
+    .thumbVariant-accessible & {
+      width: calc(var(--handleSize) + (var(--handleBorderSize) * 2));
+      height: calc(var(--handleSize) + (var(--handleBorderSize) * 2));
+      border-width: var(--handleBorderSize);
+      border-color: var(--handleBorderColor);
+      border-style: solid;
+      box-sizing: border-box;
+      box-shadow: var(--handleShadow);
+    }
+    /* stylelint-enable max-nesting-depth */
 
     &:hover {
       background: var(--handleHoverBackground);
@@ -38,19 +53,37 @@
   }
 
   &::-webkit-slider-thumb {
-    margin-top: calc(-1 * var(--handleSize) / 4);
+    .thumbVariant-deprecated & {
+      margin-top: calc(-1 * var(--handleSize) / 4);
+    }
+
+    .thumbVariant-accessible & {
+      margin-top: calc(-1 * (var(--handleSize) + (var(--handleBorderSize) * 2)) / 4);
+    }
   }
 
   &:focus,
   &:active {
     outline: none;
 
-    /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+    /* stylelint-disable max-nesting-depth, selector-pseudo-element-no-unknown */
     &::range-thumb {
-      box-shadow:
-        0 0.0625rem 0 var(--handleShadowColor),
-        0 0 0 var(--handleFocusOutlineWidth) var(--handleFocusOutlineColor);
+      .thumbVariant-deprecated & {
+        background: var(--handleFocusBackground);
+        box-shadow:
+          0 0.0625rem 0 var(--handleShadowColor),
+          0 0 0 var(--handleFocusOutlineWidth) var(--handleFocusOutlineColor);
+      }
+
+      .thumbVariant-accessible & {
+        background: var(--handleFocusBackground);
+        box-shadow:
+          var(--handleShadow),
+          inset 0 0 0 var(--handleFocusInset) var(--handleFocusBackground),
+          inset 0 0 0 calc(var(--handleFocusInset) + var(--handleFocusRingSize)) var(--handleFocusRingColor);
+      }
     }
+    /* stylelint-enable max-nesting-depth, selector-pseudo-element-no-unknown */
   }
 
   /* remove outline in FF */

--- a/packages/ui-range-input/src/RangeInput/theme.js
+++ b/packages/ui-range-input/src/RangeInput/theme.js
@@ -24,17 +24,32 @@
 
 import { alpha, darken } from '@instructure/ui-color-utils'
 
-export default function generator({ colors, typography, spacing, forms }) {
+export default function generator({
+  colors,
+  borders,
+  typography,
+  spacing,
+  forms
+}) {
   return {
     minWidth: '12.5rem',
 
     handleSize: '1.5rem',
     handleBackground: colors.backgroundBrand,
-    handleShadowColor: darken(colors.borderBrand, 15),
+    handleBorderColor: colors.borderLightest,
+    handleBorderSize: borders.widthMedium,
+    handleShadow:
+      '0 0.0625rem 0.125rem rgba(0, 0, 0, .2), 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1)',
 
-    handleHoverBackground: colors.backgroundBrand,
+    handleFocusInset: borders?.widthSmall,
+    handleFocusRingSize: borders?.widthMedium,
+    handleFocusRingColor: colors?.backgroundLightest,
 
     handleFocusBackground: colors.backgroundBrand,
+    handleHoverBackground: colors.backgroundBrand,
+
+    // Deprecated, remove with "deprecated" thumbVariant
+    handleShadowColor: darken(colors.borderBrand, 15),
     handleFocusOutlineColor: alpha(colors.borderBrand, 40),
     handleFocusOutlineWidth: '0.75em',
 
@@ -61,10 +76,12 @@ export default function generator({ colors, typography, spacing, forms }) {
 generator.canvas = function (variables) {
   return {
     handleBackground: variables['ic-brand-primary'],
-    handleShadowColor: darken(variables['ic-brand-primary'], 15),
-    handleFocusOutlineColor: alpha(variables['ic-brand-primary'], 40),
     handleHoverBackground: variables['ic-brand-primary'],
     handleFocusBackground: variables['ic-brand-primary'],
-    valueBackground: variables['ic-brand-font-color-dark']
+    valueBackground: variables['ic-brand-font-color-dark'],
+
+    // Deprecated, remove with "deprecated" thumbVariant
+    handleShadowColor: darken(variables['ic-brand-primary'], 15),
+    handleFocusOutlineColor: alpha(variables['ic-brand-primary'], 40)
   }
 }


### PR DESCRIPTION
Closes: INSTUI-3462

Backported change from V8: the previous thumb design is not fully accessible (doesn't have
sufficiant color contrast and focus indication), so it has become deprecated. For this feature to be
non-breaking, we indtroduced a new `thumbVariant` prop on the component. The `deprecated` variant
(and connected theme variables) will be removed in V9, please use the `accessible` variant.