### PR TITLE
Lodash tree-shaking via babel plugin

### DIFF
--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -101,7 +101,8 @@ module.exports = function (
       }
     ],
     require('@babel/plugin-syntax-dynamic-import').default,
-    require('babel-plugin-transform-undefined-to-void')
+    require('babel-plugin-transform-undefined-to-void'),
+    require('babel-plugin-lodash')
   ])
 
   if (process.env.NODE_ENV === 'production') {

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -36,6 +36,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-istanbul": "^6.0.0",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-macros": "^3",
     "babel-plugin-transform-ensure-ignore": "^0.1.0",
     "babel-plugin-transform-remove-console": "^6.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,7 +265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.8.3":
+"@babel/helper-module-imports@npm:^7.0.0-beta.49, @babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.12.13, @babel/helper-module-imports@npm:^7.16.7, @babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.8.3":
   version: 7.18.6
   resolution: "@babel/helper-module-imports@npm:7.18.6"
   dependencies:
@@ -374,10 +374,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/helper-string-parser@npm:7.19.4"
+  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
@@ -1628,6 +1642,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.0.0-beta.49":
+  version: 7.20.2
+  resolution: "@babel/types@npm:7.20.2"
+  dependencies:
+    "@babel/helper-string-parser": ^7.19.4
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: 57e76e5f21876135f481bfd4010c87f2d38196bb0a2bc60a28d6e55e3afa90cdd9accf164e4cb71bdfb620517fa0a0cb5600cdce36c21d59fdaccfbb899c024c
+  languageName: node
+  linkType: hard
+
 "@base2/pretty-print-object@npm:1.0.1":
   version: 1.0.1
   resolution: "@base2/pretty-print-object@npm:1.0.1"
@@ -2556,6 +2581,7 @@ __metadata:
     babel-loader: ^8.1.0
     babel-plugin-dynamic-import-node: ^2.3.0
     babel-plugin-istanbul: ^6.0.0
+    babel-plugin-lodash: ^3.3.4
     babel-plugin-macros: ^3
     babel-plugin-transform-ensure-ignore: ^0.1.0
     babel-plugin-transform-remove-console: ^6.9.4
@@ -10881,6 +10907,19 @@ __metadata:
   dependencies:
     "@types/babel__traverse": "npm:^7.0.6"
   checksum: 9f0d23fcf94448e302e201665d7232303a548107adf545590b09f22a747755387cb9dc676d22884a298b17d11ede5401436e1b70fa574eee3efa61ad1230c8e6
+  languageName: node
+  linkType: hard
+
+"babel-plugin-lodash@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "babel-plugin-lodash@npm:3.3.4"
+  dependencies:
+    "@babel/helper-module-imports": ^7.0.0-beta.49
+    "@babel/types": ^7.0.0-beta.49
+    glob: ^7.1.1
+    lodash: ^4.17.10
+    require-package-name: ^2.0.1
+  checksum: 044a4261e689b7058cdcbd4a37e5229797e652534a889a553e7d3cff87cf72283e4a68d3be4c3c305c96214f77f2e09ca376c68c45923aeb0de14514b0fb27d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix similar to this one: https://github.com/instructure/instructure-ui/pull/1015 , but solved in a different way.
I am totally surprised it was reverted in https://github.com/instructure/instructure-ui/pull/1017 , and I cannot figure out who (and why) decided to for such a step **backward**.

Direct one-by-one imports are the most effective way to make the bundle slim when it comes to lodash.
The other way is to use a babel plugin. Ref: https://www.blazemeter.com/blog/import-lodash-libraries
This PR uses the plugin.

---

In my case, I am using `@instructure/emotion` and couple simple UI components from this library.

**BEFORE:**

![before--emotion-fix](https://user-images.githubusercontent.com/1695878/200090132-ce09da0c-7a4b-4415-aa62-4dfb5c8c8f09.png)


---

**AFTER:**

![after--babel-fix](https://user-images.githubusercontent.com/1695878/200090167-aebd4c6c-e44c-4063-b00b-9271422eefb5.png)


---

A change similar to #1015 would result in a similar bundle size:

![after--emotion-fix](https://user-images.githubusercontent.com/1695878/200090201-7c6bf4eb-f297-4a41-9aaa-900688af44ad.png)

but I guess someone decided to not maintain one-by-one imports.