### PR TITLE
INSTUI-3823 Get InstUI build on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/react-dom": "^18.2.7",
     "chalk": "^4.1.2",
     "commitizen": "^4.3.0",
+    "cross-spawn": "^7.0.3",
     "danger": "^11.2.6",
     "esbuild": "^0.18.12",
     "eslint": "^8.44.0",
@@ -80,8 +81,7 @@
     "netlify-cli": "13.2.2",
     "npm-run-all": "^4.1.5",
     "typescript": "5.1.6",
-    "webpack": "^5.88.1",
-    "cross-spawn": "^7.0.3"
+    "webpack": "^5.88.1"
   },
   "engines": {
     "node": ">=14",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "generate:component": "yarn workspace @instructure/instui-cli instui create component",
     "generate:package": "yarn workspace @instructure/instui-cli instui create package",
     "commit": "ui-scripts commit",
-    "bootstrap": "time yarn node scripts/bootstrap.js",
+    "bootstrap": "yarn node scripts/bootstrap.js",
     "build": "lerna run build --stream",
     "build:watch": "lerna run build:watch --stream",
     "build:docs": "lerna run bundle --stream --scope docs-app",
@@ -80,7 +80,8 @@
     "netlify-cli": "13.2.2",
     "npm-run-all": "^4.1.5",
     "typescript": "5.1.6",
-    "webpack": "^5.88.1"
+    "webpack": "^5.88.1",
+    "cross-spawn": "^7.0.3"
   },
   "engines": {
     "node": ">=14",

--- a/packages/__docs__/buildScripts/DataTypes.mts
+++ b/packages/__docs__/buildScripts/DataTypes.mts
@@ -23,9 +23,14 @@
  */
 
 // This is the format of the saved JSON files
-type ProcessedFile = ParsedCodeData &
+import { Documentation } from 'react-docgen'
+
+type ProcessedFile =
+  Documentation &
   YamlMetaInfo &
-  PackagePathData & { id: string; title: string }
+  ParsedJSDoc &
+  PackagePathData &
+  { title: string, id:string }
 
 type PackagePathData = {
   extension: string
@@ -46,6 +51,7 @@ type YamlMetaInfo = {
   describes?: string
   description: string
   id?: string
+  title?: string
   isWIP?: boolean
   order?: string
   parent?: string
@@ -54,30 +60,23 @@ type YamlMetaInfo = {
   tags?: string
 }
 
-// this is parsed by getReactDoc/getJSDoc
-type ParsedCodeData = {
-  // these are from JSDoc
-  // it can have Buffer type only during parsing
-  description?: string | Buffer
-  displayName?: string
-  kind?: string
-  //TODO This seems always be empty, remove it (added via JSDoc)
-  sections?: any[]
-  undocumented?: boolean
+type ParsedJSDoc = {
+  comment?: string,
+  meta?: any,
+  description?: string,
+  kind?: string,
+  name?: string,
   params?: {
     description?: string
     defaultValue?: string | number | boolean
     name: string
     type?: { names: string[] }
     optional?: boolean
-  }[]
-  returns?: JSDocFunctionReturns[]
-  // these are from https://github.com/reactjs/react-docgen/blob/main/src/Documentation.ts
-  props?: Record<string, PropDescriptor>
-  context?: Record<string, PropDescriptor>
-  childContext?: Record<string, PropDescriptor>
-  composes?: string[]
-  methods?: MethodDescriptor[] // TODO seems always empty, processFile filters all out
+  }[],
+  returns?: JSDocFunctionReturns[],
+  longName?: string,
+  sections?: any[],
+  undocumented?: boolean
 }
 
 type JSDocFunctionReturns = {
@@ -86,7 +85,7 @@ type JSDocFunctionReturns = {
     names: string[]
   }
 }
-
+// TODO remove these types, now we can get them directly from react-docgen
 interface MethodParameter {
   name: string
   type?: TypeDescriptor | null
@@ -95,17 +94,6 @@ interface MethodParameter {
 
 interface MethodReturn {
   type: TypeDescriptor | undefined
-}
-
-type MethodModifier = 'static' | 'generator' | 'async' | 'get' | 'set'
-
-interface MethodDescriptor {
-  name: string
-  description?: string | null
-  docblock: string | null
-  modifiers: MethodModifier[]
-  params: MethodParameter[]
-  returns: MethodReturn | null
 }
 
 interface PropDescriptor {
@@ -281,10 +269,8 @@ export type {
   ProcessedFile,
   PackagePathData,
   YamlMetaInfo,
-  ParsedCodeData,
   JSDocFunctionReturns,
   PropDescriptor,
-  MethodDescriptor,
   MethodParameter,
   MethodReturn,
   TypeDescriptor,
@@ -298,5 +284,6 @@ export type {
   IconFormat,
   IconGlyph,
   MainDocsData,
-  MainIconsData
+  MainIconsData,
+  ParsedJSDoc
 }

--- a/packages/__docs__/buildScripts/build-docs.ts
+++ b/packages/__docs__/buildScripts/build-docs.ts
@@ -41,6 +41,7 @@ import { getFrontMatter } from './utils/getFrontMatter'
 
 const buildDir = './__build__/'
 const projectRoot = path.resolve(__dirname, '../../../')
+const packagesDir = '../..'
 // there need to be required otherwise TSC will mess up the directory structure
 // in the build directory
 const rootPackage = require('../../../package.json') // root package.json
@@ -55,14 +56,15 @@ const library: LibraryOptions = {
 
 const pathsToProcess = [
   // these can be commented out for faster debugging
-  'CHANGELOG.md',
-  '**/packages/**/*.md', // package READMEs
-  '**/docs/**/*.md', // general docs
-  '**/src/*.{js,ts,tsx}', // util src files
-  '**/src/*/*.{js,ts,tsx}', // component src files
-  '**/src/*/*/*.{js,ts,tsx}', // child component src files,
-  'CODE_OF_CONDUCT.md',
-  'LICENSE.md'
+  //'CHANGELOG.md',
+  //'**/packages/**/*.md', // package READMEs
+  //'**/docs/**/*.md', // general docs
+  //'**/src/*.{js,ts,tsx}', // util src files
+  //'**/src/*/*.{js,ts,tsx}', // component src files
+  //'**/src/*/*/*.{js,ts,tsx}', // child component src files,
+  //'CODE_OF_CONDUCT.md',
+  //'LICENSE.md',
+  '**/debounce.ts'
 ]
 
 const pathsToIgnore = [
@@ -111,23 +113,23 @@ const pathsToIgnore = [
 
 function buildDocs() {
   // eslint-disable-next-line no-console
-  console.log('start building application data')
+  console.log('Start building application data')
 
   const { COPY_VERSIONS_JSON = '1' } = process.env
   const shouldDoTheVersionCopy = Boolean(parseInt(COPY_VERSIONS_JSON))
 
-  const files = pathsToProcess.map((file) => path.resolve(projectRoot, file))
-
-  const ignore = pathsToIgnore.map((file) => path.resolve(projectRoot, file))
-
+  const files = pathsToProcess.map((file) => path.posix.join(packagesDir, file))
+  const ignore = pathsToIgnore.map((file) => path.posix.join(packagesDir, file))
   globby(files, { ignore })
     .then((matches) => {
       fs.mkdirSync(buildDir + 'docs/', { recursive: true })
       // eslint-disable-next-line no-console
-      console.log('Parsing markdown and source files...')
-      const docs = matches.map((fullPath) => {
+      console.log(
+        'Parsing markdown and source files... (' + matches.length + ' files)'
+      )
+      const docs = matches.map((relativePath) => {
         // loop trough every source and Readme file
-        return processSingleFile(fullPath)
+        return processSingleFile(path.resolve(relativePath))
       })
       const themes = parseThemes()
       const clientProps = getClientProps(docs, library)

--- a/packages/__docs__/buildScripts/processFile.mts
+++ b/packages/__docs__/buildScripts/processFile.mts
@@ -24,15 +24,15 @@
 
 import fs from 'fs'
 import path from 'path'
-import { parseDoc } from './utils/parseDoc'
-import { getPathInfo } from './utils/getPathInfo'
-import type { LibraryOptions, ProcessedFile } from './DataTypes'
+import { parseDoc } from './utils/parseDoc.mjs'
+import { getPathInfo } from './utils/getPathInfo.mjs'
+import type { LibraryOptions, ProcessedFile } from './DataTypes.mjs'
 
 export function processFile(
   fullPath: string,
   projectRoot: string,
   library: LibraryOptions
-) {
+): ProcessedFile {
   // eslint-disable-next-line no-console
   console.info(`Processing ${fullPath}`)
   const source = fs.readFileSync(fullPath)
@@ -40,10 +40,10 @@ export function processFile(
   const pathInfo = getPathInfo(fullPath, projectRoot, library)
 
   const doc = parseDoc(fullPath, source, (err: Error) => {
-    console.warn('Error when parsing ', fullPath, err.toString())
+    console.warn('Error when parsing ', fullPath, ":\n", err.stack)
   })
-  const docData = { ...doc, ...pathInfo } as ProcessedFile
-  // TODO dockblock is always undefined. Either show this or delete.
+  const docData: ProcessedFile = { ...doc, ...pathInfo } as ProcessedFile
+  // TODO docblock is always undefined. Either show this or delete.
   docData.methods = docData.methods
     ? docData.methods.filter((method) => method.docblock !== null)
     : undefined

--- a/packages/__docs__/buildScripts/processFile.ts
+++ b/packages/__docs__/buildScripts/processFile.ts
@@ -53,8 +53,8 @@ export function processFile(
     // exist if it was in the description at the top
     docId = docData.id
   } else if (
-    lowerPath.includes('/index.js') ||
-    lowerPath.includes('/index.tsx')
+    lowerPath.includes(path.sep + 'index.js') ||
+    lowerPath.includes(path.sep + 'index.tsx')
   ) {
     docId = path.basename(dirName) // return its folder name
   } else if (lowerPath.includes('readme.md')) {

--- a/packages/__docs__/buildScripts/utils/getClientProps.mts
+++ b/packages/__docs__/buildScripts/utils/getClientProps.mts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import type { LibraryOptions, ParsedDoc, ProcessedFile } from '../DataTypes'
+import type { LibraryOptions, ParsedDoc, ProcessedFile } from '../DataTypes.mjs'
 
 const CATEGORY_DELIMITER = '/'
 

--- a/packages/__docs__/buildScripts/utils/getFrontMatter.mts
+++ b/packages/__docs__/buildScripts/utils/getFrontMatter.mts
@@ -23,7 +23,7 @@
  */
 
 import grayMatter from 'gray-matter'
-import { YamlMetaInfo } from '../DataTypes'
+import { YamlMetaInfo } from '../DataTypes.mjs'
 
 export function getFrontMatter(description: string | Buffer = '') {
   const matter = grayMatter(description)

--- a/packages/__docs__/buildScripts/utils/getJSDoc.mts
+++ b/packages/__docs__/buildScripts/utils/getJSDoc.mts
@@ -23,12 +23,12 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore This package does not have typings :(
+// @ts-ignore no typing :(
 import jsdoc from 'jsdoc-api'
-import { ParsedCodeData } from '../DataTypes'
+import type { ParsedJSDoc } from '../DataTypes.mjs'
 
 export function getJSDoc(source: Buffer, error: (err: Error) => void) {
-  let doc: ParsedCodeData = {}
+  let doc: ParsedJSDoc = {}
   try {
     const sections = jsdoc
       .explainSync({

--- a/packages/__docs__/buildScripts/utils/getJSDoc.mts
+++ b/packages/__docs__/buildScripts/utils/getJSDoc.mts
@@ -50,8 +50,8 @@ export function getJSDoc(source: Buffer, error: (err: Error) => void) {
       sections[0] ||
       {}
     if (process.platform === 'win32' && module.description) {
-      // JSDOC bug https://github.com/jsdoc/jsdoc/issues/2067
-      module.description = module.description.replace("\r", "\r\n")
+      // JSDoc bug https://github.com/jsdoc/jsdoc/issues/2067
+      module.description = module.description.replace(/\r/g, "\r\n")
     }
     doc = {
       ...module,

--- a/packages/__docs__/buildScripts/utils/getJSDoc.mts
+++ b/packages/__docs__/buildScripts/utils/getJSDoc.mts
@@ -49,6 +49,10 @@ export function getJSDoc(source: Buffer, error: (err: Error) => void) {
       )[0] ||
       sections[0] ||
       {}
+    if (process.platform === 'win32' && module.description) {
+      // JSDOC bug https://github.com/jsdoc/jsdoc/issues/2067
+      module.description = module.description.replace("\r", "\r\n")
+    }
     doc = {
       ...module,
       sections: sections

--- a/packages/__docs__/buildScripts/utils/getPathInfo.mts
+++ b/packages/__docs__/buildScripts/utils/getPathInfo.mts
@@ -24,7 +24,7 @@
 
 import path from 'path'
 import fs from 'fs'
-import type { LibraryOptions, PackagePathData } from '../DataTypes'
+import type { LibraryOptions, PackagePathData } from '../DataTypes.mjs'
 
 export function getPathInfo(
   resourcePath: string,

--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://instructure.design",
   "bugs": "https://github.com/instructure/instructure-ui/issues",
   "scripts": {
-    "prestart": "yarn build:scripts:ts && node -e 'require(\"./lib/build-docs.js\").buildDocs()'",
+    "prestart": "yarn build:scripts:ts && node -e 'import(\"./lib/build-docs.mjs\").then(file => file.buildDocs());'\n",
     "start": "yarn prestart && run -T ui-scripts bundle && ui-scripts server -p 8001",
     "start:watch": "yarn prestart && run -T ui-scripts bundle --watch -p 8080",
     "bundle": "yarn prestart && run -T ui-scripts bundle",
@@ -140,7 +140,7 @@
     "jsdoc-api": "^7.2.0",
     "mkdirp": "^1.0.4",
     "raw-loader": "^4.0.2",
-    "react-docgen": "6.0.0-alpha.0",
+    "react-docgen": "6.0.2",
     "svg-inline-loader": "^0.8.2",
     "webpack-bundle-analyzer": "^4.9.0"
   }

--- a/packages/__docs__/tsconfig.node.build.json
+++ b/packages/__docs__/tsconfig.node.build.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.node.json",
   "compilerOptions": {
     "declarationDir": "./types",
-    "outDir": "./lib"
+    "module": "ES2022",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "outDir": "./lib",
+    "resolveJsonModule": true
   },
   "include": ["buildScripts/**/*"]
 }

--- a/packages/command-utils/lib/index.js
+++ b/packages/command-utils/lib/index.js
@@ -27,7 +27,7 @@ const path = require('path')
 const which = require('which')
 const rl = require('readline')
 const chalk = require('chalk')
-const childProcess = require('child_process')
+const crossSpawn = require('cross-spawn')
 
 function info(...args) {
   console.info(chalk.blue(...args)) // eslint-disable-line no-console
@@ -97,7 +97,7 @@ async function runCommandsConcurrently(commands) {
 }
 
 function runCommandSync(bin, args = [], envVars = {}, opts = {}) {
-  const result = childProcess.spawnSync(bin, args, {
+  const result = crossSpawn.sync(bin, args, {
     env: { ...process.env, ...envVars },
     stdio: 'inherit',
     windowsHide: true,
@@ -107,7 +107,7 @@ function runCommandSync(bin, args = [], envVars = {}, opts = {}) {
 }
 
 async function runCommandAsync(bin, args = [], envVars = {}, opts = {}) {
-  const result = childProcess.spawn(bin, args, {
+  const result = crossSpawn.spawn(bin, args, {
     env: { ...process.env, ...envVars },
     stdio: 'inherit',
     windowsHide: true,

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -19,7 +19,6 @@
     "chalk": "^4.1.2",
     "concurrently": "^8.2.0",
     "cross-env": "^7.0.3",
-    "execa": "^5.1.1",
     "which": "^2.0.2"
   },
   "publishConfig": {

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "concurrently": "^8.2.0",
-    "cross-env": "^7.0.3",
     "which": "^2.0.2"
   },
   "publishConfig": {

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/command-utils",
   "version": "8.39.0",
-  "description": "Node CLI utilties made by Instructure Inc.",
+  "description": "Node CLI utilities made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./lib/index.js",
   "repository": {
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "concurrently": "^8.2.0",
     "which": "^2.0.2"
   },
   "publishConfig": {

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "which": "^2.0.2"
+    "cross-spawn": "^7.0.3",
+    "which": "^3.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/instui-cli/lib/handlers/handleUpgradePackages.js
+++ b/packages/instui-cli/lib/handlers/handleUpgradePackages.js
@@ -141,7 +141,7 @@ async function updateResolutions({ pkg, packages, path, version }) {
         const { stdout } = runCommandSync(
           'yarn',
           ['info', `${packageName}`, 'dist-tags', '--json'],
-          [],
+          {},
           { stdio: 'pipe' }
         )
         const { data } = JSON.parse(stdout)

--- a/packages/instui-config/scripts/generate-package-list.mjs
+++ b/packages/instui-config/scripts/generate-package-list.mjs
@@ -28,7 +28,7 @@ import { error, info, runCommandSync } from '@instructure/command-utils'
 
 export default ({ outputDir, name = 'package-list.json' }) => {
   try {
-    const { stdout } = runCommandSync('lerna', ['list', '--json'], [], {
+    const { stdout } = runCommandSync('lerna', ['list', '--json'], {}, {
       stdio: 'pipe'
     })
     const packages = JSON.parse(stdout)

--- a/packages/ui-calendar/src/Calendar/Day/props.ts
+++ b/packages/ui-calendar/src/Calendar/Day/props.ts
@@ -75,17 +75,14 @@ type CalendarDayOwnProps = {
    * @param {Object} data - additional data
    * @param data.date - the date of the corresponding `<Calendar.Day />`
    */
-  onClick?: (event: MouseEvent<ViewProps>, { date }: { date: string }) => void
+  onClick?: (event: MouseEvent<ViewProps>, date: { date: string }) => void
   /**
    * Callback fired on key down.
    * @param {Object} event - the key down event
    * @param {Object} data - additional data
    * @param data.date - the date of the corresponding `<Calendar.Day />`
    */
-  onKeyDown?: (
-    event: KeyboardEvent<ViewProps>,
-    { date }: { date: string }
-  ) => void
+  onKeyDown?: (event: KeyboardEvent<ViewProps>, data: { date: string }) => void
   /**
    * A ref function for the underlying DOM element.
    */

--- a/packages/ui-editable/src/InPlaceEdit/props.ts
+++ b/packages/ui-editable/src/InPlaceEdit/props.ts
@@ -58,10 +58,7 @@ type InPlaceEditOwnProps = {
    * Return value:
    * - element: the editor DOM sub-tree.
    */
-  renderEditor: ({
-    onBlur,
-    editorRef
-  }: {
+  renderEditor: (data: {
     onBlur: () => void
     editorRef: (el: HTMLElement | null) => void
   }) => React.ReactNode

--- a/packages/ui-navigation/src/AppNav/props.ts
+++ b/packages/ui-navigation/src/AppNav/props.ts
@@ -80,7 +80,7 @@ type AppNavOwnProps = {
    * the navigation changes. Passes in the `visibleItemsCount` as
    * a parameter.
    */
-  onUpdate?: ({ visibleItemsCount }: { visibleItemsCount: number }) => void
+  onUpdate?: (visibleItemsCount: { visibleItemsCount: number }) => void
   /**
    * Sets the number of navigation items that are visible.
    */

--- a/packages/ui-scripts/lib/build/babel.js
+++ b/packages/ui-scripts/lib/build/babel.js
@@ -62,7 +62,7 @@ export default {
     babelArgs = babelArgs.concat([
       src,
       '--ignore',
-      '"src/**/*.test.js","src/**/__tests__/**"'
+      'src/**/*.test.js,src/**/__tests__/**'
     ])
 
     let envVars = {}

--- a/packages/ui-scripts/lib/build/babel.js
+++ b/packages/ui-scripts/lib/build/babel.js
@@ -61,7 +61,8 @@ export default {
 
     babelArgs = babelArgs.concat([
       src,
-      '--ignore "src/**/*.test.js","src/**/__tests__/**"'
+      '--ignore',
+      '"src/**/*.test.js","src/**/__tests__/**"'
     ])
 
     let envVars = {}
@@ -89,7 +90,7 @@ export default {
           ...envVars,
           ...{ TRANSFORM_IMPORTS: '1' }
         }),
-        getCommand(specifyCJSFormat, [], [])
+        getCommand(specifyCJSFormat, [])
       ]
     }
 
@@ -97,6 +98,6 @@ export default {
       (obj, key) => ({ ...obj, [key]: commands[key] }),
       {}
     )
-    process.exit(runCommandsConcurrently(commandsToRun).status)
+    runCommandsConcurrently(commandsToRun)
   }
 }

--- a/packages/ui-scripts/lib/build/babel.js
+++ b/packages/ui-scripts/lib/build/babel.js
@@ -64,36 +64,31 @@ export default {
       '--ignore "src/**/*.test.js","src/**/__tests__/**"'
     ])
 
-    let envVars = [
-      OMIT_INSTUI_DEPRECATION_WARNINGS
-        ? `OMIT_INSTUI_DEPRECATION_WARNINGS=1`
-        : false
-    ]
+    let envVars = {}
+    if (OMIT_INSTUI_DEPRECATION_WARNINGS) {
+      envVars = { ...envVars, OMIT_INSTUI_DEPRECATION_WARNINGS: '1' }
+    }
 
     if (argv.watch) {
-      envVars = envVars.concat(['NODE_ENV=development']).filter(Boolean)
+      envVars = { ...envVars, NODE_ENV: 'development' }
       babelArgs.push('--watch')
     } else {
-      envVars = envVars
-        .concat([
-          `NODE_ENV=${BABEL_ENV || NODE_ENV || 'production'}`,
-          DEBUG ? `DEBUG=1` : false
-        ])
-        .filter(Boolean)
+      envVars = { ...envVars, NODE_ENV: BABEL_ENV || NODE_ENV || 'production' }
+      if (DEBUG) {
+        envVars = { ...envVars, DEBUG: '1' }
+      }
     }
 
     const commands = {
-      es: getCommand(
-        'babel',
-        [...babelArgs, '--out-dir', 'es'],
-        [...envVars, 'ES_MODULES=1']
-      ),
+      es: getCommand('babel', [...babelArgs, '--out-dir', 'es'], {
+        ...envVars,
+        ...{ ES_MODULES: '1' }
+      }),
       cjs: [
-        getCommand(
-          'babel',
-          [...babelArgs, '--out-dir', 'lib'],
-          [...envVars, 'TRANSFORM_IMPORTS=1']
-        ),
+        getCommand('babel', [...babelArgs, '--out-dir', 'lib'], {
+          ...envVars,
+          ...{ TRANSFORM_IMPORTS: '1' }
+        }),
         getCommand(specifyCJSFormat, [], [])
       ]
     }
@@ -102,7 +97,6 @@ export default {
       (obj, key) => ({ ...obj, [key]: commands[key] }),
       {}
     )
-
     process.exit(runCommandsConcurrently(commandsToRun).status)
   }
 }

--- a/packages/ui-scripts/lib/build/examples.js
+++ b/packages/ui-scripts/lib/build/examples.js
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import path from 'path'
-import { runCommandsConcurrently, getCommand } from '@instructure/command-utils'
+import { runCommandSync, resolveBin } from '@instructure/command-utils'
 
 export default {
   command: 'examples',
@@ -75,11 +75,8 @@ export default {
         envVars = { ...envVars, DEBUG: '1' }
       }
     }
-
     process.exit(
-      runCommandsConcurrently({
-        storybook: getCommand(command, commandArgs, envVars)
-      }).status
+      runCommandSync(resolveBin(command), commandArgs, envVars).status
     )
   }
 }

--- a/packages/ui-scripts/lib/build/examples.js
+++ b/packages/ui-scripts/lib/build/examples.js
@@ -40,11 +40,10 @@ export default {
 
     let command, commandArgs
 
-    let envVars = [
-      OMIT_INSTUI_DEPRECATION_WARNINGS
-        ? `OMIT_INSTUI_DEPRECATION_WARNINGS=1`
-        : false
-    ]
+    let envVars = {}
+    if (OMIT_INSTUI_DEPRECATION_WARNINGS) {
+      envVars = { ...envVars, OMIT_INSTUI_DEPRECATION_WARNINGS: '1' }
+    }
 
     if (argv.watch) {
       command = 'start-storybook'
@@ -59,19 +58,22 @@ export default {
         '--no-manager-cache',
         '--quiet'
       ]
-      envVars = envVars
-        .concat(['NODE_ENV=development', 'DEBUG=1'])
-        .filter(Boolean)
+      envVars = {
+        ...envVars,
+        NODE_ENV: 'development',
+        DEBUG: '1'
+      }
     } else {
       command = 'build-storybook'
       commandArgs = ['-c', '.storybook', '-o', '__build__', '--quiet']
-      envVars = envVars
-        .concat([
-          `NODE_ENV=production`,
-          `NODE_PATH=${rootPath}`,
-          DEBUG ? `DEBUG=1` : false
-        ])
-        .filter(Boolean)
+      envVars = {
+        ...envVars,
+        NODE_ENV: 'production',
+        NODE_PATH: rootPath
+      }
+      if (DEBUG) {
+        envVars = { ...envVars, DEBUG: '1' }
+      }
     }
 
     process.exit(

--- a/packages/ui-scripts/lib/build/webpack.js
+++ b/packages/ui-scripts/lib/build/webpack.js
@@ -39,27 +39,29 @@ export default {
 
     let command, webpackArgs
 
-    let envVars = [
-      OMIT_INSTUI_DEPRECATION_WARNINGS
-        ? `OMIT_INSTUI_DEPRECATION_WARNINGS=1`
-        : false
-    ]
+    let envVars = {}
+    if (OMIT_INSTUI_DEPRECATION_WARNINGS) {
+      envVars = { ...envVars, OMIT_INSTUI_DEPRECATION_WARNINGS: '1' }
+    }
 
     if (argv.watch) {
       command = 'webpack'
-      envVars = envVars
-        .concat(['NODE_ENV=development', 'DEBUG=1'])
-        .filter(Boolean)
+      envVars = {
+        ...envVars,
+        NODE_ENV: 'development',
+        DEBUG: '1'
+      }
       webpackArgs = ['serve', '--mode=development', `--port=${port}`]
     } else {
       command = 'webpack'
-      envVars = envVars
-        .concat([
-          `NODE_ENV=${NODE_ENV || 'production'}`,
-          'NODE_OPTIONS=--max_old_space_size=120000',
-          DEBUG ? `DEBUG=1` : false
-        ])
-        .filter(Boolean)
+      envVars = {
+        ...envVars,
+        NODE_ENV: NODE_ENV || 'production',
+        NODE_OPTIONS: '--max_old_space_size=120000'
+      }
+      if (DEBUG) {
+        envVars = { ...envVars, DEBUG: '1' }
+      }
       webpackArgs = ['--mode=production']
     }
 

--- a/packages/ui-scripts/lib/build/webpack.js
+++ b/packages/ui-scripts/lib/build/webpack.js
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { runCommandsConcurrently, getCommand } from '@instructure/command-utils'
+import { runCommandSync, resolveBin } from '@instructure/command-utils'
 
 export default {
   command: 'bundle',
@@ -64,11 +64,8 @@ export default {
       }
       webpackArgs = ['--mode=production']
     }
-
     process.exit(
-      runCommandsConcurrently({
-        webpack: getCommand(command, webpackArgs, envVars)
-      }).status
+      runCommandSync(resolveBin(command), webpackArgs, envVars).status
     )
   }
 }

--- a/packages/ui-scripts/lib/commands/publish.js
+++ b/packages/ui-scripts/lib/commands/publish.js
@@ -157,7 +157,7 @@ async function* publishPackages(packages, version, tag) {
       const { stdout } = await runCommandAsync(
         'npm',
         ['info', pkg.name, '--json'],
-        [],
+        {},
         {
           stdio: 'pipe'
         }
@@ -192,7 +192,7 @@ async function publishPackage(pkg, tag) {
     })
 
   const publishArgs = ['publish', pkg.location, '--tag', tag]
-  await runCommandAsync('npm', publishArgs, [])
+  await runCommandAsync('npm', publishArgs)
 
   return wait(500)
 }

--- a/packages/ui-scripts/lib/commands/server.js
+++ b/packages/ui-scripts/lib/commands/server.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { runCommandsConcurrently, getCommand } from '@instructure/command-utils'
+import { runCommandSync, resolveBin } from '@instructure/command-utils'
 
 export default {
   command: 'server',
@@ -35,8 +35,9 @@ export default {
     }
   },
   handler: (argv) => {
-    runCommandsConcurrently({
-      server: getCommand('http-server', ['__build__', '-p', argv.port])
-    })
+    process.exit(
+      runCommandSync(resolveBin('http-server'), ['__build__', '-p', argv.port])
+        .status
+    )
   }
 }

--- a/packages/ui-scripts/lib/commands/server.js
+++ b/packages/ui-scripts/lib/commands/server.js
@@ -36,7 +36,7 @@ export default {
   },
   handler: (argv) => {
     runCommandsConcurrently({
-      server: getCommand('http-server', ['__build__', '-p', argv.port], [])
+      server: getCommand('http-server', ['__build__', '-p', argv.port])
     })
   }
 }

--- a/packages/ui-scripts/lib/test/lint.js
+++ b/packages/ui-scripts/lib/test/lint.js
@@ -62,7 +62,6 @@ export default {
         '--allow-empty-input'
       ])
     }
-
-    process.exit(runCommandsConcurrently(commands).status)
+    runCommandsConcurrently(commands)
   }
 }

--- a/packages/ui-scripts/lib/utils/git.js
+++ b/packages/ui-scripts/lib/utils/git.js
@@ -29,7 +29,7 @@ const USERNAME = 'instructure-ui-ci'
 const EMAIL = 'instui-dev@instructure.com'
 
 export const runGitCommand = (args = []) => {
-  const { stdout } = runCommandSync('git', args, [], { stdio: 'pipe' })
+  const { stdout } = runCommandSync('git', args, {}, { stdio: 'pipe' })
   return stdout && stdout.toString().trim()
 }
 

--- a/packages/ui-scripts/lib/utils/git.js
+++ b/packages/ui-scripts/lib/utils/git.js
@@ -30,7 +30,7 @@ const EMAIL = 'instui-dev@instructure.com'
 
 export const runGitCommand = (args = []) => {
   const { stdout } = runCommandSync('git', args, [], { stdio: 'pipe' })
-  return stdout && stdout.trim()
+  return stdout && stdout.toString().trim()
 }
 
 const setupGit = () => {
@@ -43,7 +43,7 @@ const setupGit = () => {
       runGitCommand(['config', 'user.name', 'instructure-ui-ci'])
     }
   } catch (e) {
-    error(e)
+    error(e.stack ? e.stack : e)
     process.exit(1)
   }
 }

--- a/packages/ui-truncate-list/src/TruncateList/props.ts
+++ b/packages/ui-truncate-list/src/TruncateList/props.ts
@@ -57,7 +57,7 @@ type TruncateListOwnProps = {
    * the navigation changes. Passes in the `visibleItemsCount` as
    * a parameter.
    */
-  onUpdate?: ({ visibleItemsCount }: { visibleItemsCount: number }) => void
+  onUpdate?: (visibleItemsCount: { visibleItemsCount: number }) => void
 
   /**
    * The spacing between list items (in 'rem', 'em' or 'px')

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -23,7 +23,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-const { execSync, fork, spawn } = require('child_process')
+const { execSync, fork } = require('child_process')
+const { spawn } = require('cross-spawn')
 const path = require('path')
 
 const opts = { stdio: 'inherit' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22713,6 +22713,7 @@ __metadata:
     "@types/react-dom": ^18.2.7
     chalk: ^4.1.2
     commitizen: ^4.3.0
+    cross-spawn: ^7.0.3
     danger: ^11.2.6
     esbuild: ^0.18.12
     eslint: ^8.44.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/code-frame@npm:7.22.10"
+  dependencies:
+    "@babel/highlight": ^7.22.10
+    chalk: ^2.4.2
+  checksum: 89a06534ad19759da6203a71bad120b1d7b2ddc016c8e07d4c56b35dea25e7396c6da60a754e8532a86733092b131ae7f661dbe6ba5d165ea777555daa2ed3c9
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.20.1, @babel/compat-data@npm:^7.20.5":
   version: 7.20.10
   resolution: "@babel/compat-data@npm:7.20.10"
@@ -184,6 +194,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.18.9":
+  version: 7.22.10
+  resolution: "@babel/core@npm:7.22.10"
+  dependencies:
+    "@ampproject/remapping": ^2.2.0
+    "@babel/code-frame": ^7.22.10
+    "@babel/generator": ^7.22.10
+    "@babel/helper-compilation-targets": ^7.22.10
+    "@babel/helper-module-transforms": ^7.22.9
+    "@babel/helpers": ^7.22.10
+    "@babel/parser": ^7.22.10
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.10
+    "@babel/types": ^7.22.10
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.2
+    semver: ^6.3.1
+  checksum: cc4efa09209fe1f733cf512e9e4bb50870b191ab2dee8014e34cd6e731f204e48476cc53b4bbd0825d4d342304d577ae43ff5fd8ab3896080673c343321acb32
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.20.7":
   version: 7.20.7
   resolution: "@babel/generator@npm:7.20.7"
@@ -192,6 +225,18 @@ __metadata:
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
   checksum: 84b6983ffdb50c80c1c2e3f3c32617a7133d8effd1065f3e0f9bba188a7d54ab42a4dd5e42b61b843c65f9dd1aa870036ff0f848ebd42707aaa8a2b6d31d04f5
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/generator@npm:7.22.10"
+  dependencies:
+    "@babel/types": ^7.22.10
+    "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
+    jsesc: ^2.5.1
+  checksum: 59a79730abdff9070692834bd3af179e7a9413fa2ff7f83dff3eb888765aeaeb2bfc7b0238a49613ed56e1af05956eff303cc139f2407eda8df974813e486074
   languageName: node
   linkType: hard
 
@@ -280,6 +325,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 8c32c873ba86e2e1805b30e0807abd07188acbe00ebb97576f0b09061cc65007f1312b589eccb4349c5a8c7f8bb9f2ab199d41da7030bf103d9f347dcd3a3cf4
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/helper-compilation-targets@npm:7.22.10"
+  dependencies:
+    "@babel/compat-data": ^7.22.9
+    "@babel/helper-validator-option": ^7.22.5
+    browserslist: ^4.21.9
+    lru-cache: ^5.1.1
+    semver: ^6.3.1
+  checksum: f6f1896816392bcff671bbe6e277307729aee53befb4a66ea126e2a91eda78d819a70d06fa384c74ef46c1595544b94dca50bef6c78438d9ffd31776dafbd435
   languageName: node
   linkType: hard
 
@@ -837,6 +895,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/helpers@npm:7.22.10"
+  dependencies:
+    "@babel/template": ^7.22.5
+    "@babel/traverse": ^7.22.10
+    "@babel/types": ^7.22.10
+  checksum: 3b1219e362df390b6c5d94b75a53fc1c2eb42927ced0b8022d6a29b833a839696206b9bdad45b4805d05591df49fc16b6fb7db758c9c2ecfe99e3e94cb13020f
+  languageName: node
+  linkType: hard
+
 "@babel/helpers@npm:^7.22.6":
   version: 7.22.6
   resolution: "@babel/helpers@npm:7.22.6"
@@ -856,6 +925,17 @@ __metadata:
     chalk: ^2.0.0
     js-tokens: ^4.0.0
   checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/highlight@npm:7.22.10"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.22.5
+    chalk: ^2.4.2
+    js-tokens: ^4.0.0
+  checksum: f714a1e1a72dd9d72f6383f4f30fd342e21a8df32d984a4ea8f5eab691bb6ba6db2f8823d4b4cf135d98869e7a98925b81306aa32ee3c429f8cfa52c75889e1b
   languageName: node
   linkType: hard
 
@@ -912,6 +992,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 470ebba516417ce8683b36e2eddd56dcfecb32c54b9bb507e28eb76b30d1c3e618fd0cfeee1f64d8357c2254514e1a19e32885cfb4e73149f4ae875436a6d59c
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/parser@npm:7.22.10"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: af51567b7d3cdf523bc608eae057397486c7fa6c2e5753027c01fe5c36f0767b2d01ce3049b222841326cc5b8c7fda1d810ac1a01af0a97bb04679e2ef9f7049
   languageName: node
   linkType: hard
 
@@ -3076,6 +3165,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/traverse@npm:7.22.10"
+  dependencies:
+    "@babel/code-frame": ^7.22.10
+    "@babel/generator": ^7.22.10
+    "@babel/helper-environment-visitor": ^7.22.5
+    "@babel/helper-function-name": ^7.22.5
+    "@babel/helper-hoist-variables": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/parser": ^7.22.10
+    "@babel/types": ^7.22.10
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 9f7b358563bfb0f57ac4ed639f50e5c29a36b821a1ce1eea0c7db084f5b925e3275846d0de63bde01ca407c85d9804e0efbe370d92cd2baaafde3bd13b0f4cdb
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/traverse@npm:7.22.5"
@@ -3120,6 +3227,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
   checksum: b39af241f0b72bba67fd6d0d23914f6faec8c0eba8015c181cbd5ea92e59fc91a52a1ab490d3520c7dbd19ddb9ebb76c476308f6388764f16d8201e37fae6811
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.22.10":
+  version: 7.22.10
+  resolution: "@babel/types@npm:7.22.10"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.5
+    to-fast-properties: ^2.0.0
+  checksum: 095c4f4b7503fa816e4094113f0ec2351ef96ff32012010b771693066ff628c7c664b21c6bd3fb93aeb46fe7c61f6b3a3c9e4ed0034d6a2481201c417371c8af
   languageName: node
   linkType: hard
 
@@ -9782,7 +9900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.1.14":
+"@types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.18.0":
   version: 7.20.1
   resolution: "@types/babel__core@npm:7.20.1"
   dependencies:
@@ -9820,6 +9938,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.3.0
   checksum: d20953338b2f012ab7750932ece0a78e7d1645b0a6ff42d49be90f55e9998085da1374a9786a7da252df89555c6586695ba4d1d4b4e88ab2b9f306bcd35e00d3
+  languageName: node
+  linkType: hard
+
+"@types/babel__traverse@npm:^7.18.0":
+  version: 7.20.1
+  resolution: "@types/babel__traverse@npm:7.20.1"
+  dependencies:
+    "@babel/types": ^7.20.7
+  checksum: 58341e23c649c0eba134a1682d4f20d027fad290d92e5740faa1279978f6ed476fc467ae51ce17a877e2566d805aeac64eae541168994367761ec883a4150221
   languageName: node
   linkType: hard
 
@@ -9946,6 +10073,13 @@ __metadata:
     "@types/chai": "npm:*"
     "@types/chai-as-promised": "npm:*"
   checksum: 6015689ef7d64d4012b7327f87c39e95397500a50eb47d456ff2a8f59824d78d8a0e805d9629970a1e767fa06a03ccc8c0c65b3605e6e1e2368d1bfeeccc831b
+  languageName: node
+  linkType: hard
+
+"@types/doctrine@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@types/doctrine@npm:0.0.5"
+  checksum: 6ecddab8e4e92bcd0a8d136def5069cbf31c85b6027c76ab1945720801ab416e5cd361b6e06159d426b0794513d81313346e138710a35b38ee9327c82221030b
   languageName: node
   linkType: hard
 
@@ -10414,6 +10548,13 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: b62f0ea3cdfa68e106391728325057ad36f1bde7ba2dfae029472c47e01e482bc77c6ba4f1dad59f3f04ee81cb597618ff7c30a33c157c0a20462b6dd6aa2d4d
+  languageName: node
+  linkType: hard
+
+"@types/resolve@npm:^1.20.2":
+  version: 1.20.2
+  resolution: "@types/resolve@npm:1.20.2"
+  checksum: 61c2cad2499ffc8eab36e3b773945d337d848d3ac6b7b0a87c805ba814bc838ef2f262fc0f109bfd8d2e0898ff8bd80ad1025f9ff64f1f71d3d4294c9f14e5f6
   languageName: node
   linkType: hard
 
@@ -17349,7 +17490,7 @@ __metadata:
     prop-types: ^15.8.1
     raw-loader: ^4.0.2
     react: ^18.2.0
-    react-docgen: 6.0.0-alpha.0
+    react-docgen: 6.0.2
     react-dom: ^18.2.0
     react-github-corner: ^2.5.0
     semver: ^7.5.4
@@ -31033,27 +31174,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-docgen@npm:6.0.0-alpha.0":
-  version: 6.0.0-alpha.0
-  resolution: "react-docgen@npm:6.0.0-alpha.0"
-  dependencies:
-    "@babel/core": ^7.7.5
-    "@babel/generator": ^7.12.11
-    "@babel/runtime": ^7.7.6
-    ast-types: ^0.14.2
-    commander: ^2.19.0
-    doctrine: ^3.0.0
-    estree-to-babel: ^3.1.0
-    neo-async: ^2.6.1
-    node-dir: ^0.1.10
-    resolve: ^1.17.0
-    strip-indent: ^3.0.0
-  bin:
-    react-docgen: bin/react-docgen.js
-  checksum: b1e7ad594a6191ca9e83d1d94e103db6d7e643ef69e9a5d7ca593f0f94e124bcbd48f89aaae8d4952b465781025c74fc7ee2dd7d433136e07a6f3e9529411416
-  languageName: node
-  linkType: hard
-
 "react-docgen@npm:6.0.0-alpha.3":
   version: 6.0.0-alpha.3
   resolution: "react-docgen@npm:6.0.0-alpha.3"
@@ -31071,6 +31191,24 @@ __metadata:
   bin:
     react-docgen: bin/react-docgen.js
   checksum: db4c300910e2ef7b854ccf4f454bd701875b787d0bc0f444f89415223e7c288a5808d6cd0f7ef6346332c9de2d068d648bc801d16b6b07a1699c3e10670c4801
+  languageName: node
+  linkType: hard
+
+"react-docgen@npm:6.0.2":
+  version: 6.0.2
+  resolution: "react-docgen@npm:6.0.2"
+  dependencies:
+    "@babel/core": ^7.18.9
+    "@babel/traverse": ^7.18.9
+    "@babel/types": ^7.18.9
+    "@types/babel__core": ^7.18.0
+    "@types/babel__traverse": ^7.18.0
+    "@types/doctrine": ^0.0.5
+    "@types/resolve": ^1.20.2
+    doctrine: ^3.0.0
+    resolve: ^1.22.1
+    strip-indent: ^4.0.0
+  checksum: f53855185e78fa87e3598e096e1781015d4a063b06802ea6e781b924ec397628fef198354d2906dc7a39eeeb0f6914fac5c38e67de0bf41793dcebab448e420a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,15 +3020,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.21.0":
-  version: 7.22.5
-  resolution: "@babel/runtime@npm:7.22.5"
-  dependencies:
-    regenerator-runtime: ^0.13.11
-  checksum: 12a50b7de2531beef38840d17af50c55a094253697600cee255311222390c68eed704829308d4fd305e1b3dfbce113272e428e9d9d45b1730e0fede997eaceb1
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.22.6":
   version: 7.22.6
   resolution: "@babel/runtime@npm:7.22.6"
@@ -4068,7 +4059,6 @@ __metadata:
   resolution: "@instructure/command-utils@workspace:packages/command-utils"
   dependencies:
     chalk: ^4.1.2
-    concurrently: ^8.2.0
     which: ^2.0.2
   languageName: unknown
   linkType: soft
@@ -15391,26 +15381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "concurrently@npm:8.2.0"
-  dependencies:
-    chalk: ^4.1.2
-    date-fns: ^2.30.0
-    lodash: ^4.17.21
-    rxjs: ^7.8.1
-    shell-quote: ^1.8.1
-    spawn-command: 0.0.2
-    supports-color: ^8.1.1
-    tree-kill: ^1.2.2
-    yargs: ^17.7.2
-  bin:
-    conc: dist/bin/concurrently.js
-    concurrently: dist/bin/concurrently.js
-  checksum: eafe6a4d9b7fda87f55ea285cfc6acd937a5286ceec8991ab48e6cc27c45fce6a5c6f45e18d7555defa15dc7d7e8941bc5a9d1ceaf182e31441d420e00333434
-  languageName: node
-  linkType: hard
-
 "config-chain@npm:^1.1.11":
   version: 1.1.13
   resolution: "config-chain@npm:1.1.13"
@@ -16462,15 +16432,6 @@ __metadata:
   version: 1.30.1
   resolution: "date-fns@npm:1.30.1"
   checksum: 86b1f3269cbb1f3ee5ac9959775ea6600436f4ee2b78430cd427b41a0c9fabf740b1a5d401c085f3003539a6f4755c7c56c19fbd70ce11f6f673f6bc8075b710
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.30.0":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": ^7.21.0
-  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
   languageName: node
   linkType: hard
 
@@ -32325,7 +32286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.4, rxjs@npm:^7.8.0, rxjs@npm:^7.8.1":
+"rxjs@npm:^7.5.4, rxjs@npm:^7.8.0":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -32887,7 +32848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
+"shell-quote@npm:^1.7.3":
   version: 1.8.1
   resolution: "shell-quote@npm:1.8.1"
   checksum: 5f01201f4ef504d4c6a9d0d283fa17075f6770bfbe4c5850b074974c68062f37929ca61700d95ad2ac8822e14e8c4b990ca0e6e9272e64befd74ce5e19f0736b
@@ -33360,13 +33321,6 @@ __metadata:
   version: 1.0.1
   resolution: "sparkles@npm:1.0.1"
   checksum: 022f4ab577291199ec3b2b795726b81d33c6b4b6ebce2ba3520c18600d23fd0c9b401eef70ba16a5480abdc1df922edcd428c2b643f28a286fed402d4a70bc40
-  languageName: node
-  linkType: hard
-
-"spawn-command@npm:0.0.2":
-  version: 0.0.2
-  resolution: "spawn-command@npm:0.0.2"
-  checksum: e35c5d28177b4d461d33c88cc11f6f3a5079e2b132c11e1746453bbb7a0c0b8a634f07541a2a234fa4758239d88203b758def509161b651e81958894c0b4b64b
   languageName: node
   linkType: hard
 
@@ -34258,7 +34212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
+"supports-color@npm:8.1.1, supports-color@npm:^8.0.0":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -35183,15 +35137,6 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
-  languageName: node
-  linkType: hard
-
-"tree-kill@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "tree-kill@npm:1.2.2"
-  bin:
-    tree-kill: cli.js
-  checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,7 +4070,6 @@ __metadata:
     chalk: ^4.1.2
     concurrently: ^8.2.0
     cross-env: ^7.0.3
-    execa: ^5.1.1
     which: ^2.0.2
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -4059,7 +4059,8 @@ __metadata:
   resolution: "@instructure/command-utils@workspace:packages/command-utils"
   dependencies:
     chalk: ^4.1.2
-    which: ^2.0.2
+    cross-spawn: ^7.0.3
+    which: ^3.0.1
   languageName: unknown
   linkType: soft
 
@@ -37135,6 +37136,17 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: fdcf3cadab414e60b86c6836e7ac9de9273561a8926f57cbc28641b602a771527239ee4d47f2689ed255666f035ba0a0d72390986cc0c4e45344491adc7d0eeb
+  languageName: node
+  linkType: hard
+
+"which@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "which@npm:3.0.1"
+  dependencies:
+    isexe: ^2.0.0
+  bin:
+    node-which: bin/which.js
+  checksum: adf720fe9d84be2d9190458194f814b5e9015ae4b88711b150f30d0f4d0b646544794b86f02c7ebeec1db2029bc3e83a7ff156f542d7521447e5496543e26890
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,7 +4069,6 @@ __metadata:
   dependencies:
     chalk: ^4.1.2
     concurrently: ^8.2.0
-    cross-env: ^7.0.3
     which: ^2.0.2
   languageName: unknown
   linkType: soft
@@ -16035,18 +16034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: "npm:^7.0.1"
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^5.0.1":
   version: 5.1.0
   resolution: "cross-spawn@npm:5.1.0"
@@ -16071,7 +16058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
This PR gets `yarn bootstrap` and `yarn dev` working on windows. `yarn test` also runs, but its quite flaky -- some tests fail, some others just throw an error.
This is accomplished by using `cross-spawn` via its API to spawn `babel`, `karma` and `webpack` instead of `concurrently` and `execa` via command line.
On OSX nothing should change except `babel` being a bit more verbose.

To test:
On OSX run our usual build/test commands, especially with parameters (e.g. `yarn test --scope..`).  
On Windows run `bootstrap`, `dev`. If you get tons of popups change the default program to run `js` files to `node.exe`