### PR TITLE
fix(ui-number-input): set numberinput type to number

### DIFF
--- a/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
@@ -89,12 +89,12 @@ describe('<NumberInput />', () => {
     const numberInput = await NumberInputLocator.find()
     const input = await numberInput.findInput()
 
-    const event = { target: { value: 'foo' } }
+    const event = { target: { value: '10' } }
     await input.change(event)
 
     expect(onChange).to.have.been.calledOnce()
     expect(onChange).to.have.been.calledWithMatch(event)
-    expect(onChange.lastCall.args[1]).to.equal('foo')
+    expect(onChange.lastCall.args[1]).to.equal('10')
   })
 
   it('passes keyboard events to the onKeyDown handler', async () => {

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -258,7 +258,7 @@ class NumberInput extends Component<NumberInputProps, NumberInputState> {
               css={this.props.styles?.input}
               aria-invalid={this.invalid ? 'true' : undefined}
               id={this.id}
-              type="text"
+              type="number"
               inputMode={this.props.inputMode}
               placeholder={placeholder}
               ref={this.handleInputRef}

--- a/packages/ui-number-input/src/NumberInput/styles.ts
+++ b/packages/ui-number-input/src/NumberInput/styles.ts
@@ -176,7 +176,10 @@ const generateStyle = (
       label: 'numberInput_input',
       ...inputStyle,
       '&:is(input)[type]': inputStyle,
-      '&:-webkit-any(input)[type]': inputStyle
+      '&:-webkit-any(input)[type]': inputStyle,
+      '&::-webkit-inner-spin-button': { display: 'none' },
+      '&::-webkit-outer-spin-button': { display: 'none' },
+      '&:is(input)[type="number"]': { MozAppearance: 'textfield' }
     }
   }
 }

--- a/packages/ui-pagination/src/Pagination/PaginationPageInput/__new-tests__/PaginationPageInput.test.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationPageInput/__new-tests__/PaginationPageInput.test.tsx
@@ -42,7 +42,7 @@ describe('<PaginationPageInput />', () => {
         screenReaderLabel={defaultSRLabel}
       />
     )
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('spinbutton')
 
     expect(input).toBeInTheDocument()
     expect(input.tagName).toBe('INPUT')
@@ -58,7 +58,7 @@ describe('<PaginationPageInput />', () => {
         screenReaderLabel={defaultSRLabel}
       />
     )
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('spinbutton')
 
     expect(input).toHaveAttribute('value', '4')
   })
@@ -73,7 +73,7 @@ describe('<PaginationPageInput />', () => {
         screenReaderLabel={defaultSRLabel}
       />
     )
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('spinbutton')
 
     expect(input).toHaveAttribute('value', '4')
 
@@ -117,7 +117,7 @@ describe('<PaginationPageInput />', () => {
         disabled
       />
     )
-    const input = screen.getByRole('textbox')
+    const input = screen.getByRole('spinbutton')
 
     expect(input).toHaveAttribute('disabled')
   })

--- a/packages/ui-pagination/src/Pagination/__new-tests__/Pagination.test.tsx
+++ b/packages/ui-pagination/src/Pagination/__new-tests__/Pagination.test.tsx
@@ -848,7 +848,7 @@ describe('<Pagination />', () => {
       )
       const numberInput = container.querySelector('input')
 
-      expect(numberInput).toHaveValue('3')
+      expect(numberInput).toHaveValue(3)
     })
 
     it('should display all arrow buttons', async () => {


### PR DESCRIPTION
Closes: INSTUI-3857

**Test**
Observe if `NumberInput` component has type `number`. Default arrows of the html input component should be hidden in every browser. Please check this in multiple browsers.