### PR TITLE
DateTimeInput: Allow the user to enter non-step divisible time values

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/README.md
@@ -45,7 +45,7 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
-#### A required DateInput with `stacked` layout that warns if the value in the past:
+#### A required DateInput with `stacked` layout that warns if the value in the past that allows the user to enter any time value:
 
 ```js
 ---
@@ -95,6 +95,7 @@ class Example extends React.Component {
             value={this.state.value}
             invalidDateTimeMessage="Invalid date!"
             messages={this.state.messages}
+            allowNonStepInput={true}
             isRequired
           />
         </div>

--- a/packages/ui-date-time-input/src/DateTimeInput/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/README.md
@@ -45,7 +45,9 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
-#### A required DateInput with `stacked` layout that warns if the value in the past that allows the user to enter any time value:
+#### A required DateInput with `stacked` layout that warns if the value in the past:
+
+This sample code also allows the user to enter an arbitrary time value by setting `allowNonStepInput` to `true`.
 
 ```js
 ---

--- a/packages/ui-date-time-input/src/DateTimeInput/__examples__/DateTimeInput.examples.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/__examples__/DateTimeInput.examples.ts
@@ -42,7 +42,8 @@ export default {
       ]
     ],
     interaction: ['enabled', 'disabled'],
-    disabledDates: [undefined]
+    disabledDates: [undefined],
+    allowNonStepInput: [false]
   },
   getComponentProps: (props) => {
     const defaultPropsForLayout =

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -850,7 +850,7 @@ describe('<DateTimeInput />', async () => {
     expect(timeInput).to.have.value(newDateTime.format('LT'))
   })
 
-  it.only('should allow the user to enter any time value if allowNonStepInput is true', async () => {
+  it('should allow the user to enter any time value if allowNonStepInput is true', async () => {
     const onChange = stub()
 
     await mount(

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -849,4 +849,41 @@ describe('<DateTimeInput />', async () => {
     expect(dateInput).to.have.value(newDateTime.format('LL'))
     expect(timeInput).to.have.value(newDateTime.format('LT'))
   })
+
+  it.only('should allow the user to enter any time value if allowNonStepInput is true', async () => {
+    const onChange = stub()
+
+    await mount(
+      <DateTimeInput
+        description="date time"
+        dateRenderLabel="date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        timeRenderLabel="time"
+        invalidDateTimeMessage="whoops"
+        locale="en-US"
+        timezone="US/Eastern"
+        onChange={onChange}
+        allowNonStepInput={true}
+      />
+    )
+
+    const dateTimeInput = await DateTimeInputLocator.find()
+
+    const timeLocator = await dateTimeInput.findTimeInput()
+    const timeInput = await timeLocator.findInput()
+    await timeInput.typeIn('7:34 PM')
+    await timeInput.keyDown('Enter') // should send onChange event
+    await timeInput.keyUp('esc') // should do nothing
+
+    const dateLocator = await dateTimeInput.findDateInput()
+    const dateInput = await dateLocator.findInput()
+    await dateInput.change({ target: { value: 'May 1, 2017' } })
+    await dateInput.keyDown('Enter')
+
+    await wait(() => {
+      expect(onChange).to.have.been.called()
+      expect(onChange.getCall(0).args[1]).to.include('2017-05-01T23:34:00.000Z')
+    })
+  })
 })

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -60,7 +60,8 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     timeStep: 30,
     messageFormat: DateTimeInput.DEFAULT_MESSAGE_FORMAT,
     isRequired: false,
-    dateFormat: 'LL' // Localized date with full month, e.g. "August 6, 2014"
+    dateFormat: 'LL', // Localized date with full month, e.g. "August 6, 2014"
+    allowNonStepInput: false
   } as const
 
   declare context: React.ContextType<typeof ApplyLocaleContext>

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -515,7 +515,8 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
       colSpacing,
       isRequired,
       interaction,
-      renderWeekdayLabels
+      renderWeekdayLabels,
+      allowNonStepInput
     } = this.props
 
     return (
@@ -573,6 +574,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
           timezone={timezone}
           inputRef={timeInputRef}
           interaction={interaction}
+          allowNonStepInput={allowNonStepInput}
         />
       </FormFieldGroup>
     )

--- a/packages/ui-date-time-input/src/DateTimeInput/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/props.ts
@@ -220,6 +220,15 @@ type DateTimeInputProps = {
    * If not specified the component will show the `invalidDateTimeMessage`.
    */
   disabledDateTimeMessage?: string | ((rawDateValue: string) => string)
+  /**
+   * Whether to allow the user to enter non-step divisible values in the time
+   * input field. Note that even if this is set to false one can enter non-step
+   * divisible values programmatically. The user will need to enter the value
+   * exactly (except for lower/uppercase) as specified by the `timeFormat` prop
+   * for it to be accepted.
+   * Default is `undefined` which equals to `false`
+   */
+  allowNonStepInput?: boolean
 }
 
 type DateTimeInputState = {
@@ -288,7 +297,8 @@ const propTypes: PropValidators<PropKeys> = {
   disabledDateTimeMessage: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func
-  ])
+  ]),
+  allowNonStepInput: PropTypes.bool
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -319,7 +329,8 @@ const allowedProps: AllowedPropKeys = [
   'timeInputRef',
   'onBlur',
   'disabledDates',
-  'disabledDateTimeMessage'
+  'disabledDateTimeMessage',
+  'allowNonStepInput'
 ]
 
 export type { DateTimeInputProps, DateTimeInputState }


### PR DESCRIPTION
Closes: INSTUI-3766

This exposes the `allowNonStepInput` prop from the underlying `TimeSelect`, it should behave the same way