### PR TITLE
fix(ui-editable): fix the Esc key event propagation inside the Editab…

### DIFF
--- a/packages/ui-editable/src/Editable/index.tsx
+++ b/packages/ui-editable/src/Editable/index.tsx
@@ -118,6 +118,7 @@ class Editable extends Component<EditableProps> {
 
   handleEditESC = (event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {
+      event.stopPropagation()
       this.enterView()
     }
   }


### PR DESCRIPTION
…le component

Previously when you hit Esc in an InPlacEdit component inside a Modal, the Modal would close.

TEST PLAN:

Create an InPlaceEdit inside a Modal, then focus the InPlaceEdit, hit Esc, the Modal should not close.