### PR TITLE
INSTUI-3487 fix(ui-date-time-input,ui-time-select): setting non step divisible value works

### DIFF
--- a/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
+++ b/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
@@ -135,6 +135,30 @@ describe('<TimeSelect />', async () => {
     expect(input.getAttribute('value')).to.equal(options[3].getTextContent())
   })
 
+  it('should accept values that are not divisible by step', async () => {
+    const onChange = stub()
+    const subject = await mount(
+      <TimeSelect
+        renderLabel="Choose an option"
+        timezone="US/Eastern"
+        onChange={onChange}
+      />
+    )
+    const select = await TimeSelectLocator.find()
+    const input = await select.findInput()
+    // this expect() is needed so TimeSelect generates some default options
+    expect(input.getAttribute('value')).to.equal('')
+
+    const value = moment.tz(
+      '1986-05-17T05:02:00.000Z',
+      moment.ISO_8601,
+      'en',
+      'US/Eastern'
+    )
+    await subject.setProps({ value: value.toISOString() })
+    expect(input.getAttribute('value')).to.equal(value.format('LT'))
+  })
+
   it('should render a default value', async () => {
     const defaultValue = moment.tz(
       '1986-05-17T18:00:00.000Z',

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -159,8 +159,14 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
         // preserve current value when changing from controlled to uncontrolled
         option = this.getOption('value', prevProps.value)
       }
+      const outsideVal = this.props.value ? this.props.value : ''
+      // value does not match an existing option
+      const date = DateTime.parse(outsideVal, this.locale(), this.timezone())
+      const label = this.props.format
+        ? date.format(this.props.format)
+        : date.toISOString()
       this.setState({
-        inputValue: option ? option.label : '',
+        inputValue: option ? option.label : label,
         selectedOptionId: option ? option.id : undefined
       })
     }


### PR DESCRIPTION
In DateTimeInput it was impossible to set a time value that is not divisible by `step`, e.g. it was
not showing "15:02" when the step value was "15".

To test: Enter a non-step divisible value in DateTimeInput