### PR TITLE
fix(ui-drawer-layout): fix drawerlayout transition bug

### DIFF
--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -126,12 +126,8 @@ class DrawerTray extends Component<
     ) as DrawerTrayPlacement
   }
 
-  get direction() {
-    return this.placement === 'end' ? 'right' : 'left'
-  }
-
   get transition(): TransitionType {
-    return `slide-${this.direction}`
+    return this.placement === 'end' ? 'fade' : 'slide-left'
   }
 
   handleContentRef = (node: HTMLDivElement | null) => {


### PR DESCRIPTION
Closes: INSTUI-4022

When placement property is set to 'end', a weird scrollbar appears during transition. Transition type is set to 'fade' as a fix.

**Test:** check if ui-drawer-layout still has a weird animation if `placement='end'`