### PR TITLE
chore: add redirect for v8 docs

### DIFF
--- a/packages/__docs__/_redirects
+++ b/packages/__docs__/_redirects
@@ -1,2 +1,3 @@
 /v6/* https://v6--preview-instui.netlify.app/:splat 200
 /v7/* https://v7--preview-instui.netlify.app/:splat 200
+/v8/* https://v8--preview-instui.netlify.app/:splat 200


### PR DESCRIPTION
this fixes the redirect for the v8 docs so https://instructure.design/v8/ works