### PR TITLE
fix(ui-tray): fix Tray component unmounting twice when closed

### DIFF
--- a/packages/ui-tray/src/Tray/index.tsx
+++ b/packages/ui-tray/src/Tray/index.tsx
@@ -70,18 +70,25 @@ class Tray extends Component<TrayProps> {
     shadow: true,
     border: false
   }
-
-  state: TrayState = {
-    transitioning: false
-  }
   ref: Element | null = null
+
+  state: TrayState
+
+  constructor(props: TrayProps) {
+    super(props)
+    this.state = {
+      transitioning: false,
+      open: props.open ?? false
+    }
+  }
+
   componentDidMount() {
     this.props.makeStyles?.()
   }
 
   componentDidUpdate(prevProps: TrayProps, _prevState: TrayState) {
     if (this.props.open !== prevProps.open) {
-      this.setState({ transitioning: true })
+      this.setState({ transitioning: true, open: this.props.open })
     }
     this.props.makeStyles?.()
   }
@@ -163,7 +170,7 @@ class Tray extends Component<TrayProps> {
       ...props
     } = this.props
 
-    const portalIsOpen = open || this.state.transitioning
+    const portalIsOpen = this.state.open || this.state.transitioning
 
     return (
       <Portal
@@ -172,54 +179,52 @@ class Tray extends Component<TrayProps> {
         insertAt={insertAt}
         mountNode={mountNode}
       >
-        {portalIsOpen && (
-          <Transition
-            in={open}
-            type={this.transition}
-            onTransition={onTransition}
-            onEnter={onEnter}
-            onEntering={onEntering}
-            onEntered={createChainedFunction(
-              this.handleTransitionComplete,
-              onEntered,
-              onOpen
-            )}
-            onExit={onExit}
-            onExiting={onExiting}
-            onExited={createChainedFunction(
-              this.handleTransitionComplete,
-              onExited,
-              onClose
-            )}
-            transitionOnMount={transitionOnMount}
-            transitionEnter={transitionEnter}
-            transitionExit={transitionExit}
+        <Transition
+          in={open}
+          type={this.transition}
+          onTransition={onTransition}
+          onEnter={onEnter}
+          onEntering={onEntering}
+          onEntered={createChainedFunction(
+            this.handleTransitionComplete,
+            onEntered,
+            onOpen
+          )}
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={createChainedFunction(
+            this.handleTransitionComplete,
+            onExited,
+            onClose
+          )}
+          transitionOnMount={transitionOnMount}
+          transitionEnter={transitionEnter}
+          transitionExit={transitionExit}
+        >
+          <span
+            {...omitProps(props, Tray.allowedProps)}
+            css={this.props.styles?.tray}
+            ref={contentRef}
           >
-            <span
-              {...omitProps(props, Tray.allowedProps)}
-              css={this.props.styles?.tray}
-              ref={contentRef}
+            <Dialog
+              as="div"
+              label={label}
+              defaultFocusElement={defaultFocusElement}
+              open
+              shouldContainFocus={
+                !this.state.transitioning && shouldContainFocus
+              }
+              shouldReturnFocus={shouldReturnFocus}
+              shouldCloseOnDocumentClick={shouldCloseOnDocumentClick}
+              shouldCloseOnEscape
+              liveRegion={liveRegion}
+              onDismiss={onDismiss}
+              role={role}
             >
-              <Dialog
-                as="div"
-                label={label}
-                defaultFocusElement={defaultFocusElement}
-                open
-                shouldContainFocus={
-                  !this.state.transitioning && shouldContainFocus
-                }
-                shouldReturnFocus={shouldReturnFocus}
-                shouldCloseOnDocumentClick={shouldCloseOnDocumentClick}
-                shouldCloseOnEscape
-                liveRegion={liveRegion}
-                onDismiss={onDismiss}
-                role={role}
-              >
-                <div css={this.props.styles?.content}>{children}</div>
-              </Dialog>
-            </span>
-          </Transition>
-        )}
+              <div css={this.props.styles?.content}>{children}</div>
+            </Dialog>
+          </span>
+        </Transition>
       </Portal>
     )
   }

--- a/packages/ui-tray/src/Tray/props.ts
+++ b/packages/ui-tray/src/Tray/props.ts
@@ -236,6 +236,6 @@ const allowedProps: AllowedPropKeys = [
   'border',
   'shadow'
 ]
-type TrayState = { transitioning: boolean }
+type TrayState = { transitioning: boolean; open: boolean }
 export type { TrayProps, TrayStyle, TrayState }
 export { propTypes, allowedProps }


### PR DESCRIPTION
INSTUI-3923

test plan
- open docs app at the `Tray` component and paste the following code:
```jsx
function TrayContent() {
  React.useEffect(() => {
    console.log("TrayContent is loaded");

    return () => console.log("Tray content is unloaded");
  }, []);
  return <>This is a test.</>;
}

const FPO = lorem.paragraph()
class Example extends React.Component {
  constructor (props) {
    super(props)
    this.state = {
      open: false
    }
  }

  hideTray = () => {
    this.setState({
      open: false
    })
  }

  renderCloseButton () {
    return (
      <Flex>
        <Flex.Item shouldGrow shouldShrink>
          <Heading>Hello</Heading>
        </Flex.Item>
        <Flex.Item>
          <CloseButton
            placement="end"
            offset="small"
            screenReaderLabel="Close"
            onClick={this.hideTray}
          />
        </Flex.Item>
      </Flex>
    )
  }

  render () {
    return (
      <div style={{ padding: '0 0 16rem 0', margin: '0 auto' }}>
        <Button
          onClick={() => { this.setState({ open: true }) }}
          ref={(c) => this._showButton = c}
        >
          Show the Tray
        </Button>
        <Tray
          label="Tray Example"
          open={this.state.open}
          onDismiss={() => { this.setState({ open: false }) }}
          size="small"
          placement="start"
        >
          <View as="div" padding="medium">
            {this.renderCloseButton()}
            <Text as="p" lineHeight="double">{FPO}</Text>
            <TrayContent/>
          </View>
        </Tray>
      </div>
    )
  }
}

render(<Example />)
```

- open and close the tray component
- the mount and unmount logs should only appear once in the console