### PR TITLE
INSTUI-3949 fix(ui-side-nav-bar): fix scrollbar appearing in closed state

### DIFF
--- a/packages/ui-side-nav-bar/src/SideNavBar/index.tsx
+++ b/packages/ui-side-nav-bar/src/SideNavBar/index.tsx
@@ -135,21 +135,19 @@ class SideNavBar extends Component<SideNavBarProps, SideNavBarState> {
         }}
       >
         <ul css={this.props.styles?.content}>{this.renderChildren()}</ul>
-        <div css={this.props.styles?.toggle}>
-          <SideNavBarItem
-            aria-expanded={!this.minimized}
-            onClick={this.handleNavToggle}
-            icon={
-              <IconMoveStartLine
-                css={this.props.styles?.toggleIcon}
-                inline={false}
-              />
-            }
-            label={
-              <ScreenReaderContent>{this.toggleMessage()}</ScreenReaderContent>
-            }
-          ></SideNavBarItem>
-        </div>
+        <SideNavBarItem
+          aria-expanded={!this.minimized}
+          onClick={this.handleNavToggle}
+          icon={
+            <IconMoveStartLine
+              css={this.props.styles?.toggleIcon}
+              inline={false}
+            />
+          }
+          label={
+            <ScreenReaderContent>{this.toggleMessage()}</ScreenReaderContent>
+          }
+        ></SideNavBarItem>
       </nav>
     )
   }

--- a/packages/ui-side-nav-bar/src/SideNavBar/props.ts
+++ b/packages/ui-side-nav-bar/src/SideNavBar/props.ts
@@ -86,7 +86,7 @@ type SideNavBarProps = SideNavBarOwnProps &
   OtherHTMLAttributes<SideNavBarOwnProps>
 
 type SideNavBarStyle = ComponentStyle<
-  'navigation' | 'list' | 'content' | 'toggle' | 'toggleIcon'
+  'navigation' | 'list' | 'content' | 'toggleIcon'
 >
 
 const propTypes: PropValidators<PropKeys> = {

--- a/packages/ui-side-nav-bar/src/SideNavBar/styles.ts
+++ b/packages/ui-side-nav-bar/src/SideNavBar/styles.ts
@@ -68,14 +68,12 @@ const generateStyle = (
       padding: '0',
       flex: '1 0 auto'
     },
-    toggle: {
+    toggleIcon: {
+      fill: componentTheme.fill,
+      margin: '0 auto',
       transform: 'translate3d(0, 0, 0)',
       transition: `all ${componentTheme.toggleTransition}`,
       ...(minimized ? { transform: 'rotate3d(0, 1, 0, -180deg)' } : {})
-    },
-    toggleIcon: {
-      fill: componentTheme.fill,
-      margin: '0 auto'
     }
   }
 }


### PR DESCRIPTION
now the CSS just rotates the icon not the whole collapse button.

TEST PLAN:
open and close the navbar example in the docs. There should be no scrollbar