### PR TITLE
fix: fix `document is undefined` SSR errors

### DIFF
--- a/packages/__docs__/src/TableOfContents/index.tsx
+++ b/packages/__docs__/src/TableOfContents/index.tsx
@@ -26,11 +26,18 @@ import React, { Component } from 'react'
 
 import { canUseDOM, ownerDocument } from '@instructure/ui-dom-utils'
 
+// TODO ESList erroneusly reports this figure out why
+// eslint-disable-next-line import/no-unresolved
 import { Link } from '@instructure/ui-link'
+// eslint-disable-next-line import/no-unresolved
 import { List } from '@instructure/ui-list'
+// eslint-disable-next-line import/no-unresolved
 import { View } from '@instructure/ui-view'
+// eslint-disable-next-line import/no-unresolved
 import { ToggleDetails } from '@instructure/ui-toggle-details'
+// eslint-disable-next-line import/no-unresolved
 import { instructure } from '@instructure/ui-themes'
+// eslint-disable-next-line import/no-unresolved
 import { InstUISettingsProvider } from '@instructure/emotion'
 import type { SpacingValues } from '@instructure/emotion'
 
@@ -67,7 +74,7 @@ class TableOfContents extends Component<
     if (canUseDOM) {
       const pageHeight = pageElement.clientHeight
       const documentHeight =
-        ownerDocument(pageElement).documentElement.clientHeight
+        ownerDocument(pageElement)!.documentElement.clientHeight
 
       // shouldn't display ToC if the page is shorter than 3 times
       // the window size, that is easily scrollable

--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -112,7 +112,7 @@ class FocusRegion {
       // If a dialog contains an <input type="file"/> element and the user opens the file picker and closes it with the
       // escape key then Firefox passes through that event which could close the parent dialog. This code prevents that
       // from happening (listening for a `cancel` event doesn't seem to work in firefox)
-      const activeElement = ownerDocument(this._contextElement).activeElement
+      const activeElement = ownerDocument(this._contextElement)?.activeElement
       const fileInputFocused =
         activeElement?.tagName === 'INPUT' &&
         (<HTMLInputElement>activeElement).type === 'file'
@@ -141,7 +141,7 @@ class FocusRegion {
 
   activate() {
     if (!this._active) {
-      const doc = ownerDocument(this._contextElement)
+      const doc = ownerDocument(this._contextElement)!
 
       this._keyboardFocusRegion.activate()
       this._screenReaderFocusRegion.activate()

--- a/packages/ui-a11y-utils/src/KeyboardFocusRegion.ts
+++ b/packages/ui-a11y-utils/src/KeyboardFocusRegion.ts
@@ -294,7 +294,7 @@ class KeyboardFocusRegion {
       if (defaultFocusElement || shouldContainFocus) {
         if (shouldContainFocus) {
           this._listeners.push(
-            addEventListener(this.doc, 'keydown', this.handleKeyDown)
+            addEventListener(this.doc!, 'keydown', this.handleKeyDown)
           )
         } else {
           this._listeners.push(
@@ -314,14 +314,14 @@ class KeyboardFocusRegion {
         }
 
         this._listeners.push(
-          addEventListener(this.doc, 'click', this.handleClick, true)
+          addEventListener(this.doc!, 'click', this.handleClick, true)
         )
 
         this._listeners.push(
           addEventListener(this.win!, 'blur', this.handleWindowBlur, false)
         )
         this._listeners.push(
-          addEventListener(this.doc, 'focus', this.handleFocus, true)
+          addEventListener(this.doc!, 'focus', this.handleFocus, true)
         )
 
         this._active = true

--- a/packages/ui-dom-utils/src/findDOMNode.ts
+++ b/packages/ui-dom-utils/src/findDOMNode.ts
@@ -54,7 +54,7 @@ const isRefObject = (obj: unknown): obj is RefObject<unknown> => {
 function findDOMNode(el?: UIElement): Element | Node | Window | undefined {
   const node = typeof el === 'function' ? el() : el
 
-  if (node === document) {
+  if (node && node === document) {
     return document.documentElement // HTMLElement
   } else if (
     node instanceof Element ||

--- a/packages/ui-dom-utils/src/getComputedStyle.ts
+++ b/packages/ui-dom-utils/src/getComputedStyle.ts
@@ -46,10 +46,7 @@ function getComputedStyle(el?: UIElement, pseudoElt?: string | null) {
     const node = el && findDOMNode(el)
     if (node) {
       const window = ownerWindow(el)
-      style =
-        window !== null
-          ? window.getComputedStyle(node as Element, pseudoElt)
-          : {}
+      style = window ? window.getComputedStyle(node as Element, pseudoElt) : {}
     }
   }
   return style as CSSStyleDeclaration

--- a/packages/ui-dom-utils/src/getFontSize.ts
+++ b/packages/ui-dom-utils/src/getFontSize.ts
@@ -54,7 +54,7 @@ function getFontSize(
     return 16
   }
 
-  const container = el || ownerDocument(el).documentElement
+  const container = el || ownerDocument(el)?.documentElement
 
   // return the cached font size if it's there
   const cachedValue = COMPUTED_CACHE.get(container)

--- a/packages/ui-dom-utils/src/getOffsetParents.ts
+++ b/packages/ui-dom-utils/src/getOffsetParents.ts
@@ -79,7 +79,7 @@ function getOffsetParents(el?: UIElement) {
       }
     }
 
-    parents.push(ownerDocument(node).body)
+    parents.push(ownerDocument(node)!.body)
   }
 
   return parents

--- a/packages/ui-dom-utils/src/ownerDocument.ts
+++ b/packages/ui-dom-utils/src/ownerDocument.ts
@@ -24,6 +24,7 @@
 
 import { findDOMNode } from './findDOMNode'
 import { UIElement } from '@instructure/shared-types'
+import canUseDOM from './canUseDOM'
 
 /**
  * ---
@@ -33,7 +34,7 @@ import { UIElement } from '@instructure/shared-types'
  * Retrieve the owner document of a specified element
  * @module ownerDocument
  * @param { Node | Window | React.ReactElement | function | null } el
- * @returns { Document } the owner document
+ * @returns { Document | null} the owner document
  */
 function ownerDocument(el?: UIElement) {
   const node = el && findDOMNode(el)
@@ -42,8 +43,8 @@ function ownerDocument(el?: UIElement) {
   if (node && 'ownerDocument' in node) {
     ownerDocument = node.ownerDocument
   }
-
-  return ownerDocument || document
+  const doc = canUseDOM ? window.document : undefined
+  return ownerDocument || doc
 }
 
 export default ownerDocument

--- a/packages/ui-position/src/calculateElementPosition.ts
+++ b/packages/ui-position/src/calculateElementPosition.ts
@@ -238,7 +238,7 @@ class PositionedElement {
     // documentElement should be calculated appropriately.
     // Otherwise we need to explictly account for that offset
     let offsetY =
-      parents.length > 1 ? 0 : getBoundingClientRect(doc.documentElement).top
+      parents.length > 1 ? 0 : getBoundingClientRect(doc?.documentElement).top
     let offsetX = 0
     let scrollY = 0
 
@@ -249,7 +249,7 @@ class PositionedElement {
       offsetY = offsetY + (child.top - parent.top)
       offsetX = offsetX + (child.left - parent.left)
 
-      if (parents[i] === doc.body) {
+      if (parents[i] === doc?.body) {
         // accounts for any margin on body
         offsetY = offsetY + parent.top
         offsetX = offsetX + parent.left
@@ -268,7 +268,7 @@ class PositionedElement {
   normalizeScrollTop(element: Node | Window | null) {
     // Account for cross browser differences with scrollTop attribute on the
     // body element https://bugs.chromium.org/p/chromium/issues/detail?id=766938
-    return ownerDocument(this.node).body === element
+    return ownerDocument(this.node)?.body === element
       ? 0
       : (element as Element).scrollTop
   }
@@ -286,7 +286,7 @@ class PositionData {
 
     if (!element || placement === 'offscreen') return
 
-    this.container = container || ownerDocument(element).body
+    this.container = container || ownerDocument(element)?.body
 
     this.element = new PositionedElement(element, placement, {
       top: this.options.offsetY,
@@ -294,7 +294,7 @@ class PositionData {
     })
 
     this.target = new PositionedElement(
-      target || this.container,
+      target || this.container!,
       over ? this.element.placement : this.element.mirroredPlacement
     )
 

--- a/packages/ui-responsive/src/QueryType.ts
+++ b/packages/ui-responsive/src/QueryType.ts
@@ -82,7 +82,10 @@ type QueryMatchListener = (
         ...args: any[]
       ) => Node | Window | React.ReactElement | React.Component),
   cb: UpdateMatches,
-  matchMedia?: (query: string, el: UIElement) => MediaQueryList | null
+  matchMedia?: (
+    query: string,
+    el: UIElement
+  ) => MediaQueryList | null | undefined
 ) => { remove: () => void }
 
 export type {

--- a/packages/ui-utils/src/px.ts
+++ b/packages/ui-utils/src/px.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { getFontSize } from '@instructure/ui-dom-utils'
+import { canUseDOM, getFontSize } from '@instructure/ui-dom-utils'
 import { parseUnit } from './parseUnit'
 import React from 'react'
 
@@ -39,26 +39,24 @@ import React from 'react'
  *
  * @module px
  *
- * @param {String} val
- * @param {Document|Window|Node|React.ReactElement |React.Component|null} el - containing element, for context measure is em (defaults to document.body)
+ * @param {String|number} val The value to look up. If it's a number its just returned as is.
+ * @param {Document|Window|Node|React.ReactElement |React.Component|null} el - containing element, for context measure is em (defaults to `document.body`)
  * @returns {Number} Returns numerical representation of pixels
  */
 function px(
   val: string | number,
   el?: Document | Window | Node | React.ReactElement | React.Component | null
 ): number {
-  const container = el || document.body
-
   // TODO !val should not be needed
   if (!val || typeof val === 'number') {
     return val as number
   }
-
   const [num, unit] = parseUnit(val)
-
   if (unit === 'rem') {
     return num * getFontSize()
   } else if (unit === 'em') {
+    const doc = canUseDOM ? document.body : null
+    const container = el || doc
     return num * getFontSize(container)
   } else {
     return num


### PR DESCRIPTION
There were some parts of the code where we try to access 'document', and this will raise errors in an SSR environment. This patch fixes these cases. Note that there might be other ones, we should have some SSR testing suite

TEST PLAN:
make a next.js app with the instructions in their site. Add components and run our utils in the render function, e.g. px(), TopNavBar

CLOSES: InstUI-3816