### PR TITLE
docs: fix textinputs breaking on search page

### DIFF
--- a/docs/patterns/Search.md
+++ b/docs/patterns/Search.md
@@ -4,7 +4,6 @@ category: Patterns
 id: Search
 ---
 
-
 ## Search
 
 Make use of the following patterns when prompting users for a search query.
@@ -12,7 +11,6 @@ Make use of the following patterns when prompting users for a search query.
 ### Auto Activated Search
 
 Results are updated in real time as the user keys in the search term.
-
 
 ```js
 ---
@@ -56,7 +54,7 @@ class AutoActivatedSearchExample extends React.Component {
 
     this.setState({
       isLoading: true,
-      searchQuery: value 
+      searchQuery: value
     })
 
     this.timeoutId = setTimeout(() => {
@@ -125,6 +123,7 @@ class AutoActivatedSearchExample extends React.Component {
             inputRef={(el) => this.inputRef = el}
             renderBeforeInput={<IconSearchLine inline={false} />}
             renderAfterInput={this.renderClearButton()}
+            shouldNotWrap
           />
         </form>
         <View as="div" padding="medium 0">
@@ -227,7 +226,6 @@ guidelines: true
 Results are updated when a user triggers the search action, via keyboard or
 mouse.
 
-
 ```js
 ---
 render: false
@@ -282,7 +280,7 @@ class ActivatedSearchExample extends React.Component {
 
   renderClearButton = () => {
     if (!this.state.value.length) return;
-    
+
     return (
       <IconButton
           type="button"
@@ -323,6 +321,7 @@ class ActivatedSearchExample extends React.Component {
                 inputRef={(el) => this.inputRef = el}
                 renderBeforeInput={<IconSearchLine inline={false} />}
                 renderAfterInput={this.renderClearButton()}
+                shouldNotWrap
               />
             </Flex.Item>
             <Flex.Item>
@@ -419,7 +418,7 @@ guidelines: true
 Search performed within an autocomplete is used to populate the form field.
 If the desired result is not found, no action is ultimately taken with this
 pattern. It can be used for a single select, or a multi-select with tags. A
-search icon may or may not be used on the left, depending on the context. 
+search icon may or may not be used on the left, depending on the context.
 
 ```js
 ---
@@ -617,6 +616,7 @@ class AutocompleteExample extends React.Component {
           onRequestSelectOption={this.handleSelectOption}
           renderBeforeInput={<IconSearchLine inline={false} />}
           renderAfterInput={this.renderAfterInput()}
+          shouldNotWrap
         >
           {filteredOptions.length > 0 ? filteredOptions.map((option) => {
             return (
@@ -677,7 +677,7 @@ guidelines: true
 <Guidelines>
   <Figure recommendation="yes" title="Do">
     <Figure.Item>
-      Provide additional information when no results are found (e.g. "Sorry, no matches were found”, “No results found”, “User not found”) 
+      Provide additional information when no results are found (e.g. "Sorry, no matches were found”, “No results found”, “User not found”)
     </Figure.Item>
     <Figure.Item>
       Use a loading spinner if autocomplete results are being retrieved asynchronously
@@ -690,7 +690,6 @@ guidelines: true
 
 Use this reference to see how various states affect how the search input is
 rendered.
-
 
 ```js
 ---
@@ -763,6 +762,7 @@ class SearchInputExample extends React.Component {
             inputRef={(el) => this.inputRef = el}
             renderBeforeInput={<IconSearchLine inline={false} />}
             renderAfterInput={this.renderClearButton()}
+            shouldNotWrap
           />
         </View>
         <FormFieldGroup


### PR DESCRIPTION
Closes: INSTUI-3940

**Test**: check if TextInputs break in mobile view on Patterns\Search page. 