### PR TITLE
fix Preview errors in docs page

### DIFF
--- a/packages/__docs__/src/Playground/index.tsx
+++ b/packages/__docs__/src/Playground/index.tsx
@@ -43,7 +43,7 @@ import generateStyle from './styles'
 import generateComponentTheme from './theme'
 
 import { AppContext } from '../App'
-import { Preview, PreviewErrorBoundary } from '../Preview'
+import Preview from '../Preview'
 import { CodeSandboxButton } from '../CodeSandboxButton'
 import type { PlaygroundProps, PlaygroundState } from './props'
 import { propTypes, allowedProps } from './props'
@@ -209,21 +209,19 @@ class Playground extends Component<PlaygroundProps, PlaygroundState> {
     const { fullscreen, rtl } = this.state
 
     return (
-      <PreviewErrorBoundary>
-        <Preview
-          code={code}
-          language={this.props.language}
-          background={
-            typeof this.props.background === 'string'
-              ? this.props.background
-              : 'light'
-          }
-          fullscreen={fullscreen}
-          rtl={rtl}
-          themeKey={themeKey}
-          themes={themes}
-        />
-      </PreviewErrorBoundary>
+      <Preview
+        code={code}
+        language={this.props.language}
+        background={
+          typeof this.props.background === 'string'
+            ? this.props.background
+            : 'light'
+        }
+        fullscreen={fullscreen}
+        rtl={rtl}
+        themeKey={themeKey}
+        themes={themes}
+      />
     )
   }
 

--- a/packages/__docs__/src/Preview/props.ts
+++ b/packages/__docs__/src/Preview/props.ts
@@ -96,7 +96,6 @@ const propTypes: PropValidators<PropKeys> = {
 }
 type PreviewState = {
   error: string | null
-  elToRender: React.ReactElement | null
 }
 const allowedProps: AllowedPropKeys = [
   'code',


### PR DESCRIPTION
cleaned up and fixed the error handling for the`<Preview/>` component in the docs page

### to test:

- go to the docs page and open a code example
- modify the example to get a ReferenceError (e.g. add a new prop `some={example}`)
- the preview should display the error
- modify the code to get rid of the error
- the error should disappear and the component preview should be displayed again