### PR TITLE
fix(ui-calendar,ui-date-input): fix date formatting and validation for different locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15733,9 +15733,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
       "dev": true
     },
     "node_modules/debounce": {

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -145,22 +145,34 @@ class Calendar extends Component<CalendarProps, CalendarState> {
   }
 
   get hasPrevMonth() {
+    // this is needed for locales that doesn't use the latin script for numbers e.g.: arabic
+    const yearNumber = Number(
+      this.state.visibleMonth
+        .clone()
+        .locale('en')
+        .subtract({ months: 1 })
+        .format('YYYY')
+    )
     return (
       !this.props.withYearPicker ||
       (this.props.withYearPicker &&
-        Number(
-          this.state.visibleMonth.clone().subtract({ months: 1 }).format('YYYY')
-        ) >= this.props.withYearPicker.startYear)
+        yearNumber >= this.props.withYearPicker.startYear)
     )
   }
 
   get hasNextMonth() {
+    // this is needed for locales that doesn't use the latin script for numbers e.g.: arabic
+    const yearNumber = Number(
+      this.state.visibleMonth
+        .clone()
+        .locale('en')
+        .subtract({ months: 1 })
+        .format('YYYY')
+    )
     return (
       !this.props.withYearPicker ||
       (this.props.withYearPicker &&
-        Number(
-          this.state.visibleMonth.clone().add({ months: 1 }).format('YYYY')
-        ) <= this.props.withYearPicker.endYear)
+        yearNumber <= this.props.withYearPicker.endYear)
     )
   }
 
@@ -227,16 +239,21 @@ class Calendar extends Component<CalendarProps, CalendarState> {
 
   handleYearChange = (
     e: React.SyntheticEvent<Element, Event>,
-    year: number
+    year: string
   ) => {
     const { withYearPicker } = this.props
     const { visibleMonth } = this.state
+    const yearNumber = Number(
+      DateTime.parse(year, this.locale(), this.timezone())
+        .locale('en')
+        .format('YYYY')
+    )
     const newDate = visibleMonth.clone()
     if (withYearPicker?.onRequestYearChange) {
-      withYearPicker.onRequestYearChange(e, year)
+      withYearPicker.onRequestYearChange(e, yearNumber)
       return
     }
-    newDate.year(year)
+    newDate.year(yearNumber)
     this.setState({ visibleMonth: newDate })
   }
 
@@ -261,12 +278,19 @@ class Calendar extends Component<CalendarProps, CalendarState> {
       ...(prevButton || nextButton ? [styles?.navigationWithButtons] : [])
     ]
 
-    const yearList: number[] = []
+    const yearList: string[] = []
 
     if (withYearPicker) {
       const { startYear, endYear } = withYearPicker
       for (let year = endYear; year >= startYear!; year--) {
-        yearList.push(year)
+        // add the years to the list with the correct locale
+        yearList.push(
+          DateTime.parse(
+            year.toString(),
+            this.locale(),
+            this.timezone()
+          ).format('YYYY')
+        )
       }
     }
 
@@ -295,7 +319,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
               width="90px"
               renderLabel=""
               assistiveText={withYearPicker.screenReaderLabel}
-              value={Number(visibleMonth.format('YYYY'))}
+              value={visibleMonth.format('YYYY')}
               onChange={(
                 e: React.SyntheticEvent<Element, Event>,
                 {
@@ -304,7 +328,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
                   value?: string | number | undefined
                   id?: string | undefined
                 }
-              ) => this.handleYearChange(e, Number(value))}
+              ) => this.handleYearChange(e, `${value}`)}
             >
               {yearList.map((year) => (
                 <SimpleSelect.Option key={year} id={`opt-${year}`} value={year}>

--- a/packages/ui-date-input/src/DateInput2/props.ts
+++ b/packages/ui-date-input/src/DateInput2/props.ts
@@ -23,14 +23,14 @@
  */
 
 import PropTypes from 'prop-types'
-import type { SyntheticEvent } from 'react'
+import type { SyntheticEvent, InputHTMLAttributes } from 'react'
 
 import { controllable } from '@instructure/ui-prop-types'
 import { FormPropTypes } from '@instructure/ui-form-field'
 import type { FormMessage } from '@instructure/ui-form-field'
-import type { Renderable, PropValidators } from '@instructure/shared-types'
+import type { OtherHTMLAttributes, Renderable, PropValidators } from '@instructure/shared-types'
 
-type DateInput2Props = {
+type DateInput2OwnProps = {
   /**
    * Specifies the input label.
    */
@@ -159,7 +159,13 @@ type DateInput2Props = {
   }
 }
 
-type PropKeys = keyof DateInput2Props
+type PropKeys = keyof DateInput2OwnProps
+
+type DateInput2Props = DateInput2OwnProps &
+  OtherHTMLAttributes<
+    DateInput2OwnProps,
+    InputHTMLAttributes<DateInput2OwnProps & Element>
+  >
 
 const propTypes: PropValidators<PropKeys> = {
   renderLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,

--- a/packages/ui-date-input/src/index.ts
+++ b/packages/ui-date-input/src/index.ts
@@ -25,3 +25,4 @@
 export { DateInput } from './DateInput'
 export { DateInput2 } from './DateInput2'
 export type { DateInputProps } from './DateInput/props'
+export type { DateInput2Props } from './DateInput2/props'


### PR DESCRIPTION
INSTUI-4155

test plan:
- try inputting dates manually into DateInput2 (in ISO format) -> validation should pass and date should be selected in the calendar popover
- after setting a date in iso format it should be formatted according to the locale
- try different locales, also ones that doesn't use the latin script for number (e.g.: arabic, hindi, etc.) -> formatting and validation should still work as expected
- try the above mentioned locales with the year picker -> logic for the year picker should work as expected (like the start and end year config)