### PR TITLE
bug(ui-dialog,ui-a11y-utils): fix focusing not yet positioned elements

### DIFF
--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -54,7 +54,6 @@ class Dialog extends Component<DialogProps> {
     shouldCloseOnEscape: true
   } as const
 
-  _timeouts: ReturnType<typeof setTimeout>[] = []
   _raf: RequestAnimationFrameType[] = []
   private _focusRegion: FocusRegion | null = null
   ref: Element | null = null
@@ -88,8 +87,6 @@ class Dialog extends Component<DialogProps> {
     if (this.props.open) {
       this.close()
     }
-    this._timeouts.forEach((timeout) => clearTimeout(timeout))
-    this._timeouts = []
     this._raf.forEach((request) => request.cancel())
     this._raf = []
   }
@@ -99,20 +96,11 @@ class Dialog extends Component<DialogProps> {
 
     this._raf.push(
       requestAnimationFrame(() => {
-        // It needs to wait a heartbeat until the content is fully loaded
-        // inside the dialog. If it contains a focusable element, it will
-        // get focused on open, and browsers scroll to the focused element.
-        // If the css is not fully applied, the element may not be in their
-        // final position, making the page jump.
-        this._timeouts.push(
-          setTimeout(() => {
-            this._focusRegion = FocusRegionManager.activateRegion(
-              this.contentElement as Element,
-              {
-                ...options
-              }
-            )
-          }, 0)
+        this._focusRegion = FocusRegionManager.activateRegion(
+          this.contentElement as Element,
+          {
+            ...options
+          }
         )
       })
     )


### PR DESCRIPTION
Fix for this issue: https://github.com/instructure/instructure-ui/issues/1181

# How to reproduce

* Remove `React.StrictMode` tag from `packages/__docs__/src/index.js`
* Replace content of `packages/__docs__/src/App/index.tsx` with:
```jsx
import { Button } from '@instructure/ui-buttons'
import { Menu } from '@instructure/ui-menu'
import React from 'react'

export const App: React.FC = () => {
  const triggerButton = <Button>Trigger</Button>

  return (
    <>
      <p style={{ fontSize: '150px' }}>
        Somthing big to require scrolling for button
      </p>
      {new Array(100).fill(null).map((_, index) => (
        <Menu key={index} trigger={triggerButton}>
          {new Array(12).fill(null).map((_, index) => (
            <Menu.Item key={index}>{index}</Menu.Item>
          ))}
        </Menu>
      ))}
    </>
  )
}
```
* Trigger any button a few times, eventually it should scroll to the top of the page.