### PR TITLE
INSTUI-3494 : support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,16 +63,16 @@
   },
   "license": "MIT",
   "resolutions": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
-    "@types/react": "^17",
+    "react": "^18",
+    "react-dom": "^18",
+    "@types/react": "^18",
     "@storybook/react/webpack": "^5"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.3",
     "@instructure/ui-scripts": "workspace:*",
     "@instructure/ui-token-scripts": "workspace:*",
-    "@types/react-dom": "^17.0.17",
+    "@types/react-dom": "^18",
     "chalk": "^4",
     "commitizen": "^4",
     "danger": "^11",

--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -116,8 +116,8 @@
     "marked": "^4",
     "moment": "^2.23.0",
     "prop-types": "^15",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "react": "^18",
+    "react-dom": "^18",
     "react-github-corner": "^2.1.0",
     "semver": "^7.3.5",
     "webpack-merge": "^5"

--- a/packages/__docs__/src/Figure/index.tsx
+++ b/packages/__docs__/src/Figure/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import React, { Component } from 'react'
+import React, { Component, PropsWithChildren } from 'react'
 import PropTypes from 'prop-types'
 
 import { omitProps, ensureSingleChild } from '@instructure/ui-react-utils'
@@ -45,7 +45,7 @@ import { Heading } from '../Heading'
 import type { FigureProps } from './props'
 import { propTypes, allowedProps } from './props'
 
