### PR TITLE
INSTUI-3795 chore(ui-scripts): fix accidentally committing with CI username and email

### DIFF
--- a/packages/ui-scripts/lib/commands/publish.js
+++ b/packages/ui-scripts/lib/commands/publish.js
@@ -28,8 +28,7 @@ import { error, info, runCommandAsync } from '@instructure/command-utils'
 import {
   checkWorkingDirectory,
   isReleaseCommit,
-  runGitCommand,
-  setupGit
+  runGitCommand
 } from '../utils/git.js'
 import { bumpPackages, createNPMRCFile } from '../utils/npm.js'
 import semver from 'semver'
@@ -63,7 +62,6 @@ export default {
 async function publish({ packageName, version, isMaintenance }) {
   const isRegularRelease = isReleaseCommit(version)
 
-  setupGit()
   createNPMRCFile()
 
   checkWorkingDirectory()


### PR DESCRIPTION
We cannot use temp credentials set for just the `commit` command because the actual commit is done by `git-cz` and it doesnt have an option to set username/email. Instead it sets these to the CI user if nothing is found