### PR TITLE
fix(ui-text-input): fix TextInput padding calculation vol.2.

### DIFF
--- a/packages/ui-text-input/src/TextInput/index.tsx
+++ b/packages/ui-text-input/src/TextInput/index.tsx
@@ -289,11 +289,11 @@ class TextInput extends Component<TextInputProps, TextInputState> {
     const computedStyle = getComputedStyle(element)
     const { width, paddingInlineStart, paddingInlineEnd } = computedStyle
 
-    if (width === 'auto') {
+    if (width === 'auto' || width === '') {
       // This is a workaround for an edge-case, when the TextInput's parent
       // is hidden on load, so the element is not visible either.
-      // In this case the computed width is going to be 'auto', so we assume
-      // it has width so that the padding won't be removed.
+      // In this case the computed width is going to be either 'auto' or '',
+      // so we assume it has width so that the padding won't be removed.
       return true
     }
 


### PR DESCRIPTION
This is a small addition for a former fix in [PR#1178](https://github.com/instructure/instructure-ui/pull/1178)

Original issue: https://github.com/instructure/instructure-ui/issues/1175