### PR TITLE
fix(ui-date-input): add `display` prop to DateInput

### DIFF
--- a/packages/ui-date-input/package.json
+++ b/packages/ui-date-input/package.json
@@ -40,6 +40,7 @@
     "@instructure/ui-text-input": "^7.20.0",
     "@instructure/ui-themeable": "^7.20.0",
     "@instructure/ui-utils": "^7.20.0",
+    "classnames": "^2",
     "prop-types": "^15"
   },
   "peerDependencies": {

--- a/packages/ui-date-input/src/DateInput/__examples__/DateInput.examples.js
+++ b/packages/ui-date-input/src/DateInput/__examples__/DateInput.examples.js
@@ -47,6 +47,7 @@ const generateDays = () => {
 }
 
 export default {
+  sectionProp: 'size',
   excludeProps: ['label'],
   propValues: {
     placement: [
@@ -89,6 +90,7 @@ export default {
     if (props.isInline && props.layout === 'inline') return true
     if (props.isShowingCalendar && props.interaction === 'disabled') return true
     if (props.isShowingCalendar && props.size !== 'medium') return true
+    if (props.isShowingCalendar && props.display !== 'inline-block') return true
     if (!props.isShowingCalendar && props.placement) return true
 
     return false

--- a/packages/ui-date-input/src/DateInput/index.js
+++ b/packages/ui-date-input/src/DateInput/index.js
@@ -24,6 +24,7 @@
 
 import React, { Children, Component } from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 
 import { Calendar } from '@instructure/ui-calendar'
 import { IconCalendarMonthLine } from '@instructure/ui-icons'
@@ -126,6 +127,10 @@ class DateInput extends Component {
      * Specifies the width of the input.
      */
     width: PropTypes.string,
+    /**
+     * Specifies the display property of the container.
+     */
+    display: PropTypes.oneOf(['inline-block', 'block']),
     /**
      * Provides a ref to the underlying input element.
      */
@@ -240,6 +245,7 @@ class DateInput extends Component {
     assistiveText: undefined,
     layout: 'stacked',
     width: null,
+    display: 'inline-block',
     inputRef: (el) => {},
     messages: undefined,
     placement: 'bottom center',
@@ -432,7 +438,7 @@ class DateInput extends Component {
   }
 
   render() {
-    const { placement, isShowingCalendar, assistiveText } = this.props
+    const { placement, isShowingCalendar, assistiveText, display } = this.props
 
     const { selectedDateId } = this
 
@@ -454,7 +460,14 @@ class DateInput extends Component {
           getOptionProps,
           getDescriptionProps
         }) => (
-          <span {...getRootProps({ className: styles.root })}>
+          <span
+            {...getRootProps({
+              className: classnames({
+                [styles.root]: true,
+                [styles[`display-${display}`]]: display
+              })
+            })}
+          >
             {this.renderInput({ getInputProps, getTriggerProps })}
             <span {...getDescriptionProps()} className={styles.assistiveText}>
               {assistiveText}

--- a/packages/ui-date-input/src/DateInput/styles.css
+++ b/packages/ui-date-input/src/DateInput/styles.css
@@ -1,4 +1,10 @@
-.root {
+.root {}
+
+.display-block {
+  display: block;
+}
+
+.display-inline-block {
   display: inline-block;
 }
 


### PR DESCRIPTION
Closes: INSTUI-3574

Adding the `display` prop allows the currently hard-coded `display: inline-block` to be overridden
on the root element in order to make it fill its container element.