### PR TITLE
chore(ui-drilldown,ui-tabs): modify lines that throw errors in React 16

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -754,6 +754,9 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
   ) => {
     const selectedOption = this.getPageChildById(id)
 
+    // TODO: this line can be removed when React 16 is no longer supported
+    event.persist()
+
     if (
       !id ||
       !selectedOption ||

--- a/packages/ui-tabs/src/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/ui-tabs/src/Tabs/__tests__/Tabs.test.tsx
@@ -25,8 +25,10 @@
 import React from 'react'
 import { expect, mount, stub, wait } from '@instructure/ui-test-utils'
 
-import { Tabs } from '../index'
 import { TabsLocator } from '../TabsLocator'
+import { Panel } from '../Panel'
+import type { TabsPanelProps } from '../Panel/props'
+import { Tabs } from '../index'
 import type { TabsProps } from '../props'
 
 describe('<Tabs />', async () => {
@@ -109,9 +111,10 @@ describe('<Tabs />', async () => {
     )
 
     const verifyChildKeys = ({ children }: TabsProps) => {
-      const childrenArray = Array.isArray(children) ? children : [children]
-      childrenArray.forEach((child: any) => {
-        // "any" is needed for React 16 compat
+      const childrenArray = (
+        Array.isArray(children) ? children : [children]
+      ) as React.ComponentElement<TabsPanelProps, Panel>[]
+      childrenArray.forEach((child) => {
         expect(child.props.renderTitle).to.equal(child.key)
       })
     }


### PR DESCRIPTION
Closes: INSTUI-3567

Note: when testing, a lot of tests will break on React 16 (`focusIn`, `focusOut` and `calledWithMatch` is not working), but fixing those would break the React 17 tests.