### PR TITLE
fix(ui-a11y-utils): use event.detail instead of event.pointerType for safari/firefox

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -94,7 +94,7 @@ class FocusRegion {
     if (
       this._options.shouldCloseOnDocumentClick &&
       event.button === 0 &&
-      event.pointerType && // if the pointerType is an empty string, the click was initiated via keyboard and we shouldn't call the dismiss fn
+      event.detail > 0 && // if event.detail is 0 then this is a keyboard and not a mouse press
       !this._contextContainsTarget
     ) {
       this.handleDismiss(event, true)


### PR DESCRIPTION
INSTUI-3956

test:
- open the docs on safari or firefox
- open a modal and try to dismiss it by clicking on the document
- the modal should close as expected