### PR TITLE
refactor(command-utils): fix runCommandAsync

### DIFF
--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -75,7 +75,10 @@ import { LoadingScreen } from '../LoadingScreen'
 import * as EveryComponent from '../../components'
 import type { AppProps, AppState, DocData, LayoutSize } from './props'
 import { propTypes, allowedProps } from './props'
-import type { LibraryOptions, MainDocsData } from '../../buildScripts/DataTypes'
+import type {
+  LibraryOptions,
+  MainDocsData
+} from '../../buildScripts/DataTypes.mjs'
 import { logError } from '@instructure/console'
 
 type AppContextType = {

--- a/packages/__docs__/src/App/props.ts
+++ b/packages/__docs__/src/App/props.ts
@@ -24,8 +24,11 @@
 
 import PropTypes from 'prop-types'
 import type { ComponentStyle, WithStyleProps } from '@instructure/emotion'
-import type { MainDocsData, ProcessedFile } from '../../buildScripts/DataTypes'
-import { MainIconsData } from '../../buildScripts/DataTypes'
+import type {
+  MainIconsData,
+  MainDocsData,
+  ProcessedFile
+} from '../../buildScripts/DataTypes'
 
 type AppOwnProps = {
   trayWidth: number

--- a/packages/__docs__/src/Methods/index.tsx
+++ b/packages/__docs__/src/Methods/index.tsx
@@ -33,6 +33,7 @@ import {
   MethodParameter,
   MethodReturn,
   TypeDescriptor
+  // eslint-disable-next-line import/no-unresolved
 } from '../../buildScripts/DataTypes'
 
 class Methods extends Component<MethodsProps> {

--- a/packages/__docs__/src/Preview/props.ts
+++ b/packages/__docs__/src/Preview/props.ts
@@ -30,7 +30,8 @@ import type {
 } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
 import type { ComponentStyle, WithStyleProps } from '@instructure/emotion'
-import { MainDocsData } from '../../buildScripts/DataTypes'
+// eslint-disable-next-line import/no-unresolved
+import type { MainDocsData } from '../../buildScripts/DataTypes'
 
 type PreviewOwnProps = {
   code: string

--- a/packages/__docs__/src/Properties/props.ts
+++ b/packages/__docs__/src/Properties/props.ts
@@ -25,7 +25,8 @@
 import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
 import type { ComponentStyle, WithStyleProps } from '@instructure/emotion'
-import { PropDescriptor } from '../../buildScripts/DataTypes'
+// eslint-disable-next-line import/no-unresolved
+import type { PropDescriptor } from '../../buildScripts/DataTypes'
 
 type PropertiesOwnProps = {
   props: Record<string, PropDescriptor>

--- a/packages/__docs__/src/Returns/index.tsx
+++ b/packages/__docs__/src/Returns/index.tsx
@@ -29,7 +29,8 @@ import { Table } from '@instructure/ui-table'
 import { compileMarkdown } from '../compileMarkdown'
 
 import type { ReturnsProps } from './props'
-import { JSDocFunctionReturns } from '../../buildScripts/DataTypes'
+// eslint-disable-next-line import/no-unresolved
+import type { JSDocFunctionReturns } from '../../buildScripts/DataTypes'
 
 class Returns extends Component<ReturnsProps> {
   renderRows() {

--- a/packages/__docs__/src/Returns/props.ts
+++ b/packages/__docs__/src/Returns/props.ts
@@ -23,7 +23,8 @@
  */
 import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
-import { JSDocFunctionReturns } from '../../buildScripts/DataTypes'
+// eslint-disable-next-line import/no-unresolved
+import type { JSDocFunctionReturns } from '../../buildScripts/DataTypes'
 
 type ReturnsOwnProps = {
   types: JSDocFunctionReturns[]

--- a/packages/__docs__/tsconfig.build.json
+++ b/packages/__docs__/tsconfig.build.json
@@ -5,7 +5,12 @@
     "module": "CommonJS",
     "composite": true
   },
-  "include": ["src/**/*", "components.js", "globals.js"],
+  "include": [
+    "src/**/*",
+    "components.js",
+    "globals.js",
+    "buildScripts/DataTypes.mts"
+  ],
   "exclude": ["__build__/**/*"],
   "references": [
     { "path": "../canvas-high-contrast-theme/tsconfig.build.json" },

--- a/packages/__docs__/webpack.config.js
+++ b/packages/__docs__/webpack.config.js
@@ -36,6 +36,7 @@ const resolveAliases = DEBUG ? { resolve: require('./resolve') } : {}
 // This needs to be a promise, so we can import build-docs.mjs
 // build-docs.mjs needs to have ESM imports because React-docgen uses ESM imports
 const configPromise = new Promise(function (resolve, reject) {
+  // eslint-disable-next-line import/no-unresolved
   import('./lib/build-docs.mjs').then((buildDocs) => {
     resolve(
       merge(baseConfig, {

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -12,7 +12,8 @@
   "bugs": "https://github.com/instructure/instructure-ui/issues",
   "scripts": {
     "lint": "run -T ui-scripts lint",
-    "lint:fix": "run -T ui-scripts lint --fix"
+    "lint:fix": "run -T ui-scripts lint --fix",
+    "build:types": "run -T tsc -p tsconfig.build.json"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/ui-scripts/lib/test/lint.js
+++ b/packages/ui-scripts/lib/test/lint.js
@@ -51,7 +51,8 @@ export default {
     if (jspaths.length) {
       commands['eslint'] = getCommand('eslint', [
         ...jspaths,
-        '--ext .js,.jsx,.ts,.tsx',
+        '--ext',
+        '.js,.jsx,.ts,.tsx',
         '--no-error-on-unmatched-pattern'
       ])
     }


### PR DESCRIPTION
We treated it as something that returns a Promise when it does not. This fixes it by wrapping it in a Promise
TEST PLAN:
Change some command temporarly (e.g. ui-scripts tag) so it uses RunCommandAsync and output its return value, e.g.
```
try {
    const res = await runCommandAsync("ls", [], {}, {stdio: 'pipe', stderr: 'pipe'})
    console.log(res)
  } catch (err) {
    console.log("RESULT", err)
  }
```