### PR TITLE
chore: update used action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -33,39 +22,15 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
-
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-
-    # Initializes the CodeQL tools for scanning.
+      uses: actions/checkout@v3
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/manual-deploy-docs.yml
+++ b/.github/workflows/manual-deploy-docs.yml
@@ -10,11 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy docs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
       - name: Install packages.
-        run: yarn install
+        run: yarn install --immutable
       - name: Set up project.
         run: yarn bootstrap
       - name: Build docs-app.

--- a/.github/workflows/manual-legacy-release-to-npm.yml
+++ b/.github/workflows/manual-legacy-release-to-npm.yml
@@ -5,11 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Release to npm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
       - name: Install packages
-        run: yarn install
+        run: yarn install --immutable
       - name: Set up project
         run: yarn bootstrap
       - name: Run tests

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,15 +4,16 @@ jobs:
   pr_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Install Node 16
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Bootstrap project
         run: yarn bootstrap
       - name: Run test for the patchset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Release to npm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
       - name: Install packages.
-        run: yarn install
+        run: yarn install --immutable
       - name: Set up project.
         run: yarn bootstrap
       - name: Run tests.
@@ -31,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Tag release commit
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up git identity
@@ -47,11 +51,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy docs to Netlify
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
       - name: Install packages.
-        run: yarn install
+        run: yarn install --immutable
       - name: Set up project.
         run: yarn bootstrap
       - name: Build docs-app.
@@ -76,10 +84,11 @@ jobs:
       run:
         working-directory: ./regression-test
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: Retrieve latest snapshot version
         run: node prepare.js
       - name: Install dependencies for regression testing

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -13,15 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Node 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: Install project dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Bootstrap project
         run: yarn bootstrap
       - name: Build Storybook examples


### PR DESCRIPTION
Also updated `actions/checkout` from v2 to v3, and `actions/setup-node` from v2 to v3 and added global package caching according to https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data.