### PR TITLE
INSTUI-3756 fix(ui-date-time-input): dateTimeInput does not trigger invalidDateTimeMessage on blur

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/README.md
@@ -65,6 +65,7 @@ class Example extends React.Component {
   onChange = (e, isoDate) => {
     let messages = []
     if (!isoDate) {
+      // this happens if an invalid date is entered
       this.setState({ messages })
       return
     }

--- a/packages/ui-date-time-input/src/DateTimeInput/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/README.md
@@ -63,9 +63,13 @@ class Example extends React.Component {
   }
 
   onChange = (e, isoDate) => {
+    let messages = []
+    if (!isoDate) {
+      this.setState({ messages })
+      return
+    }
     const now = new Date()
     const newValue = new Date(isoDate)
-    let messages = []
     if ( newValue.valueOf() <= now.valueOf()) {
       messages = [{text: 'That date-time is in the past', type: 'hint'}]
     }

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -564,6 +564,9 @@ describe('<DateTimeInput />', async () => {
       />
     )
     const dateTimeInput = await DateTimeInputLocator.find()
+    const dateLocator = await dateTimeInput.findDateInput()
+    const dateInput = await dateLocator.findInput()
+    await dateInput.focusOut()
     expect(await dateTimeInput.find(':contains(whoops)')).to.exist()
   })
 
@@ -580,6 +583,9 @@ describe('<DateTimeInput />', async () => {
       />
     )
     const dateTimeInput = await DateTimeInputLocator.find()
+    const dateLocator = await dateTimeInput.findDateInput()
+    const dateInput = await dateLocator.findInput()
+    await dateInput.focusOut()
     expect(await dateTimeInput.find(':contains(whoops)')).to.exist()
   })
 
@@ -608,6 +614,9 @@ describe('<DateTimeInput />', async () => {
       await dateTimeInput.find(':contains(May 1, 2017 1:30 PM)')
     ).to.exist()
     await subject.setProps({ value: 'A very invalid date' })
+    const dateLocator = await dateTimeInput.findDateInput()
+    const dateInput = await dateLocator.findInput()
+    await dateInput.focusOut()
     expect(await dateTimeInput.find(':contains(whoops)')).to.exist()
   })
 

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -159,7 +159,42 @@ describe('<DateTimeInput />', async () => {
     expect(timeInput).to.have.value('12:00 AM')
   })
 
