### PR TITLE
refactor(emotion): import lodash functions directly to leverage tree-shaking

### DIFF
--- a/packages/emotion/src/getTheme.ts
+++ b/packages/emotion/src/getTheme.ts
@@ -21,7 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { merge, cloneDeep } from 'lodash'
+import merge from 'lodash/merge'
+import cloneDeep from 'lodash/cloneDeep'
 import { canvas } from '@instructure/ui-themes'
 import { ThemeRegistry } from '@instructure/theme-registry'
 import { isBaseTheme } from '@instructure/ui-utils'

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -29,7 +29,7 @@ import type {
   RefAttributes
 } from 'react'
 
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 
 import { warn } from '@instructure/console'


### PR DESCRIPTION
Hey, I was analysing the size of my own bundle when I noticed that the entire lodash package is included.
Before and after images of the change using rollup-plugin-visualizer:

Before             |  After
:-------------------------:|:-------------------------:
<img width="1378" alt="Before the changes" src="https://user-images.githubusercontent.com/5323731/169598624-547422d8-b4cd-4082-8e4b-fe293f356adc.png">  |  <img width="1373" alt="After the changes" src="https://user-images.githubusercontent.com/5323731/169598634-0a07d651-2565-4c8f-bb12-163792764a49.png">

The sizes are very misleading in the images, but the effect of the change is noticeable in the bundled vendor chunk:

```
Before
dist/assets/vendor.1f7b611d.js   625.92 KiB / gzip: 180.75 KiB

After
dist/assets/vendor.ed38cdcb.js   574.10 KiB / gzip: 163.07 KiB
```