### PR TITLE
feat(ui-top-nav-bar): add onclick prop for hidden menu items

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/props.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/props.ts
@@ -199,6 +199,13 @@ type TopNavBarItemOwnProps = {
   ) => void
 
   /**
+   * Only fires when the item is hidden because of truncation or mobile view. Intended to be used for navigation when the item would otherwise be a link.
+   */
+  onHiddenClick?: (
+    event: React.MouseEvent<ViewOwnProps> | React.KeyboardEvent<ViewOwnProps>
+  ) => void
+
+  /**
    * __In desktop mode__, the callback fired when the item's submenu ([Drilldown](#Drilldown)) is toggled open/closed.
    */
   onSubmenuToggle?: DrilldownProps['onToggle']
@@ -298,6 +305,7 @@ const propTypes: PropValidators<PropKeys> = {
   renderIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   href: PropTypes.string,
   onClick: PropTypes.func,
+  onHiddenClick: PropTypes.func,
   onSubmenuToggle: PropTypes.func,
   onMouseOver: PropTypes.func,
   onMouseOut: PropTypes.func,
@@ -324,6 +332,7 @@ const allowedProps: AllowedPropKeys = [
   'renderIcon',
   'href',
   'onClick',
+  'onHiddenClick',
   'onSubmenuToggle',
   'onMouseOver',
   'onMouseOut',

--- a/packages/ui-top-nav-bar/src/TopNavBar/utils/mapItemsForDrilldown.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/utils/mapItemsForDrilldown.tsx
@@ -206,7 +206,13 @@ const renderMappedItemsAsDrilldownOptions = (
   mappedItems: ItemMappedForDrilldownOption[]
 ) => {
   return mappedItems.map<DrilldownOptionChild>((mappedItem) => {
-    const { optionData } = mappedItem
+    const { optionData, item: originalItem } = mappedItem
+    const onHiddenClick = originalItem.props.onHiddenClick
+
+    if (onHiddenClick) {
+      // if the `onHiddenClick` prop is provided for the MenuItem it should overwrite the `onClick` prop if there is any
+      optionData.onOptionClick = onHiddenClick as any
+    }
 
     return (
       <Drilldown.Option


### PR DESCRIPTION
INSTUI-4058

test plan:

- go to a navbar example
- add the new `onHiddenClick` prop and `href` to the items
- visible items should behave as a link and not have the onclick behaviour
- hidden/truncated items should not be a link and have the onclick fn