### PR TITLE
docs(ui-color-picker,ui-drilldown): redo Drilldown type export

### DIFF
--- a/packages/ui-color-picker/src/ColorPreset/index.tsx
+++ b/packages/ui-color-picker/src/ColorPreset/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, SyntheticEvent } from 'react'
+import { Component } from 'react'
 
 import { withStyle, jsx } from '@instructure/emotion'
 import { passthroughProps } from '@instructure/ui-react-utils'
@@ -36,7 +36,7 @@ import { Tooltip } from '@instructure/ui-tooltip'
 import { Popover } from '@instructure/ui-popover'
 import { Text } from '@instructure/ui-text'
 import { Drilldown } from '@instructure/ui-drilldown'
-import type { DrilldownOnSelectArgs } from '@instructure/ui-drilldown'
+import type { DrilldownProps } from '@instructure/ui-drilldown'
 import { IconAddLine, IconCheckDarkSolid } from '@instructure/ui-icons'
 
 import { ColorIndicator } from '../ColorIndicator'
@@ -96,8 +96,8 @@ class ColorPreset extends Component<ColorPresetProps, ColorPresetState> {
   }
 
   onMenuItemSelected =
-    (color: string) =>
-    (_e: SyntheticEvent<Element, Event>, args: DrilldownOnSelectArgs) => {
+    (color: string): DrilldownProps['onSelect'] =>
+    (_e, args) => {
       if (args.value === 'select') {
         this.props.onSelect(color)
       }

--- a/packages/ui-drilldown/src/Drilldown/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/props.ts
@@ -64,21 +64,6 @@ type SeparatorChild = React.ComponentElement<
   DrilldownSeparatorProps,
   DrilldownSeparator
 >
-type DrilldownOnSelectArgs = {
-  value: DrilldownOptionValue | DrilldownOptionValue[]
-  isSelected: boolean
-  selectedOption: OptionChild
-  drilldown: Drilldown
-}
-type DrilldownOnToggleArgs = {
-  shown: boolean
-  drilldown: Drilldown
-  pageHistory: string[]
-  goToPage: (
-    pageId: string
-  ) => { prevPageId: string; newPageId: string } | undefined
-  goToPreviousPage: () => { prevPageId: string; newPageId: string } | undefined
-}
 
 type DrilldownOwnProps = {
   /**
@@ -167,13 +152,31 @@ type DrilldownOwnProps = {
    */
   onToggle?: (
     event: React.UIEvent | React.FocusEvent,
-    args: DrilldownOnToggleArgs
+    args: {
+      shown: boolean
+      drilldown: Drilldown
+      pageHistory: string[]
+      goToPage: (
+        pageId: string
+      ) => { prevPageId: string; newPageId: string } | undefined
+      goToPreviousPage: () =>
+        | { prevPageId: string; newPageId: string }
+        | undefined
+    }
   ) => void
 
   /**
    * Callback fired when an item within the `<Drilldown />` is selected
    */
-  onSelect?: (event: React.SyntheticEvent, args: DrilldownOnSelectArgs) => void
+  onSelect?: (
+    event: React.SyntheticEvent,
+    args: {
+      value: DrilldownOptionValue | DrilldownOptionValue[]
+      isSelected: boolean
+      selectedOption: OptionChild
+      drilldown: Drilldown
+    }
+  ) => void
 
   /**
    * If a trigger is supplied, callback fired when the `<Drilldown />` is closed
@@ -370,8 +373,6 @@ export type {
   PageChild,
   GroupChild,
   OptionChild,
-  SeparatorChild,
-  DrilldownOnSelectArgs,
-  DrilldownOnToggleArgs
+  SeparatorChild
 }
 export { propTypes, allowedProps }

--- a/packages/ui-drilldown/src/index.ts
+++ b/packages/ui-drilldown/src/index.ts
@@ -23,8 +23,4 @@
  */
 
 export { Drilldown } from './Drilldown'
-export type {
-  DrilldownProps,
-  DrilldownOnSelectArgs,
-  DrilldownOnToggleArgs
-} from './Drilldown/props'
+export type { DrilldownProps } from './Drilldown/props'


### PR DESCRIPTION
If we declare the type of the arguments as separate a type, the docs app won't be able to pick it up
and list them in detail.