### PR TITLE
feat(ui-date-input): add year picker to DateInput and note to use the new api

### DIFF
--- a/packages/ui-date-input/src/DateInput/README.md
+++ b/packages/ui-date-input/src/DateInput/README.md
@@ -35,7 +35,42 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
+### With year picker
+
+```javascript
+---
+type: example
+---
+class Example extends React.Component {
+  state = { value: '' }
+
+  render () {
+    return (
+      <DateInput
+        renderLabel="Choose a date"
+        assistiveText="Type a date or use arrow keys to navigate date picker."
+        width="20rem"
+        isInline
+        value={this.state.value}
+        onChange={(e, value)=> this.setState({value:value.value})}
+        invalidDateErrorMessage="Invalid date"
+        withYearPicker={{
+          screenReaderLabel: "Year picker",
+          startYear:1999,
+          endYear:2024,
+          maxHeight: "200px"
+        }}
+      />
+    )
+  }
+}
+
+render(<Example />)
+```
+
 ### Composing a DateInput in your Application
+
+> **Important note**: this is the legacy API for the DateInput. It is much easier to use the way described above and more importantly: less buggy and has better accesibility. Please don't use this version and if you are having an issue with the DateInput, check if you are using the new version already and consider updating if not.
 
 `DateInput` uses `Calendar` internally. See [Calendar](#Calendar) for more detailed
 documentation and guided examples. `DateInput` shares many of the same `Calendar`

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -331,7 +331,8 @@ class DateInput extends Component<DateInputProps, DateInputState> {
       value,
       onChange,
       disabledDates,
-      currentDate
+      currentDate,
+      withYearPicker
     } = this.props
 
     const isValidDate = value
@@ -368,7 +369,8 @@ class DateInput extends Component<DateInputProps, DateInputState> {
           renderNavigationLabel,
           renderWeekdayLabels,
           renderNextMonthButton: this.renderMonthNavigationButton('next'),
-          renderPrevMonthButton: this.renderMonthNavigationButton('prev')
+          renderPrevMonthButton: this.renderMonthNavigationButton('prev'),
+          withYearPicker
         }) as CalendarProps)}
         {...noChildrenProps}
       >
@@ -424,7 +426,7 @@ class DateInput extends Component<DateInputProps, DateInputState> {
           width,
           messages,
           onChange: this.handleInputChange,
-          onBlur: createChainedFunction(onBlur, this.handleHideCalendar),
+          onBlur,
           inputRef: createChainedFunction(ref, this.handleInputRef),
           interaction,
           isRequired,
@@ -482,8 +484,11 @@ class DateInput extends Component<DateInputProps, DateInputState> {
               placement={placement}
               isShowingContent={isShowingCalendar}
               positionTarget={this._input}
-              shouldReturnFocus={false}
-              shouldFocusContentOnTriggerBlur
+              shouldContainFocus
+              shouldReturnFocus
+              onHideContent={(e) =>
+                setTimeout(() => this.handleHideCalendar(e), 0)
+              } // has to be wrapped in setTimeout otherwise the popover would open instantly after closing
             >
               {this.renderCalendar({ getListProps, getOptionProps })}
             </Popover>

--- a/packages/ui-date-input/src/DateInput/props.ts
+++ b/packages/ui-date-input/src/DateInput/props.ts
@@ -250,6 +250,24 @@ type DateInputOwnProps = {
    * property or a context property.
    **/
   timezone?: string
+
+  /**
+   * If set, years can be picked from a dropdown.
+   * It accepts an object.
+   * screenReaderLabel: string // e.g.: i18n("pick a year")
+   *
+   * onRequestYearChange?:(e: React.MouseEvent,requestedYear: number): void // if set, on year change, only this will be called and no internal change will take place
+   *
+   * startYear: number // e.g.: 2001, sets the start year of the selectable list
+   *
+   * endYear: number // e.g.: 2030, sets the end year of the selectable list
+   */
+  withYearPicker?: {
+    screenReaderLabel: string
+    onRequestYearChange?: (e: any, requestedYear: number) => void
+    startYear: number
+    endYear: number
+  }
 }
 
 type PropKeys = keyof DateInputOwnProps
@@ -308,7 +326,8 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.string
   ]),
   locale: PropTypes.string,
-  timezone: PropTypes.string
+  timezone: PropTypes.string,
+  withYearPicker: PropTypes.object
 }
 
 const allowedProps: AllowedPropKeys = [


### PR DESCRIPTION
also fixed the broken a11y for DateInput

test plan:
- check the example for the DateInput with the year picker -> try if works as expected
- check both the example with and without the year picker for a11y
- check the notice for the old DateInput api

Closes: INSTUI-4097