### PR TITLE
feat(ui-time-select): allow non-step input value with new prop

### DIFF
--- a/packages/ui-i18n/src/DateTime.ts
+++ b/packages/ui-i18n/src/DateTime.ts
@@ -51,26 +51,39 @@ function now(locale: string, timezone: string) {
  * @param {String} dateString
  * @param {String} locale
  * @param {String} timezone
+ * @param {String} format
+ * @param {Boolean} strict
  * @returns {String} ISO 8601 string
  */
-function parse(dateString: string, locale: string, timezone: string) {
+function parse(
+  dateString: string,
+  locale: string,
+  timezone: string, // list all available localized formats, from most specific to least
+  format = [
+    moment.ISO_8601,
+    'llll',
+    'LLLL',
+    'lll',
+    'LLL',
+    'll',
+    'LL',
+    'l',
+    'L'
+  ],
+  strict = false
+) {
   _checkParams(locale, timezone)
-  // list all available localized formats, from most specific to least
-  return moment.tz(
-    dateString,
-    [moment.ISO_8601, 'llll', 'LLLL', 'lll', 'LLL', 'll', 'LL', 'l', 'L'],
-    locale,
-    timezone
-  )
+  return moment.tz(dateString, format, locale, strict, timezone)
 }
 
 /**
- * Determines if a string is a valid ISO 8601 string
+ * Determines if a string is a valid date/time string
  * @param {String} dateString
+ * @param {Array} formats see https://momentjs.com/docs/#/displaying/format/ default is ISO_8601
  * @returns {Boolean} true if dateString is a valid ISO 8601 string
  */
-function isValid(dateString: string) {
-  return moment(dateString, [moment.ISO_8601]).isValid()
+function isValid(dateString: string, formats = [moment.ISO_8601]) {
+  return moment(dateString, formats).isValid()
 }
 
 /**

--- a/packages/ui-time-select/package.json
+++ b/packages/ui-time-select/package.json
@@ -33,6 +33,7 @@
     "@instructure/ui-select": "8.34.0",
     "@instructure/ui-test-locator": "8.34.0",
     "@instructure/ui-testable": "8.34.0",
+    "@instructure/ui-utils": "8.34.0",
     "prop-types": "^15.8.1"
   },
   "devDependencies": {

--- a/packages/ui-time-select/src/TimeSelect/README.md
+++ b/packages/ui-time-select/src/TimeSelect/README.md
@@ -5,6 +5,7 @@ describes: TimeSelect
 `TimeSelect` component is a higher level abstraction of [Select](#Select) specifically for selecting time values. The list of possible values can be configured via the component's props. If you need to select times and dates, be sure to check out the documentation around [Time and Date patterns](#TimeDate).
 
 ### Uncontrolled
+
 For the most basic implementations, `TimeSelect` can be uncontrolled. If desired, the `defaultValue` prop can be used to set the initial selection.
 
 ```javascript
@@ -15,11 +16,13 @@ render: true
 <TimeSelect
   renderLabel="Choose a time"
   onChange={(e, { value }) => console.log(value)}
+  onHideOptions={(e)=> console.log("hide opts")}
   // defaultValue={new Date().toISOString()}
 />
 ```
 
 ### Controlled
+
 To use `TimeSelect` controlled, simply provide the `value` prop an ISO string. The `onChange` callback provides the ISO value of the corresponding option that was selected. Use this value to update the state.
 
 ```javascript
@@ -54,7 +57,29 @@ render(
 )
 ```
 
+### Freeform input
+
+By default, the user can only set a value that is divisible by `step` (although the component allows to set any valid time value programmatically). You can allow the user to set any valid value with typing in by setting `allowNonStepInput` to `true`. You can use the `onInputChange` event to see whether the current input is valid and its current value.
+Note that the exact value needed to be typed by the user depends on their `locale`:
+
+```javascript
+---
+example: true
+render: true
+---
+<TimeSelect
+  renderLabel="Choose a time"
+  onChange={(e, { value }) => console.log("change",value)}
+  onInputChange={(e, value, isoValue)=> console.log("inputChange", value, isoValue)}
+  defaultValue="2022-05-12T05:30:00.000Z"
+  locale="en_AU"
+  timezone='US/Eastern'
+  allowNonStepInput
+/>
+```
+
 ### Guidelines
+
 ```js
 ---
 guidelines: true
@@ -62,6 +87,7 @@ guidelines: true
 <Guidelines>
   <Figure recommendation="yes" title="Do">
     <Figure.Item>Use a default value of 11:59 pm for implementations that have to do with due dates</Figure.Item>
+    <Figure.Item>Respect the user's `locale` and `timezone` browser settings (the component does this by itself when not setting `locale` or `timezone`).</Figure.Item>
   </Figure>
 </Guidelines>
 ```

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -211,6 +211,32 @@ type TimeSelectOwnProps = {
    * property.
    */
   timezone?: string
+  /**
+   * Whether to allow the user to enter non-step divisible values in the input field.
+   * Note that even if this is set to `false` one can enter non-step divisible values programatically.
+   * The user will need to enter the value exactly (except for lower/uppercase) as specified by the `format` prop  for
+   * it to be accepted.
+   *
+   * Default is `false`
+   */
+  allowNonStepInput?: boolean
+  /**
+   * Callback fired when text input value changes.
+   */
+  onInputChange?: (
+    /**
+     * The raw HTML input event
+     */
+    event: React.ChangeEvent<HTMLInputElement>,
+    /**
+     * The text value in the input field.
+     */
+    value: string,
+    /**
+     * Current value as ISO datetime string, undefined it its a non-valid value.
+     */
+    valueAsISOString?: string
+  ) => void
 }
 
 const propTypes: PropValidators<PropKeys> = {
@@ -243,7 +269,9 @@ const propTypes: PropValidators<PropKeys> = {
   renderBeforeInput: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   renderAfterInput: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   locale: PropTypes.string,
-  timezone: PropTypes.string
+  timezone: PropTypes.string,
+  allowNonStepInput: PropTypes.bool,
+  onInputChange: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -276,7 +304,9 @@ const allowedProps: AllowedPropKeys = [
   'renderBeforeInput',
   'renderAfterInput',
   'locale',
-  'timezone'
+  'timezone',
+  'allowNonStepInput',
+  'onInputChange'
 ]
 
 type TimeSelectOptions = {
@@ -286,12 +316,22 @@ type TimeSelectOptions = {
 }
 
 type TimeSelectState = {
+  /**
+   * The current value in the input field, not necessarily a valid time
+   */
   inputValue: string
   options: TimeSelectOptions[]
   filteredOptions: TimeSelectOptions[]
+  /**
+   * Whether to show the options list.
+   */
   isShowingOptions: boolean
   highlightedOptionId?: string
   selectedOptionId?: string
+  /**
+   * Last valid input when nonStepInput is true
+   */
+  lastValidInput?: string
 }
 
 export type { TimeSelectProps, TimeSelectState, TimeSelectOptions }

--- a/packages/ui-time-select/tsconfig.build.json
+++ b/packages/ui-time-select/tsconfig.build.json
@@ -15,6 +15,7 @@
     { "path": "../ui-select/tsconfig.build.json" },
     { "path": "../ui-test-locator/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
+    { "path": "../ui-utils/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
     { "path": "../ui-test-utils/tsconfig.build.json" },
     { "path": "../shared-types/tsconfig.build.json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4474,6 +4474,7 @@ __metadata:
     "@instructure/ui-test-locator": 8.34.0
     "@instructure/ui-test-utils": 8.34.0
     "@instructure/ui-testable": 8.34.0
+    "@instructure/ui-utils": 8.34.0
     moment-timezone: ^0.5.40
     prop-types: ^15.8.1
   peerDependencies:


### PR DESCRIPTION
When setting `allowNonStepInput` to `true` one can enter any valid time value. It needs to be typed exactly (except for upper/lowercase)