### PR TITLE
INSTUI-3492 Setting the value on a DateTimeInput does not change the time

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -764,4 +764,41 @@ describe('<DateTimeInput />', async () => {
       })
     ).to.not.exist()
   })
+
+  it('should update Date and Time inputs when value prop changes', async () => {
+    const locale = 'en-US'
+    const timezone = 'US/Eastern'
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', locale, timezone)
+
+    const subject = await mount(
+      <DateTimeInput
+        description="date time"
+        dateRenderLabel="date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        timeRenderLabel="time"
+        invalidDateTimeMessage="whoops"
+        locale={locale}
+        timezone={timezone}
+        value={dateTime.toISOString()}
+      />
+    )
+
+    const dateTimeInput = await DateTimeInputLocator.find()
+    expect(
+      await dateTimeInput.find(':contains(May 1, 2017 1:30 PM)')
+    ).to.exist()
+    const newDateStr = '2022-03-29T19:00Z'
+    const newDateTime = DateTime.parse(newDateStr, locale, timezone)
+    await subject.setProps({ value: newDateStr })
+
+    const dateLocator = await dateTimeInput.findDateInput()
+    const timeLocator = await dateTimeInput.findTimeInput()
+
+    const dateInput = await dateLocator.findInput()
+    const timeInput = await timeLocator.findInput()
+
+    expect(dateInput).to.have.value(newDateTime.format('LL'))
+    expect(timeInput).to.have.value(newDateTime.format('LT'))
+  })
 })

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -68,7 +68,6 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
 
   static contextType = ApplyLocaleContext
 
-  private _timeInput?: TimeSelect
   ref: Element | null = null // This is used by Tooltip for positioning
 
   handleRef = (el: Element | null) => {
@@ -136,13 +135,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
             .month(this.state.iso.month())
             .year(this.state.iso.year())
         }
-        const newTimeSelectValue = this.state?.timeSelectValue
-          ? this.state.timeSelectValue
-          : this._timeInput
-              ?.getBaseDate()
-              .minute(parsed.minute())
-              .hour(parsed.hour())
-              .toISOString()
+        const newTimeSelectValue = parsed.toISOString()
         if (this.isDisabledDate(parsed)) {
           let text =
             typeof this.props.disabledDateTimeMessage === 'function'
@@ -357,10 +350,6 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
         this.props.onBlur?.(e)
       }, 0)
     }
-  }
-
-  timeInputComponentRef = (node: TimeSelect) => {
-    this._timeInput = node
   }
 
   handleShowCalendar = (_event: SyntheticEvent) => {
@@ -589,7 +578,6 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
           value={this.state.timeSelectValue}
           onChange={this.handleTimeChange}
           onBlur={this.handleBlur}
-          ref={this.timeInputComponentRef}
           renderLabel={timeRenderLabel}
           locale={locale}
           format={timeFormat}

--- a/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
+++ b/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
@@ -135,6 +135,31 @@ describe('<TimeSelect />', async () => {
     expect(input.getAttribute('value')).to.equal(options[3].getTextContent())
   })
 
+  it('should keep selection when value changes', async () => {
+    const onChange = stub()
+    const locale = 'en-US'
+    const timezone = 'US/Eastern'
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', locale, timezone)
+
+    const subject = await mount(
+      <TimeSelect
+        renderLabel="Choose an option"
+        value={dateTime.toISOString()}
+        timezone="US/Eastern"
+        onChange={onChange}
+      />
+    )
+    const select = await TimeSelectLocator.find()
+    const input = await select.findInput()
+
+    expect(input.getAttribute('value')).to.equal(dateTime.format('LT'))
+
+    const newDateStr = '2022-03-29T19:00Z'
+    const newDateTime = DateTime.parse(newDateStr, locale, timezone)
+    await subject.setProps({ value: newDateTime })
+    expect(input.getAttribute('value')).to.equal(newDateTime.format('LT'))
+  })
+
   it('should accept values that are not divisible by step', async () => {
     const onChange = stub()
     const subject = await mount(

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -144,7 +144,9 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
   componentDidUpdate(prevProps: TimeSelectProps) {
     if (
       this.props.step !== prevProps.step ||
-      this.props.format !== prevProps.format
+      this.props.format !== prevProps.format ||
+      this.props.locale !== prevProps.locale ||
+      this.props.timezone !== prevProps.timezone
     ) {
       // options change, reset everything
       // when controlled, selection will be preserved
@@ -153,11 +155,15 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
     }
 
     if (this.props.value !== prevProps.value) {
+      const normalizedValue = this.normalizeISOTime(this.props.value)
       // value changed
-      let option = this.getOption('value', this.props.value)
-      if (typeof this.props.value === 'undefined') {
+      const initState = this.getInitialState()
+      this.setState(initState)
+      // options need to be passed because state is not set immediately
+      let option = this.getOption('value', normalizedValue, initState.options)
+      if (typeof normalizedValue === 'undefined') {
         // preserve current value when changing from controlled to uncontrolled
-        option = this.getOption('value', prevProps.value)
+        option = this.getOption('value', this.normalizeISOTime(prevProps.value))
       }
       const outsideVal = this.props.value ? this.props.value : ''
       // value does not match an existing option
@@ -170,6 +176,15 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
         selectedOptionId: option ? option.id : undefined
       })
     }
+  }
+
+  // value needs to be normalized because e.g. 2022-03-29T19:00Z and
+  // 2022-03-29T19:00:00.000Z refer to the same time in the same timezone.
+  normalizeISOTime(value?: string) {
+    if (!value) {
+      return value
+    }
+    return DateTime.parse(value, this.locale(), this.timezone()).toISOString()
   }
 
   getInitialState(): TimeSelectState {
@@ -193,7 +208,11 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
 
     if (typeof initialValue === 'string') {
       // get option based on value or defaultValue, if provided
-      const option = this.getOption('value', initialValue, options)
+      const option = this.getOption(
+        'value',
+        this.normalizeISOTime(initialValue),
+        options
+      )
       if (option) {
         // value matches an existing option
         return option


### PR DESCRIPTION
On a DateTimeInput when changing `value` to a different day/timezone the value is lost, this PR fixes this issue.

The root cause was that `TimeSelect` stores the possible selections in a hashmap where the keys are ISO dates, so if one would change the value from e.g. "2022-04-22T16:30" to "2022-04-01T16:30" the selection would be lots since its a different time value. This change also makes it easier to set dates in `DateTimeInput` which needed to adjust the date value for `TimeSelect` every time setting the value on it.