### PR TITLE
fix(ui-a11y-utils,ui-dom-utils): fix FocusRegion when its inside an iframe

### DIFF
--- a/packages/ui-a11y-utils/src/scopeTab.ts
+++ b/packages/ui-a11y-utils/src/scopeTab.ts
@@ -31,6 +31,13 @@ import {
 } from '@instructure/ui-dom-utils'
 import type { UIElement } from '@instructure/shared-types'
 
+/**
+ * return focus to the beginning of the region when trying to tab out or to
+ * the end of the region when pressing shift+tab on the first element
+ * @param element the element whose DOM subtree to check
+ * @param event
+ * @param onLeavingFinalTabbable
+ */
 function scopeTab(
   element: UIElement | undefined,
   event: React.KeyboardEvent,

--- a/packages/ui-dom-utils/src/findDOMNode.ts
+++ b/packages/ui-dom-utils/src/findDOMNode.ts
@@ -51,7 +51,9 @@ const isRefObject = (obj: unknown): obj is RefObject<unknown> => {
  * @param { Node | Window | React.ReactElement | React.Component | function } el - component, DOM node, or function returning a DOM node
  * @returns { Node | Window | null | undefined } The root node of this element
  */
-function findDOMNode(el?: UIElement): Element | Node | Window | undefined {
+function findDOMNode(
+  el?: UIElement
+): Element | Node | Window | Document | undefined {
   const node = typeof el === 'function' ? el() : el
 
   if (node && node === document) {

--- a/packages/ui-dom-utils/src/findFocusable.ts
+++ b/packages/ui-dom-utils/src/findFocusable.ts
@@ -91,10 +91,10 @@ function positioned(element: Element | Node) {
   if (POS.includes((element as HTMLElement).style.position?.toLowerCase())) {
     return true
   }
+  const style = getComputedStyle(element)
   if (
-    POS.includes(
-      getComputedStyle(element).getPropertyValue('position')?.toLowerCase()
-    )
+    'getPropertyValue' in style &&
+    POS.includes(style.getPropertyValue('position')?.toLowerCase())
   ) {
     return true
   }
@@ -107,6 +107,7 @@ function visible(element: Element) {
   while (el) {
     if (el === document.body) break
     if (el instanceof ShadowRoot) break
+    if (el.nodeType == Node.DOCUMENT_NODE) break // if it's an iframe
     if (hidden(el)) return false
     if (positioned(el)) break
     el = el.parentNode

--- a/packages/ui-dom-utils/src/getActiveElement.ts
+++ b/packages/ui-dom-utils/src/getActiveElement.ts
@@ -37,6 +37,13 @@ import { isDefinedCustomElement } from './isDefinedCustomElement'
 function getActiveElement(doc?: Document) {
   const activeElement = (doc || document).activeElement
 
+  // TODO make it detect embedded iframes:
+  // https://stackoverflow.com/questions/25420219/find-focused-element-in-document-with-many-iframes
+  const contentDocument =
+    activeElement && (activeElement as HTMLIFrameElement).contentDocument
+  if (contentDocument && contentDocument.activeElement) {
+    return contentDocument.activeElement
+  }
   //check if activeElement is a custom element or not
   if (activeElement && isDefinedCustomElement(activeElement)) {
     return activeElement.shadowRoot!.activeElement

--- a/packages/ui-dom-utils/src/getComputedStyle.ts
+++ b/packages/ui-dom-utils/src/getComputedStyle.ts
@@ -40,16 +40,21 @@ import type { UIElement } from '@instructure/shared-types'
  * @param { string | null | undefined } pseudoElt - A string specifying the pseudo-element to match. Omitted (or null ) for real elements.
  * @returns { Object } object containing css properties and values for the element
  */
-function getComputedStyle(el?: UIElement, pseudoElt?: string | null) {
-  let style = {}
+function getComputedStyle(
+  el?: UIElement,
+  pseudoElt?: string | null
+): CSSStyleDeclaration {
+  let style = {} // TODO(breaking) return undefined instead!
   if (canUseDOM) {
     const node = el && findDOMNode(el)
     if (node) {
       const window = ownerWindow(el)
-      style = window ? window.getComputedStyle(node as Element, pseudoElt) : {}
+      if (window && node instanceof Element) {
+        style = window.getComputedStyle(node, pseudoElt)
+      }
     }
   }
-  return style as CSSStyleDeclaration
+  return style as CSSStyleDeclaration // TODO this is broken. It can return {}
 }
 
 export default getComputedStyle


### PR DESCRIPTION
WIP, needs unit tests

fix that will allow to create focus trap inside an iframe like
```
const main = document.getElementById('iframe').contentWindow.document.getElementById('main2')
FocusRegionManager.activateRegion(main)
```