### PR TITLE
docs: fix playground reset on resize

### DIFF
--- a/packages/__docs__/src/Description/index.tsx
+++ b/packages/__docs__/src/Description/index.tsx
@@ -32,11 +32,18 @@ import type { DescriptionProps } from './props'
 class Description extends Component<DescriptionProps> {
   static propTypes = propTypes
   static allowedProps = allowedProps
+  private compiledMarkdown: any[] | null = null
+
+  componentDidMount() {
+    this.compiledMarkdown = compileMarkdown(this.props.content, {
+      title: this.props.title
+    })
+  }
 
   render() {
-    const { id, title, content } = this.props
+    const { id } = this.props
 
-    return <div id={id}>{compileMarkdown(content, { title })}</div>
+    return <div id={id}>{this.compiledMarkdown}</div>
   }
 }
 


### PR DESCRIPTION
Closes: INSTUI-3838

TEST PLAN:
Open up the docs app. Change something in the playground. Resize the screen. check if the playground reset or not