### PR TITLE
Refactor(ui-babel-preset): Revert accidental build change

### DIFF
--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -88,6 +88,11 @@ module.exports = function (
     require('@babel/plugin-proposal-optional-chaining').default,
     require('@babel/plugin-transform-destructuring').default,
     [require('@babel/plugin-proposal-decorators').default, { legacy: true }], // must run before plugins that set displayName!
+    [
+      require('@babel/plugin-transform-typescript').default,
+      { allowDeclareFields: true }
+    ], // needed by plugin-proposal-class-properties
+    require('@babel/plugin-proposal-class-properties').default, // needed for Webpack 4 compat
     require('./babel-plugin-add-displayname-for-react'),
     require('@babel/plugin-proposal-export-default-from').default,
     [
@@ -149,7 +154,6 @@ module.exports = function (
       ]
     ].concat(plugins)
   }
-
   return {
     presets,
     plugins,

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -36,8 +36,8 @@ module.exports = function (
   const envPresetConfig = opts.node ? getNodeEnvConfig() : getWebEnvConfig(opts)
 
   const presets = [
-    [require('@babel/preset-typescript').default, { allowDeclareFields: true }],
     [require('@babel/preset-env').default, envPresetConfig],
+    [require('@babel/preset-typescript').default, { allowDeclareFields: true }],
     [require('@babel/preset-react').default, { useBuiltIns: true }]
   ]
 
@@ -88,11 +88,6 @@ module.exports = function (
     require('@babel/plugin-proposal-optional-chaining').default,
     require('@babel/plugin-transform-destructuring').default,
     [require('@babel/plugin-proposal-decorators').default, { legacy: true }], // must run before plugins that set displayName!
-    [
-      require('@babel/plugin-transform-typescript').default,
-      { allowDeclareFields: true }
-    ], // needed by plugin-proposal-class-properties
-    require('@babel/plugin-proposal-class-properties').default, // needed for Webpack 4 compat
     require('./babel-plugin-add-displayname-for-react'),
     require('@babel/plugin-proposal-export-default-from').default,
     [
@@ -185,6 +180,9 @@ function getWebEnvConfig(opts) {
     // debug: true, // un-comment if you want to see what browsers are being targeted and what plugins that means it will activate
     exclude: ['transform-typeof-symbol'],
     // have to include this plugin because babel-loader can't handle the `??` operator
-    include: ['proposal-nullish-coalescing-operator']
+    include: [
+      'proposal-nullish-coalescing-operator',
+      'proposal-class-properties'
+    ]
   }
 }

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -179,9 +179,10 @@ function getWebEnvConfig(opts) {
     modules: opts.esModules ? false : 'commonjs',
     // debug: true, // un-comment if you want to see what browsers are being targeted and what plugins that means it will activate
     exclude: ['transform-typeof-symbol'],
-    // have to include this plugin because babel-loader can't handle the `??` operator
     include: [
+      // have to include this plugin because babel-loader can't handle the `??` operator
       'proposal-nullish-coalescing-operator',
+      // needed for Webpack 4 compat
       'proposal-class-properties'
     ]
   }

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.13.10",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-export-default-from": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.8.3",
@@ -26,6 +27,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.9.0",
     "@babel/plugin-transform-react-display-name": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.13.10",
+    "@babel/plugin-transform-typescript": "^7.13.10",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.13.0",

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.13.10",
+    "@babel/core": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-export-default-from": "^7.8.3",

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -27,7 +27,6 @@
     "@babel/plugin-transform-react-constant-elements": "^7.9.0",
     "@babel/plugin-transform-react-display-name": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.13.10",
-    "@babel/plugin-transform-typescript": "^7.13.10",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,7 +469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.12.1, @babel/plugin-proposal-class-properties@npm:^7.13.0, @babel/plugin-proposal-class-properties@npm:^7.17.12":
+"@babel/plugin-proposal-class-properties@npm:^7.12.1, @babel/plugin-proposal-class-properties@npm:^7.13.0, @babel/plugin-proposal-class-properties@npm:^7.17.12, @babel/plugin-proposal-class-properties@npm:^7.8.3":
   version: 7.17.12
   resolution: "@babel/plugin-proposal-class-properties@npm:7.17.12"
   dependencies:
@@ -1361,7 +1361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.17.12":
+"@babel/plugin-transform-typescript@npm:^7.13.10, @babel/plugin-transform-typescript@npm:^7.17.12":
   version: 7.18.4
   resolution: "@babel/plugin-transform-typescript@npm:7.18.4"
   dependencies:
@@ -2348,6 +2348,7 @@ __metadata:
   resolution: "@instructure/ui-babel-preset@workspace:packages/ui-babel-preset"
   dependencies:
     "@babel/core": ^7.13.10
+    "@babel/plugin-proposal-class-properties": ^7.8.3
     "@babel/plugin-proposal-decorators": ^7.8.3
     "@babel/plugin-proposal-export-default-from": ^7.8.3
     "@babel/plugin-proposal-optional-chaining": ^7.8.3
@@ -2357,6 +2358,7 @@ __metadata:
     "@babel/plugin-transform-react-constant-elements": ^7.9.0
     "@babel/plugin-transform-react-display-name": ^7.8.3
     "@babel/plugin-transform-runtime": ^7.13.10
+    "@babel/plugin-transform-typescript": ^7.13.10
     "@babel/preset-env": ^7.9.5
     "@babel/preset-react": ^7.9.4
     "@babel/preset-typescript": ^7.13.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,7 +1393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.13.10, @babel/plugin-transform-typescript@npm:^7.17.12":
+"@babel/plugin-transform-typescript@npm:^7.17.12":
   version: 7.18.4
   resolution: "@babel/plugin-transform-typescript@npm:7.18.4"
   dependencies:
@@ -2408,7 +2408,6 @@ __metadata:
     "@babel/plugin-transform-react-constant-elements": ^7.9.0
     "@babel/plugin-transform-react-display-name": ^7.8.3
     "@babel/plugin-transform-runtime": ^7.13.10
-    "@babel/plugin-transform-typescript": ^7.13.10
     "@babel/preset-env": ^7.9.5
     "@babel/preset-react": ^7.9.4
     "@babel/preset-typescript": ^7.13.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,7 +91,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:>=7.2.2, @babel/core@npm:^7.1.0, @babel/core@npm:^7.11.4, @babel/core@npm:^7.12.10, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.10, @babel/core@npm:^7.13.16, @babel/core@npm:^7.7.5":
+"@babel/core@npm:>=7.2.2, @babel/core@npm:^7.1.0, @babel/core@npm:^7.11.4, @babel/core@npm:^7.12.10, @babel/core@npm:^7.12.3, @babel/core@npm:^7.13.16, @babel/core@npm:^7.7.5":
   version: 7.18.2
   resolution: "@babel/core@npm:7.18.2"
   dependencies:
@@ -111,6 +111,29 @@ __metadata:
     json5: ^2.2.1
     semver: ^6.3.0
   checksum: 14a4142c12e004cd2477b7610408d5788ee5dd821ee9e4de204cbb72d9c399d858d9deabc3d49914d5d7c2927548160c19bdc7524b1a9f6acc1ec96a8d9848dd
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.18.2":
+  version: 7.18.5
+  resolution: "@babel/core@npm:7.18.5"
+  dependencies:
+    "@ampproject/remapping": ^2.1.0
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.18.2
+    "@babel/helper-compilation-targets": ^7.18.2
+    "@babel/helper-module-transforms": ^7.18.0
+    "@babel/helpers": ^7.18.2
+    "@babel/parser": ^7.18.5
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.18.5
+    "@babel/types": ^7.18.4
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.1
+    semver: ^6.3.0
+  checksum: e20c3d69a07eb564408d611b827c2f5db56f05f1ca7cb3046f3823a1cf6b13c032f02d4b8ffe1e4593699e86e0f25ca1aee6228486c1ebea48d21aaeb28e6718
   languageName: node
   linkType: hard
 
@@ -429,6 +452,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: e05b2dc720c4b200e088258f3c2a2de5041c140444edc38181d1217b10074e881a7133162c5b62356061f26279f08df5a06ec14c5842996ee8601ad03c57a44f
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.18.5":
+  version: 7.18.5
+  resolution: "@babel/parser@npm:7.18.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 4976349d8681af215fd5771bd5b74568cc95a2e8bf2afcf354bf46f73f3d6f08d54705f354b1d0012f914dd02a524b7d37c5c1204ccaafccb9db3c37dba96a9b
   languageName: node
   linkType: hard
 
@@ -1609,7 +1641,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7, @babel/types@npm:^7.16.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.17.0, @babel/types@npm:^7.17.12, @babel/types@npm:^7.18.0, @babel/types@npm:^7.18.2, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/traverse@npm:^7.18.5":
+  version: 7.18.5
+  resolution: "@babel/traverse@npm:7.18.5"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.18.2
+    "@babel/helper-environment-visitor": ^7.18.2
+    "@babel/helper-function-name": ^7.17.9
+    "@babel/helper-hoist-variables": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/parser": ^7.18.5
+    "@babel/types": ^7.18.4
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: cc0470c880e15a748ca3424665c65836dba450fd0331fb28f9d30aa42acd06387b6321996517ab1761213f781fe8d657e2c3ad67c34afcb766d50653b393810f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7, @babel/types@npm:^7.16.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.17.0, @babel/types@npm:^7.17.12, @babel/types@npm:^7.18.0, @babel/types@npm:^7.18.2, @babel/types@npm:^7.18.4, @babel/types@npm:^7.2.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.4.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.18.4
   resolution: "@babel/types@npm:7.18.4"
   dependencies:
@@ -2347,7 +2397,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@instructure/ui-babel-preset@workspace:packages/ui-babel-preset"
   dependencies:
-    "@babel/core": ^7.13.10
+    "@babel/core": ^7.18.2
     "@babel/plugin-proposal-class-properties": ^7.8.3
     "@babel/plugin-proposal-decorators": ^7.8.3
     "@babel/plugin-proposal-export-default-from": ^7.8.3


### PR DESCRIPTION
For some reason after a Babel update 'static' variable modifiers have started to appear in the
compiled es/ and lib/ folders. https://diff.intrinsic.com/@instructure/ui-avatar/8.25.0/8.25.1-snapshot-10 T. This was causing issues with Webpack 4 build. This commit reverts this by adding the `proposal-class-properties` Babel plugin back.