### PR TITLE
fix(ui-responsive): round dimensions for query matcher

### DIFF
--- a/packages/ui-responsive/src/addElementQueryMatchListener.ts
+++ b/packages/ui-responsive/src/addElementQueryMatchListener.ts
@@ -142,7 +142,12 @@ function updateElementMatches(
   size?: Size
 ): QueriesMatching | null {
   const node = findDOMNode(el)
-  const { width, height } = size || getBoundingClientRect(node)
+  let { width, height } = size || getBoundingClientRect(node)
+
+  // round dimensions to make sure matcher can match queries with integer values
+  width = Math.floor(width)
+  height = Math.floor(height)
+
   const matchingQueries = parseQuery(query, node)({ width, height })
   const newMatches = Object.keys(matchingQueries)
     .filter((key) => matchingQueries[key])


### PR DESCRIPTION
Closes: INSTUI-3785

If dimensions are fractions, integer breakpoints are not going to match with them. Rounding width and height values solves this issue.

### **Test plan:**

1. Set up breakpoints in a Responsive component (or use the example code added in a followup)
2. Resize width and check if props object is not empty
