### PR TITLE
feat(ui-top-nav-bar): add workaround hack for new topnav design with the old api

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/index.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/index.tsx
@@ -601,6 +601,8 @@ class TopNavBarSmallViewportLayout extends Component<
 
         {!this.hasBreadcrumbBlock && !this.isInPlaceDialogOpen && (
           <div css={styles?.navbar}>
+            {this.props.renderNavbarStartDangerousHack &&
+              this.props.renderNavbarStartDangerousHack}
             {this.renderMenuTrigger()}
             {this.hasActionItemsBlock(renderActionItems) && renderActionItems}
           </div>

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/props.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/props.ts
@@ -113,6 +113,11 @@ type SmallViewportLayoutOwnProps = {
    * Callback fired when an item is selected in the dropdown menu
    */
   onDropdownMenuSelect?: DrilldownProps['onSelect']
+
+  /**
+   * A way to add generic html/react content to the start (left side) of the nav bar. This is a temporary workaround if you are using a design that is not possible to achive in the TopNavBar normally.
+   */
+  renderNavbarStartDangerousHack?: React.ReactNode
 }
 
 type TopNavBarSmallViewportLayoutOwnProps = CommonTopNavBarLayoutProps &

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/props.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/props.ts
@@ -167,7 +167,8 @@ const smallViewportPropTypes: PropValidators<SmallViewportPropKeys> = {
   }),
   trayMountNode: PropTypes.oneOfType([element, PropTypes.func]),
   onDropdownMenuToggle: PropTypes.func,
-  onDropdownMenuSelect: PropTypes.func
+  onDropdownMenuSelect: PropTypes.func,
+  renderNavbarStartDangerousHack: PropTypes.node
 }
 
 const propTypes: PropValidators<PropKeys> = {


### PR DESCRIPTION
INSTUI-4121

test plan:

- open topnav example
- resize viewport to display smallviewportlayout
- add `renderNavbarStartDangerousHack` prop to the `smallViewportConfig`
- test if the "hack" shows up in small viewport (and not in desktop view)