### PR TITLE
INSTUI-4130 Do not emit failed prop type warning when setting CondensedButton's color to 'secondary'

### DIFF
--- a/packages/ui-buttons/src/CondensedButton/props.ts
+++ b/packages/ui-buttons/src/CondensedButton/props.ts
@@ -121,7 +121,7 @@ const propTypes: PropValidators<PropKeys> = {
   elementRef: PropTypes.func,
   as: PropTypes.elementType,
   interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
-  color: PropTypes.oneOf(['primary', 'primary-inverse']),
+  color: PropTypes.oneOf(['primary', 'primary-inverse', 'secondary']),
   margin: ThemeablePropTypes.spacing,
   cursor: PropTypes.string,
   href: PropTypes.string,


### PR DESCRIPTION
TEST PLAN:
set CondensedButton's color prop to secondary. There should be no failed prop type warning in the console