### PR TITLE
feat(ui-responsive): add `display` prop to Responsive

### DIFF
--- a/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
+++ b/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
@@ -165,4 +165,29 @@ describe('<Responsive />', async () => {
 
     expect(renderSpy).to.have.been.calledOnce()
   })
+
+  it('should apply the `display` prop', async () => {
+    const renderSpy = spy()
+    await mount(
+      <div style={{ width: 200 }} id="testContainer">
+        <Responsive
+          query={{
+            small: { maxWidth: 300 },
+            medium: { minWidth: 300 },
+            large: { minWidth: 800 }
+          }}
+          render={(props, matches) => {
+            renderSpy(props, matches)
+            return <div>hello</div>
+          }}
+          display="inline-flex"
+        />
+      </div>
+    )
+
+    const responsiveDiv = document.querySelector('#testContainer')
+      ?.firstChild as HTMLDivElement
+
+    expect(responsiveDiv.style.display).to.equal('inline-flex')
+  })
 })

--- a/packages/ui-responsive/src/Responsive/index.tsx
+++ b/packages/ui-responsive/src/Responsive/index.tsx
@@ -168,7 +168,7 @@ class Responsive extends Component<ResponsiveProps> {
 
   render() {
     const { matches, hasRendered } = this.state
-    const { props, render, children } = this.props
+    const { props, render, children, display } = this.props
     let renderFunc
     // Responsive needs to render once to measure the dom and obtain matches.
     // Calling the render prop on this initial render can cause visual side
@@ -180,7 +180,7 @@ class Responsive extends Component<ResponsiveProps> {
     }
 
     return (
-      <div ref={this.ref}>
+      <div ref={this.ref} style={{ display }}>
         {renderFunc && renderFunc(this.mergeProps(matches, props), matches)}
       </div>
     )

--- a/packages/ui-responsive/src/Responsive/props.ts
+++ b/packages/ui-responsive/src/Responsive/props.ts
@@ -77,6 +77,13 @@ type ResponsiveOwnProps = {
     props?: ResponsivePropsObject | null,
     matches?: QueriesMatching
   ) => any
+
+  /**
+   * The Responsive component is rendered as a `<div>`,
+   * so it has `display="block"` by default.
+   * You can override the display value with this prop.
+   */
+  display?: 'inline' | 'block' | 'inline-block' | 'flex' | 'inline-flex'
 }
 
 type PropKeys = keyof ResponsiveOwnProps
@@ -90,7 +97,14 @@ const propTypes: PropValidators<PropKeys> = {
   query: PropTypes.objectOf(ResponsivePropTypes.validQuery).isRequired,
   props: PropTypes.objectOf(PropTypes.object),
   render: PropTypes.func,
-  children: PropTypes.func
+  children: PropTypes.func,
+  display: PropTypes.oneOf([
+    'inline',
+    'block',
+    'inline-block',
+    'flex',
+    'inline-flex'
+  ])
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -98,7 +112,8 @@ const allowedProps: AllowedPropKeys = [
   'query',
   'props',
   'render',
-  'children'
+  'children',
+  'display'
 ]
 
 export type {


### PR DESCRIPTION
Closes: INSTUI-3540

The Responsive component is rendered as a `<div>`, so it has `display="block"` by default, but can
be changed with the new `display` prop.