### PR TITLE
INSTUI-3575 : fix ReactDOM.render warnings in docs

### DIFF
--- a/packages/__docs__/src/Hero/index.tsx
+++ b/packages/__docs__/src/Hero/index.tsx
@@ -348,6 +348,7 @@ class Hero extends Component<HeroProps> {
             <Img
               src="https://instui-docs.s3.us-east-2.amazonaws.com/hero2.jpg"
               display="block"
+              rel="prefetch"
               constrain="cover"
               overlay={{
                 color: styles?.backgroundColor as string,

--- a/packages/__docs__/src/Preview/index.tsx
+++ b/packages/__docs__/src/Preview/index.tsx
@@ -24,17 +24,13 @@
 
 /** @jsx jsx */
 import React, { Component } from 'react'
-import ReactDOM from 'react-dom'
-
+import { createRoot, Root } from 'react-dom/client'
 import { DIRECTION, TextDirectionContext } from '@instructure/ui-i18n'
 import { InstUISettingsProvider, withStyle, jsx } from '@instructure/emotion'
 import { canvas } from '@instructure/ui-themes'
-
 import generateStyle from './styles'
 import generateComponentTheme from './theme'
-
 import { compileAndRenderExample } from '../compileAndRenderExample'
-
 import { propTypes, allowedProps } from './props'
 import type { PreviewProps, PreviewState } from './props'
 
@@ -53,6 +49,7 @@ class Preview extends Component<PreviewProps, PreviewState> {
   }
 
   private _mountNode?: HTMLDivElement | null
+  private _root?: Root
 
   constructor(props: PreviewProps) {
     super(props)
@@ -79,17 +76,10 @@ class Preview extends Component<PreviewProps, PreviewState> {
     this.props.makeStyles?.()
   }
 
-  componentWillUnmount() {
-    if (this._mountNode) {
-      ReactDOM.unmountComponentAtNode(this._mountNode)
-    }
-  }
-
   executeCode(code: string) {
-    const mountNode = this._mountNode
-
-    if (mountNode) {
-      ReactDOM.unmountComponentAtNode(mountNode)
+    if (this._root) {
+      this._root.unmount()
+      this._root = undefined
     }
 
     this.setState({ error: null })
@@ -112,7 +102,8 @@ class Preview extends Component<PreviewProps, PreviewState> {
           </TextDirectionContext.Provider>
         </InstUISettingsProvider>
       )
-      ReactDOM.render(elToRender, mountNode!)
+      this._root = createRoot(this._mountNode!)
+      this._root.render(elToRender)
     }
 
     compileAndRenderExample({
@@ -124,8 +115,9 @@ class Preview extends Component<PreviewProps, PreviewState> {
   }
 
   handleError = (err: Error) => {
-    if (this._mountNode) {
-      ReactDOM.unmountComponentAtNode(this._mountNode)
+    if (this._root) {
+      this._root.unmount()
+      this._root = undefined
     }
     this.setState({
       error: err.toString()

--- a/packages/__docs__/src/index.html
+++ b/packages/__docs__/src/index.html
@@ -19,7 +19,7 @@
 
     <!-- homepage hero image -->
     <link
-      rel="preload"
+      rel="prefetch"
       href="https://instui-docs.s3.us-east-2.amazonaws.com/hero2.jpg"
       as="image"
     />

--- a/packages/__docs__/src/index.js
+++ b/packages/__docs__/src/index.js
@@ -23,16 +23,15 @@
  */
 
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 
 import { App } from './App'
 import { canvas } from '@instructure/ui-themes'
 import { InstUISettingsProvider } from '@instructure/emotion'
 import '../globals'
 
-ReactDOM.render(
+createRoot(document.getElementById('app')).render(
   <InstUISettingsProvider theme={canvas}>
     <App />
-  </InstUISettingsProvider>,
-  document.getElementById('app')
+  </InstUISettingsProvider>
 )


### PR DESCRIPTION
Update syntax to the Ract 18 one.

Also fix "The resource
https://instui-docs.s3.us-east-2.amazonaws.com/hero2.jpg was preloaded using link preload but not
used within a few seconds from the window's load event." warnings