### PR TITLE
Update `yarn.lock` file after version bump 

### DIFF
--- a/packages/ui-scripts/src/bump.ts
+++ b/packages/ui-scripts/src/bump.ts
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { execSync } from 'node:child_process'
 import { getPackageJSON } from '@instructure/pkg-utils'
 import { error, info } from '@instructure/command-utils'
 
@@ -44,6 +45,8 @@ async function bump(packageName: any, requestedVersion: any) {
 
   try {
     releaseVersion = await bumpPackages(packageName, requestedVersion)
+    info('📦  Running yarn install to update yarn.lock file!')
+    execSync('yarn install', { stdio: 'inherit' })
   } catch (err: any) {
     error(err)
     process.exit(1)


### PR DESCRIPTION
In yarn 3 the `yarn install` in CI environments has the flag `--immutable` automatically turned on, which means it will fail when the yarn.lock file has been modified by the install. The bump script actually modifies every package's version so when you do an install after the bump the lockfile will be updated as well.

This PR changes the bump script to automatically include the lockfile change in the bump commit so it won't fail in CI anymore.