### PR TITLE
fix(ui-webpack-config): fix icon fonts not loading correctly

### DIFF
--- a/packages/ui-webpack-config/config/module/rules.js
+++ b/packages/ui-webpack-config/config/module/rules.js
@@ -59,17 +59,11 @@ const rules = [
   {
     // eslint-disable-next-line no-useless-escape
     test: /\.(eot|woff2?|otf|svg|ttf)([\?]?.*)$/,
-    loader: 'url-loader', // TODO use https://webpack.js.org/guides/asset-modules
-    options: {
-      limit: 8192
-    }
+    type: 'asset/resource'
   },
   {
     test: /\.(png|jpg|jpeg|gif)$/,
-    loader: 'url-loader', // TODO use https://webpack.js.org/guides/asset-modules
-    options: {
-      limit: 8192
-    }
+    type: 'asset/resource'
   }
 ]
 

--- a/packages/ui-webpack-config/package.json
+++ b/packages/ui-webpack-config/package.json
@@ -25,7 +25,6 @@
     "stylelint": "^14",
     "terser-webpack-plugin": "^5",
     "thread-loader": "^3",
-    "url-loader": "^4",
     "webpack": "^5"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,7 +4466,6 @@ __metadata:
     stylelint: ^14
     terser-webpack-plugin: ^5
     thread-loader: ^3
-    url-loader: ^4
     webpack: ^5
   languageName: unknown
   linkType: soft
@@ -33682,7 +33681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-loader@npm:^4, url-loader@npm:^4.1.1":
+"url-loader@npm:^4.1.1":
   version: 4.1.1
   resolution: "url-loader@npm:4.1.1"
   dependencies:


### PR DESCRIPTION
Using the Asset Modules os Webpack 5 instead of url-loader fixed the issue of icon fonts not loading
correctly. https://webpack.js.org/guides/asset-modules/