### PR TITLE
fix(ui-tree-browser): improve TreeBrowser keyboard only navigation

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/index.tsx
@@ -128,26 +128,30 @@ class TreeBrowser extends Component<TreeBrowserProps, TreeBrowserState> {
   }
 
   handleKeyDown = (event: React.KeyboardEvent, node?: CollectionData) => {
-    event.stopPropagation()
     switch (event.keyCode) {
       case keycode.codes.down:
       case keycode.codes.j:
+        event.stopPropagation()
         this.moveFocus(1)
         break
       case keycode.codes.up:
       case keycode.codes.k:
+        event.stopPropagation()
         this.moveFocus(-1)
         break
       case keycode.codes.home:
       case keycode.codes.end:
+        event.stopPropagation()
         this.homeOrEnd(event.keyCode)
         break
       case keycode.codes.left:
       case keycode.codes.right:
+        event.stopPropagation()
         this.handleLeftOrRightArrow(event.keyCode, node)
         break
       case keycode.codes.enter:
       case keycode.codes.space:
+        event.stopPropagation()
         this.handleActivation(event, node)
         break
       default:


### PR DESCRIPTION
In the current implementation, when the `TreeBrowser` component is placed as the last focusable element within a modal, attempting to navigate forward using the Tab button disrupts the tab navigation cycle.

This happens because `stopPropagation` is called on all keydown events by default in `handleKeyDown`.

## Before change:


https://github.com/instructure/instructure-ui/assets/15729147/7c7db4ca-4c3c-48fd-b537-23a3219c2e83


## After change:

https://github.com/instructure/instructure-ui/assets/15729147/0fb3af21-b83b-4b5b-8927-d1407608d473


