### PR TITLE
feat(ui-link): add `role` and `forceButtonRole ` prop to Link component

### DIFF
--- a/packages/ui-link/src/Link/__examples__/Link.examples.js
+++ b/packages/ui-link/src/Link/__examples__/Link.examples.js
@@ -37,7 +37,9 @@ export default {
   },
   getComponentProps: (props) => {
     return {
-      href: 'http://instructure.design'
+      href: 'http://instructure.design',
+      forceButtonRole: false,
+      role: undefined
     }
   },
   getExampleProps: (props) => {

--- a/packages/ui-link/src/Link/__tests__/Link.test.js
+++ b/packages/ui-link/src/Link/__tests__/Link.test.js
@@ -311,6 +311,51 @@ describe('<Link />', async () => {
     })
   })
 
+  describe('when a `role` is provided', async () => {
+    it('should set role', async () => {
+      await mount(
+        <Link href="example.html" role="button">
+          Hello World
+        </Link>
+      )
+      expect(await LinkLocator.find('[role="button"]')).to.exist()
+    })
+
+    it('should not override button role when it is forced by default', async () => {
+      const onClick = stub()
+      await mount(
+        <Link role="link" onClick={onClick} as="a">
+          Hello World
+        </Link>
+      )
+      const link = await LinkLocator.find()
+      expect(link.getAttribute('role')).to.equal('button')
+    })
+  })
+
+  describe('when a `forceButtonRole` is set to false', async () => {
+    it('should not force button role', async () => {
+      const onClick = stub()
+      await mount(
+        <Link onClick={onClick} as="a" forceButtonRole={false}>
+          Hello World
+        </Link>
+      )
+      const link = await LinkLocator.find()
+      expect(link.getAttribute('role')).to.equal(null)
+    })
+
+    it('should override button role with `role` prop', async () => {
+      const onClick = stub()
+      await mount(
+        <Link role="link" onClick={onClick} as="a" forceButtonRole={false}>
+          Hello World
+        </Link>
+      )
+      expect(await LinkLocator.find('[role="link"]')).to.exist()
+    })
+  })
+
   describe('when a `to` is provided', async () => {
     it('should render an anchor element', async () => {
       await mount(<Link to="/example">Hello World</Link>)

--- a/packages/ui-link/src/Link/index.js
+++ b/packages/ui-link/src/Link/index.js
@@ -78,6 +78,15 @@ class Link extends Component {
      */
     as: PropTypes.elementType,
     /**
+     * The ARIA role of the element.
+     */
+    role: PropTypes.string,
+    /**
+     * If the Link has an onClick handler but is not a button element,
+     * force ARIA role to be "button".
+     */
+    forceButtonRole: PropTypes.bool,
+    /**
      * Determines if the link is enabled or disabled
      */
     interaction: PropTypes.oneOf(['enabled', 'disabled']),
@@ -144,6 +153,8 @@ class Link extends Component {
     display: undefined,
     color: 'link',
     as: undefined,
+    role: undefined,
+    forceButtonRole: true,
     iconPlacement: 'start',
     isWithinText: true,
     onClick: undefined,
@@ -239,6 +250,16 @@ class Link extends Component {
     return hasVisibleChildren(this.props.children)
   }
 
+  get role() {
+    const { role, forceButtonRole, onClick } = this.props
+
+    if (forceButtonRole) {
+      return onClick && this.element !== 'button' ? 'button' : role
+    }
+
+    return role
+  }
+
   focus() {
     this._link && this._link.focus()
   }
@@ -284,10 +305,11 @@ class Link extends Component {
     const { interaction } = this
 
     const isDisabled = interaction === 'disabled'
-    const role = onClick && this.element !== 'button' ? 'button' : null
+
     const type =
       this.element === 'button' || this.element === 'input' ? 'button' : null
-    const tabIndex = role === 'button' && !isDisabled ? '0' : null
+
+    const tabIndex = this.role === 'button' && !isDisabled ? '0' : null
 
     return (
       <View
@@ -301,7 +323,7 @@ class Link extends Component {
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         aria-disabled={isDisabled ? 'true' : null}
-        role={role}
+        role={this.role}
         type={type}
         tabIndex={tabIndex}
         className={classnames(classes)}


### PR DESCRIPTION
Closes: INSTUI-3484

Setting the new `forceButtonRole` prop to false turns off the default logic which forced the aria role `button` on Link when it has an onClick handler and is not a button element.