### PR TITLE
INSTUI-3954 feat(ui-date-time-input): add showMessages prop

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -654,6 +654,37 @@ describe('<DateTimeInput />', async () => {
     expect(await dateTimeInput.find(':contains(hello world)')).to.exist()
   })
 
+  it('should not show built in message when `showMessages` is false', async () => {
+    const locale = 'en-US'
+    const timezone = 'US/Eastern'
+    const dateTime = DateTime.parse('2017-05-01T17:30Z', locale, timezone)
+    const subject = await mount(
+      <DateTimeInput
+        description="date time"
+        dateRenderLabel="date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        timeRenderLabel="time"
+        invalidDateTimeMessage="whoops"
+        locale={locale}
+        timezone={timezone}
+        value={dateTime.toISOString()}
+        showMessages={false}
+      />
+    )
+    const dateTimeInput = await DateTimeInputLocator.find()
+    expect(
+      await dateTimeInput.find(':contains(2017)', { expectEmpty: true })
+    ).to.not.exist()
+    await subject.setProps({
+      messages: [{ text: 'hello world', type: 'success' }]
+    })
+    expect(await dateTimeInput.find(':contains(hello world)')).to.exist()
+    await subject.setProps({ showMessages: true })
+    expect(await dateTimeInput.find(':contains(hello world)')).to.exist()
+    expect(await dateTimeInput.find(':contains(2017)')).to.exist()
+  })
+
   it('should read locale and timezone from context', async () => {
     const onChange = stub()
     const dateTime = DateTime.parse('2017-05-01T17:30Z', 'en-US', 'GMT')

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -57,6 +57,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     colSpacing: 'medium',
     rowSpacing: 'small',
     timeStep: 30,
+    showMessages: true,
     messageFormat: DateTimeInput.DEFAULT_MESSAGE_FORMAT,
     isRequired: false,
     dateFormat: 'LL', // Localized date with full month, e.g. "August 6, 2014"
@@ -517,6 +518,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
       timeInputRef,
       locale,
       timezone,
+      showMessages,
       messages,
       layout,
       rowSpacing,
@@ -536,7 +538,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
         vAlign="top"
         elementRef={this.handleRef}
         messages={[
-          ...(this.state.message ? [this.state.message] : []),
+          ...(showMessages && this.state.message ? [this.state.message] : []),
           ...(messages || [])
         ]}
       >

--- a/packages/ui-date-time-input/src/DateTimeInput/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/props.ts
@@ -122,7 +122,14 @@ type DateTimeInputProps = {
    **/
   invalidDateTimeMessage: string | ((rawDateValue: string) => string)
   /**
-   * Messages to be displayed
+   * Toggles whether to show built-in messages (the date/time, or the
+   * `invalidDateTimeMessage`). Even when set to `false` the component will
+   * show user supplied messages by the `messages` prop.
+   * @default true
+   */
+  showMessages?: boolean
+  /**
+   * Extra message(s) to be displayed.
    */
   messages?: FormMessage[]
   /**
@@ -275,6 +282,7 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.string,
     PropTypes.func
   ]).isRequired,
+  showMessages: PropTypes.bool,
   messages: PropTypes.arrayOf(FormPropTypes.message),
   messageFormat: PropTypes.string,
   layout: PropTypes.oneOf(['stacked', 'columns', 'inline']),
@@ -315,6 +323,7 @@ const allowedProps: AllowedPropKeys = [
   'locale',
   'timezone',
   'invalidDateTimeMessage',
+  'showMessages',
   'messages',
   'messageFormat',
   'layout',


### PR DESCRIPTION
This new prop enables to hide the date/time/error messages beneath the input fields. Default is true, the messages are shown. It does not hide user-supplied messages in the 'messages' field.

TEST PLAN:
set `showMessages` to false and check that no datetime/error messages are shown.