### PR TITLE
fix(ui-truncate-text): fix TruncateText not working inside TopNavBar.Item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60337,7 +60337,7 @@
         "@instructure/ui-form-field": "8.45.0",
         "@instructure/ui-icons": "8.45.0",
         "@instructure/ui-react-utils": "8.45.0",
-        "@instructure/ui-scripts": "*",
+        "@instructure/ui-scripts": "^8.45.0",
         "@instructure/ui-test-locator": "8.45.0",
         "@instructure/ui-test-utils": "8.45.0",
         "@instructure/ui-testable": "8.45.0",

--- a/packages/ui-truncate-text/src/TruncateText/styles.ts
+++ b/packages/ui-truncate-text/src/TruncateText/styles.ts
@@ -44,6 +44,7 @@ const generateStyle = (
       display: 'block',
       overflow: 'hidden',
       wordWrap: 'break-word',
+      whiteSpace: 'normal',
       fontFamily: componentTheme.fontFamily
     },
     auto: { label: 'truncateText__auto', height: '100%' },


### PR DESCRIPTION
INSTUI-3883

### test plan:

- check the example from the jira issue, the text should be truncated:

```tsx
<TopNavBar.Item>
  <div style={{width: '5rem', display:"inline-block"}}>
    <TruncateText>
    Long text that should be truncated, but it's really not truncated
    </TruncateText>
  </div>
</TopNavBar.Item>
```