### PR TITLE
feat(emotion,shared-types,ui-theme-tokens): add mediumSmall spacing to themes

### DIFF
--- a/packages/emotion/src/styleUtils/ThemeablePropValues.ts
+++ b/packages/emotion/src/styleUtils/ThemeablePropValues.ts
@@ -80,6 +80,7 @@ const ThemeablePropValues = {
     xxSmall: 'xx-small',
     xSmall: 'x-small',
     small: 'small',
+    mediumSmall: 'mediumSmall',
     medium: 'medium',
     large: 'large',
     xLarge: 'x-large',
@@ -89,29 +90,31 @@ const ThemeablePropValues = {
 
 // SPACING
 type SpacingKeys = keyof typeof ThemeablePropValues.SPACING
-type SpacingValues = typeof ThemeablePropValues.SPACING[SpacingKeys]
+type SpacingValues = (typeof ThemeablePropValues.SPACING)[SpacingKeys]
 type Spacing = CSSShorthandValue<SpacingValues>
 
 // SHADOW_TYPES
 type ShadowKeys = keyof typeof ThemeablePropValues.SHADOW_TYPES
-type Shadow = typeof ThemeablePropValues.SHADOW_TYPES[ShadowKeys]
+type Shadow = (typeof ThemeablePropValues.SHADOW_TYPES)[ShadowKeys]
 
 // STACKING_TYPES
 type StackingKeys = keyof typeof ThemeablePropValues.STACKING_TYPES
-type Stacking = typeof ThemeablePropValues.STACKING_TYPES[StackingKeys]
+type Stacking = (typeof ThemeablePropValues.STACKING_TYPES)[StackingKeys]
 
 // BACKGROUNDS
 type BackgroundKeys = keyof typeof ThemeablePropValues.BACKGROUNDS
-type Background = typeof ThemeablePropValues.BACKGROUNDS[BackgroundKeys]
+type Background = (typeof ThemeablePropValues.BACKGROUNDS)[BackgroundKeys]
 
 // BORDER_RADII
 type BorderRadiiKeys = keyof typeof ThemeablePropValues.BORDER_RADII
-type BorderRadiiValues = typeof ThemeablePropValues.BORDER_RADII[BorderRadiiKeys]
+type BorderRadiiValues =
+  (typeof ThemeablePropValues.BORDER_RADII)[BorderRadiiKeys]
 type BorderRadii = CSSShorthandValue<BorderRadiiValues>
 
 // BORDER_WIDTHS
 type BorderWidthKeys = keyof typeof ThemeablePropValues.BORDER_WIDTHS
-type BorderWidthValues = typeof ThemeablePropValues.BORDER_WIDTHS[BorderWidthKeys]
+type BorderWidthValues =
+  (typeof ThemeablePropValues.BORDER_WIDTHS)[BorderWidthKeys]
 type BorderWidth = CSSShorthandValue<BorderWidthValues>
 
 export default ThemeablePropValues

--- a/packages/shared-types/src/BaseTheme.ts
+++ b/packages/shared-types/src/BaseTheme.ts
@@ -70,6 +70,7 @@ type Spacing = {
   xxSmall: string | 0
   xSmall: string | 0
   small: string | 0
+  mediumSmall: string | 0
   medium: string | 0
   large: string | 0
   xLarge: string | 0

--- a/packages/ui-theme-tokens/src/canvas/spacing.ts
+++ b/packages/ui-theme-tokens/src/canvas/spacing.ts
@@ -29,6 +29,7 @@ const spacing: Spacing = Object.freeze({
   xxSmall: '0.375rem', // 6px
   xSmall: '0.5rem', // 8px
   small: '0.75rem', // 12px
+  mediumSmall: '1rem', // 16px
   medium: '1.5rem', // 24px
   large: '2.25rem', // 36px
   xLarge: '3rem', // 48px

--- a/packages/ui-theme-tokens/src/instructure/spacing.ts
+++ b/packages/ui-theme-tokens/src/instructure/spacing.ts
@@ -29,6 +29,7 @@ const spacing: Spacing = Object.freeze({
   xxSmall: '0.375rem',
   xSmall: '0.75rem',
   small: '1rem',
+  mediumSmall: '1.25rem',
   medium: '1.5rem',
   large: '2.25rem',
   xLarge: '3rem',


### PR DESCRIPTION
Closes: INSTUI-3829

IMSG (InstUI Mini Style Guide) adds a new unit for spacing called: mediumSmall. 

- Canvas/High contrast: 16px
- Instructure: 20px

Test plan:

1. run the documentation app
2. under Themes menu check if the above spacing options are present for every theme
3. pick a component and change its margin value to mediumSmall
4. check if the component's margin changed accordingly (16px for Canvas/High Contrast themes, 20px for Instucture)