### PR TITLE
fix(ui-top-nav-bar): keep width unchanged when active status is set t…

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/styles.ts
@@ -108,7 +108,8 @@ const generateStyle = (
       color: inverseColor ? componentTheme.colorInverse : componentTheme.color,
 
       ...(isActive && {
-        fontWeight: componentTheme.activeItemFontWeight
+        fontWeight: componentTheme.activeItemFontWeight,
+        letterSpacing: -0.1818
       }),
 
       '*': {


### PR DESCRIPTION
…o topnavbar.item

Closes: INSTUI-4085

Setting the letterSpacing as a workaround makes the width unchanged during state changes.