### PR TITLE
feat(ui-tabs): expose `defaultOverflowY` theme variable on Tabs.Panel

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -1243,6 +1243,7 @@ export type TabsPanelTheme = {
   borderColor: Colors['borderMedium']
   borderWidth: Border['widthSmall']
   borderStyle: Border['style']
+  defaultOverflowY: string
 }
 
 export type TabsTabTheme = {

--- a/packages/ui-tabs/src/Tabs/Panel/styles.ts
+++ b/packages/ui-tabs/src/Tabs/Panel/styles.ts
@@ -69,7 +69,9 @@ const generateStyle = (
       borderLeft: 'none',
       borderRight: 'none',
       borderBottom: 'none',
-      overflowY: 'auto',
+      // we exposed this so in some use cases it can be set to "visible",
+      // e.g. when a 100% width button's focus ring would get cropped
+      overflowY: componentTheme.defaultOverflowY,
       ...(maxHeight && { overflow: 'auto' })
     }
   }

--- a/packages/ui-tabs/src/Tabs/Panel/theme.ts
+++ b/packages/ui-tabs/src/Tabs/Panel/theme.ts
@@ -48,7 +48,8 @@ const generateComponentTheme = (theme: Theme): TabsPanelTheme => {
     background: colors?.backgroundLightest,
     borderColor: colors?.borderMedium,
     borderWidth: borders?.widthSmall,
-    borderStyle: borders?.style
+    borderStyle: borders?.style,
+    defaultOverflowY: 'auto'
   }
 
   return {


### PR DESCRIPTION
Closes: INSTUI-3553

This theme variable allows the default `overflowY` to be set to `visible` on Tabs.Panel. It is
useful, when there is a 100% width interactive element (e.g. Button) in the panel, in which case the
focus ring would be cropped. Note, that this only works when the panel is not scrollable vertically.