### PR TITLE
INSTUI-3772 Refactor(ui-time-select): rewrite logic if allowNonStepInput is true

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -185,7 +185,7 @@ describe('<DateTimeInput />', async () => {
     const timeInput = await timeLocator.findInput()
 
     await timeInput.change({ target: { value: '1:00 PM' } })
-    await timeInput.keyDown('enter')
+    await timeInput.focusOut()
 
     await wait(() => {
       expect(messageSpy).to.have.been.called()
@@ -873,8 +873,7 @@ describe('<DateTimeInput />', async () => {
     const timeLocator = await dateTimeInput.findTimeInput()
     const timeInput = await timeLocator.findInput()
     await timeInput.typeIn('7:34 PM')
-    await timeInput.keyDown('Enter') // should send onChange event
-    await timeInput.keyUp('esc') // should do nothing
+    await timeInput.focusOut()
 
     const dateLocator = await dateTimeInput.findDateInput()
     const dateInput = await dateLocator.findInput()

--- a/packages/ui-time-select/src/TimeSelect/README.md
+++ b/packages/ui-time-select/src/TimeSelect/README.md
@@ -2,7 +2,7 @@
 describes: TimeSelect
 ---
 
-`TimeSelect` component is a higher level abstraction of [Select](#Select) specifically for selecting time values. The list of possible values can be configured via the component's props. If you need to select times and dates, be sure to check out the documentation around [Time and Date patterns](#TimeDate).
+`TimeSelect` component is a higher level abstraction of [Select](#Select) specifically for selecting time values. The list of possible values can be configured via the component's props.
 
 ### Uncontrolled
 

--- a/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
+++ b/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
@@ -444,6 +444,26 @@ describe('<TimeSelect />', async () => {
     expect(input.getAttribute('value')).to.equal('7:34 PM')
   })
 
+  it('should round down seconds when applicable', async () => {
+    const onChange = stub()
+    await mount(
+      <TimeSelect
+        renderLabel="Choose a time"
+        allowNonStepInput={true}
+        locale="en_AU"
+        format="LTS" // shows seconds
+        timezone="US/Eastern"
+        onChange={onChange}
+      />
+    )
+    const select = await TimeSelectLocator.find()
+    const input = await select.findInput()
+    await input.change({ target: { value: '' } })
+    await input.typeIn('04:45:55 AM')
+    await input.focusOut() // sends onChange event
+    expect(input.getAttribute('value')).to.equal('4:45:00 AM')
+  })
+
   it('adding event listeners does not break functionality', async () => {
     const onChange = stub()
     const onKeyDown = stub()

--- a/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
+++ b/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
@@ -135,7 +135,7 @@ describe('<TimeSelect />', async () => {
     expect(input.getAttribute('value')).to.equal(options[3].getTextContent())
   })
 
-  it('should not change value in controlled mode', async () => {
+  it('Pressing ESC should reset the value in controlled mode', async () => {
     const onChange = stub()
     const onKeyDown = stub()
     const handleInputChange = stub()
@@ -161,6 +161,26 @@ describe('<TimeSelect />', async () => {
     expect(onKeyDown).to.have.been.called()
     expect(handleInputChange).to.have.been.called()
     expect(input.getAttribute('value')).to.equal('')
+  })
+
+  it('value should not be changeable via user input in controlled mode', async () => {
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', 'en-US', 'GMT')
+    await mount(
+      <TimeSelect
+        renderLabel="Choose a time"
+        allowNonStepInput={true}
+        value={dateTime.toISOString()}
+        locale="en_AU"
+        timezone="US/Eastern"
+      />
+    )
+    const select = await TimeSelectLocator.find()
+    const input = await select.findInput()
+    await input.change({ target: { value: '' } })
+    await input.typeIn('1:45 PM')
+    await input.keyDown('Enter')
+    await input.focusOut()
+    expect(input.getAttribute('value')).to.equal('1:30 PM')
   })
 
   it('should keep selection when value changes', async () => {

--- a/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
+++ b/packages/ui-time-select/src/TimeSelect/__tests__/TimeSelect.test.tsx
@@ -135,6 +135,34 @@ describe('<TimeSelect />', async () => {
     expect(input.getAttribute('value')).to.equal(options[3].getTextContent())
   })
 
+  it('should not change value in controlled mode', async () => {
+    const onChange = stub()
+    const onKeyDown = stub()
+    const handleInputChange = stub()
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', 'en-US', 'GMT')
+    const subject = await mount(
+      <TimeSelect
+        renderLabel="Choose a time"
+        allowNonStepInput={true}
+        value={dateTime.toISOString()}
+        locale="en_AU"
+        timezone="US/Eastern"
+        onChange={onChange}
+        onInputChange={handleInputChange}
+        onKeyDown={onKeyDown}
+      />
+    )
+    const select = await TimeSelectLocator.find()
+    const input = await select.findInput()
+    await subject.setProps({ value: '' })
+    await input.typeIn('7:45 PM')
+    await input.keyUp('Esc') // should reset the value
+    expect(onChange).to.have.been.not.called()
+    expect(onKeyDown).to.have.been.called()
+    expect(handleInputChange).to.have.been.called()
+    expect(input.getAttribute('value')).to.equal('')
+  })
+
   it('should keep selection when value changes', async () => {
     const onChange = stub()
     const locale = 'en-US'
@@ -378,12 +406,10 @@ describe('<TimeSelect />', async () => {
 
   it('should allow non-step value when allowNonStepInput=true', async () => {
     const onChange = stub()
-    const dateTime = DateTime.parse('2017-05-01T17:30Z', 'en-US', 'GMT')
-    const subject = await mount(
+    await mount(
       <TimeSelect
         renderLabel="Choose a time"
         allowNonStepInput={true}
-        value={dateTime.toISOString()}
         locale="en_AU"
         timezone="US/Eastern"
         onChange={onChange}
@@ -391,10 +417,8 @@ describe('<TimeSelect />', async () => {
     )
     const select = await TimeSelectLocator.find()
     const input = await select.findInput()
-    await subject.setProps({ value: '' })
     await input.typeIn('7:34 PM')
-    await input.keyDown('Enter') // sends onChange event
-    await input.keyUp('esc') // should do nothing
+    await input.focusOut() // sends onChange event
     expect(onChange).to.have.been.called()
     expect(lastCall(onChange)[1].value).to.exist()
     expect(input.getAttribute('value')).to.equal('7:34 PM')
@@ -404,12 +428,10 @@ describe('<TimeSelect />', async () => {
     const onChange = stub()
     const onKeyDown = stub()
     const handleInputChange = stub()
-    const dateTime = DateTime.parse('2017-05-01T17:30Z', 'en-US', 'GMT')
-    const subject = await mount(
+    await mount(
       <TimeSelect
         renderLabel="Choose a time"
         allowNonStepInput={true}
-        value={dateTime.toISOString()}
         locale="en_AU"
         timezone="US/Eastern"
         onChange={onChange}
@@ -419,10 +441,8 @@ describe('<TimeSelect />', async () => {
     )
     const select = await TimeSelectLocator.find()
     const input = await select.findInput()
-    await subject.setProps({ value: '' })
     await input.typeIn('7:45 PM')
-    await input.keyDown('Enter') // sends onChange event
-    await input.keyUp('esc') // should do nothing
+    await input.focusOut() // sends onChange event
     expect(onChange).to.have.been.called()
     expect(onKeyDown).to.have.been.called()
     expect(handleInputChange).to.have.been.called()

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -289,17 +289,28 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
   }
 
   filterOptions(inputValue: string) {
-    if (this.props.allowNonStepInput && inputValue.length < 3) {
+    let inputNoSeconds = inputValue
+    // if the input contains seconds disregard them (e.g. if format = LTS)
+    if (inputValue.length > 5) {
+      // e.g. "5:34:"
+      const input = this.parseInputText(inputValue)
+      if (input.isValid()) {
+        input.set({ second: 0 })
+        inputNoSeconds = input.format(this.props.format)
+      }
+    }
+
+    if (this.props.allowNonStepInput && inputNoSeconds.length < 3) {
       // could show too many results, show only step values
       return this.state?.options.filter((option: TimeSelectOptions) => {
         return (
-          option.label.toLowerCase().startsWith(inputValue.toLowerCase()) &&
+          option.label.toLowerCase().startsWith(inputNoSeconds.toLowerCase()) &&
           option.value.minute() % this.props.step! == 0
         )
       })
     }
     return this.state?.options.filter((option: TimeSelectOptions) =>
-      option.label.toLowerCase().startsWith(inputValue.toLowerCase())
+      option.label.toLowerCase().startsWith(inputNoSeconds.toLowerCase())
     )
   }
 

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -211,8 +211,13 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
     return {
       inputValue: initialSelection ? initialSelection.label : '',
       options: initialOptions,
+      // 288 = 5 min step
       filteredOptions:
-        initialOptions.length > 30 ? this.filterOptions('') : initialOptions,
+        initialOptions.length > 288
+          ? initialOptions.filter(
+              (opt) => opt.value.minute() % this.props.step! === 0
+            )
+          : initialOptions,
       isShowingOptions: false,
       highlightedOptionId: initialSelection ? initialSelection.id : undefined,
       selectedOptionId: initialSelection ? initialSelection.id : undefined

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -309,15 +309,19 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
     const value = event.target.value
     const newOptions = this.filterOptions(value)
     if (newOptions?.length == 1) {
-      // if there is only 1 option, it will be automatically selected.
-      // This will cause an onChange event to fire when handleBlurOrEsc is called
+      // if there is only 1 option, it will be automatically selected except
+      // if in controlled mode (it would commit this change)
       if (!this.isControlled) {
         this.setState({ selectedOptionId: newOptions[0].id })
       }
       this.setState({ fireChangeOnBlur: newOptions[0] })
     } else {
       this.setState({
-        selectedOptionId: undefined,
+        // needs not to lose selectedOptionId in controlled mode otherwise it'd
+        // revert to the default or '' instead of the set value
+        selectedOptionId: this.isControlled
+          ? this.state.selectedOptionId
+          : undefined,
         fireChangeOnBlur: undefined
       })
     }
@@ -349,7 +353,7 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
         isShowingOptions: false,
         highlightedOptionId: undefined
       }))
-      // others are set in OnHideOptions
+      // others are set in handleBlurOrEsc
     }
     this.props.onKeyDown?.(event)
   }

--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -145,7 +145,8 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
       this.props.step !== prevProps.step ||
       this.props.format !== prevProps.format ||
       this.props.locale !== prevProps.locale ||
-      this.props.timezone !== prevProps.timezone
+      this.props.timezone !== prevProps.timezone ||
+      this.props.allowNonStepInput !== prevProps.allowNonStepInput
     ) {
       // options change, reset everything
       // when controlled, selection will be preserved

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -79,6 +79,9 @@ type TimeSelectOwnProps = {
   id?: string
   /**
    * The format to use when displaying the possible and currently selected options.
+   * This component currently rounds seconds down to the minute.
+   * Defaults to `LT`, which is localized time without seconds, e.g. "16:45" or
+   * "4:45 PM"
    *
    * See [moment](https://momentjs.com/docs/#/displaying/format/) for the list
    * of available formats.

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -142,13 +142,17 @@ type TimeSelectOwnProps = {
    */
   mountNode?: PositionMountNode
   /**
-   * Callback fired when a new option is selected.
+   * Callback fired when a new option is selected. This can happen in the
+   * following ways:
+   * 1. User clicks/presses enter on an option in the dropdown
+   * 2. User enters a valid time manually and presses enter/tabs away/clicks
+   *    outside
    * @param event - the event object
-   * @param data - additional data
+   * @param data - additional data containing the value and the input string
    */
   onChange?: (
     event: React.SyntheticEvent,
-    data: { value?: string; inputText: string }
+    data: { value: string; inputText: string }
   ) => void
   /**
    * Callback fired when text input receives focus.
@@ -312,7 +316,7 @@ const allowedProps: AllowedPropKeys = [
 
 type TimeSelectOptions = {
   // the ID of this option, ISO date without spaces
-  id?: string
+  id: string
   // the actual date value
   value: Moment
   // the label shown to the user
@@ -324,7 +328,14 @@ type TimeSelectState = {
    * The current value in the input field, not necessarily a valid time
    */
   inputValue: string
+  /**
+   * All possible options. Filtered down because if `allowNonStepInput` is true
+   * it'd be 24*60 options and filtered by user input.
+   */
   options: TimeSelectOptions[]
+  /**
+   * The options shown in the options list.
+   */
   filteredOptions: TimeSelectOptions[]
   /**
    * Whether to show the options list.
@@ -335,9 +346,13 @@ type TimeSelectState = {
    * not necessarily selected
    */
   highlightedOptionId?: string
+  /**
+   * The ID of the selected option in the options list dropdown
+   */
   selectedOptionId?: string
   /**
-   * Last valid input when nonStepInput is true
+   * Holds the previous value committed value of inputValue.
+   * Used when nonStepInput is true
    */
   lastValidInput?: string
 }

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -42,6 +42,7 @@ import type {
 } from '@instructure/ui-position'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 import { Renderable } from '@instructure/shared-types'
+import type { Moment } from 'moment-timezone'
 
 type PropKeys = keyof TimeSelectOwnProps
 
@@ -310,8 +311,11 @@ const allowedProps: AllowedPropKeys = [
 ]
 
 type TimeSelectOptions = {
+  // the ID of this option, ISO date without spaces
   id?: string
-  value?: string
+  // the actual date value
+  value: Moment
+  // the label shown to the user
   label: string
 }
 
@@ -326,6 +330,10 @@ type TimeSelectState = {
    * Whether to show the options list.
    */
   isShowingOptions: boolean
+  /**
+   * The highlighted option in the dropdown e.g. by hovering,
+   * not necessarily selected
+   */
   highlightedOptionId?: string
   selectedOptionId?: string
   /**

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -144,9 +144,8 @@ type TimeSelectOwnProps = {
   /**
    * Callback fired when a new option is selected. This can happen in the
    * following ways:
-   * 1. User clicks/presses enter on an option in the dropdown
-   * 2. User enters a valid time manually and presses enter/tabs away/clicks
-   *    outside
+   * 1. User clicks/presses enter on an option in the dropdown and focuses away
+   * 2. User enters a valid time manually and focuses away
    * @param event - the event object
    * @param data - additional data containing the value and the input string
    */
@@ -351,10 +350,9 @@ type TimeSelectState = {
    */
   selectedOptionId?: string
   /**
-   * Holds the previous value committed value of inputValue.
-   * Used when nonStepInput is true
+   * fire onChange event when the popup closes?
    */
-  lastValidInput?: string
+  fireChangeOnBlur?: TimeSelectOptions
 }
 
 export type { TimeSelectProps, TimeSelectState, TimeSelectOptions }


### PR DESCRIPTION
The autocomplete behaviour is now different if `allowNonStepInput` is `true`:   
- if the user types in 1 or 2 letters it offers the step inputs as choices. 
- if more it will show all the minutes

Now one can enter a value with the following methods:   
1. User clicks/presses enter on an option in the dropdown and focuses away
2. User enters a valid time manually and focuses away

To test:
test all the examples of `TimeSelect` and `DateTimeInput`