### PR TITLE
feat(ui-drilldown): allow controlled functionality when selecting options

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/DrilldownGroup/__tests__/DrilldownGroup.test.tsx
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownGroup/__tests__/DrilldownGroup.test.tsx
@@ -45,6 +45,51 @@ const checkSelectedValues = async (
 }
 
 describe('<Drilldown.Group />', async () => {
+  it('should not allow de-selecting an option when selectableType = "single"', async () => {
+    const options = ['one', 'two', 'three']
+    const Example = ({ opts }: { opts: typeof options }) => {
+      return (
+        <Drilldown rootPageId="page0">
+          <Drilldown.Page id="page0">
+            <Drilldown.Group id="group0" selectableType="single">
+              {opts.map((opt) => {
+                return (
+                  <Drilldown.Option
+                    key={opt}
+                    value={opt}
+                    name={opt}
+                    id={opt}
+                    defaultSelected={opt === 'three'}
+                  >
+                    {opt}
+                  </Drilldown.Option>
+                )
+              })}
+            </Drilldown.Group>
+          </Drilldown.Page>
+        </Drilldown>
+      )
+    }
+
+    await mount(<Example opts={options} />)
+
+    let drilldown = await DrilldownLocator.find()
+    let selectedOption = await drilldown.find('#three')
+
+    expect(selectedOption.getDOMNode().getAttribute('aria-checked')).to.be.eq(
+      'true'
+    )
+
+    selectedOption.click()
+
+    drilldown = await DrilldownLocator.find()
+    selectedOption = await drilldown.find('#three')
+
+    expect(selectedOption.getDOMNode().getAttribute('aria-checked')).to.be.eq(
+      'true'
+    )
+  })
+
   it("shouldn't render non-DrilldownGroup children", async () => {
     stub(console, 'error')
     await mount(

--- a/packages/ui-drilldown/src/Drilldown/DrilldownOption/__tests__/DrilldownOption.test.tsx
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownOption/__tests__/DrilldownOption.test.tsx
@@ -31,6 +31,76 @@ import { Drilldown } from '../../index'
 import { DrilldownLocator } from '../../DrilldownLocator'
 
 describe('<Drilldown.Option />', async () => {
+  it('should allow setting "selected" property on Options', async () => {
+    await mount(
+      <Drilldown rootPageId="page0">
+        <Drilldown.Page id="page0">
+          <Drilldown.Group id="group0">
+            <Drilldown.Option id="groupOption01">Option - 1</Drilldown.Option>
+            <Drilldown.Option selected id="groupOption02">
+              Option - 2
+            </Drilldown.Option>
+            <Drilldown.Option id="groupOption03">Option - 3</Drilldown.Option>
+            <Drilldown.Option id="groupOption04">Option - 4</Drilldown.Option>
+          </Drilldown.Group>
+        </Drilldown.Page>
+      </Drilldown>
+    )
+    const drilldown = await DrilldownLocator.find()
+    const selectedOption = await drilldown.find('#groupOption02')
+
+    expect(selectedOption.getDOMNode().getAttribute('aria-checked')).to.be.eq(
+      'true'
+    )
+  })
+  it('should allow controlled behaviour', async () => {
+    const options = ['one', 'two', 'three']
+    const Example = ({
+      opts,
+      selected
+    }: {
+      opts: typeof options
+      selected: string
+    }) => {
+      return (
+        <Drilldown rootPageId="page0">
+          <Drilldown.Page id="page0">
+            <Drilldown.Group id="group0">
+              {opts.map((opt) => {
+                return (
+                  <Drilldown.Option
+                    key={opt}
+                    value={opt}
+                    name={opt}
+                    id={opt}
+                    selected={selected === opt}
+                  >
+                    {opt}
+                  </Drilldown.Option>
+                )
+              })}
+            </Drilldown.Group>
+          </Drilldown.Page>
+        </Drilldown>
+      )
+    }
+    const subject = await mount(<Example opts={options} selected="two" />)
+    let drilldown = await DrilldownLocator.find()
+    let opts = await drilldown.findAllOptions()
+
+    expect(opts[0].getDOMNode().getAttribute('aria-checked')).to.be.eq('false')
+    expect(opts[1].getDOMNode().getAttribute('aria-checked')).to.be.eq('true')
+    expect(opts[2].getDOMNode().getAttribute('aria-checked')).to.be.eq('false')
+
+    subject.setProps({ selected: 'three' })
+
+    drilldown = await DrilldownLocator.find()
+    opts = await drilldown.findAllOptions()
+
+    expect(opts[0].getDOMNode().getAttribute('aria-checked')).to.be.eq('false')
+    expect(opts[1].getDOMNode().getAttribute('aria-checked')).to.be.eq('false')
+    expect(opts[2].getDOMNode().getAttribute('aria-checked')).to.be.eq('true')
+  })
   describe('id prop', async () => {
     it('should throw warning the id is not provided', async () => {
       stub(console, 'error')

--- a/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
@@ -79,6 +79,11 @@ type DrilldownOptionOwnProps = {
   disabled?: boolean
 
   /**
+   * Whether the option is selected or not. (Setting this property assumes controlled behaviour)
+   */
+  selected?: boolean
+
+  /**
    * The value of the option. Should be set for options in selectable groups.
    */
   value?: DrilldownOptionValue
@@ -181,6 +186,7 @@ const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   subPageId: PropTypes.string,
   disabled: PropTypes.bool,
+  selected: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   href: PropTypes.string,
   as: PropTypes.elementType,
@@ -202,6 +208,7 @@ const allowedProps: AllowedPropKeys = [
   'children',
   'subPageId',
   'disabled',
+  'selected',
   'value',
   'href',
   'as',

--- a/packages/ui-drilldown/src/Drilldown/__tests__/Drilldown.test.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__tests__/Drilldown.test.tsx
@@ -591,7 +591,6 @@ describe('<Drilldown />', async () => {
           </Drilldown.Page>
         </Drilldown>
       )
-
       const drilldown = await DrilldownLocator.find()
       const container = await drilldown.findSizableContainer()
       const containerNode = container.getDOMNode()

--- a/packages/ui-drilldown/src/Drilldown/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/props.ts
@@ -286,12 +286,17 @@ type DrilldownStyleProps = {
   hasHighlightedOption: boolean
 }
 
+type SelectedGroupOptionsMap = {
+  [groupId: string]: Map<string, DrilldownOptionValue>
+}
+
 type DrilldownState = {
   isShowingPopover: boolean
   activePageId: string
   highlightedOptionId?: string
   // needed for rerender
   lastSelectedId?: string
+  selectedGroupOptionsMap: SelectedGroupOptionsMap
 }
 
 const propTypes: PropValidators<PropKeys> = {
@@ -388,6 +393,7 @@ export type {
   PageChild,
   GroupChild,
   OptionChild,
-  SeparatorChild
+  SeparatorChild,
+  SelectedGroupOptionsMap
 }
 export { propTypes, allowedProps }

--- a/packages/ui-tray/src/Tray/__tests__/Tray.test.tsx
+++ b/packages/ui-tray/src/Tray/__tests__/Tray.test.tsx
@@ -49,7 +49,7 @@ describe('<Tray />', async () => {
         Hello World
       </Tray>
     )
-    // debugger
+
     const tray = await TrayLocator.find(':label(Tray Example)')
     await wait(() => expect(tray.getTextContent()).to.equal('Hello World'))
   })


### PR DESCRIPTION
Closes: INSTUI-3685

users now are allowed to set a newly added `selected` property on `Drilldown.Option` which allows them to control the

selection logic from outside of the component fix `selectableType=single`allowing de-selecting options
TEST PLAN:
run the test cases, verify that
[this](https://codesandbox.io/s/flamboyant-glitter-2dt3bg?file=/index.js) use case is working as expected