### PR TITLE
fix(ui-color-picker): fix broken commonjs import for color-picker

### DIFF
--- a/packages/ui-color-picker/src/ColorIndicator/styles.ts
+++ b/packages/ui-color-picker/src/ColorIndicator/styles.ts
@@ -23,9 +23,10 @@
  */
 
 import type { ColorIndicatorProps, ColorIndicatorStyle } from './props'
-import { ColorIndicatorTheme } from '@instructure/shared-types'
+import type { ColorIndicatorTheme } from '@instructure/shared-types'
 import type { RGBAType } from '@instructure/ui-color-utils'
-import { colorToRGB, isValid } from '@instructure/ui-color-utils'
+import { isValid } from '@instructure/ui-color-utils'
+import { colorToRGB } from '@instructure/ui-color-utils'
 
 const calcBlendedColor = (c1: RGBAType, c2: RGBAType) => {
   // 0.4 as decided by design


### PR DESCRIPTION
INSTUI-3828

`babel-plugin-transform-imports` has a bug which sometimes breaks the commonjs build. This is a workaround for that.

### test plan:

- build the project (`yarn bootstrap`)
- modify the `ColorPicker` example to use the commonjs build:
  - in `ui-color-picker/src/index.ts` modify the `ColorPicker` import to `export { ColorPicker } from '../lib/ColorPicker'`
- check the docs example if it's working