### PR TITLE
chore: add jest setup script to mock missing context api

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testMatch: ['**/__new-tests__/**/*.test.tsx'],
+  setupFiles: ['./scripts/setup-jest.js'],
   coverageThreshold: {
     global: {
       statements: 87,

--- a/scripts/setup-jest.js
+++ b/scripts/setup-jest.js
@@ -1,0 +1,3 @@
+// via https://stackoverflow.com/questions/48828759/unit-test-raises-error-because-of-getcontext-is-not-implemented
+// eslint-disable-next-line no-undef, notice/notice
+HTMLCanvasElement.prototype.getContext = jest.fn()


### PR DESCRIPTION
without this the jest tests don't fail but still logs some errors

more info: https://stackoverflow.com/questions/48828759/unit-test-raises-error-because-of-getcontext-is-not-implemented