### PR TITLE
docs(ui-drilldown,ui-editable,ui-position): remove `experimental` tag…

### DIFF
--- a/packages/__docs__/buildScripts/DataTypes.ts
+++ b/packages/__docs__/buildScripts/DataTypes.ts
@@ -42,7 +42,6 @@ type PackagePathData = {
 
 // YAML descriptions exported with gray-matter
 type YamlMetaInfo = {
-  experimental?: boolean
   category?: string
   describes?: string
   description: string

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -465,13 +465,6 @@ class App extends Component<AppProps, AppState> {
         }
       >
         {this.renderThemeSelect()}
-        {currentData.experimental && (
-          <div>
-            <Pill color="info" margin="small 0">
-              Experimental
-            </Pill>
-          </div>
-        )}
         <Section id={currentData.id} heading={heading}>
           <Document
             doc={{

--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -103,7 +103,6 @@ type SelectedGroupOptionsMap = Map<string, DrilldownOptionValue>
 /**
 ---
 category: components
-experimental: true
 ---
 @tsProps
 **/

--- a/packages/ui-editable/src/Editable/index.tsx
+++ b/packages/ui-editable/src/Editable/index.tsx
@@ -39,7 +39,6 @@ import type {
 /**
 ---
 category: components
-experimental: true
 ---
 @tsProps
 **/

--- a/packages/ui-position/src/Position/__tests__/Position.test.tsx
+++ b/packages/ui-position/src/Position/__tests__/Position.test.tsx
@@ -38,10 +38,6 @@ describe('<Position />', async () => {
     overflow: 'auto'
   }
 
-  beforeEach(async () => {
-    stub(console, 'warn') // suppress experimental warnings
-  })
-
   it('should render', async () => {
     await mount(
       <div style={{ padding: '50px' }}>


### PR DESCRIPTION
… from the docs app

We've found that the "experimental" flag is misleading on the components, prevents users from using
the component, and are usually left there for long time. We've decided to remove it from our
documentation.