### PR TITLE
INSTUI-3701 fix(ui-modal): fix screenreader focus order in Chrome

### DIFF
--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -29,6 +29,7 @@
     "@instructure/shared-types": "8.33.1",
     "@instructure/ui-buttons": "8.33.1",
     "@instructure/ui-dialog": "8.33.1",
+    "@instructure/ui-dom-utils": "8.33.1",
     "@instructure/ui-motion": "8.33.1",
     "@instructure/ui-overlays": "8.33.1",
     "@instructure/ui-portal": "8.33.1",

--- a/packages/ui-modal/src/Modal/ModalBody/props.ts
+++ b/packages/ui-modal/src/Modal/ModalBody/props.ts
@@ -58,6 +58,10 @@ type ModalBodyProps = ModalBodyOwnProps &
 
 type ModalBodyStyle = ComponentStyle<'modalBody'>
 
+type ModalBodyState = {
+  isFirefox: boolean
+}
+
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node,
   padding: ThemeablePropTypes.spacing,
@@ -79,5 +83,5 @@ const allowedProps: AllowedPropKeys = [
   'overflow'
 ]
 
-export type { ModalBodyProps, ModalBodyStyle }
+export type { ModalBodyProps, ModalBodyState, ModalBodyStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-modal/tsconfig.build.json
+++ b/packages/ui-modal/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "../shared-types/tsconfig.build.json" },
     { "path": "../ui-buttons/tsconfig.build.json" },
     { "path": "../ui-dialog/tsconfig.build.json" },
+    { "path": "../ui-dom-utils/tsconfig.build.json" },
     { "path": "../ui-motion/tsconfig.build.json" },
     { "path": "../ui-overlays/tsconfig.build.json" },
     { "path": "../ui-portal/tsconfig.build.json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,7 @@ __metadata:
     "@instructure/ui-buttons": 8.33.1
     "@instructure/ui-color-utils": 8.33.1
     "@instructure/ui-dialog": 8.33.1
+    "@instructure/ui-dom-utils": 8.33.1
     "@instructure/ui-motion": 8.33.1
     "@instructure/ui-overlays": 8.33.1
     "@instructure/ui-portal": 8.33.1


### PR DESCRIPTION
Screenreader was skipping modal content in Chrome because we made a View focusable. This fix makes the View unfocusable