### PR TITLE
A11y: Pressing escape on an open media picker in a tray will close the tray too

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -109,7 +109,19 @@ class FocusRegion {
       event.keyCode === keycode.codes.esc &&
       !event.defaultPrevented
     ) {
-      this.handleDismiss(event)
+      // If a dialog contains an <input type="file"/> element and the user opens the file picker and closes it with the
+      // escape key then Firefox passes through that event which could close the parent dialog. This code prevents that
+      // from happening (listening for a `cancel` event doesn't seem to work in firefox)
+      const activeElement = ownerDocument(this._contextElement).activeElement
+      const fileInputFocused =
+        activeElement?.tagName === 'INPUT' &&
+        (<HTMLInputElement>activeElement).type === 'file'
+
+      if (fileInputFocused) {
+        ;(<HTMLInputElement>activeElement).blur()
+      } else {
+        this.handleDismiss(event)
+      }
     }
   }
 


### PR DESCRIPTION
Closes: INSTUI-3804

probably should wait until #1228 is merged

test plan:

- use firefox (the bug was not present in chrome)
- add an  `<input type="file"/>` inside a `Tray`/`Dialog`/`Modal`/etc component
- open the dialog then the file browser
- press escape when the file browser is open
- the dialog shouldn't close