### PR TITLE
INSTUI-3576 fix TS type and propType for liveRegion prop

### DIFF
--- a/packages/shared-types/src/CommonTypes.ts
+++ b/packages/shared-types/src/CommonTypes.ts
@@ -58,7 +58,11 @@ export type Renderable<P = never> =
  * element, that represents the part of the DOM that is not hidden from the
  * screen reader
  */
-export type LiveRegion = (() => Element) | Element[] | Element
+export type LiveRegion =
+  | (() => Element[])
+  | (() => Element)
+  | Element[]
+  | Element
 
 interface InstUIBaseComponent {
   componentId?: string

--- a/packages/shared-types/src/CommonTypes.ts
+++ b/packages/shared-types/src/CommonTypes.ts
@@ -63,6 +63,7 @@ export type LiveRegion =
   | (() => Element)
   | Element[]
   | Element
+  | null
 
 interface InstUIBaseComponent {
   componentId?: string

--- a/packages/shared-types/src/CommonTypes.ts
+++ b/packages/shared-types/src/CommonTypes.ts
@@ -59,9 +59,9 @@ export type Renderable<P = never> =
  * screen reader
  */
 export type LiveRegion =
-  | (() => Element[])
-  | (() => Element)
-  | Element[]
+  | (() => (Element | null)[])
+  | (() => Element | null)
+  | (Element | null)[]
   | Element
   | null
 

--- a/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.ts
+++ b/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.ts
@@ -28,7 +28,7 @@ import { FocusRegionOptions } from './FocusRegionOptions'
 class ScreenReaderFocusRegion {
   private _parents: HTMLElement[] = []
   private _nodes: Element[] = []
-  private _liveRegion: (Element | undefined)[]
+  private _liveRegion: (Element | undefined | null)[]
   private _contextElement: Element | Node | null
   private _options: FocusRegionOptions
   private _observer: MutationObserver | null = null

--- a/packages/ui-dialog/src/Dialog/props.ts
+++ b/packages/ui-dialog/src/Dialog/props.ts
@@ -95,12 +95,12 @@ const propTypes: PropValidators<PropKeys> = {
    * the screen reader when the focus region is active
    */
   liveRegion: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.elementType),
+    PropTypes.elementType,
     PropTypes.func
   ]),
   /**
-   * When set to true or its an array that includes the 'keyboard' string,
+   * When set to true, or it is an array that includes the 'keyboard' string,
    * the keyboard and screenreader focus is trapped; when set to 'screenreader'
    * only the screenreader focus is trapped.
    */

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/props.ts
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/props.ts
@@ -206,7 +206,7 @@ const propTypes: PropValidators<PropKeys> = {
   liveRegion: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.elementType),
     PropTypes.elementType,
-    PropTypes.number
+    PropTypes.func
   ]),
   onDismiss: PropTypes.func,
   shouldContainFocus: PropTypes.bool,

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/props.ts
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/props.ts
@@ -204,9 +204,9 @@ const propTypes: PropValidators<PropKeys> = {
   mountNode: PropTypes.oneOfType([element, PropTypes.func]),
   defaultFocusElement: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   liveRegion: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
-    PropTypes.func
+    PropTypes.arrayOf(PropTypes.elementType),
+    PropTypes.elementType,
+    PropTypes.number
   ]),
   onDismiss: PropTypes.func,
   shouldContainFocus: PropTypes.bool,

--- a/packages/ui-modal/src/Modal/props.ts
+++ b/packages/ui-modal/src/Modal/props.ts
@@ -225,8 +225,8 @@ const propTypes: PropValidators<PropKeys> = {
   mountNode: PropTypes.oneOfType([element, PropTypes.func]),
   insertAt: PropTypes.oneOf(['bottom', 'top']),
   liveRegion: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.elementType),
+    PropTypes.elementType,
     PropTypes.func
   ]),
   transition: transitionTypePropType,

--- a/packages/ui-popover/src/Popover/props.ts
+++ b/packages/ui-popover/src/Popover/props.ts
@@ -308,8 +308,8 @@ const propTypes: PropValidators<PropKeys> = {
   mountNode: PositionPropTypes.mountNode,
   insertAt: PropTypes.oneOf(['bottom', 'top']),
   liveRegion: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.elementType),
+    PropTypes.elementType,
     PropTypes.func
   ]),
   id: PropTypes.string,

--- a/packages/ui-tray/src/Tray/props.ts
+++ b/packages/ui-tray/src/Tray/props.ts
@@ -175,8 +175,8 @@ const propTypes: PropValidators<PropKeys> = {
   mountNode: PropTypes.oneOfType([element, PropTypes.func]),
   insertAt: PropTypes.oneOf(['bottom', 'top']),
   liveRegion: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.elementType),
+    PropTypes.elementType,
     PropTypes.func
   ]),
   onTransition: PropTypes.func,


### PR DESCRIPTION
`liveRegion` can be a function that returns an array of DOM elements. Also its propType was
erroneously allowing React elements when it should only allow native DOM elements triggering false
prop validation errors.