-class FigureItem extends Component {
+class FigureItem extends Component<PropsWithChildren> {
   static displayName = 'FigureItem'
 
   static propTypes = {

--- a/packages/__docs__/src/Select/props.ts
+++ b/packages/__docs__/src/Select/props.ts
@@ -24,11 +24,12 @@
 import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Renderable } from '@instructure/shared-types'
 
 type SelectOwnProps = {
   name: string
-  renderLabel: React.ReactNode | (() => void)
-  renderBeforeInput?: React.ReactNode | (() => void)
+  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderBeforeInput?: Renderable
   id?: string
   value?: string
   onChange?: (e: React.SyntheticEvent, params: { value: string }) => void

--- a/packages/__docs__/src/Theme/index.tsx
+++ b/packages/__docs__/src/Theme/index.tsx
@@ -74,27 +74,29 @@ class Theme extends Component<ThemeProps> {
     name: string,
     value: string | number | { text: string; color: string }
   ) {
-    let valueText = value
+    let valueText: string
     let valueColor = ''
     let convertedValue
     if (typeof value === 'object') {
       convertedValue = value.color
       valueColor = value.color
       valueText = value.text
+    } else if (typeof value === 'string') {
+      valueText = value
+    } else {
+      valueText = String(value)
     }
-    if (typeof valueText === 'string') {
-      if (valueText.charAt(0) === '#' && this._colorMap) {
-        convertedValue = valueText
-        valueColor = valueText
-        valueText = this._colorMap[valueText]
-      } else {
-        const values = valueText.split(' ')
-        const convertedValues = values.map((value) => {
-          return value.slice(-2) === 'em' ? `${px(value)}px` : value
-        })
-        if (valueText !== convertedValues.join(' ')) {
-          convertedValue = convertedValues.join(' ')
-        }
+    if (valueText.charAt(0) === '#' && this._colorMap) {
+      convertedValue = valueText
+      valueColor = valueText
+      valueText = this._colorMap[valueText]
+    } else {
+      const values = valueText.split(' ')
+      const convertedValues = values.map((value) => {
+        return value.slice(-2) === 'em' ? `${px(value)}px` : value
+      })
+      if (valueText !== convertedValues.join(' ')) {
+        convertedValue = convertedValues.join(' ')
       }
     }
 

--- a/packages/__docs__/src/ToggleBlockquote/Paragraph/props.ts
+++ b/packages/__docs__/src/ToggleBlockquote/Paragraph/props.ts
@@ -25,11 +25,11 @@ import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
 import { PropsWithChildren } from 'react'
 
-type PropKeys = keyof PropsWithChildren
+type PropKeys = keyof PropsWithChildren<unknown> // <unknown> is needed for React 17 compatibility
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type ParagraphProps = PropsWithChildren
+type ParagraphProps = PropsWithChildren<unknown> // <unknown> is needed for React 17 compatibility
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.string

--- a/packages/__docs__/src/ToggleBlockquote/Paragraph/props.ts
+++ b/packages/__docs__/src/ToggleBlockquote/Paragraph/props.ts
@@ -23,16 +23,13 @@
  */
 import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
-import { ReactChildren } from 'react'
-type ParagraphOwnProps = {
-  children?: ReactChildren
-}
+import { PropsWithChildren } from 'react'
 
-type PropKeys = keyof ParagraphOwnProps
+type PropKeys = keyof PropsWithChildren
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type ParagraphProps = ParagraphOwnProps
+type ParagraphProps = PropsWithChildren
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.string

--- a/packages/__docs__/src/ToggleBlockquote/props.ts
+++ b/packages/__docs__/src/ToggleBlockquote/props.ts
@@ -27,7 +27,7 @@ import { PropsWithChildren } from 'react'
 
 type ToggleBlockquoteOwnProps = {
   summary: string
-} & PropsWithChildren
+} & PropsWithChildren<unknown> // <unknown> is needed for React 17 compatibility
 
 type PropKeys = keyof ToggleBlockquoteOwnProps
 

--- a/packages/__docs__/src/ToggleBlockquote/props.ts
+++ b/packages/__docs__/src/ToggleBlockquote/props.ts
@@ -23,11 +23,11 @@
  */
 import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
-import { ReactChildren } from 'react'
+import { PropsWithChildren } from 'react'
+
 type ToggleBlockquoteOwnProps = {
-  children?: ReactChildren
   summary: string
-}
+} & PropsWithChildren
 
 type PropKeys = keyof ToggleBlockquoteOwnProps
 

--- a/packages/__examples__/package.json
+++ b/packages/__examples__/package.json
@@ -39,8 +39,8 @@
     "@storybook/react": "^6",
     "@storybook/theming": "^6",
     "chromatic": "^6",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "react": "^18",
+    "react-dom": "^18",
     "story2sketch": "^1",
     "webpack-merge": "^5"
   },

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -32,7 +32,7 @@
     "babel-plugin-macros": "^3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -43,7 +43,7 @@
     "@types/lodash": "^4.14.171"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -23,7 +23,9 @@
     "access": "public"
   },
   "dependencies": {
-    "prop-types": "^15",
-    "react": "^17.0.0"
+    "prop-types": "^15"
+  },
+  "peerDependencies": {
+    "react": ">=16.8 <=18"
   }
 }

--- a/packages/shared-types/src/CommonTypes.ts
+++ b/packages/shared-types/src/CommonTypes.ts
@@ -22,7 +22,16 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import React, {
+  ClassicComponent,
+  ClassicComponentClass,
+  ClassType,
+  ComponentClass,
+  ComponentState,
+  ReactHTML,
+  ReactNode,
+  ReactSVG
+} from 'react'
 
 /** Element func parameter, mainly for the `findDOMNode` util */
 export type UIElement =
@@ -32,6 +41,17 @@ export type UIElement =
   | React.Component
   | (() => Node | Window | null | undefined)
   | null
+
+/** Type that is renderable by `callRenderProp` **/
+export type Renderable<P = never> =
+  | keyof ReactHTML
+  | keyof ReactSVG
+  | ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>
+  | ComponentClass
+  | ReactNode
+  | ((data: P) => ReactNode | Element)
+  | (() => ReactNode | Element)
+  | Element
 
 /**
  * A DOM element or an array of DOM elements or a method that returns a DOM

--- a/packages/template-app/package.json
+++ b/packages/template-app/package.json
@@ -25,8 +25,8 @@
     "@instructure/ui-text": "8.26.3",
     "@instructure/ui-themes": "8.26.3",
     "@instructure/ui-view": "8.26.3",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^4"

--- a/packages/template-component/package.json
+++ b/packages/template-component/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "sideEffects": false
 }

--- a/packages/ui-a11y-content/package.json
+++ b/packages/ui-a11y-content/package.json
@@ -40,7 +40,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-a11y-utils/package.json
+++ b/packages/ui-a11y-utils/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-alerts/package.json
+++ b/packages/ui-alerts/package.json
@@ -45,8 +45,8 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-alerts/src/Alert/props.ts
+++ b/packages/ui-alerts/src/Alert/props.ts
@@ -32,7 +32,11 @@ import type {
   WithStyleProps,
   ComponentStyle
 } from '@instructure/emotion'
-import type { AlertTheme, PropValidators } from '@instructure/shared-types'
+import type {
+  AlertTheme,
+  PropValidators,
+  Renderable
+} from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
 type AlertOwnProps = {
@@ -73,7 +77,7 @@ type AlertOwnProps = {
   /**
    * Close button label. Can be a React component
    */
-  renderCloseButtonLabel?: (() => ReactNode) | ReactNode
+  renderCloseButtonLabel?: Renderable
   /**
    * Callback after the alert is closed
    */
@@ -97,7 +101,9 @@ type PropKeys = keyof AlertOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type AlertProps = AlertOwnProps & WithStyleProps<AlertTheme, AlertStyle> & WithDeterministicIdProps
+type AlertProps = AlertOwnProps &
+  WithStyleProps<AlertTheme, AlertStyle> &
+  WithDeterministicIdProps
 
 type AlertStyle = ComponentStyle<'alert' | 'icon' | 'closeButton' | 'content'>
 

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-avatar/src/Avatar/props.ts
+++ b/packages/ui-avatar/src/Avatar/props.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React, { SyntheticEvent } from 'react'
+import { SyntheticEvent } from 'react'
 import PropTypes from 'prop-types'
 
 import { ThemeablePropTypes } from '@instructure/emotion'
@@ -38,6 +38,7 @@ import type {
   OtherHTMLAttributes,
   PropValidators
 } from '@instructure/shared-types'
+import { Renderable } from '@instructure/shared-types'
 
 type AvatarOwnProps = {
   /**
@@ -96,7 +97,7 @@ type AvatarOwnProps = {
   /**
    * An icon, or function that returns an icon that gets displayed. If the `src` prop is provided, `src` will have priority.
    */
-  renderIcon?: React.ReactNode | (() => React.ReactNode)
+  renderIcon?: Renderable
 }
 
 export type AvatarState = {

--- a/packages/ui-badge/package.json
+++ b/packages/ui-badge/package.json
@@ -42,7 +42,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-badge/src/Badge/props.ts
+++ b/packages/ui-badge/src/Badge/props.ts
@@ -39,6 +39,7 @@ import type {
 } from '@instructure/emotion'
 import type { PlacementPropValues } from '@instructure/ui-position'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type { PropsWithChildren } from 'react'
 
 type BadgeOwnProps = {
   count?: number
@@ -48,7 +49,6 @@ type BadgeOwnProps = {
    * would stop the count at 99.
    */
   countUntil?: number
-  children?: React.ReactNode
   /**
    * Render Badge as a counter (`count`) or as a smaller dot (`notification`) with
    * no count number displayed.
@@ -82,13 +82,15 @@ type BadgeOwnProps = {
    * `bottom start`, and `start center`
    */
   placement: PlacementPropValues
-}
+} & PropsWithChildren<unknown> // <unknown is needed for React 17 support
 
 type PropKeys = keyof BadgeOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type BadgeProps = BadgeOwnProps & WithStyleProps<BadgeTheme, BadgeStyle> & WithDeterministicIdProps
+type BadgeProps = BadgeOwnProps &
+  WithStyleProps<BadgeTheme, BadgeStyle> &
+  WithDeterministicIdProps
 
 type BadgeStyle = ComponentStyle<'badge' | 'wrapper'>
 

--- a/packages/ui-billboard/package.json
+++ b/packages/ui-billboard/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-billboard/src/Billboard/props.ts
+++ b/packages/ui-billboard/src/Billboard/props.ts
@@ -39,6 +39,7 @@ import type {
 } from '@instructure/shared-types'
 import type { ViewProps } from '@instructure/ui-view'
 import React, { MouseEvent } from 'react'
+import { Renderable } from '@instructure/shared-types'
 type HeroIconSize = 'medium' | 'x-large' | 'large'
 type BillboardOwnProps = {
   /**
@@ -76,7 +77,7 @@ type BillboardOwnProps = {
    * `onClick`. That would cause the Billboard to render as a button or link
    * and would result in nested interactive content.
    */
-  message?: React.ReactNode | (() => React.ReactNode)
+  message?: Renderable
   /**
    * If you add an onClick prop, the Billboard renders as a clickable button
    */

--- a/packages/ui-breadcrumb/package.json
+++ b/packages/ui-breadcrumb/package.json
@@ -43,7 +43,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/props.ts
+++ b/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/props.ts
@@ -27,7 +27,8 @@ import PropTypes from 'prop-types'
 
 import type {
   OtherHTMLAttributes,
-  PropValidators
+  PropValidators,
+  Renderable
 } from '@instructure/shared-types'
 import type { ViewOwnProps } from '@instructure/ui-view'
 
@@ -51,7 +52,7 @@ type BreadcrumbLinkOwnProps = {
   /**
    * Add an icon to the Breadcrumb.Link
    */
-  renderIcon?: React.ReactNode | (() => React.ReactNode)
+  renderIcon?: Renderable
   /**
    * Place the icon before or after the text in the Breadcrumb.Link
    */

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-buttons/src/BaseButton/props.ts
+++ b/packages/ui-buttons/src/BaseButton/props.ts
@@ -42,6 +42,7 @@ import type {
 } from '@instructure/shared-types'
 import type { Cursor } from '@instructure/ui-prop-types'
 import type { ViewProps } from '@instructure/ui-view'
+import { Renderable } from '@instructure/shared-types'
 
 type BaseButtonOwnProps = {
   /**
@@ -149,7 +150,7 @@ type BaseButtonOwnProps = {
   /**
    * An icon, or function that returns an icon.
    */
-  renderIcon?: React.ReactNode | (() => React.ReactNode)
+  renderIcon?: Renderable
 
   // Deprecated `string` tabIndex type
   /**

--- a/packages/ui-buttons/src/IconButton/props.ts
+++ b/packages/ui-buttons/src/IconButton/props.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import React, { ReactNode } from 'react'
 import PropTypes from 'prop-types'
 
 import { ThemeablePropTypes } from '@instructure/emotion'
@@ -33,7 +33,8 @@ import type {
   AsElementType,
   PropValidators,
   BaseButtonTheme,
-  OtherHTMLAttributes
+  OtherHTMLAttributes,
+  Renderable
 } from '@instructure/shared-types'
 import type { Cursor } from '@instructure/ui-prop-types'
 import type { ViewProps } from '@instructure/ui-view'
@@ -42,17 +43,17 @@ type IconButtonOwnProps = {
   /**
    * An icon, or function returning an icon (identical to the `renderIcon` prop).
    */
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 
   /**
    * An icon, or function that returns an icon (identical to the `children` prop).
    */
-  renderIcon?: React.ReactNode | (() => React.ReactNode)
+  renderIcon?: Renderable
 
   /**
    * An accessible label for the `IconButton`.
    */
-  screenReaderLabel: string
+  screenReaderLabel: ReactNode
 
   /**
    * Specifies the type of the `IconButton`'s underlying html element.

--- a/packages/ui-buttons/src/ToggleButton/props.ts
+++ b/packages/ui-buttons/src/ToggleButton/props.ts
@@ -38,6 +38,7 @@ import type {
   PositionMountNode
 } from '@instructure/ui-position'
 import type { ViewProps } from '@instructure/ui-view'
+import { Renderable } from '@instructure/shared-types'
 
 type ToggleButtonOwnProps = {
   /**
@@ -53,7 +54,7 @@ type ToggleButtonOwnProps = {
   /**
    * An icon or function that returns an icon
    */
-  renderIcon: React.ReactNode | (() => React.ReactNode)
+  renderIcon: Renderable
 
   /**
    * Toggles the `aria-pressed` attribute on the button (`true` if `pressed`; `false` if `unpressed`)

--- a/packages/ui-byline/package.json
+++ b/packages/ui-byline/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-calendar/package.json
+++ b/packages/ui-calendar/package.json
@@ -46,7 +46,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-calendar/src/Calendar/Day/props.ts
+++ b/packages/ui-calendar/src/Calendar/Day/props.ts
@@ -34,12 +34,13 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import { KeyboardEvent, MouseEvent } from 'react'
 import type { ViewProps } from '@instructure/ui-view'
+import { Renderable } from '@instructure/shared-types'
 
 type CalendarDayOwnProps = {
   /**
    * The rendered representation of the corresponding date.
    */
-  children?: React.ReactNode | ((...args: any[]) => React.ReactNode)
+  children?: Renderable
   /**
    * An ISO 8601 formatted string representing the date corresponding to
    * this `<Calendar.Day />`

--- a/packages/ui-calendar/src/Calendar/props.ts
+++ b/packages/ui-calendar/src/Calendar/props.ts
@@ -36,6 +36,7 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import React, { ReactElement } from 'react'
 import type { CalendarDayProps } from './Day/props'
+import { Renderable } from '@instructure/shared-types'
 
 type CalendarOwnProps = {
   /**
@@ -49,19 +50,19 @@ type CalendarOwnProps = {
    * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
    * `renderIcon` to [IconArrowOpenEnd](#iconography).
    */
-  renderNextMonthButton?: React.ReactNode | (() => React.ReactNode)
+  renderNextMonthButton?: Renderable
   /**
    * A button to render in the navigation header. The recommendation is to
    * compose it with the [IconButton](#Button) component by setting the `size`
    * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
    * `renderIcon` to [IconArrowOpenStart](#iconography).
    */
-  renderPrevMonthButton?: React.ReactNode | (() => React.ReactNode)
+  renderPrevMonthButton?: Renderable
   /**
    * Content to render in the navigation header. The recommendation is to include
    * the name of the current rendered month along with the year.
    */
-  renderNavigationLabel?: React.ReactNode | (() => React.ReactNode)
+  renderNavigationLabel?: Renderable
   /**
    * An array of labels containing the name of each day of the week. The visible
    * portion of the label should be abbreviated (no longer than three characters).
@@ -71,7 +72,7 @@ type CalendarOwnProps = {
    * full day name for assistive technologies and the children containing the
    * abbreviation. ex. `[<AccessibleContent alt="Sunday">Sun</AccessibleContent>, ...]`
    */
-  renderWeekdayLabels: (React.ReactNode | (() => React.ReactNode))[]
+  renderWeekdayLabels: Renderable[]
   /**
    * Callback fired when the next month button is clicked in the navigation
    * header, requesting to render the next month.

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -48,7 +48,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-code-editor/package.json
+++ b/packages/ui-code-editor/package.json
@@ -44,7 +44,7 @@
     "react-codemirror2": "^7.2.1"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-color-picker/package.json
+++ b/packages/ui-color-picker/package.json
@@ -53,7 +53,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-date-input/package.json
+++ b/packages/ui-date-input/package.json
@@ -44,7 +44,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -155,7 +155,7 @@ class DateInput extends Component<DateInputProps> {
   }
 
   renderDays(getOptionProps: SelectableRender['getOptionProps']) {
-    const children = this.props.children as ReactElement<CalendarDayProps>
+    const children = this.props.children as ReactElement<CalendarDayProps>[]
 
     return Children.map(children, (day) => {
       const { date, isOutsideMonth } = day.props

--- a/packages/ui-date-input/src/DateInput/props.ts
+++ b/packages/ui-date-input/src/DateInput/props.ts
@@ -35,6 +35,7 @@ import type { CalendarDayProps } from '@instructure/ui-calendar'
 import type { FormMessage } from '@instructure/ui-form-field'
 import type { PlacementPropValues } from '@instructure/ui-position'
 import type {
+  Renderable,
   OtherHTMLAttributes,
   PropValidators
 } from '@instructure/shared-types'
@@ -45,7 +46,7 @@ type DateInputOwnProps = {
   /**
    * Specifies the input label.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
   /**
    * Specifies the input value.
    */
@@ -181,14 +182,14 @@ type DateInputOwnProps = {
    * prop to `icon`, the `size` prop to `small`, and setting the `icon` prop to
    * [IconArrowOpenEnd](#iconography).
    */
-  renderNextMonthButton?: (() => React.ReactNode) | React.ReactNode
+  renderNextMonthButton?: Renderable
   /**
    * A button to render in the calendar navigation header. The recommendation is
    * to compose it with the [Button](#Button) component, setting the `variant`
    * prop to `icon`, the `size` prop to `small`, and setting the `icon` prop to
    * [IconArrowOpenStart](#iconography).
    */
-  renderPrevMonthButton?: (() => React.ReactNode) | React.ReactNode
+  renderPrevMonthButton?: Renderable
   /**
    * children of type `<DateInput.Day />` There should be exactly 42 provided (6
    * weeks).

--- a/packages/ui-date-time-input/package.json
+++ b/packages/ui-date-time-input/package.json
@@ -46,7 +46,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-date-time-input/src/DateTimeInput/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/props.ts
@@ -30,7 +30,7 @@ import { I18nPropTypes } from '@instructure/ui-i18n'
 import type { Moment } from '@instructure/ui-i18n'
 import PropTypes from 'prop-types'
 import { controllable } from '@instructure/ui-prop-types'
-import type { PropValidators } from '@instructure/shared-types'
+import type { PropValidators, Renderable } from '@instructure/shared-types'
 
 type DateTimeInputProps = {
   /**
@@ -40,7 +40,7 @@ type DateTimeInputProps = {
   /**
    * The label over the DateInput
    **/
-  dateRenderLabel: React.ReactNode | ((...args: any[]) => React.ReactNode)
+  dateRenderLabel: Renderable
   /**
    * The screen reader label for the calendar navigation header's prev month
    * button
@@ -69,7 +69,7 @@ type DateTimeInputProps = {
   /**
    * The label over the time input
    **/
-  timeRenderLabel: React.ReactNode | (() => React.ReactNode)
+  timeRenderLabel: Renderable
   /**
    * The number of minutes to increment by when generating the allowable time options.
    */

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-dom-utils/package.json
+++ b/packages/ui-dom-utils/package.json
@@ -31,8 +31,8 @@
     "@instructure/shared-types": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-drawer-layout/package.json
+++ b/packages/ui-drawer-layout/package.json
@@ -49,7 +49,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-drilldown/package.json
+++ b/packages/ui-drilldown/package.json
@@ -48,7 +48,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
@@ -32,9 +32,13 @@ import type {
   AsElementType
 } from '@instructure/shared-types'
 import type { WithStyleProps } from '@instructure/emotion'
-import type { OptionsItemProps } from '@instructure/ui-options'
+import type {
+  OptionsItemRenderProps,
+  OptionsItemProps
+} from '@instructure/ui-options'
 
 import Drilldown from '../index'
+import { Renderable } from '@instructure/shared-types'
 
 type DrilldownOptionValue = string | number | undefined
 
@@ -46,7 +50,7 @@ type RenderContentProps = {
   as: DrilldownOptionOwnProps['as']
   role: DrilldownOptionOwnProps['role']
   variant: DrilldownOptionVariant
-  vAlign: RenderContentVAlign
+  vAlign?: RenderContentVAlign
   isSelected: boolean
 }
 
@@ -99,27 +103,21 @@ type DrilldownOptionOwnProps = {
    *
    * If a function is provided, it has a `props` parameter.
    */
-  renderLabelInfo?:
-    | React.ReactNode
-    | ((props: RenderContentProps) => React.ReactNode)
+  renderLabelInfo?: Renderable<RenderContentProps>
 
   /**
    * Content to render before the label.
    *
    * If a function is provided, it has a `props` parameter.
    */
-  renderBeforeLabel?:
-    | React.ReactNode
-    | ((props: RenderContentProps) => React.ReactNode)
+  renderBeforeLabel?: Renderable<OptionsItemRenderProps>
 
   /**
    * Content to render after the label.
    *
    * If a function is provided, it has a `props` parameter.
    */
-  renderAfterLabel?:
-    | React.ReactNode
-    | ((props: RenderContentProps) => React.ReactNode)
+  renderAfterLabel?: Renderable<OptionsItemRenderProps>
 
   /**
    * Sets the vAlign of renderBeforeLabel content

--- a/packages/ui-drilldown/src/Drilldown/DrilldownPage/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownPage/props.ts
@@ -37,6 +37,7 @@ import DrilldownOption from '../DrilldownOption'
 import DrilldownSeparator from '../DrilldownSeparator'
 
 import type { OptionChild, SeparatorChild, GroupChild } from '../props'
+import { Renderable } from '@instructure/shared-types'
 
 type PageChildren = GroupChild | OptionChild | SeparatorChild
 
@@ -52,7 +53,7 @@ type DrilldownPageOwnProps = {
   /**
    * The title of the page displayed in the header
    */
-  renderTitle?: React.ReactNode | (() => React.ReactNode)
+  renderTitle?: Renderable
 
   /**
    * Label for the optional "action" option in the header (e.g.: "Select all")
@@ -66,8 +67,8 @@ type DrilldownPageOwnProps = {
    * is the title of the previous page.
    */
   renderBackButtonLabel?:
-  | React.ReactNode
-  | ((prevPageTitle?: React.ReactNode) => React.ReactNode)
+    | React.ReactNode
+    | ((prevPageTitle?: React.ReactNode) => React.ReactNode)
 
   /**
    * Callback fired when the "action" option is clicked in the header

--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -24,7 +24,7 @@
 
 /** @jsx jsx */
 /** @jsxFrag React.Fragment */
-import React, { Component, ReactElement } from 'react'
+import React, { Component, ReactElement, ReactNode } from 'react'
 
 import { warn, error } from '@instructure/console'
 import { testable } from '@instructure/ui-testable'
@@ -1129,7 +1129,10 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
 
     const optionLabel = callRenderProp(children, {
       id,
-      variant: optionProps.variant,
+      variant: optionProps.variant as Exclude<
+        OptionsItemProps['variant'],
+        'selected'
+      >,
       isSelected
     })
 
@@ -1142,7 +1145,10 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
     }
 
     const renderLabelProps = {
-      variant: optionProps.variant,
+      variant: optionProps.variant as Exclude<
+        OptionsItemProps['variant'],
+        'selected'
+      >,
       vAlign: afterLabelContentVAlign,
       as,
       role: optionProps.role,
@@ -1154,19 +1160,17 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
       typeof optionProps.renderBeforeLabel === 'function' &&
       !optionProps.renderBeforeLabel?.prototype?.isReactComponent
     ) {
-      optionProps.renderBeforeLabel = optionProps.renderBeforeLabel.bind(
-        null,
-        renderLabelProps
-      )
+      optionProps.renderBeforeLabel = (
+        optionProps.renderBeforeLabel as () => ReactNode
+      ).bind(null, renderLabelProps)
     }
     if (
       typeof optionProps.renderAfterLabel === 'function' &&
       !optionProps.renderAfterLabel?.prototype?.isReactComponent
     ) {
-      optionProps.renderAfterLabel = optionProps.renderAfterLabel.bind(
-        null,
-        renderLabelProps
-      )
+      optionProps.renderAfterLabel = (
+        optionProps.renderAfterLabel as () => ReactNode
+      ).bind(null, renderLabelProps)
     }
 
     const labelInfo =

--- a/packages/ui-editable/package.json
+++ b/packages/ui-editable/package.json
@@ -41,8 +41,8 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-editable/src/Editable/__tests__/Editable.test.tsx
+++ b/packages/ui-editable/src/Editable/__tests__/Editable.test.tsx
@@ -116,6 +116,9 @@ describe('<Editable />', async () => {
 
     const editable = within(subject.getDOMNode())
     await editable.mouseOver()
+    // We need to wait 1 frame in React 18 for the render() call to be executed
+    await new Promise((r) => setTimeout(r))
+
     props = (
       renderSpy.lastCall.args[0] as EditableRenderProps
     ).getEditButtonProps()
@@ -123,6 +126,8 @@ describe('<Editable />', async () => {
     expect(props.isVisible).to.be.true()
 
     await editable.mouseOut()
+    // We need to wait 1 frame in React 18 for the render() call to be executed
+    await new Promise((r) => setTimeout(r))
     props = (
       renderSpy.lastCall.args[0] as EditableRenderProps
     ).getEditButtonProps()

--- a/packages/ui-editable/src/Editable/props.ts
+++ b/packages/ui-editable/src/Editable/props.ts
@@ -28,10 +28,10 @@ import type { PropValidators } from '@instructure/shared-types'
 
 type GetContainerProps = (props?: Record<string, any>) => {
   ref: React.RefCallback<any>
-  onMouseOver: (event: React.MouseEvent) => void
-  onMouseOut: (event: React.MouseEvent) => void
-  onMouseDown?: (event: React.MouseEvent) => void
-  onKeyUp?: (event: React.KeyboardEvent) => void
+  onMouseOver: (event: React.MouseEvent<any>) => void
+  onMouseOut: (event: React.MouseEvent<any>) => void
+  onMouseDown?: (event: React.MouseEvent<any>) => void
+  onKeyUp?: (event: React.KeyboardEvent<any>) => void
   readOnly?: boolean
 } & Record<string, any>
 

--- a/packages/ui-expandable/package.json
+++ b/packages/ui-expandable/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -44,7 +44,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-file-drop/src/FileDrop/__tests__/FileDrop.test.tsx
+++ b/packages/ui-file-drop/src/FileDrop/__tests__/FileDrop.test.tsx
@@ -272,7 +272,7 @@ describe('<FileDrop />', async () => {
       type RenderLabelProps = {
         isDragAccepted: boolean
         isDragRejected: boolean
-        interaction: boolean
+        interaction?: string
       }
       let result: RenderLabelProps = {} as RenderLabelProps
       const label: FileDropProps['renderLabel'] = (props) => {
@@ -288,7 +288,7 @@ describe('<FileDrop />', async () => {
       type RenderLabelProps = {
         isDragAccepted: boolean
         isDragRejected: boolean
-        interaction: boolean
+        interaction?: string
       }
       let result: RenderLabelProps = {} as RenderLabelProps
       const label: FileDropProps['renderLabel'] = (props) => {

--- a/packages/ui-file-drop/src/FileDrop/props.ts
+++ b/packages/ui-file-drop/src/FileDrop/props.ts
@@ -39,10 +39,11 @@ import type {
   OtherHTMLAttributes
 } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 type RenderLabelProps = {
   isDragAccepted: boolean
   isDragRejected: boolean
-  interaction: boolean
+  interaction: FileDropOwnProps['interaction']
 }
 type FileDropOwnProps = {
   /**
@@ -53,7 +54,7 @@ type FileDropOwnProps = {
    * The content of FileDrop; can be a component or React node.
    * Components receive `isDragAccepted` and `isDragRejected` as props.
    */
-  renderLabel: ((props: RenderLabelProps) => React.ReactNode) | React.ReactNode
+  renderLabel: Renderable<RenderLabelProps>
   /**
    * The mime media type/s or file extension/s allowed to be dropped inside
    */

--- a/packages/ui-flex/package.json
+++ b/packages/ui-flex/package.json
@@ -37,7 +37,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-flex/src/Flex/index.tsx
+++ b/packages/ui-flex/src/Flex/index.tsx
@@ -88,7 +88,8 @@ class Flex extends Component<FlexProps> {
   }
 
   renderChildren(children: FlexProps['children']) {
-    return Children.map(children, (child) => {
+    // TODO this might fail if children are () => ReactNode
+    return Children.map(children as React.ReactNode, (child) => {
       if (!child) {
         return null
       }

--- a/packages/ui-flex/src/Flex/props.ts
+++ b/packages/ui-flex/src/Flex/props.ts
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import { ThemeablePropTypes } from '@instructure/emotion'
@@ -31,7 +30,8 @@ import type {
   AsElementType,
   PropValidators,
   FlexTheme,
-  OtherHTMLAttributes
+  OtherHTMLAttributes,
+  Renderable
 } from '@instructure/shared-types'
 import type {
   Spacing,
@@ -47,7 +47,7 @@ type FlexOwnProps = {
    * Note that if you do not use `Flex.Item`, the `withVisualDebug` and
    * `direction` props will not automatically be set on the children.
    */
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 
   /**
    * the element type to render as

--- a/packages/ui-focusable/package.json
+++ b/packages/ui-focusable/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-form-field/package.json
+++ b/packages/ui-form-field/package.json
@@ -42,7 +42,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-grid/package.json
+++ b/packages/ui-grid/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-heading/package.json
+++ b/packages/ui-heading/package.json
@@ -40,7 +40,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-i18n/package.json
+++ b/packages/ui-i18n/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-icons/package.json
+++ b/packages/ui-icons/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-img/package.json
+++ b/packages/ui-img/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-link/package.json
+++ b/packages/ui-link/package.json
@@ -45,7 +45,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-link/src/Link/__tests__/Link.test.tsx
+++ b/packages/ui-link/src/Link/__tests__/Link.test.tsx
@@ -22,12 +22,12 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { expect, mount, stub, within, wait } from '@instructure/ui-test-utils'
 import { Link } from '../index'
 import { LinkLocator } from '../LinkLocator'
 
-class TruncateText extends React.Component {
+class TruncateText extends React.Component<PropsWithChildren> {
   render() {
     return <span>{this.props.children}</span>
   }

--- a/packages/ui-link/src/Link/__tests__/Link.test.tsx
+++ b/packages/ui-link/src/Link/__tests__/Link.test.tsx
@@ -26,8 +26,8 @@ import React, { PropsWithChildren } from 'react'
 import { expect, mount, stub, within, wait } from '@instructure/ui-test-utils'
 import { Link } from '../index'
 import { LinkLocator } from '../LinkLocator'
-
-class TruncateText extends React.Component<PropsWithChildren> {
+// <unknown> is needed for React 17 compatibility
+class TruncateText extends React.Component<PropsWithChildren<unknown>> {
   render() {
     return <span>{this.props.children}</span>
   }

--- a/packages/ui-link/src/Link/props.ts
+++ b/packages/ui-link/src/Link/props.ts
@@ -40,6 +40,7 @@ import type {
   ComponentStyle
 } from '@instructure/emotion'
 import type { ViewOwnProps } from '@instructure/ui-view'
+import { Renderable } from '@instructure/shared-types'
 
 type LinkOwnProps = {
   /**
@@ -94,7 +95,7 @@ type LinkOwnProps = {
    * Add an SVG icon to the Link. Do not add icons directly as
    * children.
    */
-  renderIcon?: (() => React.ReactNode) | React.ReactNode
+  renderIcon?: Renderable
 
   /**
    * Place the icon before or after the text in the Link.

--- a/packages/ui-list/package.json
+++ b/packages/ui-list/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-list/src/InlineList/InlineListItem/props.ts
+++ b/packages/ui-list/src/InlineList/InlineListItem/props.ts
@@ -73,7 +73,7 @@ type InlineListItemOwnProps = {
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
-} & PropsWithChildren
+} & PropsWithChildren<unknown> // <unknown> is needed for React 17 compatibility
 
 type PropKeys = keyof InlineListItemOwnProps
 

--- a/packages/ui-list/src/InlineList/InlineListItem/props.ts
+++ b/packages/ui-list/src/InlineList/InlineListItem/props.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import { PropsWithChildren } from 'react'
 import PropTypes from 'prop-types'
 
 import { ThemeablePropTypes } from '@instructure/emotion'
@@ -39,7 +39,6 @@ import type {
 } from '@instructure/shared-types'
 
 type InlineListItemOwnProps = {
-  children: React.ReactNode | (() => React.ReactNode)
   /**
    * Inherits delimiter from the parent InlineList component
    */
@@ -74,7 +73,7 @@ type InlineListItemOwnProps = {
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
-}
+} & PropsWithChildren
 
 type PropKeys = keyof InlineListItemOwnProps
 

--- a/packages/ui-list/src/List/ListItem/props.ts
+++ b/packages/ui-list/src/List/ListItem/props.ts
@@ -73,7 +73,7 @@ type ListItemOwnProps = {
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
-} & PropsWithChildren
+} & PropsWithChildren<unknown> // <unknown> is needed for React 17 compatibility
 
 type PropKeys = keyof ListItemOwnProps
 

--- a/packages/ui-list/src/List/ListItem/props.ts
+++ b/packages/ui-list/src/List/ListItem/props.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import { PropsWithChildren } from 'react'
 import PropTypes from 'prop-types'
 
 import { ThemeablePropTypes } from '@instructure/emotion'
@@ -39,7 +39,6 @@ import type {
 } from '@instructure/shared-types'
 
 type ListItemOwnProps = {
-  children: React.ReactNode | (() => React.ReactNode)
   /**
    * Inherits delimiter from the parent List component.
    */
@@ -74,7 +73,7 @@ type ListItemOwnProps = {
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
-}
+} & PropsWithChildren
 
 type PropKeys = keyof ListItemOwnProps
 

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -48,7 +48,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 /** @jsx jsx */
-import React, { Component } from 'react'
+import React, { Component, MouseEventHandler } from 'react'
 import keycode from 'keycode'
 
 import { IconCheckSolid, IconArrowOpenEndSolid } from '@instructure/ui-icons'
@@ -43,6 +43,7 @@ import generateComponentTheme from './theme'
 
 import { propTypes, allowedProps } from './props'
 import type { MenuItemProps, MenuItemState } from './props'
+import type { ViewOwnProps } from '@instructure/ui-view'
 
 /**
 ---
@@ -115,7 +116,7 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
     }
   }
 
-  handleClick = (e: React.MouseEvent) => {
+  handleClick = (e: React.MouseEvent<ViewOwnProps>) => {
     const { onSelect, onClick, disabled, value } = this.props
     const selected = !this.selected
 
@@ -254,7 +255,7 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
               : 'false'
             : undefined
         }
-        onClick={this.handleClick}
+        onClick={this.handleClick as MouseEventHandler}
         onKeyUp={createChainedFunction(onKeyUp, this.handleKeyUp)}
         onKeyDown={createChainedFunction(onKeyDown, this.handleKeyDown)}
         ref={this.handleRef}

--- a/packages/ui-menu/src/Menu/MenuItem/props.ts
+++ b/packages/ui-menu/src/Menu/MenuItem/props.ts
@@ -35,9 +35,10 @@ import type {
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type { ViewOwnProps } from '@instructure/ui-view'
 
 type OnMenuItemSelect = (
-  e: React.MouseEvent,
+  e: React.MouseEvent<ViewOwnProps>,
   value: MenuItemOwnProps['value'],
   selected: MenuItemOwnProps['selected'],
   args: MenuItem
@@ -60,7 +61,7 @@ type MenuItemOwnProps = {
    * when used with the `selected` prop, the component will not control its own state
    */
   onSelect?: OnMenuItemSelect
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: (e: React.MouseEvent<ViewOwnProps>) => void
   onKeyDown?: (e: React.KeyboardEvent) => void
   onKeyUp?: (e: React.KeyboardEvent) => void
   onMouseOver?: (e: React.MouseEvent, args: MenuItem) => void
@@ -84,7 +85,8 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type MenuItemProps = MenuItemOwnProps &
   WithStyleProps<MenuItemTheme, MenuItemStyle> &
-  OtherHTMLAttributes<MenuItemOwnProps> & WithDeterministicIdProps
+  OtherHTMLAttributes<MenuItemOwnProps> &
+  WithDeterministicIdProps
 
 type MenuItemStyle = ComponentStyle<'menuItem' | 'icon' | 'label'>
 

--- a/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/index.tsx
@@ -45,6 +45,7 @@ import generateComponentTheme from './theme'
 
 import { propTypes, allowedProps } from './props'
 import type { MenuGroupProps, MenuGroupState } from './props'
+import type { ViewOwnProps } from '@instructure/ui-view'
 
 type MenuItemChild = React.ComponentElement<MenuItemProps, MenuItem>
 type MenuSeparatorChild = React.ComponentElement<
@@ -126,7 +127,7 @@ class MenuItemGroup extends Component<MenuGroupProps, MenuGroupState> {
   }
 
   updateSelected = (
-    e: React.MouseEvent,
+    e: React.MouseEvent<ViewOwnProps>,
     value: MenuItemProps['value'],
     items: MenuGroupState['selected'],
     selected: MenuItemProps['selected'],

--- a/packages/ui-menu/src/Menu/MenuItemGroup/props.ts
+++ b/packages/ui-menu/src/Menu/MenuItemGroup/props.ts
@@ -41,6 +41,7 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { MenuItemProps } from '../MenuItem/props'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type { ViewOwnProps } from '@instructure/ui-view'
 
 type MenuGroupOwnProps = {
   label: React.ReactNode
@@ -61,7 +62,7 @@ type MenuGroupOwnProps = {
    * call this function when a menu item is selected
    */
   onSelect?: (
-    e: React.MouseEvent,
+    e: React.MouseEvent<ViewOwnProps>,
     updated: MenuItemProps['value'][],
     selected: MenuItemProps['selected'],
     item: MenuItem

--- a/packages/ui-metric/package.json
+++ b/packages/ui-metric/package.json
@@ -40,7 +40,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-metric/src/Metric/props.ts
+++ b/packages/ui-metric/src/Metric/props.ts
@@ -22,20 +22,20 @@
  * SOFTWARE.
  */
 
-import { ReactNode } from 'react'
 import PropTypes from 'prop-types'
 
 import type {
   PropValidators,
   MetricTheme,
-  OtherHTMLAttributes
+  OtherHTMLAttributes,
+  Renderable
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type MetricOwnProps = {
   textAlign: 'start' | 'center' | 'end'
-  renderLabel?: ((props?: any) => ReactNode) | ReactNode
-  renderValue?: ((props?: any) => ReactNode) | ReactNode
+  renderLabel?: Renderable
+  renderValue?: Renderable
   /**
    * Set to true when a child of MetricGroup so the appropriate
    * aria labels get set

--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -40,7 +40,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "devDependencies": {
     "@instructure/ui-babel-preset": "8.26.3",

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-navigation/package.json
+++ b/packages/ui-navigation/package.json
@@ -51,7 +51,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-navigation/src/AppNav/Item/index.tsx
+++ b/packages/ui-navigation/src/AppNav/Item/index.tsx
@@ -35,6 +35,7 @@ import {
 import { testable } from '@instructure/ui-testable'
 
 import { View } from '@instructure/ui-view'
+import type { ViewOwnProps } from '@instructure/ui-view'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 import type { ScreenReaderContentProps } from '@instructure/ui-a11y-content'
 
@@ -88,7 +89,7 @@ class Item extends Component<AppNavItemProps> {
     }
   }
 
-  handleClick = (e: React.MouseEvent<Element>) => {
+  handleClick = (e: React.MouseEvent<ViewOwnProps, MouseEvent>) => {
     const { isDisabled, onClick } = this.props
 
     if (isDisabled) {

--- a/packages/ui-navigation/src/AppNav/Item/props.ts
+++ b/packages/ui-navigation/src/AppNav/Item/props.ts
@@ -32,21 +32,23 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { Cursor } from '@instructure/ui-prop-types'
 import React from 'react'
+import type { ViewOwnProps } from '@instructure/ui-view'
+import { Renderable } from '@instructure/shared-types'
 
 type AppNavItemOwnProps = {
   /**
    * The text to display. If the `icon` prop is used, label text must be wrapped
    * in `ScreenReaderContent`.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
   /**
    * Content to display after the renderLabel text, such as a badge
    */
-  renderAfter?: React.ReactNode | (() => React.ReactNode)
+  renderAfter?: Renderable
   /**
    * The visual to display (ex. an Image, Logo, Avatar, or Icon)
    */
-  renderIcon?: React.ReactNode | (() => React.ReactNode)
+  renderIcon?: Renderable
   /**
    * If the item goes to a new page, pass an href
    */
@@ -54,7 +56,7 @@ type AppNavItemOwnProps = {
   /**
    * If the item does not go to a new page, pass an onClick
    */
-  onClick?: (event: React.MouseEvent<Element>) => void
+  onClick?: (event: React.MouseEvent<ViewOwnProps>) => void
   /**
    * Denotes which item is currently selected
    */

--- a/packages/ui-navigation/src/AppNav/props.ts
+++ b/packages/ui-navigation/src/AppNav/props.ts
@@ -39,6 +39,7 @@ import type {
   AppNavTheme,
   OtherHTMLAttributes
 } from '@instructure/shared-types'
+import { Renderable } from '@instructure/shared-types'
 
 type AppNavOwnProps = {
   /**
@@ -53,12 +54,12 @@ type AppNavOwnProps = {
   /**
    * Content to display before the navigation items, such as a logo
    */
-  renderBeforeItems?: React.ReactNode | (() => React.ReactNode)
+  renderBeforeItems?: Renderable
   /**
    * Content to display after the navigation items, aligned to the far end
    * of the navigation
    */
-  renderAfterItems?: React.ReactNode | (() => React.ReactNode)
+  renderAfterItems?: Renderable
   /**
    * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
    * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
@@ -73,7 +74,7 @@ type AppNavOwnProps = {
    * Customize the text displayed in the menu trigger when links overflow
    * the overall nav width.
    */
-  renderTruncateLabel?: React.ReactNode | (() => React.ReactNode)
+  renderTruncateLabel?: Renderable
   /**
    * Called whenever the navigation items are updated or the size of
    * the navigation changes. Passes in the `visibleItemsCount` as

--- a/packages/ui-number-input/package.json
+++ b/packages/ui-number-input/package.json
@@ -42,7 +42,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-number-input/src/NumberInput/props.ts
+++ b/packages/ui-number-input/src/NumberInput/props.ts
@@ -34,16 +34,19 @@ import type {
   OtherHTMLAttributes,
   PickPropsWithExceptions
 } from '@instructure/shared-types'
-import type { InteractionType } from '@instructure/ui-react-utils'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { FormFieldOwnProps, FormMessage } from '@instructure/ui-form-field'
-import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type {
+  InteractionType,
+  WithDeterministicIdProps
+} from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type NumberInputOwnProps = {
   /**
    * The form field label.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
 
   /**
    * The id of the input. One is generated if not supplied.
@@ -179,13 +182,13 @@ type NumberInputProps =
     FormFieldOwnProps,
     'label' | 'inline' | 'id' | 'elementRef'
   > &
-  NumberInputOwnProps &
-  WithStyleProps<NumberInputTheme, NumberInputStyle> &
-  OtherHTMLAttributes<
-    NumberInputOwnProps,
-    InputHTMLAttributes<NumberInputOwnProps>
-  >
-  & WithDeterministicIdProps
+    NumberInputOwnProps &
+    WithStyleProps<NumberInputTheme, NumberInputStyle> &
+    OtherHTMLAttributes<
+      NumberInputOwnProps,
+      InputHTMLAttributes<NumberInputOwnProps>
+    > &
+    WithDeterministicIdProps
 
 type NumberInputStyle = ComponentStyle<
   | 'numberInput'

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -41,7 +41,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-options/src/Options/Item/props.ts
+++ b/packages/ui-options/src/Options/Item/props.ts
@@ -22,20 +22,20 @@
  * SOFTWARE.
  */
 
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import type {
   AsElementType,
   PropValidators,
   OptionsItemTheme,
-  OtherHTMLAttributes
+  OtherHTMLAttributes,
+  Renderable
 } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type OptionsItemRenderProps = {
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
   /**
    * Element type to render as. Will be set to `<a>` if href is provided.
    */
@@ -60,16 +60,12 @@ type OptionsItemOwnProps = OptionsItemRenderProps & {
    * Content to render before the label
    * (if you pass a function, it has the `props` as its parameter)
    */
-  renderBeforeLabel?:
-    | React.ReactNode
-    | ((props: OptionsItemRenderProps) => React.ReactNode)
+  renderBeforeLabel?: Renderable<OptionsItemRenderProps>
   /**
    * Content to render after the label
    * (if you pass a function, it has the `props` as its parameter)
    */
-  renderAfterLabel?:
-    | React.ReactNode
-    | ((props: OptionsItemRenderProps) => React.ReactNode)
+  renderAfterLabel?: Renderable<OptionsItemRenderProps>
   /**
    * Sets the vAlign of renderBeforeLabel content
    */
@@ -81,7 +77,7 @@ type OptionsItemOwnProps = OptionsItemRenderProps & {
   /**
    * Additional "secondary" description text
    */
-  description?: React.ReactNode | (() => React.ReactNode)
+  description?: Renderable
   /**
    * The ARIA role of the description element
    */

--- a/packages/ui-options/src/Options/Item/styles.ts
+++ b/packages/ui-options/src/Options/Item/styles.ts
@@ -26,6 +26,7 @@ import { matchComponentTypes } from '@instructure/ui-react-utils'
 
 import type { OptionsItemTheme } from '@instructure/shared-types'
 import type { OptionsItemProps, OptionsItemStyle } from './props'
+import { ReactNode } from 'react'
 
 /**
  * ---
@@ -49,8 +50,8 @@ const generateStyle = (
     beforeLabelContentVAlign,
     afterLabelContentVAlign
   } = props
-
-  const containsList = matchComponentTypes(children, ['Options'])
+  // TODO if children are () => ReactNode this wont match anything
+  const containsList = matchComponentTypes(children as ReactNode, ['Options'])
 
   // used for label and description too
   const variantVariants = {

--- a/packages/ui-options/src/Options/props.ts
+++ b/packages/ui-options/src/Options/props.ts
@@ -34,6 +34,7 @@ import type {
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type OptionsOwnProps = {
   /**
@@ -51,7 +52,7 @@ type OptionsOwnProps = {
   /**
    * Content to render as a label. Mostly for when the component is nested
    */
-  renderLabel?: React.ReactNode | (() => React.ReactNode)
+  renderLabel?: Renderable
 
   //TODO children has to be typed better
   //e.g.: ChildrenPropTypes.oneOf(['Options', 'Item', 'Separator']))

--- a/packages/ui-overlays/package.json
+++ b/packages/ui-overlays/package.json
@@ -55,7 +55,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-pages/package.json
+++ b/packages/ui-pages/package.json
@@ -41,7 +41,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-pagination/package.json
+++ b/packages/ui-pagination/package.json
@@ -50,7 +50,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -44,7 +44,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-popover/package.json
+++ b/packages/ui-popover/package.json
@@ -48,7 +48,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-popover/src/Popover/props.ts
+++ b/packages/ui-popover/src/Popover/props.ts
@@ -40,7 +40,8 @@ import type { BidirectionalProps } from '@instructure/ui-i18n'
 import type {
   PropValidators,
   LiveRegion,
-  UIElement
+  UIElement,
+  Renderable
 } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
@@ -257,12 +258,12 @@ type PopoverOwnProps = {
   /**
    * The element that triggers the popover
    */
-  renderTrigger?: React.ReactNode | (() => React.ReactNode)
+  renderTrigger?: Renderable
 
   /**
    * The content to be shown by the popover
    */
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 
   /**
    * Provides a reference to the underlying HTML root element
@@ -270,7 +271,9 @@ type PopoverOwnProps = {
   elementRef?: (element: Element | null) => void
 }
 
-type PopoverProps = PopoverOwnProps & BidirectionalProps & WithDeterministicIdProps
+type PopoverProps = PopoverOwnProps &
+  BidirectionalProps &
+  WithDeterministicIdProps
 
 type PopoverState = {
   placement: PopoverOwnProps['placement']

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -37,8 +37,8 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-position/package.json
+++ b/packages/ui-position/package.json
@@ -44,7 +44,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-position/src/Position/index.tsx
+++ b/packages/ui-position/src/Position/index.tsx
@@ -124,7 +124,7 @@ class Position extends Component<PositionProps, PositionState> {
     return (
       !deepEqual(this.state, nextState) ||
       !shallowEqual(this.props, nextProps) ||
-      !shallowEqual(this.context, nextContext)
+      !shallowEqual(this.context as any, nextContext)
     )
   }
 

--- a/packages/ui-position/src/Position/props.ts
+++ b/packages/ui-position/src/Position/props.ts
@@ -38,12 +38,13 @@ import type {
   ElementPosition
 } from '../PositionPropTypes'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type PositionOwnProps = {
   /**
    * The node to use as the position target
    */
-  renderTarget?: React.ReactNode | (() => React.ReactNode)
+  renderTarget?: Renderable
 
   /**
    * The target to be used when not using `renderTarget`
@@ -134,7 +135,8 @@ type PropKeys = keyof PositionOwnProps
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type PositionProps = PositionOwnProps &
-  WithStyleProps<PositionTheme, PositionStyle> & WithDeterministicIdProps
+  WithStyleProps<PositionTheme, PositionStyle> &
+  WithDeterministicIdProps
 
 const propTypes: PropValidators<PropKeys> = {
   renderTarget: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/packages/ui-progress/package.json
+++ b/packages/ui-progress/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-progress/src/ProgressBar/index.tsx
+++ b/packages/ui-progress/src/ProgressBar/index.tsx
@@ -106,7 +106,10 @@ class ProgressBar extends Component<ProgressBarProps> {
     // But leaving aria-valuetext because JAWS ignores aria-label
     const labelAndValueText = `${screenReaderLabel} ${valueText}`
 
-    const value = callRenderProp(renderValue, { valueNow, valueMax })
+    const value = callRenderProp(renderValue, {
+      valueNow: valueNow!,
+      valueMax: valueMax!
+    })
 
     /* eslint-disable jsx-a11y/no-redundant-roles, jsx-a11y/no-noninteractive-element-to-interactive-role */
     return (

--- a/packages/ui-progress/src/ProgressBar/props.ts
+++ b/packages/ui-progress/src/ProgressBar/props.ts
@@ -36,6 +36,7 @@ import type {
   ProgressBarTheme,
   OtherHTMLAttributes
 } from '@instructure/shared-types'
+import { Renderable } from '@instructure/shared-types'
 
 export type ProgressBarMeterColor =
   | 'info'
@@ -72,7 +73,7 @@ type ProgressBarOwnProps = {
    * A function to format the displayed value. If null the value will not display.
    * Takes `valueNow` and `valueMax` as parameters.
    */
-  renderValue?: ((values: Values) => React.ReactNode) | React.ReactNode
+  renderValue?: Renderable<Values>
   /**
    * Controls the overall color scheme of the component
    */

--- a/packages/ui-progress/src/ProgressCircle/index.tsx
+++ b/packages/ui-progress/src/ProgressCircle/index.tsx
@@ -139,7 +139,10 @@ class ProgressCircle extends Component<
     // But leaving aria-valuetext because JAWS ignores aria-label
     const labelAndValueText = `${screenReaderLabel} ${valueText}`
 
-    const value = callRenderProp(renderValue, { valueNow, valueMax })
+    const value = callRenderProp(renderValue, {
+      valueNow: valueNow!,
+      valueMax: valueMax!
+    })
 
     const style = {
       strokeDashoffset: `${styles?.dashOffset}em`

--- a/packages/ui-progress/src/ProgressCircle/props.ts
+++ b/packages/ui-progress/src/ProgressCircle/props.ts
@@ -33,7 +33,8 @@ import type {
   PropValidators,
   AsElementType,
   ProgressCircleTheme,
-  OtherHTMLAttributes
+  OtherHTMLAttributes,
+  Renderable
 } from '@instructure/shared-types'
 
 export type ProgressCircleMeterColor =
@@ -71,7 +72,7 @@ type ProgressCircleOwnProps = {
    * A function to format the displayed value. If null the value will not display.
    * Takes `valueNow` and `valueMax` as parameters.
    */
-  renderValue?: ((values: Values) => React.ReactNode) | React.ReactNode
+  renderValue?: Renderable<Values>
   /**
    * Controls the overall color scheme of the component
    */

--- a/packages/ui-prop-types/package.json
+++ b/packages/ui-prop-types/package.json
@@ -30,7 +30,7 @@
     "prop-types": ">= 15.7.0"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-radio-input/package.json
+++ b/packages/ui-radio-input/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-range-input/package.json
+++ b/packages/ui-range-input/package.json
@@ -46,7 +46,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-rating/package.json
+++ b/packages/ui-rating/package.json
@@ -43,7 +43,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-react-utils/package.json
+++ b/packages/ui-react-utils/package.json
@@ -37,8 +37,8 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-react-utils/src/__tests__/callRenderProp.test.tsx
+++ b/packages/ui-react-utils/src/__tests__/callRenderProp.test.tsx
@@ -108,7 +108,7 @@ describe('callRenderProp', async () => {
     })
 
     it('should pass props correctly to React classes', async () => {
-      type FooProps = { shape: 'circle' | 'rectangle' }
+      type FooProps = { shape?: string }
       class Foo extends React.Component<FooProps> {
         static propTypes = {
           shape: PropTypes.oneOf(['circle', 'rectangle'])

--- a/packages/ui-react-utils/src/callRenderProp.ts
+++ b/packages/ui-react-utils/src/callRenderProp.ts
@@ -22,17 +22,8 @@
  * SOFTWARE.
  */
 
-import React, {
-  ClassicComponent,
-  ClassicComponentClass,
-  ClassType,
-  ComponentClass,
-  ComponentState,
-  FunctionComponent,
-  ReactHTML,
-  ReactNode,
-  ReactSVG
-} from 'react'
+import React from 'react'
+import type { Renderable } from '@instructure/shared-types'
 
 /**
  * ---
@@ -43,21 +34,7 @@ import React, {
  * @param value
  * @param props
  */
-function callRenderProp<P>(
-  value:
-    | keyof ReactHTML
-    | keyof ReactSVG
-    | FunctionComponent<P>
-    | ClassType<
-        P,
-        ClassicComponent<P, ComponentState>,
-        ClassicComponentClass<P>
-      >
-    | ComponentClass<P>
-    | ReactNode
-    | (() => ReactNode),
-  props: P = {} as P
-) {
+function callRenderProp<P>(value: Renderable<P>, props: P = {} as P) {
   if (typeof value === 'function') {
     // In react 16, `createElement` accepts a function. In react 15 we get an
     // error on rendering the result. Evaluate the function here if it is not a

--- a/packages/ui-responsive/package.json
+++ b/packages/ui-responsive/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "eslint": "^7",
-    "react": ">=16.8 <=17",
+    "react": ">=16.8 <=18",
     "webpack": "^5"
   },
   "publishConfig": {

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -50,7 +50,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-select/src/Select/Group/props.ts
+++ b/packages/ui-select/src/Select/Group/props.ts
@@ -29,14 +29,15 @@ import { Option } from '../Option'
 
 import type {
   OtherHTMLAttributes,
-  PropValidators
+  PropValidators,
+  Renderable
 } from '@instructure/shared-types'
 
 type SelectGroupOwnProps = {
   /**
    * The label associated with the group options.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
   /**
    * Children of type `<SimpleSelect.Option />` that will be considered part of the group.
    */

--- a/packages/ui-select/src/Select/Option/props.ts
+++ b/packages/ui-select/src/Select/Option/props.ts
@@ -27,7 +27,8 @@ import PropTypes from 'prop-types'
 
 import type {
   OtherHTMLAttributes,
-  PropValidators
+  PropValidators,
+  Renderable
 } from '@instructure/shared-types'
 
 type OptionProps = {
@@ -53,9 +54,7 @@ type OptionProps = {
   children?: React.ReactNode
 }
 
-type RenderSelectOptionLabel =
-  | React.ReactNode
-  | ((args: OptionProps) => React.ReactNode)
+type RenderSelectOptionLabel = Renderable<OptionProps>
 
 type SelectOptionOwnProps = OptionProps & {
   /**

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -352,7 +352,7 @@ class Select extends Component<SelectProps> {
       | ((_args: OptionsItemRenderProps) => React.ReactNode) => {
       return typeof renderOptionLabel === 'function' &&
         !renderOptionLabel?.prototype?.isReactComponent
-        ? renderOptionLabel.bind(null, {
+        ? (renderOptionLabel as any).bind(null, {
             id,
             isDisabled,
             isSelected,

--- a/packages/ui-select/src/Select/props.ts
+++ b/packages/ui-select/src/Select/props.ts
@@ -159,7 +159,7 @@ type PropsFromTextInput = {
   /**
    * The form field label.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
 
   /**
    * The size of the text input.

--- a/packages/ui-select/src/Select/props.ts
+++ b/packages/ui-select/src/Select/props.ts
@@ -45,6 +45,7 @@ import type {
   PositionMountNode
 } from '@instructure/ui-position'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type SelectOwnProps = {
   /**
@@ -220,13 +221,13 @@ type PropsFromTextInput = {
    * Content to display before the text input. This will commonly be an icon or
    * tags to show multiple selections.
    */
-  renderBeforeInput?: React.ReactNode | (() => React.ReactNode)
+  renderBeforeInput?: Renderable
 
   /**
    * Content to display after the text input. This content will replace the
    * default arrow icons.
    */
-  renderAfterInput?: React.ReactNode | (() => React.ReactNode)
+  renderAfterInput?: Renderable
 
   /**
    * Prevents the default behavior of wrapping the input and rendered content
@@ -261,7 +262,8 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type SelectProps = SelectOwnProps &
   WithStyleProps<SelectTheme, SelectStyle> &
-  OtherHTMLAttributes<SelectOwnProps, InputHTMLAttributes<SelectOwnProps>> & WithDeterministicIdProps
+  OtherHTMLAttributes<SelectOwnProps, InputHTMLAttributes<SelectOwnProps>> &
+  WithDeterministicIdProps
 
 type SelectStyle = ComponentStyle<'select' | 'icon' | 'assistiveText'>
 

--- a/packages/ui-selectable/package.json
+++ b/packages/ui-selectable/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-simple-select/package.json
+++ b/packages/ui-simple-select/package.json
@@ -42,7 +42,7 @@
     "@instructure/ui-test-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-simple-select/src/SimpleSelect/Option/props.ts
+++ b/packages/ui-simple-select/src/SimpleSelect/Option/props.ts
@@ -29,18 +29,17 @@ import type {
   OtherHTMLAttributes,
   PropValidators
 } from '@instructure/shared-types'
+import { Renderable } from '@instructure/shared-types'
 
 type OptionProps = {
   id: SimpleSelectOptionOwnProps['id']
-  isDisabled: SimpleSelectOptionOwnProps['isDisabled']
-  isSelected: boolean
-  isHighlighted: boolean
-  children: SimpleSelectOptionOwnProps['children']
+  isDisabled?: SimpleSelectOptionOwnProps['isDisabled']
+  isSelected?: boolean
+  isHighlighted?: boolean
+  children?: React.ReactNode
 }
 
-type RenderSimpleSelectOptionLabel =
-  | React.ReactNode
-  | ((args: OptionProps) => React.ReactNode)
+type RenderSimpleSelectOptionLabel = Renderable<OptionProps>
 
 type SimpleSelectOptionOwnProps = {
   /**

--- a/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
@@ -38,8 +38,6 @@ import { SimpleSelect } from '../index'
 import { SimpleSelectLocator } from '../SimpleSelectLocator'
 import SimpleSelectExamples from '../__examples__/SimpleSelect.examples'
 
-import type { SimpleSelectOptionProps } from '../Option/props'
-
 type ExampleOption = 'foo' | 'bar' | 'baz'
 
 describe('<SimpleSelect />', async () => {
@@ -326,7 +324,7 @@ describe('<SimpleSelect />', async () => {
   })
 
   it('should render dynamically colored icons before option', async () => {
-    const renderBeforeLabel = (props: Partial<SimpleSelectOptionProps>) => {
+    const renderBeforeLabel = (props: any) => {
       return <IconCheckSolid color={props.isDisabled ? 'warning' : 'brand'} />
     }
 

--- a/packages/ui-simple-select/src/SimpleSelect/index.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/index.tsx
@@ -345,7 +345,7 @@ class SimpleSelect extends Component<SimpleSelectProps, SimpleSelectState> {
     const getRenderLabel = (renderLabel: RenderSimpleSelectOptionLabel) => {
       return typeof renderLabel === 'function' &&
         !renderLabel?.prototype?.isReactComponent
-        ? renderLabel.bind(null, {
+        ? (renderLabel as any).bind(null, {
             id,
             isDisabled,
             isSelected,

--- a/packages/ui-simple-select/src/SimpleSelect/props.ts
+++ b/packages/ui-simple-select/src/SimpleSelect/props.ts
@@ -45,6 +45,7 @@ import type {
 } from '@instructure/ui-position'
 import type { SelectOwnProps } from '@instructure/ui-select'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type SimpleSelectOwnProps = PropsPassedToSelect & {
   /**
@@ -84,7 +85,7 @@ type SimpleSelectOwnProps = PropsPassedToSelect & {
   /**
    * Content to display in the list when no options are available.
    */
-  renderEmptyOption?: React.ReactNode | (() => React.ReactNode)
+  renderEmptyOption?: Renderable
 
   /**
    * Children of type `<SimpleSelect.Option />` or `<SimpleSelect.Group />`.
@@ -200,13 +201,13 @@ type PropsPassedToSelect = {
   /**
    * Content to display before the text input. This will commonly be an icon.
    */
-  renderBeforeInput?: React.ReactNode | (() => React.ReactNode)
+  renderBeforeInput?: Renderable
 
   /**
    * Content to display after the text input. This content will replace the
    * default arrow icons.
    */
-  renderAfterInput?: React.ReactNode | (() => React.ReactNode)
+  renderAfterInput?: Renderable
 
   /**
    * Callback fired when text input receives focus.
@@ -238,7 +239,8 @@ type SimpleSelectProps = PickPropsWithExceptions<
   OtherHTMLAttributes<
     SimpleSelectOwnProps,
     InputHTMLAttributes<SimpleSelectOwnProps>
-  > & WithDeterministicIdProps
+  > &
+  WithDeterministicIdProps
 
 type SimpleSelectState = {
   inputValue?: string

--- a/packages/ui-simple-select/src/SimpleSelect/props.ts
+++ b/packages/ui-simple-select/src/SimpleSelect/props.ts
@@ -97,7 +97,7 @@ type PropsPassedToSelect = {
   /**
    * The form field label.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
 
   /**
    * The id of the text input. One is generated if not supplied.

--- a/packages/ui-source-code-editor/package.json
+++ b/packages/ui-source-code-editor/package.json
@@ -59,7 +59,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -42,7 +42,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-spinner/src/Spinner/props.ts
+++ b/packages/ui-spinner/src/Spinner/props.ts
@@ -37,12 +37,13 @@ import type {
   SpinnerTheme
 } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type SpinnerOwnProps = {
   /**
    * Give the spinner a title to be read by screenreaders
    */
-  renderTitle?: (() => React.ReactNode) | React.ReactNode
+  renderTitle?: Renderable
   /**
    * Different-sized spinners
    */
@@ -70,7 +71,8 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type SpinnerProps = SpinnerOwnProps &
   WithStyleProps<SpinnerTheme, SpinnerStyle> &
-  OtherHTMLAttributes<SpinnerOwnProps> & WithDeterministicIdProps
+  OtherHTMLAttributes<SpinnerOwnProps> &
+  WithDeterministicIdProps
 
 type SpinnerStyle = ComponentStyle<
   'spinner' | 'circle' | 'circleTrack' | 'circleSpin'

--- a/packages/ui-svg-images/package.json
+++ b/packages/ui-svg-images/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -44,7 +44,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-table/src/Table/Cell/props.ts
+++ b/packages/ui-table/src/Table/Cell/props.ts
@@ -22,24 +22,24 @@
  * SOFTWARE.
  */
 
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type {
   OtherHTMLAttributes,
   PropValidators,
+  Renderable,
   TableCellTheme
 } from '@instructure/shared-types'
 
 type TableCellOwnProps = {
   isStacked?: boolean
-  header?: React.ReactNode | (() => React.ReactNode)
+  header?: Renderable
   /**
    * Control the text alignment in cell
    */
   textAlign?: 'start' | 'center' | 'end'
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 }
 
 type PropKeys = keyof TableCellOwnProps

--- a/packages/ui-table/src/Table/ColHeader/index.tsx
+++ b/packages/ui-table/src/Table/ColHeader/index.tsx
@@ -86,7 +86,7 @@ class ColHeader extends Component<TableColHeaderProps> {
     if (onRequestSort) {
       return <IconMiniArrowDoubleLine css={{ opacity: '30%' }} />
     }
-    return null
+    return undefined
   }
 
   render() {

--- a/packages/ui-table/src/Table/ColHeader/props.ts
+++ b/packages/ui-table/src/Table/ColHeader/props.ts
@@ -66,7 +66,7 @@ type TableColHeaderOwnProps = {
    * The column header scope attribute. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope
    */
   scope?: 'row' | 'col' | 'rowgroup' | 'colgroup' | 'auto'
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: React.ReactNode
 }
 
 type PropKeys = keyof TableColHeaderOwnProps

--- a/packages/ui-table/src/Table/Head/props.ts
+++ b/packages/ui-table/src/Table/Head/props.ts
@@ -32,13 +32,14 @@ import { Row } from '../Row'
 import type {
   OtherHTMLAttributes,
   PropValidators,
+  Renderable,
   TableHeadTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableHeadOwnProps = {
   isStacked?: boolean
-  renderSortLabel?: React.ReactNode | (() => React.ReactNode)
+  renderSortLabel?: Renderable
   /**
    * `Table.Row`
    */

--- a/packages/ui-table/src/Table/RowHeader/props.ts
+++ b/packages/ui-table/src/Table/RowHeader/props.ts
@@ -22,12 +22,12 @@
  * SOFTWARE.
  */
 
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import type {
   OtherHTMLAttributes,
   PropValidators,
+  Renderable,
   TableRowHeaderTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
@@ -38,7 +38,7 @@ type TableRowHeaderOwnProps = {
    * Control the text alignment in row header
    */
   textAlign?: 'start' | 'center' | 'end'
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 }
 
 type PropKeys = keyof TableRowHeaderOwnProps

--- a/packages/ui-tabs/package.json
+++ b/packages/ui-tabs/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-tabs/src/Tabs/Tab/props.ts
+++ b/packages/ui-tabs/src/Tabs/Tab/props.ts
@@ -28,6 +28,7 @@ import PropTypes from 'prop-types'
 import type {
   OtherHTMLAttributes,
   PropValidators,
+  Renderable,
   TabsTabTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
@@ -48,7 +49,7 @@ type TabsTabOwnProps = {
     event: React.KeyboardEvent<ViewOwnProps>,
     tabData: { index: number; id: string }
   ) => void
-  children?: React.ReactNode | (() => React.ReactNode)
+  children?: Renderable
 }
 
 type PropKeys = keyof TabsTabOwnProps

--- a/packages/ui-tabs/src/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/ui-tabs/src/Tabs/__tests__/Tabs.test.tsx
@@ -110,7 +110,8 @@ describe('<Tabs />', async () => {
 
     const verifyChildKeys = ({ children }: TabsProps) => {
       const childrenArray = Array.isArray(children) ? children : [children]
-      childrenArray.forEach((child) => {
+      childrenArray.forEach((child: any) => {
+        // "any" is needed for React 16 compat
         expect(child.props.renderTitle).to.equal(child.key)
       })
     }

--- a/packages/ui-tag/package.json
+++ b/packages/ui-tag/package.json
@@ -42,7 +42,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-test-sandbox/package.json
+++ b/packages/ui-test-sandbox/package.json
@@ -32,8 +32,8 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-test-sandbox/src/utils/reactComponentWrapper.tsx
+++ b/packages/ui-test-sandbox/src/utils/reactComponentWrapper.tsx
@@ -25,15 +25,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 const createRoot = async () => {
-  try {
-    return await import('react-dom/client')
-  } catch (e) {
-    // swallow error, createRoot was added in React 18
-    return undefined
-  }
+  // eslint-disable-next-line import/no-unresolved
+  return await import('react-dom/client')
 }
 import PropTypes from 'prop-types'
-import { Root } from 'react-dom/client'
+
+// copied from React 18's source
+interface Root {
+  render(children: React.ReactNode): void
+  unmount(): void
+}
 
 interface WrapperProp extends React.ComponentProps<React.ElementType> {
   Component: React.ElementType

--- a/packages/ui-test-utils/package.json
+++ b/packages/ui-test-utils/package.json
@@ -45,8 +45,8 @@
     "wait-for-expect": "^3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-testable/package.json
+++ b/packages/ui-testable/package.json
@@ -32,8 +32,8 @@
     "@instructure/ui-dom-utils": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-text-area/package.json
+++ b/packages/ui-text-area/package.json
@@ -44,7 +44,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-text-input/package.json
+++ b/packages/ui-text-input/package.json
@@ -43,7 +43,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-text-input/src/TextInput/props.ts
+++ b/packages/ui-text-input/src/TextInput/props.ts
@@ -28,7 +28,6 @@ import PropTypes from 'prop-types'
 import { FormPropTypes } from '@instructure/ui-form-field'
 import { controllable } from '@instructure/ui-prop-types'
 
-import type { InteractionType } from '@instructure/ui-react-utils'
 import type { FormFieldProps, FormMessage } from '@instructure/ui-form-field'
 import type {
   OtherHTMLAttributes,
@@ -36,13 +35,17 @@ import type {
   TextInputTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
-import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type {
+  InteractionType,
+  WithDeterministicIdProps
+} from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type TextInputOwnProps = {
   /**
    * The form field label.
    */
-  renderLabel?: React.ReactNode | (() => React.ReactNode)
+  renderLabel?: Renderable
 
   /**
    * Determines the underlying native HTML `<input>` element's `type`.
@@ -146,12 +149,12 @@ type TextInputOwnProps = {
   /**
    * Content to display before the input text, such as an icon
    */
-  renderBeforeInput?: React.ReactNode | (() => React.ReactNode)
+  renderBeforeInput?: Renderable
 
   /**
    * Content to display after the input text, such as an icon
    */
-  renderAfterInput?: React.ReactNode | (() => React.ReactNode)
+  renderAfterInput?: Renderable
 
   /**
    * Callback executed when the input fires a change event.

--- a/packages/ui-text/package.json
+++ b/packages/ui-text/package.json
@@ -37,7 +37,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-time-select/package.json
+++ b/packages/ui-time-select/package.json
@@ -41,7 +41,7 @@
     "moment-timezone": "^0.5.33"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -57,7 +57,7 @@ type TimeSelectOwnProps = {
   /**
    * The form field label.
    */
-  renderLabel: React.ReactNode | (() => React.ReactNode)
+  renderLabel: Renderable
   /**
    * Whether to default to the first option when `defaultValue` hasn't been specified.
    */
@@ -174,12 +174,12 @@ type TimeSelectOwnProps = {
   /**
    * Content to display before the text input. This will commonly be an icon.
    */
-  renderBeforeInput?: React.ReactNode | (() => React.ReactNode)
+  renderBeforeInput?: Renderable
   /**
    * Content to display after the text input. This content will replace the
    * default arrow icons.
    */
-  renderAfterInput?: React.ReactNode | (() => React.ReactNode)
+  renderAfterInput?: Renderable
   /**
    * A standard language identifier.
    *

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -40,6 +40,7 @@ import type {
   PositionConstraint
 } from '@instructure/ui-position'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type PropKeys = keyof TimeSelectOwnProps
 
@@ -49,8 +50,8 @@ type TimeSelectProps = TimeSelectOwnProps &
   OtherHTMLAttributes<
     TimeSelectOwnProps,
     InputHTMLAttributes<TimeSelectOwnProps>
-  >
-  & WithDeterministicIdProps
+  > &
+  WithDeterministicIdProps
 
 type TimeSelectOwnProps = {
   /**
@@ -169,7 +170,7 @@ type TimeSelectOwnProps = {
   /**
    * Content to display in the list when no options are available.
    */
-  renderEmptyOption?: React.ReactNode | (() => React.ReactNode)
+  renderEmptyOption?: Renderable
   /**
    * Content to display before the text input. This will commonly be an icon.
    */

--- a/packages/ui-toggle-details/package.json
+++ b/packages/ui-toggle-details/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-toggle-details/src/ToggleGroup/props.ts
+++ b/packages/ui-toggle-details/src/ToggleGroup/props.ts
@@ -30,7 +30,8 @@ import { controllable } from '@instructure/ui-prop-types'
 import {
   AsElementType,
   OtherHTMLAttributes,
-  PropValidators
+  PropValidators,
+  Renderable
 } from '@instructure/shared-types'
 
 type ToggleGroupOwnProps = {
@@ -71,11 +72,11 @@ type ToggleGroupOwnProps = {
   /**
    * The icon displayed in the toggle button when the content is hidden
    */
-  icon?: React.ReactNode | ((...args: any[]) => React.ReactElement)
+  icon?: Renderable
   /**
    * The icon displayed in the toggle button when the content is showing
    */
-  iconExpanded?: React.ReactNode | ((...args: any[]) => React.ReactElement)
+  iconExpanded?: Renderable
   /**
    * Transition content into view
    */

--- a/packages/ui-tooltip/package.json
+++ b/packages/ui-tooltip/package.json
@@ -43,7 +43,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component } from 'react'
+import { Component, ReactNode } from 'react'
 
 import {
   getElementType,
@@ -116,7 +116,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
       const props = omitProps(this.props, Tooltip.allowedProps)
       return (
         <Trigger {...props} {...triggerProps}>
-          {children}
+          {
+            children as ReactNode /*TODO check if it can be TooltipRenderChildren, this might cause a crash*/
+          }
         </Trigger>
       )
     } else if (typeof children === 'function') {

--- a/packages/ui-tooltip/src/Tooltip/props.ts
+++ b/packages/ui-tooltip/src/Tooltip/props.ts
@@ -42,6 +42,7 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { PopoverOwnProps } from '@instructure/ui-popover'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import { Renderable } from '@instructure/shared-types'
 
 type TooltipRenderChildrenArgs = {
   focused: boolean
@@ -70,7 +71,7 @@ type TooltipOwnProps = {
   /**
    * The content to render in the tooltip
    */
-  renderTip: React.ReactNode | (() => React.ReactNode)
+  renderTip: Renderable
 
   /**
    * Whether or not the tooltip content is shown, when controlled
@@ -163,6 +164,7 @@ type PropsPassableToPopover = Omit<
   | 'shouldReturnFocus'
   | 'placement'
   | 'color'
+  | 'children'
   | 'mountNode'
   | 'constrain'
   | 'shadow'

--- a/packages/ui-tray/package.json
+++ b/packages/ui-tray/package.json
@@ -45,7 +45,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -43,7 +43,7 @@
     "prop-types": "^15"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-tree-browser/src/TreeBrowser/props.ts
+++ b/packages/ui-tree-browser/src/TreeBrowser/props.ts
@@ -33,6 +33,7 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import React, { ReactElement } from 'react'
 import type { TreeBrowserButtonProps } from './TreeButton/props'
+import { Renderable } from '@instructure/shared-types'
 
 type TreeBrowserOwnProps = {
   /**
@@ -107,11 +108,9 @@ type TreeBrowserBaseProps = {
 type TreeBrowserCommonProps = {
   size?: 'small' | 'medium' | 'large'
   variant?: 'folderTree' | 'indent'
-  collectionIcon?: React.ReactNode | ((props: unknown) => React.ReactNode)
-  collectionIconExpanded?:
-    | React.ReactNode
-    | ((props: unknown) => React.ReactNode)
-  itemIcon?: React.ReactNode | ((props: unknown) => React.ReactNode)
+  collectionIcon?: Renderable
+  collectionIconExpanded?: Renderable
+  itemIcon?: Renderable
   renderContent?: (props: TreeBrowserButtonProps) => JSX.Element
 }
 

--- a/packages/ui-truncate-text/package.json
+++ b/packages/ui-truncate-text/package.json
@@ -44,7 +44,7 @@
     "@types/escape-html": "^1"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -36,8 +36,8 @@
     "keycode": "^2"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17",
-    "react-dom": ">=16.8 <=17"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-view/package.json
+++ b/packages/ui-view/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-themes": "8.26.3"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=17"
+    "react": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -107,6 +107,6 @@
   "sideEffects": false,
   "peerDependencies": {
     "react": ">= 16.8 <=17",
-    "react-dom": ">= 16.8 <= 17"
+    "react-dom": ">= 16.8 <= 18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8644,13 +8644,13 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:^18":
-  version: 18.0.14
-  resolution: "@types/react@npm:18.0.14"
+  version: 18.0.15
+  resolution: "@types/react@npm:18.0.15"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 608eb57a383eedc54c79949673e5e8314f6b0c61542bff58721c8c47a18c23e2832e77c656050c2c2c004b62cf25582136c7c56fe1b6263a285c065fae31dbcf
+  checksum: e22cc388d1c145aa184787e44dc28db4789976c704cd5db475c170bb76a560eb81def5f346cfe750949bb3d43ad88822b8cbb9f19b1286e3795892a8263e7715
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,7 @@ __metadata:
     "@types/babel-plugin-macros": ^2.8.4
     babel-plugin-macros: ^3
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2345,7 +2345,7 @@ __metadata:
     lodash: ^4
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2412,7 +2412,8 @@ __metadata:
   resolution: "@instructure/shared-types@workspace:packages/shared-types"
   dependencies:
     prop-types: ^15
-    react: ^17.0.0
+  peerDependencies:
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2429,8 +2430,8 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     "@instructure/ui-view": 8.26.3
     html-webpack-plugin: ^4
-    react: ^17.0.0
-    react-dom: ^17.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -2449,7 +2450,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2495,7 +2496,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2516,7 +2517,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2543,8 +2544,8 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2567,7 +2568,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2633,7 +2634,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2655,7 +2656,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2680,7 +2681,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2711,7 +2712,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2731,7 +2732,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2758,7 +2759,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2788,7 +2789,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2814,7 +2815,7 @@ __metadata:
     prop-types: ^15
     react-codemirror2: ^7.2.1
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2863,7 +2864,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2901,7 +2902,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2929,7 +2930,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2958,7 +2959,7 @@ __metadata:
     "@instructure/ui-testable": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -2972,8 +2973,8 @@ __metadata:
     "@instructure/ui-babel-preset": 8.26.3
     "@instructure/ui-test-utils": 8.26.3
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3004,7 +3005,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3034,7 +3035,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3057,8 +3058,8 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3099,7 +3100,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3125,7 +3126,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3144,7 +3145,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3162,7 +3163,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3186,7 +3187,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3209,7 +3210,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3231,7 +3232,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3253,7 +3254,7 @@ __metadata:
     moment-timezone: ^0.5
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3294,7 +3295,7 @@ __metadata:
     gulp: ^4.0.2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3315,7 +3316,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3369,7 +3370,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3392,7 +3393,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3422,7 +3423,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3444,7 +3445,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3474,7 +3475,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3495,7 +3496,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3528,7 +3529,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3552,7 +3553,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3575,7 +3576,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3612,7 +3613,7 @@ __metadata:
     no-scroll: ^2.1.0
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3635,7 +3636,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3667,7 +3668,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3693,7 +3694,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3723,7 +3724,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3742,8 +3743,8 @@ __metadata:
     "@instructure/ui-test-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3769,7 +3770,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3792,7 +3793,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3805,7 +3806,7 @@ __metadata:
     "@instructure/ui-test-utils": 8.26.3
     prop-types: ">= 15.7.0"
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3828,7 +3829,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3856,7 +3857,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3881,7 +3882,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3901,8 +3902,8 @@ __metadata:
     hoist-non-react-statics: ^3.3.2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3923,7 +3924,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -3963,7 +3964,7 @@ __metadata:
     yargs: ^16
   peerDependencies:
     eslint: ^7
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
     webpack: ^5
   dependenciesMeta:
     "@storybook/react":
@@ -4003,7 +4004,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4023,7 +4024,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4047,7 +4048,7 @@ __metadata:
     "@instructure/ui-testable": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4088,7 +4089,7 @@ __metadata:
     lodash: ^4
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4112,7 +4113,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4143,7 +4144,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4169,7 +4170,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4200,7 +4201,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4224,7 +4225,7 @@ __metadata:
     "@instructure/ui-view": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4279,8 +4280,8 @@ __metadata:
     prop-types: ^15
     sinon: ^13
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4308,8 +4309,8 @@ __metadata:
     sinon-chai: ^3
     wait-for-expect: ^3
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4324,8 +4325,8 @@ __metadata:
     "@instructure/ui-test-utils": 8.26.3
     prop-types: ^15.6.2
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4351,7 +4352,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4376,7 +4377,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4395,7 +4396,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4444,7 +4445,7 @@ __metadata:
     moment-timezone: ^0.5.33
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4475,7 +4476,7 @@ __metadata:
     "@instructure/uid": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4518,7 +4519,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4545,7 +4546,7 @@ __metadata:
     "@instructure/ui-utils": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4570,7 +4571,7 @@ __metadata:
     keycode: ^2
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4596,7 +4597,7 @@ __metadata:
     escape-html: ^1
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4615,8 +4616,8 @@ __metadata:
     json-stable-stringify: ^1.0.1
     keycode: ^2
   peerDependencies:
-    react: ">=16.8 <=17"
-    react-dom: ">=16.8 <=17"
+    react: ">=16.8 <=18"
+    react-dom: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4639,7 +4640,7 @@ __metadata:
     "@instructure/ui-themes": 8.26.3
     prop-types: ^15
   peerDependencies:
-    react: ">=16.8 <=17"
+    react: ">=16.8 <=18"
   languageName: unknown
   linkType: soft
 
@@ -4740,7 +4741,7 @@ __metadata:
     jest: ^24.9.0
   peerDependencies:
     react: ">= 16.8 <=17"
-    react-dom: ">= 16.8 <= 17"
+    react-dom: ">= 16.8 <= 18"
   languageName: unknown
   linkType: soft
 
@@ -8624,12 +8625,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^17.0.17":
-  version: 17.0.17
-  resolution: "@types/react-dom@npm:17.0.17"
+"@types/react-dom@npm:^18":
+  version: 18.0.5
+  resolution: "@types/react-dom@npm:18.0.5"
   dependencies:
-    "@types/react": ^17
-  checksum: 23caf98aa03e968811560f92a2c8f451694253ebe16b670929b24eaf0e7fa62ba549abe9db0ac028a9d8a9086acd6ab9c6c773f163fa21224845edbc00ba6232
+    "@types/react": "*"
+  checksum: cd48b81950f499b52a3f0c08261f00046f9b7c96699fa249c9664e257e820daf6ecac815cd1028cebc9d105094adc39d047d1efd79214394b8b2d515574c0787
   languageName: node
   linkType: hard
 
@@ -8642,14 +8643,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^17":
-  version: 17.0.45
-  resolution: "@types/react@npm:17.0.45"
+"@types/react@npm:^18":
+  version: 18.0.14
+  resolution: "@types/react@npm:18.0.14"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 3cc13a02824c13f6fa4807a83abd065ac1d9943359e76bd995cc7cd2b4148c1176ebd54a30a9f4eb8a0f141ff359d712876f256c4fee707e4290607ef8410b3e
+  checksum: 608eb57a383eedc54c79949673e5e8314f6b0c61542bff58721c8c47a18c23e2832e77c656050c2c2c004b62cf25582136c7c56fe1b6263a285c065fae31dbcf
   languageName: node
   linkType: hard
 
@@ -15123,9 +15124,9 @@ __metadata:
     moment: ^2.23.0
     prop-types: ^15
     raw-loader: ^4
-    react: ^17.0.0
+    react: ^18
     react-docgen: 6.0.0-alpha.0
-    react-dom: ^17.0.0
+    react-dom: ^18
     react-github-corner: ^2.1.0
     semver: ^7.3.5
     svg-inline-loader: ^0.8.0
@@ -15158,9 +15159,9 @@ __metadata:
     chromatic: ^6
     globby: ^11
     prop-types: ^15
-    react: ^17.0.0
+    react: ^18
     react-docgen: ^6.0.0-alpha.0
-    react-dom: ^17.0.0
+    react-dom: ^18
     story2sketch: ^1
     webpack: ^5
     webpack-merge: ^5
@@ -20475,7 +20476,7 @@ __metadata:
     "@babel/cli": ^7.17.3
     "@instructure/ui-scripts": "workspace:*"
     "@instructure/ui-token-scripts": "workspace:*"
-    "@types/react-dom": ^17.0.17
+    "@types/react-dom": ^18
     chalk: ^4
     commitizen: ^4
     danger: ^11
@@ -28661,16 +28662,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.0":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:^18":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    scheduler: "npm:^0.20.2"
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -28733,13 +28733,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^17.0.0":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:^18":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+    loose-envify: ^1.1.0
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -30073,13 +30072,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+    loose-envify: ^1.1.0
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Note that it's still not running sometimes in parallel mode because we're still using `ReactDOM.render` in a few places (e.g. Alert)

To test:
Set React's version to 17 in the main package JSON's `resolutions` field and run some tests