### PR TITLE
fix(ui-dialog): menu closes when clicking on submenu

### DIFF
--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -106,9 +106,13 @@ class Dialog extends Component<DialogProps> {
   }
 
   close() {
-    if (this._focusRegion) {
-      FocusRegionManager.blurRegion(this.contentElement, this._focusRegion.id)
-    }
+    const { _focusRegion, contentElement } = this
+    // setTimeout is used here to delay the blur after the mousedown event in FocusRegion for correct execution order
+    setTimeout(() => {
+      if (_focusRegion) {
+        FocusRegionManager.blurRegion(contentElement, _focusRegion.id)
+      }
+    }, 0)
   }
 
   focus() {


### PR DESCRIPTION
INSTUI-4023

test plan:

- use the following `Menu` example:

```jsx
class Example extends React.Component {
  constructor (props) {
    super(props)

    this.state = {
      singleSelection: ['itemOne'],
      multipleSelection: ['optionOne', 'optionThree']
    }
  }

  handleSingleSelect = (e, newSelected) => {
    alert(newSelected)
    this.setState({
      singleSelection: newSelected
    })
  };

  handleNoSelect = (e, newSelected) => {
    alert('no select')
    e.preventDefault()
    e.stopPropagation()
  };

  render () {
    return (
    <View padding="medium" textAlign="center">
      <Menu
        placement="bottom"
        trigger={
          <Button>Menu</Button>
        }
        onSelect={this.handleSingleSelect}
        mountNode={() => document.getElementById('main')}
      >
        <Menu.Item value="mastery">Learning Mastery</Menu.Item>
        <Menu.Item href="https://instructure.github.io/instructure-ui/">Default (Grid view)</Menu.Item>
        <Menu.Item disabled>Individual (List view)</Menu.Item>
        <Menu label="More Options" onSelect={this.handleNoSelect}>
           <Menu.Item value="optionOne">
              Option 1
            </Menu.Item>
            <Menu.Item value="optionTwo">
              Option 2
            </Menu.Item>
            <Menu.Item value="optionThree">
              Option 3
            </Menu.Item>
        </Menu>
       
      </Menu>
    </View>
    )
  }
}

render(<Example />)

```

- clicking on "More options" should close the submenu but not the parent menu