### PR TITLE
chore: do not allow PR merge if there is a Chromatic change

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-      - v7_maintenance
+      - v8_maintenance
   pull_request:
     branches:
       - master
-      - v7_maintenance
+      - v8_maintenance
 jobs:
   chromatic_deployment:
     runs-on: ubuntu-latest
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Node 18
-        uses: actions/setup-node@v3
+      - name: Install Node 20
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install project dependencies
         run: npm ci
       - name: Bootstrap project
@@ -27,9 +27,8 @@ jobs:
       - name: Build Storybook examples
         run: npm run build-storybook
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: d8b52d7c3367 # We have to set this as a string so VRT can be run from forked branches as well.
-          exitZeroOnChanges: true
           storybookBuildDir: ./packages/__examples__/__build__


### PR DESCRIPTION
This will mark the Chromatic check red in a PR until either the change is accepted or there is no change.

see: https://www.chromatic.com/docs/github-actions/#command-exit-code-for-required-checks
Also update Chromatic GH action runner versions

