### PR TITLE
feat(ui-link): add `role` and `forceButtonRole ` prop to Link component

### DIFF
--- a/packages/ui-link/src/Link/__examples__/Link.examples.ts
+++ b/packages/ui-link/src/Link/__examples__/Link.examples.ts
@@ -40,7 +40,9 @@ export default {
   },
   getComponentProps: () => {
     return {
-      href: 'http://instructure.design'
+      href: 'http://instructure.design',
+      forceButtonRole: false,
+      role: undefined
     }
   },
   getExampleProps: (props) => {

--- a/packages/ui-link/src/Link/__tests__/Link.test.tsx
+++ b/packages/ui-link/src/Link/__tests__/Link.test.tsx
@@ -314,6 +314,51 @@ describe('<Link />', async () => {
     })
   })
 
+  describe('when a `role` is provided', async () => {
+    it('should set role', async () => {
+      await mount(
+        <Link href="example.html" role="button">
+          Hello World
+        </Link>
+      )
+      expect(await LinkLocator.find('[role="button"]')).to.exist()
+    })
+
+    it('should not override button role when it is forced by default', async () => {
+      const onClick = stub()
+      await mount(
+        <Link role="link" onClick={onClick} as="a">
+          Hello World
+        </Link>
+      )
+      const link = await LinkLocator.find()
+      expect(link.getAttribute('role')).to.equal('button')
+    })
+  })
+
+  describe('when a `forceButtonRole` is set to false', async () => {
+    it('should not force button role', async () => {
+      const onClick = stub()
+      await mount(
+        <Link onClick={onClick} as="a" forceButtonRole={false}>
+          Hello World
+        </Link>
+      )
+      const link = await LinkLocator.find()
+      expect(link.getAttribute('role')).to.equal(null)
+    })
+
+    it('should override button role with `role` prop', async () => {
+      const onClick = stub()
+      await mount(
+        <Link role="link" onClick={onClick} as="a" forceButtonRole={false}>
+          Hello World
+        </Link>
+      )
+      expect(await LinkLocator.find('[role="link"]')).to.exist()
+    })
+  })
+
   describe('when a `to` is provided', async () => {
     it('should render an anchor element', async () => {
       await mount(<Link to="/example">Hello World</Link>)

--- a/packages/ui-link/src/Link/index.tsx
+++ b/packages/ui-link/src/Link/index.tsx
@@ -65,7 +65,8 @@ class Link extends Component<LinkProps, LinkState> {
     interaction: undefined,
     color: 'link',
     iconPlacement: 'start',
-    isWithinText: true
+    isWithinText: true,
+    forceButtonRole: true
   } as const
 
   state = { hasFocus: false }
@@ -182,6 +183,16 @@ class Link extends Component<LinkProps, LinkState> {
     return hasVisibleChildren(this.props.children)
   }
 
+  get role() {
+    const { role, forceButtonRole, onClick } = this.props
+
+    if (forceButtonRole) {
+      return onClick && this.element !== 'button' ? 'button' : role
+    }
+
+    return role
+  }
+
   focus() {
     this.ref && (this.ref as HTMLElement).focus()
   }
@@ -211,15 +222,17 @@ class Link extends Component<LinkProps, LinkState> {
       isWithinText,
       ...props
     } = this.props
+
     const { interaction } = this
 
     const isDisabled = interaction === 'disabled'
-    const role = onClick && this.element !== 'button' ? 'button' : undefined
+
     const type =
       this.element === 'button' || this.element === 'input'
         ? 'button'
         : undefined
-    const tabIndex = role === 'button' && !isDisabled ? 0 : undefined
+
+    const tabIndex = this.role === 'button' && !isDisabled ? 0 : undefined
 
     return (
       <View
@@ -233,7 +246,7 @@ class Link extends Component<LinkProps, LinkState> {
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         aria-disabled={isDisabled ? 'true' : undefined}
-        role={role}
+        role={this.role}
         type={type}
         tabIndex={tabIndex}
         css={this.props.styles?.link}

--- a/packages/ui-link/src/Link/props.ts
+++ b/packages/ui-link/src/Link/props.ts
@@ -68,6 +68,17 @@ type LinkOwnProps = {
   as?: AsElementType
 
   /**
+   * The ARIA role of the element.
+   */
+  role?: string
+
+  /**
+   * If the Link has an onClick handler but is not a button element,
+   * force ARIA role to be "button".
+   */
+  forceButtonRole?: boolean
+
+  /**
    * Determines if the link is enabled or disabled
    */
   interaction?: 'enabled' | 'disabled'
@@ -142,6 +153,8 @@ const propTypes: PropValidators<PropKeys> = {
   color: PropTypes.oneOf(['link', 'link-inverse']),
   elementRef: PropTypes.func,
   as: PropTypes.elementType,
+  role: PropTypes.string,
+  forceButtonRole: PropTypes.bool,
   interaction: PropTypes.oneOf(['enabled', 'disabled']),
   margin: ThemeablePropTypes.spacing,
   renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
@@ -165,6 +178,8 @@ const allowedProps: AllowedPropKeys = [
   'color',
   'elementRef',
   'as',
+  'role',
+  'forceButtonRole',
   'interaction',
   'margin',
   'renderIcon',


### PR DESCRIPTION
Closes: INSTUI-3483

Setting the new `forceButtonRole` prop to false turns off the default logic which forced the aria role `button` on Link when it has an onClick handler and is not a button element.