### PR TITLE
chore: fix yarn2 not running prepare script for hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "husky:pre-commit": "npm-run-all update:package:list commit:package:list lint:staged ts:check:references",
     "husky:pre-push": "yarn lint:commit",
     "build-storybook": "lerna run bundle --stream --scope docs-examples",
-    "prepare": "husky install",
+    "postinstall": "husky install",
     "ts:check": "lerna run ts:check --stream",
     "ts:check:references": "yarn node scripts/checkTSReferences.js"
   },


### PR DESCRIPTION
INSTUI-3830

from the [official husky docs](https://typicode.github.io/husky/getting-started.html#yarn-2)

### test plan:

- make a fresh clone of this repo
- checkout this PR
- run `yarn install` and `yarn bootstrap`
- create some changes
- commit the changes -> a husky hook should run commitizen/commitlint