### PR TITLE
Inst UI 3832 responsive breakpoints

### DIFF
--- a/packages/ui-responsive/src/Responsive/README.md
+++ b/packages/ui-responsive/src/Responsive/README.md
@@ -81,3 +81,48 @@ example: true
   }}
 </Responsive>
 ```
+
+### Defining multiple breakpoints
+
+Setting up multiple media query breakpoints is supported. You can use 4 breakpoints at the same time: `minWidth`, `maxWidth`, `minHeight`,
+`maxHeight`. In the following example, the use of two breakpoints, the `minWidth` and `maxWidth`, are used to render the component with the `medium` label.
+
+**Note:** Overlapping breakpoints for height are not fully supported.
+
+```js
+---
+example: true
+---
+<Responsive
+  match="media"
+  query={{
+    small: { maxWidth: 400 },
+    medium: { minWidth: 401, maxWidth: 599 },
+    large: { minWidth: 600}
+  }}
+>
+  {(props, matches) => {
+    if (matches.includes('large')) {
+      return (
+        <Billboard
+          message="Large breakpoint"
+          hero={<IconUserLine />}
+          style={{ border: '10px solid #aaa' }}
+        />
+      )
+    } else if (matches.includes('medium') && !matches.includes('large')) {
+      return (
+        <Byline description="Medium breakpoint">
+          <Avatar name="Alexander Hamilton" />
+        </Byline>
+      )
+    } else {
+      return (
+        <Pill color="primary">
+          Small breakpoint
+        </Pill>
+      )
+    }
+  }}
+</Responsive>
+```

--- a/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
+++ b/packages/ui-responsive/src/Responsive/__tests__/Responsive.test.tsx
@@ -190,4 +190,35 @@ describe('<Responsive />', async () => {
 
     expect(responsiveDiv.style.display).to.equal('inline-flex')
   })
+
+  it('should provide correct props in case of multiple breakpoints in query', async () => {
+    const renderSpy = spy()
+    const props = {
+      small: { withBorder: true, background: 'transparent' },
+      medium: { options: [1, 2, 3], icons: { edit: true, flag: false } },
+      large: { margin: 'small', label: 'hello world', describedBy: 'fakeId' }
+    }
+    await mount(
+      <div style={{ width: 800, height: 400 }}>
+        <Responsive
+          props={props}
+          query={{
+            small: { maxWidth: 300 },
+            medium: { maxWidth: 800 },
+            large: {
+              minWidth: 800,
+              maxWidth: 1000
+            }
+          }}
+          render={(props, matches) => {
+            renderSpy(props, matches)
+            return <div>hello</div>
+          }}
+        />
+      </div>
+    )
+    expect(
+      deepEqual(renderSpy.lastCall.args[0], { ...props.medium, ...props.large })
+    ).to.be.true()
+  })
 })


### PR DESCRIPTION
Add support for multiple breakpoints in media queries.

**Test plan:**

1. Go to the Responsive component page of the InstUI docs app
2. Add extra breakpoints (`minWidth`, `maxWidth`) into the query part of the Responsive component
3. Check if errors are popping up & newly added breakpoints work as intended to CSS specifications & the appropriate part of the HTML is getting rendered