### PR TITLE
perf(ui-select): improve perf for large amount of items

### DIFF
--- a/packages/ui-options/src/Options/index.tsx
+++ b/packages/ui-options/src/Options/index.tsx
@@ -136,6 +136,7 @@ class Options extends Component<OptionsProps> {
       if (matchComponentTypes(child, ['Item', 'Separator'])) {
         return safeCloneElement(child, { as: this.childAs || child.props.as })
       }
+
       return undefined
     })
   }


### PR DESCRIPTION
This PR aims to fix the rendering performance of `Select` and `SimpleSelect` in case of large amount of `Select.Option`s are passed to them.

This "fix" is more of a temporary solution since it only addresses the problem in `Select`.
The main issue is that component that use the `<Option>` sub-component are prone to this performance problem because they often just expose a wrapper Option component (like `Select.Option`, that is essentially a facade, just used for proptype checking) and then internally map from this wrapper to the `Option` component, and because of this re-mapping it is hard to use common optimization techniques to get better performance.

This PR add a new memoed layer between to this mapping of `Select.Option` => `Options.Item`. The main problem was that in case the `Select` receives a large enough of items to render, when any of the props changed on the `Select.Option` basically every item had to be re-rendered.
This memoed layer circumvents this, and checks whether any prop changed since the last render on the `Select.Option` and only re-renders in cases that are actually changing props. (such as highlighting an item) 

### How to test this out locally
Copy and paste this [code](https://gist.github.com/Brailor/cb9b29322805ec23d8d21e7cd62a2664) to `packages/__docs__/src/index.js` and observe the results. Highlighting and selecting items should feel much more seamless.