### PR TITLE
docs(ui-select): add example for voiceover announcement for multiselect option removal

### DIFF
--- a/packages/ui-select/src/Select/README.md
+++ b/packages/ui-select/src/Select/README.md
@@ -534,7 +534,8 @@ class MultipleSelectExample extends React.Component {
     const newSelection = this.state.selectedOptionId.filter((id) => id !== tag)
     this.setState({
       selectedOptionId: newSelection,
-      highlightedOptionId: null
+      highlightedOptionId: null,
+      announcement: `${this.getOptionById(tag).label} removed`,
     }, () => {
       this.inputRef.focus()
     })


### PR DESCRIPTION
INSTUI-3994
#1334 

test plan:
- go to the multiselect example in docs (`/#Select/#Highlighting%20and%20selecting%20options`)
- turn on voiceover
- add and remove an option
- `<option name> removed` should be read by the screen reader