### PR TITLE
fix focus region issues

### DIFF
--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -177,7 +177,7 @@ class Popover extends Component<PopoverProps, PopoverState> {
       // the FocusRegionManager via Dialog
       this._focusRegion = new FocusRegion(this._contentElement, {
         shouldCloseOnEscape: false,
-        shouldCloseOnDocumentClick: true,
+        shouldCloseOnDocumentClick: false,
         onDismiss: this.hide
       })
 

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -174,6 +174,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         elementRef={this.handleRef}
+        shouldCloseOnDocumentClick={false}
       >
         <span id={this._id} css={styles?.tooltip} role="tooltip">
           {/* TODO: figure out how to add a ref to this */}


### PR DESCRIPTION
INSTUI-3938

this PR fixes several issues related to the `shouldCloseOnDocumentClick` option in focus region. these are:

1. changing the content of a dialog (modal/popover/etc) dismisses it which can be observed in the [Drilldown Menu pattern](https://instructure.design/#DrilldownMenu) or in this [example](https://codesandbox.io/s/laughing-euclid-5gzdq3?file=/src/App.js)
2. if a dialog has an input field and you highlight the text with mouse and you release the mouse button when the cursor is outside the dialog then the dialog closes (which was fixed previously but reoccured recently)
3. tooltips closed on click as they were having the `shouldCloseOnDocumentClick` option set to true

### test plan:

- go to the [Drilldown Menu example](https://1371--preview-instui.netlify.app/#DrilldownMenu) and test the following things:
  - clicking on the trigger should open the menu, clicking on the trigger again should close it
  - clicking outside the menu when it's open should close it
  - clicking on a menu item shouldn't close the popover
  - clicking on a menu item dragging the mouse outside the popover while holding don't the mouse button shouldn't close the popover