### PR TITLE
typing cleanup; better comments in Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/__docs__/babel.config.js
+++ b/packages/__docs__/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/canvas-high-contrast-theme/babel.config.js
+++ b/packages/canvas-high-contrast-theme/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/canvas-theme/babel.config.js
+++ b/packages/canvas-theme/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/console/babel.config.js
+++ b/packages/console/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/debounce/babel.config.js
+++ b/packages/debounce/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/emotion/babel.config.js
+++ b/packages/emotion/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/instructure-theme/babel.config.js
+++ b/packages/instructure-theme/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-a11y-content/babel.config.js
+++ b/packages/ui-a11y-content/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-a11y-utils/babel.config.js
+++ b/packages/ui-a11y-utils/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-a11y-utils/src/__tests__/ScreenReaderFocusRegion.test.tsx
+++ b/packages/ui-a11y-utils/src/__tests__/ScreenReaderFocusRegion.test.tsx
@@ -144,12 +144,11 @@ describe('ScreenReaderFocusRegion', async () => {
     content.appendChild(desc)
 
     screenReaderFocusRegion.handleDOMMutation([
-      ({ addedNodes: [desc], removedNodes: [] } as unknown) as MutationRecord
+      { addedNodes: [desc], removedNodes: [] } as unknown as MutationRecord
     ])
 
     Array.from(content.childNodes).forEach((node) => {
-      // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.
-      expect(node.getAttribute('aria-hidden')).to.not.exist()
+      expect((node as Element).getAttribute('aria-hidden')).to.not.exist()
     })
   })
 
