### PR TITLE
fix(theme-registry): fix theme registry name collision

### DIFF
--- a/packages/theme-registry/src/ThemeRegistry.ts
+++ b/packages/theme-registry/src/ThemeRegistry.ts
@@ -42,7 +42,7 @@ import type {
 
 declare global {
   // eslint-disable-next-line no-var
-  var GLOBAL_THEME_REGISTRY: Registry<RegisteredTheme>
+  var __GLOBAL_THEME_REGISTRY__: Registry<RegisteredTheme>
 }
 
 type Registry<T extends RegisteredTheme> = {
@@ -57,7 +57,7 @@ type RegisteredTheme<T extends BaseTheme = BaseTheme> = T & {
 }
 
 const DEFAULT_THEME_KEY = '@@themeRegistryDefaultTheme'
-const GLOBAL_THEME_REGISTRY = 'GLOBAL_THEME_REGISTRY'
+const GLOBAL_THEME_REGISTRY = '__GLOBAL_THEME_REGISTRY__'
 
 // initialize the registry:
 if (globalThis[GLOBAL_THEME_REGISTRY]) {


### PR DESCRIPTION
Closes: INSTUI-3499

the v7 and v8 version used the same key for the theme registry.
this could cause issues when one
part of the application is still on v7 but another part is already on v8