### PR TITLE
chore: dont use package-lock for regression test in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Retrieve latest snapshot version
         run: node prepare.js
       - name: Install dependencies for regression testing
-        run: npm ci
+        run: npm install --no-package-lock
       - name: Build project and start the server
         run: |
           npm run build:${{ matrix.bundler }}


### PR DESCRIPTION
[previously](https://github.com/instructure/instructure-ui/blob/1800e2886180119af392f1d0f43e101a088b0ff7/.github/workflows/release.yml#L95) with yarn we didn't use a lock file for regression test, this change copies that behaviour

test plan: you can't. it only runs on master