### PR TITLE
docs(ui-drilldown): clarify usage of `as` prop for Drilldown.Option

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownOption/props.ts
@@ -96,7 +96,7 @@ type DrilldownOptionOwnProps = {
   href?: string
 
   /**
-   * Element type to render as. Will be set to `<a>` if href is provided. If the parent is "ul" or "ol", the option is forced to be "li" element.
+   * Element type to render as. Will be set to `<a>` if href is provided. If the parent is "ul" or "ol", the option is forced to be "li" element. *Important*: `Drilldown` is rendered as `ul` by default so you *have to* change that as well if you want to use this prop.
    */
   as?: AsElementType
 


### PR DESCRIPTION
Closes: INSTUI-3926

test plan:

- open docs for Drilldown component
- check props for Drilldown.Option -> it should be clear how to use the `as` prop
- check if you can set the `as` prop following the docs and inspect the element if it had worked (e.g. try setting it `as="form"`)