### PR TITLE
Inst UI 3740/add contenteditable to focusableSelector

### DIFF
--- a/packages/ui-dom-utils/src/findFocusable.ts
+++ b/packages/ui-dom-utils/src/findFocusable.ts
@@ -37,6 +37,19 @@
 import { getComputedStyle, findDOMNode, elementMatches } from './'
 import { UIElement } from '@instructure/shared-types'
 
+const focusableSelector = [
+  'a[href]',
+  'frame',
+  'iframe',
+  'object',
+  'input:not([type=hidden])',
+  'select',
+  'textarea',
+  'button',
+  '*[tabindex]',
+  '[contenteditable="true"]'
+].join(',')
+
 function findFocusable(
   el?: UIElement,
   filter?: (el: Element) => boolean,
@@ -50,9 +63,6 @@ function findFocusable(
   ) {
     return []
   }
-
-  const focusableSelector =
-    'a[href],frame,iframe,object,input:not([type=hidden]),select,textarea,button,*[tabindex]'
 
   let matches = Array.from(
     (element as Element | Document).querySelectorAll(focusableSelector)


### PR DESCRIPTION
findFocusable doesn’t match elements with `contenteditable=true`. In my case, it causes it to skip the next element and goes straight to the close button. Somehow going backward works fine 🤷 

Before:

https://user-images.githubusercontent.com/1939060/223365814-ea9ce84f-005a-4e28-a858-0130aababc95.mov

After:

https://user-images.githubusercontent.com/1939060/223365875-43c15442-5dcf-46e4-9974-2d7443c93af2.mov