@@ -181,24 +180,20 @@ describe('ScreenReaderFocusRegion', async () => {
     const content = (await main.find('[data-test-content]')).getDOMNode()
     const screenReaderFocusRegion = new ScreenReaderFocusRegion(content)
 
-    const attrsMap = {}
+    const attrsMap: Record<string, Attr[]> = {}
     const parentNodes = await main.findAll('[data-test-parent]')
     parentNodes.forEach((node) => {
-      // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      attrsMap[node.getAttribute('id')] = [...node.getDOMNode().attributes]
+      attrsMap[node.getAttribute('id')!] = [...node.getDOMNode().attributes]
     })
-
     screenReaderFocusRegion.activate()
     screenReaderFocusRegion.deactivate()
 
     parentNodes.forEach((node) => {
-      // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      const preNodeAttrs = attrsMap[node.getAttribute('id')]
+      const preNodeAttrs = attrsMap[node.getAttribute('id')!]
       const postNodeAttrs = [...node.getDOMNode().attributes]
 
       expect(preNodeAttrs.length).to.equal(postNodeAttrs.length) // both should have same number of attributes
 
-      // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'preNodeAttribute' implicitly has an 'an... Remove this comment to see the full error message
       preNodeAttrs.forEach((preNodeAttribute) => {
         const matchingAttribute = postNodeAttrs.filter(
           (postNodeAttribute) =>
@@ -262,8 +257,8 @@ describe('ScreenReaderFocusRegion', async () => {
     const content = (await main.find('[data-test-content]')).getDOMNode()
     const ignore = (await main.find('[data-test-ignore]')).getDOMNode()
 
-    // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'iframe' implicitly has an 'any' type.
-    const getIframeBody = (iframe) => iframe.getDOMNode().contentDocument.body
+    const getIframeBody = (iframe: any) =>
+      iframe.getDOMNode().contentDocument.body
 
     const alwaysHidden = getIframeBody(
       await main.find('iframe[title="always-hidden"]')

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -150,8 +150,9 @@ module.exports = function (
     ].concat(plugins)
   }
   return {
-    presets,
+    // Note: Babel runs plugins always before presets
     plugins,
+    presets,
     // see https://babeljs.io/docs/en/assumptions
     assumptions: {
       setPublicClassFields: true
@@ -180,9 +181,10 @@ function getWebEnvConfig(opts) {
     // debug: true, // un-comment if you want to see what browsers are being targeted and what plugins that means it will activate
     exclude: ['transform-typeof-symbol'],
     include: [
-      // have to include this plugin because babel-loader can't handle the `??` operator
+      // webpack 4 uses acorn 6, which only supports features up to ES2020
+      // have to include this plugin because webpack 4 can't parse the `??` operator
       'proposal-nullish-coalescing-operator',
-      // needed for Webpack 4 compat
+      // have to include this plugin because webpack 4 can't parse class properties (like 'static)
       'proposal-class-properties'
     ]
   }

--- a/packages/ui-badge/babel.config.js
+++ b/packages/ui-badge/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-buttons/babel.config.js
+++ b/packages/ui-buttons/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-calendar/babel.config.js
+++ b/packages/ui-calendar/babel.config.js
@@ -23,10 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-date-input/babel.config.js
+++ b/packages/ui-date-input/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-decorator/babel.config.js
+++ b/packages/ui-decorator/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-dialog/babel.config.js
+++ b/packages/ui-dialog/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-dom-utils/babel.config.js
+++ b/packages/ui-dom-utils/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-dom-utils/src/__tests__/findTabbable.test.tsx
+++ b/packages/ui-dom-utils/src/__tests__/findTabbable.test.tsx
@@ -37,8 +37,7 @@ describe('findTabbable', async () => {
         <div>
           <a href="#">Yep</a>
           <div>Nope</div>
-          {/* @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'number | ... Remove this comment to see the full error message */}
-          <div tabIndex="1">Yep</div>
+          <div tabIndex={1}>Yep</div>
           <input type="text" value="Yep" readOnly />
           <div>
             <button>Yep</button>

--- a/packages/ui-dom-utils/src/__tests__/isVisible.test.tsx
+++ b/packages/ui-dom-utils/src/__tests__/isVisible.test.tsx
@@ -112,8 +112,7 @@ describe('isVisible', async () => {
         </span>
       </div>
     )
-    // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
-    const textNode = document.getElementById('test-2').childNodes[0]
+    const textNode = document.getElementById('test-2')!.childNodes[0]
     const nonrecursive = isVisible(textNode, false)
     const recursive = isVisible(textNode)
     expect(nonrecursive).to.equal(true)

--- a/packages/ui-editable/babel.config.js
+++ b/packages/ui-editable/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-file-drop/babel.config.js
+++ b/packages/ui-file-drop/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -111,7 +111,7 @@ class FileDrop extends Component<FileDropProps, FileDropState> {
   }
 
   enterCounter = 0
-  fileInputEl: HTMLInputElement | null = null
+  fileInputEl?: HTMLInputElement
   defaultId: string | null = null
   messagesId = ''
 

--- a/packages/ui-file-drop/src/FileDrop/utils/__tests__/getEventFiles.test.ts
+++ b/packages/ui-file-drop/src/FileDrop/utils/__tests__/getEventFiles.test.ts
@@ -24,6 +24,7 @@
 
 import { expect } from '@instructure/ui-test-utils'
 import { getEventFiles } from '../getEventFiles'
+import React from 'react'
 
 describe('getEventFiles', () => {
   const chromeDragEnter = {
@@ -66,21 +67,20 @@ describe('getEventFiles', () => {
   }
 
   it('should return items on chrome dragenter event', () => {
-    // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
-    expect(getEventFiles(chromeDragEnter)).to.be.equal(
-      chromeDragEnter.dataTransfer.items
-    )
+    expect(
+      getEventFiles(chromeDragEnter as unknown as React.DragEvent)
+    ).to.be.equal(chromeDragEnter.dataTransfer.items)
   })
 
   it('should return items on a firefox dragenter event', () => {
-    // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
-    expect(getEventFiles(firefoxDragEnter)).to.be.equal(
-      firefoxDragEnter.dataTransfer.items
-    )
+    expect(
+      getEventFiles(firefoxDragEnter as unknown as React.DragEvent)
+    ).to.be.equal(firefoxDragEnter.dataTransfer.items)
   })
 
   it('should return empty array on a safari dragenter event', () => {
-    // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
-    expect(getEventFiles(safariDragEnter).length).to.be.equal(0)
+    expect(
+      getEventFiles(safariDragEnter as unknown as React.DragEvent).length
+    ).to.be.equal(0)
   })
 })

--- a/packages/ui-file-drop/src/FileDrop/utils/getEventFiles.ts
+++ b/packages/ui-file-drop/src/FileDrop/utils/getEventFiles.ts
@@ -26,7 +26,7 @@ import React from 'react'
 
 function getEventFiles(
   event: React.DragEvent | React.ChangeEvent,
-  inputEl: HTMLInputElement | null
+  inputEl?: HTMLInputElement
 ): ArrayLike<DataTransferItem | File | never> {
   if ('dataTransfer' in event) {
     const dt = event.dataTransfer

--- a/packages/ui-heading/babel.config.js
+++ b/packages/ui-heading/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-icons/babel.config.js
+++ b/packages/ui-icons/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-img/babel.config.js
+++ b/packages/ui-img/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-menu/babel.config.js
+++ b/packages/ui-menu/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-metric/babel.config.js
+++ b/packages/ui-metric/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-metric/src/Metric/index.tsx
+++ b/packages/ui-metric/src/Metric/index.tsx
@@ -59,23 +59,16 @@ class Metric extends Component<MetricProps> {
   }
 
   componentDidMount() {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles()
+    this.props.makeStyles?.()
   }
 
   componentDidUpdate() {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles()
+    this.props.makeStyles?.()
   }
 
   render() {
-    const {
-      textAlign,
-      renderLabel,
-      renderValue,
-      isGroupChild,
-      ...rest
-    } = this.props
+    const { textAlign, renderLabel, renderValue, isGroupChild, ...rest } =
+      this.props
 
     return (
       <div

--- a/packages/ui-metric/src/MetricGroup/index.tsx
+++ b/packages/ui-metric/src/MetricGroup/index.tsx
@@ -59,13 +59,11 @@ class MetricGroup extends Component<MetricGroupProps> {
   }
 
   componentDidMount() {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles()
+    this.props.makeStyles?.()
   }
 
   componentDidUpdate() {
-    // @ts-expect-error ts-migrate(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
-    this.props.makeStyles()
+    this.props.makeStyles?.()
   }
 
   renderChildren() {

--- a/packages/ui-motion/babel.config.js
+++ b/packages/ui-motion/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-options/babel.config.js
+++ b/packages/ui-options/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-pill/babel.config.js
+++ b/packages/ui-pill/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-popover/babel.config.js
+++ b/packages/ui-popover/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-position/babel.config.js
+++ b/packages/ui-position/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-progress/babel.config.js
+++ b/packages/ui-progress/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-prop-types/babel.config.js
+++ b/packages/ui-prop-types/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-react-utils/babel.config.js
+++ b/packages/ui-react-utils/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-svg-images/babel.config.js
+++ b/packages/ui-svg-images/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-test-locator/babel.config.js
+++ b/packages/ui-test-locator/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-test-queries/babel.config.js
+++ b/packages/ui-test-queries/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-test-sandbox/babel.config.js
+++ b/packages/ui-test-sandbox/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-test-utils/babel.config.js
+++ b/packages/ui-test-utils/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-testable/babel.config.js
+++ b/packages/ui-testable/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
@@ -244,19 +244,17 @@ class TreeCollection extends Component<
         aria-setsize={this.childCount}
         aria-level={this.itemsLevel}
         {...ariaSelected}
-        // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => void' is not assignable ... Remove this comment to see the full error message
-        onClick={(e, n) => {
+        onClick={(e) => {
           if (typeof child.props.onClick === 'function') {
-            child.props.onClick(e, n)
+            child.props.onClick(e)
           } else {
             e.stopPropagation()
           }
         }}
         onFocus={(e) => this.handleFocus(e, itemHash)}
-        // @ts-expect-error ts-migrate(2322) FIXME: Type '(e: any, n: any) => void' is not assignable ... Remove this comment to see the full error message
-        onKeyDown={(e, n) => {
+        onKeyDown={(e) => {
           if (typeof child.props.onKeyDown === 'function') {
-            child.props.onKeyDown(e, n)
+            child.props.onKeyDown(e)
           } else {
             onKeyDown?.(e, itemHash)
           }

--- a/packages/ui-truncate-text/src/TruncateText/utils/__tests__/truncate.test.tsx
+++ b/packages/ui-truncate-text/src/TruncateText/utils/__tests__/truncate.test.tsx
@@ -223,8 +223,7 @@ describe('truncate', () => {
     )
 
     const result = truncate(stage!, { maxLines: 'auto' })
-    // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-    const text = stage.textContent
+    const text = stage!.textContent
 
     expect(text).to.not.equal({ defaultText })
     expect(text!.length).to.not.equal(1)

--- a/packages/ui-utils/babel.config.js
+++ b/packages/ui-utils/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-utils/src/__tests__/mergeDeep.test.ts
+++ b/packages/ui-utils/src/__tests__/mergeDeep.test.ts
@@ -55,7 +55,6 @@ describe('mergeDeep', () => {
 
     const result = mergeDeep(obj1, obj2, obj3)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.equal('bar')
   })
 
@@ -66,9 +65,7 @@ describe('mergeDeep', () => {
     const result = mergeDeep({}, obj1, obj2)
 
     expect(result).to.deep.equal({ a: { b: 1, c: 2 } })
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.not.deep.equal(obj1.a)
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.not.deep.equal(obj2.a)
   })
 
@@ -87,11 +84,8 @@ describe('mergeDeep', () => {
 
     const result = mergeDeep(obj1, obj2)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.deep.equal([1, 2, [3, 4]])
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a[2]).to.deep.equal([3, 4])
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'b' does not exist on type '{}'.
     expect(result.b).to.deep.equal(obj2.b)
   })
 
@@ -101,9 +95,7 @@ describe('mergeDeep', () => {
 
     const result = mergeDeep(obj1, obj2)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.deep.equal([1, 2, [3, 4], 5, 6])
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a[2]).to.deep.equal([3, 4])
   })
 
@@ -114,9 +106,7 @@ describe('mergeDeep', () => {
 
     const result = mergeDeep(obj1, obj2, obj3)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.deep.equal([1, 2, [3, 4], 5, 6])
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a[2]).to.deep.equal([3, 4])
   })
 
@@ -127,18 +117,16 @@ describe('mergeDeep', () => {
 
     const result = mergeDeep(obj1, obj2, obj3)
 
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'a' does not exist on type '{}'.
     expect(result.a).to.deep.equal(['foo', 'bar'])
   })
 
   it('should copy source properties', () => {
-    // @ts-expect-error ts-migrate(2554) FIXME: Expected 0 arguments, but got 1.
     expect(mergeDeep({ test: true }).test).to.be.true()
   })
 
   it('should not clone objects created with custom constructor', () => {
     function TestType() {}
-    // @ts-expect-error ts-migrate(7009) FIXME: 'new' expression, whose target lacks a construct s... Remove this comment to see the full error message
+    // @ts-expect-error intentional "new"
     const func = new TestType()
     expect(mergeDeep(func)).to.deep.equal(func)
   })

--- a/packages/ui-utils/src/mergeDeep.ts
+++ b/packages/ui-utils/src/mergeDeep.ts
@@ -34,7 +34,7 @@
  * @param {Object} args objects to merge
  * @returns {Object} a new object with items from all arguments
  */
-function mergeDeep(...args: Record<string, unknown>[]) {
+function mergeDeep(...args: Record<string, unknown>[]): Record<string, any> {
   // note: This could be typed as the union of its args, but since
   // its barely used its not worth the effort currently
   let target = {}

--- a/packages/ui-view/babel.config.js
+++ b/packages/ui-view/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),

--- a/packages/ui-view/src/View/props.ts
+++ b/packages/ui-view/src/View/props.ts
@@ -132,8 +132,8 @@ type ViewOwnProps = {
   insetBlockEnd?: string
   /**
    * Manually control if the `View` should display a focus outline. When left undefined (which is the default)
-   * the focus outline will display automatically if the `View` is focusable and receives focus. Note: the focus
-   * outline only will display when the `position` prop is set to `relative`.
+   * the focus outline will display automatically if the `View` is focusable and receives focus.
+   * Note: This props is applicable only when the position prop is set to relative.
    */
   withFocusOutline?: boolean
   /**

--- a/packages/ui/babel.config.js
+++ b/packages/ui/babel.config.js
@@ -23,11 +23,6 @@
  */
 
 module.exports = {
-  shouldPrintComment(value) {
-    const isTsRelatedComment = /@ts-expect-error|FIXME/.test(value)
-
-    return !isTsRelatedComment
-  },
   presets: [
     [
       require('@instructure/ui-babel-preset'),


### PR DESCRIPTION
the ts-expect-errors are no longer needed since we've typed all the components.
I've also added some better explanations in our Babel config and typed 2-3 files that we've left out.