### PR TITLE
chore: add script to delete node_modules recursively

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build:types": "tsc -b tsconfig.references.json",
     "build:ts": "lerna run prepare-build --stream --scope @instructure/ui-icons && npm run build:types --verbose",
     "clean": "node scripts/clean.js",
+    "clean-node": "node scripts/clean.js --nuke_node",
     "export:icons": "lerna run export --stream --scope @instructure/ui-icons",
     "bump": "ui-scripts bump",
     "release": "ui-scripts publish",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -25,6 +25,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const url = require('url')
 
 const NODE_PACKAGES = [
   'ui-icons-build',
@@ -57,6 +58,7 @@ function deleteDirs(dirs = []) {
     fs.rmSync(dir, { force: true, recursive: true })
   })
 }
+// deletes built files from tooling packages (NODE_PACKAGES const)
 function clean() {
   const packagesPath = path.resolve('./packages')
   const dir = fs.opendirSync(packagesPath)
@@ -74,8 +76,27 @@ function clean() {
     }
   }
 }
+// deletes node_modules recursively
+function removeNodeModules() {
+  const dirs = fs.readdirSync('.', { recursive: true, withFileTypes: true })
+  const toRemove = []
+  for (const dir of dirs) {
+    if (dir.isDirectory() && dir.name.toLowerCase() === 'node_modules') {
+      toRemove.push(url.pathToFileURL(path.join(dir.parentPath, dir.name)))
+    }
+  }
+  deleteDirs(toRemove)
+}
+
 // eslint-disable-next-line no-console
-console.info('cleaning packages...')
+console.info('Deleting built files from tooling packages...')
 clean()
+const args = process.argv.slice(2)
+if (args.length > 0 && args[0] === '--nuke_node') {
+  // eslint-disable-next-line no-console
+  console.info('Deleting node_modules recursively...')
+  removeNodeModules()
+}
+
 // eslint-disable-next-line no-console
 console.info('clean finished')


### PR DESCRIPTION
This new script deletes all `node_modules` folders recursively which is useful when `npm install` fails for some reason and these folders are in a corrupted state

TEST PLAN:
run `npm run clean-node` and observe that all `node_modules` folders are deleted