### PR TITLE
fix(ui-top-nav-bar): lowered topnavbar zindex so it goes below trays/popovers/modals/etc

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/styles.ts
@@ -66,6 +66,7 @@ const generateStyle = (
       alignItems: 'stretch',
       justifyContent: 'space-between',
       height: componentTheme.desktopHeight,
+      position: 'relative',
       zIndex: componentTheme.desktopZIndex,
       maxWidth: '100%',
       overflow: 'hidden',

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/theme.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/theme.ts
@@ -43,7 +43,7 @@ const generateComponentTheme = (theme: Theme): TopNavBarLayoutDesktopTheme => {
     desktopBottomBorder: 'none',
     desktopBottomBorderInverse: `${borders?.widthSmall} ${borders?.style} ${colors?.borderMedium}`,
     desktopHeight: '4rem',
-    desktopZIndex: stacking?.topmost + 1,
+    desktopZIndex: stacking?.topmost - 1, // -1 so it is below tray/modal/popover/etc TODO find a better solution
 
     desktopInlinePadding: spacing.small,
     desktopBrandContainerInlineMargin: `0 ${spacing.medium}`,

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/theme.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/theme.ts
@@ -50,7 +50,7 @@ const generateComponentTheme = (
 
     smallViewportTrayPosition: 'fixed',
     smallViewportTrayFixTopPosition: undefined,
-    smallViewportTrayZIndex: stacking?.topmost + 1,
+    smallViewportTrayZIndex: stacking?.topmost - 1, // -1 so it is below tray/modal/popover/etc TODO find a better solution
 
     smallViewportDropdownMenuActiveOptionFontWeight: typography?.fontWeightBold,
     smallViewportDropdownMenuActiveOptionIndicatorSpacing: '0.25rem',


### PR DESCRIPTION
INSTUI-4116

explanation:

- topnavbar desktop layout z-index didn't have any effect because of the missing `position: relative`
- topnavbar was positioned above everything else (including tray/modal/popovers/etc) which is not the desired behavior according to the design team

test plan:

- add a tray component and a topnavbar to the same page and check if tray is above topnavbar is both small viewport and desktop
- add a select/popover/menu to tray and check if the stacking order is still correct (no menu behind navbar or tray)