### PR TITLE
Remove `lodash` dependency from component packages

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -94,7 +94,7 @@ const calculateSizes = async () => {
   // so that the rest of the workflow actions are not executed on master
   // eslint-disable-next-line no-console
   console.log('switching back to feature branch...')
-  await git(`checkout ${danger.github.pr.head.ref}`)
+  await git(`checkout -d ${headCommitSha}`)
   execSync('yarn install')
 }
 

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -34,13 +34,11 @@
     "@instructure/ui-themes": "8.31.0",
     "@instructure/ui-utils": "8.31.0",
     "hoist-non-react-statics": "^3.3.2",
-    "lodash": "^4",
     "prop-types": "^15"
   },
   "devDependencies": {
     "@instructure/ui-babel-preset": "8.31.0",
-    "@instructure/ui-test-utils": "8.31.0",
-    "@types/lodash": "^4.14.171"
+    "@instructure/ui-test-utils": "8.31.0"
   },
   "peerDependencies": {
     "react": ">=16.8 <=18"

--- a/packages/emotion/src/getTheme.ts
+++ b/packages/emotion/src/getTheme.ts
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { merge, cloneDeep } from 'lodash'
 import { canvas } from '@instructure/ui-themes'
 import { ThemeRegistry } from '@instructure/theme-registry'
-import { isBaseTheme } from '@instructure/ui-utils'
+import { isBaseTheme, mergeDeep } from '@instructure/ui-utils'
 
 import type { BaseTheme } from '@instructure/shared-types'
 
@@ -81,11 +80,9 @@ const getTheme =
           'No theme provided for [InstUISettingsProvider], using default `canvas` theme.'
         )
       }
-      //TODO: replace cloneDeeps with native `structuredClone` API
-      //once we hit last 2 version browser support
-      currentTheme = cloneDeep(globalTheme || canvas)
+      currentTheme = globalTheme || canvas
     } else {
-      currentTheme = cloneDeep(ancestorTheme)
+      currentTheme = ancestorTheme
     }
 
     const themeName = currentTheme.key
@@ -98,13 +95,7 @@ const getTheme =
       (themeOrOverride as Overrides).themeOverrides ||
       {}
 
-    const finalTheme = merge(
-      {},
-      currentTheme,
-      merge({}, themeOrOverride, currentThemeOverrides)
-    )
-
-    return finalTheme
+    return mergeDeep(currentTheme, themeOrOverride, currentThemeOverrides)
   }
 
 export default getTheme

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -176,7 +176,8 @@ function getWebEnvConfig(opts) {
       browsers: require('@instructure/browserslist-config-instui')
     },
     useBuiltIns: 'entry',
-    corejs: 3,
+    // this version has to match the version in package.json
+    corejs: '3.26.1',
     modules: opts.esModules ? false : 'commonjs',
     // debug: true, // un-comment if you want to see what browsers are being targeted and what plugins that means it will activate
     exclude: ['transform-typeof-symbol'],

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-ensure-ignore": "^0.1.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-plugin-transform-undefined-to-void": "^6.9.4",
-    "core-js": "^3.2.1"
+    "core-js": "3.26.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-source-code-editor/package.json
+++ b/packages/ui-source-code-editor/package.json
@@ -25,8 +25,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "8.31.0",
     "@instructure/ui-test-queries": "8.31.0",
-    "@instructure/ui-test-utils": "8.31.0",
-    "@types/lodash": "^4"
+    "@instructure/ui-test-utils": "8.31.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
@@ -55,7 +54,6 @@
     "@instructure/ui-themes": "8.31.0",
     "@instructure/ui-utils": "8.31.0",
     "@lezer/highlight": "^1.0.0",