-  it('should call invalidDateTimeMessage if time is set w/o a date', async () => {
+  it('should call invalidDateTimeMessage if time is set w/o a date and is required', async () => {
+    const props = {
+      invalidDateTimeMessage: (_rawd: unknown) => 'whoops'
+    }
+    const messageSpy = spy(props, 'invalidDateTimeMessage')
+
+    await mount(
+      <DateTimeInput
+        description="date time"
+        dateRenderLabel="date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        timeRenderLabel="time"
+        locale="en-US"
+        timezone="US/Eastern"
+        isRequired
+        {...props}
+      />
+    )
+
+    const dateTimeInput = await DateTimeInputLocator.find()
+    const timeLocator = await dateTimeInput.findTimeInput()
+
+    const timeInput = await timeLocator.findInput()
+
+    await timeInput.change({ target: { value: '1:00 PM' } })
+    await timeInput.keyDown('enter')
+
+    await wait(() => {
+      expect(messageSpy).to.have.been.called()
+    })
+
+    expect(await dateTimeInput.find(':contains(whoops)')).to.exist()
+  })
+
+  it('should not call invalidDateTimeMessage if time is set w/o a date', async () => {
     const props = {
       invalidDateTimeMessage: (_rawd: unknown) => 'whoops'
     }
@@ -187,10 +222,14 @@ describe('<DateTimeInput />', async () => {
     await timeInput.keyDown('enter')
 
     await wait(() => {
-      expect(messageSpy).to.have.been.called()
+      expect(messageSpy).to.have.not.been.called()
     })
 
-    expect(await dateTimeInput.find(':contains(whoops)')).to.exist()
+    expect(
+      await dateTimeInput.find(':contains(whoops)', {
+        expectEmpty: true
+      })
+    ).to.not.exist()
   })
 
   it('should fire the onChange event when DateInput value changes', async () => {

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -169,13 +169,13 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
           renderedDate: parsed.clone()
         }
       }
-      if (dateStr.length > 0 || this.props.isRequired) {
-        const text =
-          typeof this.props.invalidDateTimeMessage === 'function'
-            ? this.props.invalidDateTimeMessage(dateStr)
-            : this.props.invalidDateTimeMessage
-        errorMsg = text ? { text, type: 'error' } : undefined
-      }
+    }
+    if (this.props.isRequired || (dateStr && dateStr.length > 0)) {
+      const text =
+        typeof this.props.invalidDateTimeMessage === 'function'
+          ? this.props.invalidDateTimeMessage(dateStr ? dateStr : '')
+          : this.props.invalidDateTimeMessage
+      errorMsg = { text: text, type: 'error' }
     }
     return {
       iso: undefined,
@@ -256,23 +256,16 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     // timeout is needed here because handleDayClick could be called in the same
     // frame, and it updates calendarSelectedDate which is read in here.
     window.setTimeout(() => {
-      // update state based on the DateInput's text value
-      if (
-        this.state.dateInputTextChanged ||
-        (event as React.KeyboardEvent).key === 'Enter'
-      ) {
+      if ((event as React.KeyboardEvent).key === 'Enter') {
+        // user pressed enter, use the selected value in the calendar
+        this.updateStateBasedOnDateInput(
+          this.state.calendarSelectedDate!,
+          event
+        )
+      } else {
+        // user clicked outside/tabbed away/pressed esc, try to use the value in dateInputText
         const dateParsed = this.tryParseDate(this.state.dateInputText)
         this.updateStateBasedOnDateInput(dateParsed, event)
-      } else {
-        // user clicked outside or tabbed away or pressed esc, reset text
-        this.setState({
-          dateInputText: this.state.iso
-            ? this.state.iso.format(this.dateFormat)
-            : '',
-          calendarSelectedDate: this.state.iso
-            ? this.state.iso.clone()
-            : undefined
-        })
       }
       this.setState({ isShowingCalendar: false, dateInputTextChanged: false })
     }, 0)
@@ -373,8 +366,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     toAlter.add({ days: 1 })
     this.setState({
       calendarSelectedDate: toAlter,
-      renderedDate: toAlter.clone(),
-      dateInputText: toAlter.format(this.dateFormat)
+      renderedDate: toAlter.clone()
     })
   }
 
@@ -390,8 +382,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     toAlter.subtract({ days: 1 })
     this.setState({
       calendarSelectedDate: toAlter,
-      renderedDate: toAlter.clone(),
-      dateInputText: toAlter.format(this.dateFormat)
+      renderedDate: toAlter.clone()
     })
   }
 

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -309,15 +309,11 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     event: SyntheticEvent,
     option: { value?: string; inputText: string }
   ) => {
-    let newValue: string | undefined
-    if (this.state.iso) {
-      newValue = option.value
-    } else {
-      // if no date is set just return the input text, it will error
-      newValue = option.inputText
-    }
+    // this.state.iso is undefined if date is invalid or not set.
+    // in this case recalculate with the dateInput's text which will result in
+    // an empty valid date (if isRequired is false) or an invalid date.
+    const newValue = this.state.iso ? option.value : this.state.dateInputText
     const newState = this.recalculateState(newValue, true, false)
-
     this.changeStateIfNeeded(newState, event)
     this.setState({ timeSelectValue: option.value })
   }

--- a/packages/ui-date-time-input/src/DateTimeInput/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/props.ts
@@ -232,8 +232,8 @@ type DateTimeInputState = {
   // the date rendered by the opened calendar. Not selected just determines
   // which month/year to show
   renderedDate: Moment
-  // The value currently displayed in the dateTime component.
-  // Just the time part is visible
+  // The value currently displayed in the dateInput component.
+  // Just the date part is visible
   dateInputText: string
   // The value currently displayed in the timeSelect component as ISO datetime
   timeSelectValue?: string

--- a/packages/ui-date-time-input/src/DateTimeInput/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/props.ts
@@ -176,7 +176,8 @@ type DateTimeInputProps = {
   )[]
   /**
    * Specifies if the input is required (its passed down to the native DOM
-   * elements).
+   * elements). If its `true` then an empty input will produce an error message
+   * (`invalidDateTimeMessage`)
    */
   isRequired?: boolean
   /**


### PR DESCRIPTION
note that there is a slight visual change, now if you move with the arrows the input text wont change.
Also now triggering the invalid date message is more consistent, it triggers on empty inputs if `isRequired` is true and does not if its false.