### PR TITLE
Fix: only import react-dom/client if exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50885,8 +50885,7 @@
         "@instructure/ui-themes": "8.53.1",
         "@instructure/ui-utils": "8.53.1",
         "@lezer/highlight": "1.1.6",
-        "prop-types": "^15.8.1",
-        "react-dom": "^18.2.0"
+        "prop-types": "^15.8.1"
       },
       "devDependencies": {
         "@instructure/ui-babel-preset": "8.53.1",
@@ -50896,7 +50895,8 @@
         "@testing-library/react": "^14.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8 <=18"
+        "react": ">=16.8 <=18",
+        "react-dom": ">=16.8 <=18"
       }
     },
     "packages/ui-spinner": {

--- a/packages/ui-source-code-editor/package.json
+++ b/packages/ui-source-code-editor/package.json
@@ -59,11 +59,11 @@
     "@instructure/ui-themes": "8.53.1",
     "@instructure/ui-utils": "8.53.1",
     "@lezer/highlight": "1.1.6",
-    "prop-types": "^15.8.1",
-    "react-dom": "^18.2.0"
+    "prop-types": "^15.8.1"
   },
   "peerDependencies": {
-    "react": ">=16.8 <=18"
+    "react": ">=16.8 <=18",
+    "react-dom": ">=16.8 <=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/SearchPanel.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/SearchPanel.tsx
@@ -23,7 +23,6 @@
  */
 
 import React, { useState } from 'react'
-import { createRoot } from 'react-dom/client'
 import {
   setSearchQuery,
   search,
@@ -40,6 +39,13 @@ import {
   IconArrowOpenUpLine,
   IconSearchLine
 } from '@instructure/ui-icons'
+
+let reactdom: any
+try {
+  reactdom = require('react-dom/client')
+} catch {
+  reactdom = require('react-dom')
+}
 
 export type SearchConfig = {
   placeholder: string
@@ -138,8 +144,15 @@ export default function customSearch(searchConfig: SearchConfig | undefined) {
         createPanel: (view) => {
           const dom = document.createElement('div')
           dom.style.padding = '8px'
-          const root = createRoot(dom)
-          root.render(<SearchPanel view={view} searchConfig={searchConfig} />)
+          if ('createRoot' in reactdom) {
+            const root = reactdom.createRoot(dom)
+            root.render(<SearchPanel view={view} searchConfig={searchConfig} />)
+          } else {
+            reactdom.render(
+              <SearchPanel view={view} searchConfig={searchConfig} />,
+              dom
+            )
+          }
           return { dom }
         }
       })


### PR DESCRIPTION
fixes issue in last release where `SourceCodeEditor` can only be used in react 18 due to `react-dom` api change