### PR TITLE
fix(ui-dom-utils): fix findFocusable throwing nullpointer exceptions

### DIFF
--- a/packages/ui-dom-utils/src/elementMatches.ts
+++ b/packages/ui-dom-utils/src/elementMatches.ts
@@ -23,7 +23,7 @@
  */
 
 import { findDOMNode } from './findDOMNode'
-import { UIElement } from '@instructure/shared-types'
+import type { UIElement } from '@instructure/shared-types'
 
 /**
  * ---

--- a/packages/ui-dom-utils/src/findDOMNode.ts
+++ b/packages/ui-dom-utils/src/findDOMNode.ts
@@ -23,8 +23,8 @@
  */
 
 import ReactDOM from 'react-dom'
-import { ReactInstance, RefObject } from 'react'
-import { UIElement } from '@instructure/shared-types'
+import type { ReactInstance, RefObject } from 'react'
+import type { UIElement } from '@instructure/shared-types'
 type ReactNodeWithRef = ReactInstance & {
   ref: RefObject<Element | ReactInstance> | Element | ReactInstance
 }

--- a/packages/ui-dom-utils/src/findFocusable.ts
+++ b/packages/ui-dom-utils/src/findFocusable.ts
@@ -35,7 +35,7 @@
  **/
 
 import { getComputedStyle, findDOMNode, elementMatches } from './'
-import { UIElement } from '@instructure/shared-types'
+import type { UIElement } from '@instructure/shared-types'
 
 const focusableSelector = [
   'a[href]',
@@ -88,16 +88,16 @@ function hidden(element: Element | Node) {
 
 function positioned(element: Element | Node) {
   const POS = ['fixed', 'absolute']
-  if (POS.includes((element as HTMLElement).style.position.toLowerCase()))
+  if (POS.includes((element as HTMLElement).style.position?.toLowerCase())) {
     return true
+  }
   if (
     POS.includes(
-      (getComputedStyle(element) as CSSStyleDeclaration)
-        .getPropertyValue('position')
-        .toLowerCase()
+      getComputedStyle(element).getPropertyValue('position')?.toLowerCase()
     )
-  )
+  ) {
     return true
+  }
   return false
 }
 

--- a/packages/ui-dom-utils/src/getComputedStyle.ts
+++ b/packages/ui-dom-utils/src/getComputedStyle.ts
@@ -25,7 +25,7 @@
 import { findDOMNode } from './findDOMNode'
 import { ownerWindow } from './ownerWindow'
 import { canUseDOM } from './canUseDOM'
-import { UIElement } from '@instructure/shared-types'
+import type { UIElement } from '@instructure/shared-types'
 
 /**
  * ---


### PR DESCRIPTION
the positioned function was throwing sometimes a nullpointer exception in Canvas tests. Also some minor typing fixes.

This PR supersedes this one: https://github.com/instructure/instructure-ui/pull/1265/files

TEST PLAN:
just check the code