### PR TITLE
WIP:: Remove `babel-plugin-transform-imports` from v8 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48968,7 +48968,6 @@
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.2",
         "@babel/runtime": "^7.23.2",
-        "@instructure/babel-plugin-transform-imports": "8.56.1",
         "@instructure/browserslist-config-instui": "8.56.1",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -29,7 +29,7 @@ module.exports = function (
     coverage: false,
     node: false,
     removeConsole: false,
-    transformImports: true,
+    transformImports: true, // TODO unused, remove all references
     importTransforms: {}
   }
 ) {
@@ -42,36 +42,6 @@ module.exports = function (
   ]
 
   let plugins = []
-
-  if (opts.transformImports) {
-    plugins.push([
-      require('@instructure/babel-plugin-transform-imports'),
-      {
-        '(@instructure/ui-[^(/|\\s)]+)$': {
-          // eslint-disable-line no-useless-escape
-          transform: (importName, matches) => {
-            const ignore = [
-              '@instructure/ui-test-queries',
-              '@instructure/ui-test-sandbox',
-              '@instructure/ui-test-utils'
-            ]
-
-            if (!matches || !matches[1] || ignore.includes(matches[1])) return
-            return `${matches[1]}/lib/${importName}`
-          }
-        },
-        // Convert any es imports to lib imports
-        '(@instructure/ui-[^(/|\\s)]+/es/[^\\s]+)$': {
-          // eslint-disable-line no-useless-escape
-          transform: (importName, matches) => {
-            if (!matches || !matches[1]) return
-            return matches[1].replace(new RegExp('/es/'), '/lib/')
-          }
-        },
-        ...(opts.importTransforms || {})
-      }
-    ])
-  }
   // Work around https://github.com/babel/babel/issues/10261, which causes
   // Babel to not use the runtime helpers for things like _objectSpread.
   // Remove this once that babel issue is fixed

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -31,7 +31,6 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",
     "@babel/runtime": "^7.23.2",
-    "@instructure/babel-plugin-transform-imports": "8.56.1",
     "@instructure/browserslist-config-instui": "8.56.1",
     "babel-loader": "^9.1.3",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/packages/ui-babel-preset/tsconfig.build.json
+++ b/packages/ui-babel-preset/tsconfig.build.json
@@ -7,9 +7,5 @@
     "outDir": "./types"
   },
   "include": ["lib"],
-  "references": [
-    {
-      "path": "../babel-plugin-transform-imports/tsconfig.build.json"
-    }
-  ]
+  "references": []
 }


### PR DESCRIPTION
was only running for the CJS build. This is just a WIP commit, the plugin will not run, but traces of it are all over the code. If it works it should be cleaned up

TEST PLAN: import the CJS build to your app. It should behave exactly like the latest InstUI