### PR TITLE
fix(ui-color-picker): add a padding to colorpicker button

### DIFF
--- a/packages/ui-color-picker/src/ColorPicker/index.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/index.tsx
@@ -116,7 +116,8 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
       hexCode: '',
       showHelperErrorMessages: false,
       openColorPicker: false,
-      mixedColor: ''
+      mixedColor: '',
+      labelHeight: 0
     }
   }
 
@@ -129,6 +130,23 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
 
     if (typeof elementRef === 'function') {
       elementRef(el)
+    }
+  }
+
+  inputContainerRef: Element | null = null
+
+  handleInputContainerRef = (el: Element | null) => {
+    this.inputContainerRef = el
+    this.setLabelHeight()
+  }
+
+  setLabelHeight = () => {
+    if (this.inputContainerRef) {
+      this.setState({
+        labelHeight:
+          this.inputContainerRef.getBoundingClientRect().y -
+          (this.inputContainerRef.parentElement?.getBoundingClientRect().y || 0)
+      })
     }
   }
 
@@ -591,6 +609,7 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
           themeOverride={{ padding: '' }}
           renderAfterInput={this.renderAfterInput()}
           renderBeforeInput={this.renderBeforeInput()}
+          inputContainerRef={this.handleInputContainerRef}
           value={this.state.hexCode}
           onChange={(event, value) => this.handleOnChange(event, value)}
           onPaste={(event) => this.handleOnPaste(event)}
@@ -598,7 +617,10 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
           messages={this.renderMessages()}
         />
         {!this.isSimple && (
-          <div css={this.props.styles?.colorMixerButtonContainer}>
+          <div
+            css={this.props.styles?.colorMixerButtonContainer}
+            style={{ paddingTop: this.state.labelHeight }}
+          >
             <div css={this.props.styles?.colorMixerButtonWrapper}>
               {this.renderPopover()}
             </div>

--- a/packages/ui-color-picker/src/ColorPicker/props.ts
+++ b/packages/ui-color-picker/src/ColorPicker/props.ts
@@ -225,6 +225,7 @@ type ColorPickerState = {
   showHelperErrorMessages: boolean
   openColorPicker: boolean
   mixedColor: string
+  labelHeight: number
 }
 
 type PropKeys = keyof ColorPickerOwnProps

--- a/packages/ui-color-picker/src/ColorPicker/styles.ts
+++ b/packages/ui-color-picker/src/ColorPicker/styles.ts
@@ -114,7 +114,7 @@ const generateStyle = (
     },
     colorMixerButtonContainer: {
       label: 'colorPicker__colorMixerButtonContainer',
-      alignSelf: 'flex-end',
+      alignSelf: 'flex-start',
       marginInlineStart: componentTheme.colorMixerButtonContainerLeftMargin
     },
     popoverContentContainer: {


### PR DESCRIPTION
Closes: INSTUI-3867

Adding a padding to color picker button calculated by the text input children element's label height and margin.

This should be replaced in INSTUI v9 with a better solution.

**Test plan**
Add 

```      
renderMessages={() => [{ type: "error", text: "Long error message" }]}
```
to a Color Picker as an attribute and check if the input field and the botton stays aligned.