### PR TITLE
INSTUI-3877 fix(ui-date-time-input): clear TimeSelect value when DateInput value is cleared

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/README.md
@@ -68,7 +68,7 @@ class Example extends React.Component {
     let messages = []
     if (!isoDate) {
       // this happens if an invalid date is entered
-      this.setState({ messages })
+      this.setState({ messages:messages, value:undefined })
       return
     }
     const now = new Date()

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -850,6 +850,47 @@ describe('<DateTimeInput />', async () => {
     expect(timeInput).to.have.value(newDateTime.format('LT'))
   })
 
+  it.only('should clear TimeSelect when DateInput is cleared', async () => {
+    const locale = 'en-US'
+    const timezone = 'US/Eastern'
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', locale, timezone)
+
+    const subject = await mount(
+      <DateTimeInput
+        description="date time"
+        dateRenderLabel="date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        timeRenderLabel="time"
+        invalidDateTimeMessage="whoops"
+        locale={locale}
+        timezone={timezone}
+        value={dateTime.toISOString()}
+      />
+    )
+
+    const dateTimeInput = await DateTimeInputLocator.find()
+    const dateLocator = await dateTimeInput.findDateInput()
+    const timeLocator = await dateTimeInput.findTimeInput()
+    const dateInput = await dateLocator.findInput()
+    const timeInput = await timeLocator.findInput()
+    // 1. clear programmatically
+    await subject.setProps({ value: undefined })
+    expect(dateInput).to.have.value('')
+    expect(timeInput).to.have.value('')
+    // 2. clear via keyboard input
+    const newDateStr = '2022-03-29T19:00Z'
+    await subject.setProps({ value: newDateStr })
+    expect(dateInput).to.have.value('March 29, 2022')
+    expect(timeInput).to.have.value('3:00 PM')
+    await dateInput.change({ target: { value: '' } })
+    await dateInput.keyUp('escape')
+    await wait(() => {
+      expect(dateInput).to.have.value('')
+      expect(timeInput).to.have.value('')
+    })
+  })
+
   it('should allow the user to enter any time value if allowNonStepInput is true', async () => {
     const onChange = stub()
 

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -850,7 +850,7 @@ describe('<DateTimeInput />', async () => {
     expect(timeInput).to.have.value(newDateTime.format('LT'))
   })
 
-  it.only('should clear TimeSelect when DateInput is cleared', async () => {
+  it('should clear TimeSelect when DateInput is cleared', async () => {
     const locale = 'en-US'
     const timezone = 'US/Eastern'
     const dateTime = DateTime.parse('2017-05-01T17:30Z', locale, timezone)
@@ -888,6 +888,9 @@ describe('<DateTimeInput />', async () => {
     await wait(() => {
       expect(dateInput).to.have.value('')
       expect(timeInput).to.have.value('')
+      dateTimeInput.find(':contains("whoops")', {
+        expectEmpty: true
+      })
     })
   })
 

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -172,7 +172,15 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
       }
     }
     // if there is no date string clear TimeSelect value
-    const clearTimeSelect = dateStr ? {} : { timeSelectValue: '' }
+    const clearTimeSelect: Partial<DateTimeInputState> = dateStr
+      ? {}
+      : {
+          timeSelectValue: '',
+          message: {
+            type: 'success',
+            text: ''
+          }
+        }
     return {
       iso: undefined,
       calendarSelectedDate: undefined,

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -171,12 +171,15 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
         }
       }
     }
+    // if there is no date string clear TimeSelect value
+    const clearTimeSelect = dateStr ? {} : { timeSelectValue: '' }
     return {
       iso: undefined,
       calendarSelectedDate: undefined,
       dateInputText: dateStr ? dateStr : '',
       renderedDate: DateTime.now(this.locale(), this.timezone()),
-      dateInputTextChanged: false
+      dateInputTextChanged: false,
+      ...clearTimeSelect
     }
   }
 
@@ -295,7 +298,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     this.changeStateIfNeeded(newState, event)
   }
 
-  handleTimeChange = (
+  updateStateBasedOnTimeSelect = (
     event: SyntheticEvent,
     option: { value?: string; inputText: string }
   ) => {
@@ -566,7 +569,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
         </DateInput>
         <TimeSelect
           value={this.state.timeSelectValue}
-          onChange={this.handleTimeChange}
+          onChange={this.updateStateBasedOnTimeSelect}
           onBlur={this.handleBlur}
           renderLabel={timeRenderLabel}
           locale={locale}


### PR DESCRIPTION
TEST PLAN:
make a DateTimeInput with `isRequired = false`. When you clear the date value the time value and the message should clear.
When isRequired = true it should display an invalid date message.