### PR TITLE
fix(ui-date-input,ui-select,ui-text-input): before/after elements should inherit input color

### DIFF
--- a/packages/ui-text-input/src/TextInput/styles.ts
+++ b/packages/ui-text-input/src/TextInput/styles.ts
@@ -171,6 +171,8 @@ const generateStyle = (
       border: `${componentTheme.borderWidth} ${componentTheme.borderStyle} ${componentTheme.borderColor}`,
       borderRadius: componentTheme.borderRadius,
       background: componentTheme.background,
+      color: componentTheme.color,
+
       '&::before': {
         content: '""',
         pointerEvents: 'none',


### PR DESCRIPTION
Closes: INSTUI-3569

The before/after icons don’t receive any color in TextInput, so they have “color: inherit“ by
default, and that ends up being black. All colors should come from theme variables.

It is fixed in TextInput, but it affects other components based on it: Select, SimpleSelect, DateInput,
DateTimeInput, TimeSelect, ColorMixer.