### PR TITLE
feat(ui-progress): add `shouldAnimate` prop to ProgressBar

### DIFF
--- a/packages/ui-progress/src/ProgressBar/README.md
+++ b/packages/ui-progress/src/ProgressBar/README.md
@@ -162,3 +162,109 @@ example: true
   valueNow={33}
 />
 ```
+
+### `shouldAnimate`
+
+The `shouldAnimate` prop makes the progress bar animate the transition between value changes, giving it a smoother look.
+
+```js
+---
+example: true
+render: false
+---
+class Example extends React.Component {
+  MIN = 0
+  MAX = 100
+
+  state = {
+    value: 25,
+    shouldAnimate: true
+  }
+
+  bound (n) {
+    if (n < this.MIN) return this.MIN
+    if (n > this.MAX) return this.MAX
+    return n
+  }
+
+  setNumber (n) {
+    return { value: this.bound(n) }
+  }
+
+  handleChange = (event, value) => {
+    const newValue = Number(value)
+
+    if (isNaN(newValue)) {
+      return
+    }
+
+    this.setState({
+      value: newValue
+    })
+  }
+
+  handleDecrement = (event) => this.setState(({ value }) => {
+    if (Number.isInteger(value)) {
+      return this.setNumber(value - 1)
+    }
+    return this.setNumber(Math.floor(value))
+  })
+
+  handleIncrement = (event) => this.setState(({ value }) => {
+    if (Number.isInteger(value)) {
+      return this.setNumber(value + 1)
+    }
+    return this.setNumber(Math.ceil(value))
+  })
+
+  handleBlur = (event) => this.setState(({ value }) => {
+    return this.setNumber(Math.round(value))
+  })
+
+  render() {
+    return (
+      <div>
+        <View
+          as="div"
+          background="primary"
+          padding="medium"
+          margin="0 0 large 0"
+        >
+          <FormFieldGroup
+            description={<ScreenReaderContent>Settings</ScreenReaderContent>}
+          >
+            <Checkbox
+              label="Should animate"
+              checked={this.state.shouldAnimate}
+              onChange={() => {
+                this.setState({ shouldAnimate: !this.state.shouldAnimate })
+              }}
+              variant="toggle"
+            />
+
+            <NumberInput
+              renderLabel={`ProgressBar value (${this.MIN}-${this.MAX})`}
+              display="inline-block"
+              onBlur={this.handleBlur}
+              onChange={this.handleChange}
+              onDecrement={this.handleDecrement}
+              onIncrement={this.handleIncrement}
+              showArrows
+              value={this.state.value}
+            />
+          </FormFieldGroup>
+        </View>
+
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          valueNow={this.state.value}
+          valueMax={this.MAX}
+          shouldAnimate={this.state.shouldAnimate}
+        />
+      </div>
+    )
+  }
+}
+
+render(<Example />)
+```

--- a/packages/ui-progress/src/ProgressBar/__examples__/ProgressBar.examples.tsx
+++ b/packages/ui-progress/src/ProgressBar/__examples__/ProgressBar.examples.tsx
@@ -31,6 +31,7 @@ const valueMax = 100
 
 export default {
   sectionProp: 'color',
+  excludeProps: ['shouldAnimate'],
   propValues: {
     valueNow: [0, 40, 80, 100],
     renderValue: [

--- a/packages/ui-progress/src/ProgressBar/index.tsx
+++ b/packages/ui-progress/src/ProgressBar/index.tsx
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 /** @jsx jsx */
 import { Component } from 'react'
 
@@ -32,6 +33,7 @@ import { withStyle, jsx } from '@instructure/emotion'
 
 import generateStyle from './styles'
 import generateComponentTheme from './theme'
+
 import type { ProgressBarProps, Values } from './props'
 import { allowedProps, propTypes } from './props'
 
@@ -57,6 +59,7 @@ class ProgressBar extends Component<ProgressBarProps> {
     valueNow: 0,
     as: 'div',
     color: 'primary',
+    shouldAnimate: false,
 
     // default to showing `success` color on completion
     meterColor: ({ valueNow, valueMax }: Values) =>
@@ -121,11 +124,8 @@ class ProgressBar extends Component<ProgressBarProps> {
         elementRef={this.handleRef}
       >
         <span css={styles?.trackLayout}>
-          {/* creates bottom border effect - <progress /> hard to style x-browser */}
-          <span css={styles?.trackBorder}></span>
-
           <progress
-            css={styles?.track}
+            css={styles?.htmlProgress}
             max={valueMax}
             value={valueNow}
             role="progressbar"
@@ -134,6 +134,10 @@ class ProgressBar extends Component<ProgressBarProps> {
             aria-valuemax={valueMax}
             aria-label={labelAndValueText}
           />
+
+          <span css={styles?.track} role="presentation" aria-hidden="true">
+            <span css={styles?.trackValue}></span>
+          </span>
         </span>
 
         {value && (

--- a/packages/ui-progress/src/ProgressBar/props.ts
+++ b/packages/ui-progress/src/ProgressBar/props.ts
@@ -53,31 +53,38 @@ type ProgressBarOwnProps = {
    * A label is required for accessibility
    */
   screenReaderLabel: string
+
   /**
    * Control the height of the progress bar
    */
   size?: 'x-small' | 'small' | 'medium' | 'large'
+
   /**
    * Maximum value (defaults to 100)
    */
   valueMax?: Values['valueMax']
+
   /**
    * Receives the progress of the event
    */
   valueNow?: Values['valueNow']
+
   /**
    * A function for formatting the text provided to screen readers via `aria-valuenow`
    */
   formatScreenReaderValue?: (values: Values) => string
+
   /**
    * A function to format the displayed value. If null the value will not display.
    * Takes `valueNow` and `valueMax` as parameters.
    */
   renderValue?: Renderable<Values>
+
   /**
    * Controls the overall color scheme of the component
    */
   color?: 'primary' | 'primary-inverse'
+
   /**
    * Control the color of the progress meter. Defaults to showing theme success
    * color on completion, based on `valueNow` and `valueMax`.
@@ -85,16 +92,24 @@ type ProgressBarOwnProps = {
   meterColor?:
     | ((values: Values) => ProgressBarMeterColor)
     | ProgressBarMeterColor
+
+  /**
+   * Whether the change of value should have a transition
+   */
+  shouldAnimate?: boolean
+
   /**
    * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
    * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
    * familiar CSS-like shorthand. For example: `margin="small auto large"`.
    */
   margin?: Spacing
+
   /**
    * Provides a reference to the component's root HTML element
    */
   elementRef?: (element: Element | null) => void
+
   /**
    * Set the element type of the component's root
    */
@@ -110,7 +125,12 @@ type ProgressBarProps = ProgressBarOwnProps &
   OtherHTMLAttributes<ProgressBarOwnProps>
 
 type ProgressBarStyle = ComponentStyle<
-  'progressBar' | 'trackLayout' | 'trackBorder' | 'track' | 'value'
+  | 'progressBar'
+  | 'trackLayout'
+  | 'track'
+  | 'trackValue'
+  | 'value'
+  | 'htmlProgress'
 >
 
 const propTypes: PropValidators<PropKeys> = {
@@ -125,6 +145,7 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.func,
     PropTypes.oneOf(['info', 'warning', 'danger', 'alert', 'success', 'brand'])
   ]),
+  shouldAnimate: PropTypes.bool,
   margin: ThemeablePropTypes.spacing,
   elementRef: PropTypes.func,
   as: PropTypes.elementType
@@ -139,6 +160,7 @@ const allowedProps: AllowedPropKeys = [
   'renderValue',
   'color',
   'meterColor',
+  'shouldAnimate',
   'margin',
   'elementRef',
   'as'

--- a/packages/ui-progress/src/ProgressBar/styles.ts
+++ b/packages/ui-progress/src/ProgressBar/styles.ts
@@ -39,12 +39,24 @@ const generateStyle = (
   componentTheme: ProgressBarTheme,
   props: ProgressBarProps
 ): ProgressBarStyle => {
-  const { valueNow = 0, valueMax = 100, size, color, meterColor } = props
+  const {
+    valueNow = 0,
+    valueMax = 100,
+    size,
+    color,
+    meterColor,
+    shouldAnimate
+  } = props
 
   const meterColorClassName =
     typeof meterColor === 'function'
       ? meterColor({ valueNow, valueMax })
       : meterColor
+
+  const currentValue =
+    valueNow > valueMax ? valueMax : valueNow < 0 ? 0 : valueNow
+
+  const currentValuePercent = `${(currentValue / valueMax) * 100}%`
 
   const sizeVariants = {
     'x-small': {
@@ -118,50 +130,30 @@ const generateStyle = (
       ...colorVariants[color!].trackLayout
     },
 
-    trackBorder: {
-      label: 'progressBar__trackBorder',
+    track: {
+      label: 'progressBar__track',
       display: 'block',
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      width: '100%',
-      height: '100%',
       boxSizing: 'border-box',
+      width: '100%',
       borderBottomWidth: componentTheme.trackBottomBorderWidth,
       borderBottomStyle: 'solid',
+      background: 'transparent',
 
+      ...sizeVariants[size!].track,
       ...colorVariants[color!].trackBorder
     },
 
-    track: {
-      label: 'progressBar__track',
-      '&[value]': {
-        display: 'block',
-        position: 'relative',
-        boxSizing: 'border-box',
-        appearance: 'none',
-        background: 'transparent',
-        width: '100%',
-        border: 'none',
+    trackValue: {
+      label: 'progressBar__trackValue',
+      display: 'block',
+      boxSizing: 'border-box',
+      height: '100%',
+      width: currentValuePercent,
+      maxWidth: '100%',
 
-        ...sizeVariants[size!].track,
-
-        '&::-webkit-progress-bar': { background: 'transparent' },
-
-        '&::-webkit-progress-value': {
-          ...(meterColorClassName &&
-            trackBackgroundVariants[color!][meterColorClassName])
-        },
-        '&::-moz-progress-bar': {
-          ...(meterColorClassName &&
-            trackBackgroundVariants[color!][meterColorClassName])
-        },
-        '&::-ms-fill': {
-          border: 'none',
-          ...(meterColorClassName &&
-            trackBackgroundVariants[color!][meterColorClassName])
-        }
-      }
+      ...(shouldAnimate && { transition: 'all 0.5s' }),
+      ...(meterColorClassName &&
+        trackBackgroundVariants[color!][meterColorClassName])
     },
 
     value: {
@@ -172,6 +164,19 @@ const generateStyle = (
       flex: '0 0 5.625rem',
 
       ...sizeVariants[size!].value
+    },
+
+    htmlProgress: {
+      label: 'progressBar__htmlProgress',
+      display: 'block',
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      width: '100%',
+      height: '100%',
+      boxSizing: 'border-box',
+      zIndex: -1,
+      opacity: 0
     }
   }
 }

--- a/packages/ui-progress/src/ProgressBar/styles.ts
+++ b/packages/ui-progress/src/ProgressBar/styles.ts
@@ -103,8 +103,8 @@ const generateStyle = (
     },
     'primary-inverse': {
       brand: { background: componentTheme.meterColorBrandInverse },
-      info: { background: componentTheme.meterColorSuccessInverse },
-      success: {},
+      info: { background: componentTheme.meterColorInfoInverse },
+      success: { background: componentTheme.meterColorSuccessInverse },
       danger: { background: componentTheme.meterColorDangerInverse },
       warning: { background: componentTheme.meterColorWarningInverse },
       alert: { background: componentTheme.meterColorAlertInverse }


### PR DESCRIPTION
Closes: INSTUI-3751

This change adds the `shouldAnimate` prop to ProgressBar, which makes animates the change between values. To implement this feature, the complement had to be be refactored to "hide" the HTML `<progress>` element in the DOM and render a custom progress bar in front of it. There are two reasons for this: it was impossible to style the HTML progress to animate in Firefox as well, but we had to keep it for accessibility purposes.