-    "lodash": "^4",
     "prop-types": "^15"
   },
   "peerDependencies": {

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
@@ -24,7 +24,7 @@
 
 /** @jsx jsx */
 import { Component } from 'react'
-import { merge, cloneDeep, isEqual } from 'lodash'
+import { deepEqual as isEqual } from '@instructure/ui-utils'
 
 import { EditorSelection, EditorState, StateEffect } from '@codemirror/state'
 import type { Transaction, TransactionSpec } from '@codemirror/state'
@@ -468,11 +468,9 @@ class SourceCodeEditor extends Component<SourceCodeEditorProps> {
     const { rtlMoveVisually } = this.props
 
     if (this.direction === 'rtl' && !rtlMoveVisually) {
+      //TODO: fix this broken logic
       // we need to clone the original so that it doesn't get overridden
-      return merge(
-        cloneDeep(defaultKeymap),
-        rtlHorizontalArrowKeymap
-      ) as KeyBinding[]
+      return [...defaultKeymap, ...rtlHorizontalArrowKeymap]
     }
 
     return defaultKeymap

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,9 +2287,7 @@ __metadata:
     "@instructure/ui-test-utils": 8.31.0
     "@instructure/ui-themes": 8.31.0
     "@instructure/ui-utils": 8.31.0
-    "@types/lodash": ^4.14.171
     hoist-non-react-statics: ^3.3.2
-    lodash: ^4
     prop-types: ^15
   peerDependencies:
     react: ">=16.8 <=18"
@@ -2560,7 +2558,7 @@ __metadata:
     babel-plugin-transform-ensure-ignore: ^0.1.0
     babel-plugin-transform-remove-console: ^6.9.4
     babel-plugin-transform-undefined-to-void: ^6.9.4
-    core-js: ^3.2.1
+    core-js: 3.26.1
   languageName: unknown
   linkType: soft
 
@@ -4035,8 +4033,6 @@ __metadata:
     "@instructure/ui-themes": 8.31.0
     "@instructure/ui-utils": 8.31.0
     "@lezer/highlight": ^1.0.0
-    "@types/lodash": ^4
-    lodash: ^4
     prop-types: ^15
   peerDependencies:
     react: ">=16.8 <=18"
@@ -8482,7 +8478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.14.171":
+"@types/lodash@npm:^4.14.167":
   version: 4.14.184
   resolution: "@types/lodash@npm:4.14.184"
   checksum: 6d9a4d67f7f9d0ec3fd21174f3dd3d00629dc1227eb469450eace53adbc1f7e2330699c28d0fe093e5f0fef0f0e763098be1f779268857213224af082b62be21
@@ -13574,6 +13570,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:3.26.1":
+  version: 3.26.1
+  resolution: "core-js@npm:3.26.1"
+  checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
+  languageName: node
+  linkType: hard
+
 "core-js@npm:^2.4.0":
   version: 2.6.12
   resolution: "core-js@npm:2.6.12"
@@ -13581,7 +13584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.0.4, core-js@npm:^3.16.2, core-js@npm:^3.2.1, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
+"core-js@npm:^3.0.4, core-js@npm:^3.16.2, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
   version: 3.25.0
   resolution: "core-js@npm:3.25.0"
   checksum: 5a72740bf5babaf2e6203da4c0e831a0b97c3fe6f21b4c1aa8601d3a927660a22128dd8f0e86ce84778c4e5372ab0fc03c7944afa7e215c7fb13b2c79d5d5504
@@ -23619,7 +23622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.7.0":
+"lodash@npm:4.17.21, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7


### PR DESCRIPTION
This PR removes our dependency on `lodash` for consumer facing packages (emotion, ui-source-code-editor), this could be achieved by using our internal utility functions instead of relying on `lodash`. 

I created 2 applications with the same code, but with different @instrucutre/ui dependencies:
- one with `lodash` still used internally:
<img width="1897" alt="Screenshot 2022-11-17 at 15 39 56" src="https://user-images.githubusercontent.com/20640237/202713949-4015b818-fb14-4a4d-94ad-8a951a728046.png">

- another one with this PR applied:
<img width="1899" alt="Screenshot 2022-11-17 at 15 40 05" src="https://user-images.githubusercontent.com/20640237/202714062-3f8a3341-085f-4f63-bdf4-cf82886d69e1.png">
