### PR TITLE
fix(ui-a11y-utils): fix regression in focus region

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -90,10 +90,11 @@ class FocusRegion {
     )
   }
 
-  handleDocumentClick = (event: React.MouseEvent) => {
+  handleDocumentClick = (event: React.PointerEvent) => {
     if (
       this._options.shouldCloseOnDocumentClick &&
       event.button === 0 &&
+      event.pointerType === 'mouse' &&
       !this._contextContainsTarget
     ) {
       this.handleDismiss(event, true)


### PR DESCRIPTION
this was fixed in #1332 and reappeared in #1371

this should be a more sufficient solution

### test plan

- open the docs app at the modal example
- use this code:

```jsx
<div style={{ padding: '0 0 11rem 0', margin: '0 auto' }}>
        <Button onClick={this.handleButtonClick}>
          {this.state.open ? 'Close' : 'Open'} the Modal
        </Button>
        <Modal
          as="form"
          open={this.state.open}
          onDismiss={() => { this.setState({ open: false }) }}
          onSubmit={this.handleFormSubmit}
          size="auto"
          label="Modal Dialog: Hello World"
          shouldCloseOnDocumentClick
        >
          <Modal.Header>
            {this.renderCloseButton()}
            <Heading>Hello World</Heading>
          </Modal.Header>
          <Modal.Body>
            <TextInput renderLabel="Example" placeholder="if you hit enter here, it should submit the form" />
            <Text lineHeight="double">{fpo}</Text>
            <Checkbox label={lorem.sentence()} value="medium" defaultChecked />
          </Modal.Body>
          <Modal.Footer>
            <Button onClick={this.handleButtonClick} margin="0 x-small 0 0">Close</Button>
            <Button color="primary" type="submit">Submit</Button>
          </Modal.Footer>
        </Modal>
      </div>
```

- open the modal
- press tabs until the focus is on the checkbox
- press space
- the modal shouldn't close