### PR TITLE
feat(ui-menu): add renderLabelInfo to Menu

### DIFF
--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -29,7 +29,8 @@ import { IconCheckSolid, IconArrowOpenEndSolid } from '@instructure/ui-icons'
 import {
   omitProps,
   getElementType,
-  withDeterministicId
+  withDeterministicId,
+  callRenderProp
 } from '@instructure/ui-react-utils'
 import { createChainedFunction } from '@instructure/ui-utils'
 import { isActiveElement, findDOMNode } from '@instructure/ui-dom-utils'
@@ -209,7 +210,7 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
   }
 
   renderContent() {
-    const { children, type } = this.props
+    const { children, type, renderLabelInfo } = this.props
 
     return (
       <span>
@@ -224,6 +225,11 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
         {type === 'flyout' && (
           <span css={this.props.styles?.icon}>
             <IconArrowOpenEndSolid />
+          </span>
+        )}
+        {renderLabelInfo && (
+          <span css={this.props.styles?.labelInfo}>
+            {callRenderProp(renderLabelInfo)}
           </span>
         )}
       </span>

--- a/packages/ui-menu/src/Menu/MenuItem/props.ts
+++ b/packages/ui-menu/src/Menu/MenuItem/props.ts
@@ -92,6 +92,10 @@ type MenuItemOwnProps = {
    * Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>).
    */
   target?: string
+  /**
+   * Content to render in the label's info region
+   */
+  renderLabelInfo?: React.ReactNode | (() => React.ReactNode)
 }
 
 type PropKeys = keyof MenuItemOwnProps
@@ -103,7 +107,7 @@ type MenuItemProps = MenuItemOwnProps &
   OtherHTMLAttributes<MenuItemOwnProps> &
   WithDeterministicIdProps
 
-type MenuItemStyle = ComponentStyle<'menuItem' | 'icon' | 'label'>
+type MenuItemStyle = ComponentStyle<'menuItem' | 'icon' | 'labelInfo' | 'label'>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node.isRequired,
@@ -120,7 +124,8 @@ const propTypes: PropValidators<PropKeys> = {
   type: PropTypes.oneOf(['button', 'checkbox', 'radio', 'flyout']),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   href: PropTypes.string,
-  target: PropTypes.string
+  target: PropTypes.string,
+  renderLabelInfo: PropTypes.node
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -138,7 +143,8 @@ const allowedProps: AllowedPropKeys = [
   'type',
   'value',
   'href',
-  'target'
+  'target',
+  'renderLabelInfo'
 ]
 type MenuItemState = {
   selected: boolean

--- a/packages/ui-menu/src/Menu/MenuItem/styles.ts
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.ts
@@ -138,6 +138,13 @@ const generateStyle = (
       ...roleIconStyles,
       ...flyoutIconStyles
     },
+    labelInfo: {
+      label: 'menuItem__labelInfo',
+      height: '100%',
+      float: 'right',
+      clear: 'right',
+      paddingRight: '1.75rem'
+    },
     label: {
       label: 'menuItem__label',
       color: componentTheme.labelColor

--- a/packages/ui-menu/src/Menu/index.tsx
+++ b/packages/ui-menu/src/Menu/index.tsx
@@ -407,6 +407,7 @@ class Menu extends Component<MenuProps> {
                     tabIndex={isTabbable ? 0 : -1}
                     type="flyout"
                     disabled={submenuDisabled}
+                    renderLabelInfo={child.props.renderLabelInfo}
                   >
                     {child.props.title || child.props.label}
                   </MenuItem>

--- a/packages/ui-menu/src/Menu/props.ts
+++ b/packages/ui-menu/src/Menu/props.ts
@@ -171,6 +171,10 @@ type MenuOwnProps = {
    * scroll and will be as tall as the content requires
    */
   maxHeight?: string | number
+  /**
+   * Content to render in the label's info region. It is only visible on nested Menus.
+   */
+  renderLabelInfo?: React.ReactNode | (() => React.ReactNode)
 }
 
 type PropKeys = keyof MenuOwnProps
@@ -218,7 +222,8 @@ const propTypes: PropValidators<PropKeys> = {
   withArrow: PropTypes.bool,
   offsetX: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   offsetY: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  maxHeight: PropTypes.string
+  maxHeight: PropTypes.string,
+  renderLabelInfo: PropTypes.node
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -248,7 +253,8 @@ const allowedProps: AllowedPropKeys = [
   'withArrow',
   'offsetX',
   'offsetY',
-  'maxHeight'
+  'maxHeight',
+  'renderLabelInfo'
 ]
 
 export type { MenuProps, MenuStyle }


### PR DESCRIPTION
Closes: INSTUI-4192

Add `renderLabelInfo` - either a string or a React.Node - prop to a `Menu`. It should be shown near the label. Override the `minWidth` theme variable if the width is not enough for the renderLabelInfo content.