### PR TITLE
fix(ui-drilldown): fix cmd+click not working on drilldown items

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -813,7 +813,7 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
       this.goToPage(subPageId)
     }
 
-    if (href) {
+    if (event.type === 'keydown' && href) {
       const optionEl = this._drilldownRef?.querySelector(
         `#${id}`
       ) as HTMLLinkElement


### PR DESCRIPTION
INSTUI-3924

test plan:

- in the TopNavBar Drilldown examples change a drilldown item's href to some url (e.g. `https://google.com`)
- cmd+click on that item -> it should open on a new tab as expected