### PR TITLE
docs: remove internal tool's doc (MaxLengthInputPrompt) page from docs

### DIFF
--- a/packages/__docs__/buildScripts/build-docs.mts
+++ b/packages/__docs__/buildScripts/build-docs.mts
@@ -114,7 +114,8 @@ const pathsToIgnore = [
   // deprecated packages and modules:
   '**/InputModeListener.{js,ts}',
   // regression testing app:
-  '**/regression-test/**'
+  '**/regression-test/**',
+  '**/packages/cz-lerna-changelog/**'
 ]
 
 function buildDocs() {


### PR DESCRIPTION
Closes: INSTUI-3984

Test plan:

Check if MaxLengthInputPrompt is still at the root of the docs navigation