### PR TITLE
fix(ui-top-nav-bar): fix TopNavBar `smallViewport mode` example

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/README.md
+++ b/packages/ui-top-nav-bar/src/TopNavBar/README.md
@@ -1714,7 +1714,8 @@ render: false
 class LayoutExample extends React.Component {
   state = {
     exampleWidth: '100%',
-    isSecondaryNavigation: false
+    isSecondaryNavigation: false,
+    isSmallViewportMenuOpen: false
   }
 
   render() {
@@ -1776,6 +1777,9 @@ class LayoutExample extends React.Component {
                       trayMountNode: () => document.getElementById('menuMountNode'),
                       dropdownMenuToggleButtonLabel: 'Toggle Menu',
                       dropdownMenuLabel: 'Main Menu',
+                      onDropdownMenuToggle: (isMenuOpen) => {
+                        this.setState({ isSmallViewportMenuOpen: isMenuOpen })
+                      },
                       alternativeTitle: inverseColor ? 'Overview' : undefined
                     }}
                     renderBrand={
@@ -1931,9 +1935,12 @@ class LayoutExample extends React.Component {
                   : '3.5rem',
                 insetInlineStart: '0px',
                 width: '100%',
-                height: this.state.isSecondaryNavigation
+                height: !this.state.isSmallViewportMenuOpen
+                  ? '0'
+                  : this.state.isSecondaryNavigation
                   ? 'calc(100% - 3.5rem - 1px)'
                   : 'calc(100% - 3.5rem)',
+
               }}
             />
 

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/index.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/index.tsx
@@ -161,6 +161,10 @@ class TopNavBarSmallViewportLayout extends Component<
 
   componentWillUnmount() {
     this._raf.forEach((request) => request.cancel())
+
+    if (this.state.isDropdownMenuOpen) {
+      this.toggleDropdownMenu()
+    }
   }
 
   get makeStylesVariables(): TopNavBarSmallViewportLayoutStyleProps {


### PR DESCRIPTION
The menu mount element was covering the page content. Set the height to 0 when menu is not open.