### PR TITLE
  INSTUI-4188 New Table API to allow custom children

### DIFF
--- a/docs/contributor-docs/v11-upgrade-guide.md
+++ b/docs/contributor-docs/v11-upgrade-guide.md
@@ -1,0 +1,25 @@
+---
+title: Upgrade Guide for Version 11
+category: Guides
+order: 99
+isWIP: true
+---
+
+# Upgrade Guide for Version 11
+
+## Removal of deprecated props/components
+
+### Table
+
+[Table](/#Table) is now using `TableContext` to pass down data to its child components, the following props are no longer passed down to their children:
+
+| Component | prop        | Substitute / Notes              |
+| --------- | ----------- | ------------------------------- |
+| `Row`     | `isStacked` | is now stored in `TableContext` |
+| `Body`    | `isStacked` | is now stored in `TableContext` |
+| `Body`    | `hover`     | is now stored in `TableContext` |
+| `Body`    | `headers`   | is now stored in `TableContext` |
+
+## Changes
+
+- `ui-dom-utils`/`getComputedStyle` can now return `undefined`: In previous versions sometimes returned an empty object which could lead to runtime exceptions when one tried to call methods of `CSSStyleDeclaration` on it.

--- a/packages/__docs__/components.js
+++ b/packages/__docs__/components.js
@@ -67,7 +67,7 @@ export {
   FormFieldLayout,
   FormFieldGroup
 } from '@instructure/ui-form-field'
-export { Table } from '@instructure/ui-table'
+export { Table, TableContext } from '@instructure/ui-table'
 export { TruncateText } from '@instructure/ui-truncate-text'
 export { ApplyLocale, TextDirectionContext } from '@instructure/ui-i18n'
 export { MetricGroup, Metric } from '@instructure/ui-metric'

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -76,13 +76,13 @@ class Body extends Component<TableBodyProps> {
             return safeCloneElement(child, {
               key: child.props.name,
               // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in next version
+              // TODO DEPRECATED, remove in v11
               hover,
               // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in next version
+              // TODO DEPRECATED, remove in v11
               isStacked,
               // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in next version
+              // TODO DEPRECATED, remove in v11
               headers
             })
           }

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, Children } from 'react'
+import { Component, Children, ContextType } from 'react'
 
 import { safeCloneElement, omitProps } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -32,8 +32,8 @@ import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
 import generateComponentTheme from './theme'
 import type { TableBodyProps } from './props'
-import type { RowChild } from '../props'
 import { allowedProps, propTypes } from './props'
+import TableContext from '../TableContext'
 
 /**
 ---
@@ -44,10 +44,10 @@ id: Table.Body
 @withStyle(generateStyle, generateComponentTheme)
 class Body extends Component<TableBodyProps> {
   static readonly componentId = 'Table.Body'
-
+  static contextType = TableContext
+  declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
   static propTypes = propTypes
-
   static defaultProps = {
     children: null
   }
@@ -61,7 +61,8 @@ class Body extends Component<TableBodyProps> {
   }
 
   render() {
-    const { children, hover, isStacked, headers, styles } = this.props
+    const { children, styles } = this.props
+    const { isStacked, hover, headers } = this.context
 
     return (
       <View
@@ -70,11 +71,17 @@ class Body extends Component<TableBodyProps> {
         css={styles?.body}
         role={isStacked ? 'rowgroup' : undefined}
       >
-        {Children.map(children as RowChild[], (child) =>
+        {Children.map(children as any[], (child) =>
           safeCloneElement(child, {
             key: child.props.name,
+            // Sent down for compatibility with custom components
+            // TODO DEPRECATED, remove in next version
             hover,
+            // Sent down for compatibility with custom components
+            // TODO DEPRECATED, remove in next version
             isStacked,
+            // Sent down for compatibility with custom components
+            // TODO DEPRECATED, remove in next version
             headers
           })
         )}

--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, Children, ContextType } from 'react'
+import { Component, Children, ContextType, isValidElement } from 'react'
 
 import { safeCloneElement, omitProps } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -71,20 +71,23 @@ class Body extends Component<TableBodyProps> {
         css={styles?.body}
         role={isStacked ? 'rowgroup' : undefined}
       >
-        {Children.map(children as any[], (child) =>
-          safeCloneElement(child, {
-            key: child.props.name,
-            // Sent down for compatibility with custom components
-            // TODO DEPRECATED, remove in next version
-            hover,
-            // Sent down for compatibility with custom components
-            // TODO DEPRECATED, remove in next version
-            isStacked,
-            // Sent down for compatibility with custom components
-            // TODO DEPRECATED, remove in next version
-            headers
-          })
-        )}
+        {Children.map(children, (child) => {
+          if (isValidElement(child)) {
+            return safeCloneElement(child, {
+              key: child.props.name,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
+              hover,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
+              isStacked,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
+              headers
+            })
+          }
+          return child
+        })}
       </View>
     )
   }

--- a/packages/ui-table/src/Table/Body/props.ts
+++ b/packages/ui-table/src/Table/Body/props.ts
@@ -33,7 +33,9 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableBodyOwnProps = {
   /**
-   * `Table.Row`
+   * Body's children should be some container component where each child represents
+   * a row.
+   * `Table.Row` by default
    */
   children?: React.ReactNode
 }

--- a/packages/ui-table/src/Table/Body/props.ts
+++ b/packages/ui-table/src/Table/Body/props.ts
@@ -33,8 +33,9 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableBodyOwnProps = {
   /**
-   * Body's children should be some container component where each child represents
+   * Body's children should be a container component where each child represents
    * a row.
+   *
    * `Table.Row` by default
    */
   children?: React.ReactNode

--- a/packages/ui-table/src/Table/Body/styles.ts
+++ b/packages/ui-table/src/Table/Body/styles.ts
@@ -31,8 +31,6 @@ import type { TableBodyStyle } from './props'
  * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
- * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
 const generateStyle = (componentTheme: TableBodyTheme): TableBodyStyle => {

--- a/packages/ui-table/src/Table/Cell/index.tsx
+++ b/packages/ui-table/src/Table/Cell/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component } from 'react'
+import { Component, ContextType } from 'react'
 
 import { omitProps, callRenderProp } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -34,6 +34,7 @@ import generateStyle from './styles'
 import generateComponentTheme from './theme'
 import type { TableCellProps } from './props'
 import { allowedProps, propTypes } from './props'
+import TableContext from '../TableContext'
 
 /**
 ---
@@ -44,7 +45,8 @@ id: Table.Cell
 @withStyle(generateStyle, generateComponentTheme)
 class Cell extends Component<TableCellProps> {
   static readonly componentId = 'Table.Cell'
-
+  static contextType = TableContext
+  declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
   static propTypes = propTypes
 
@@ -62,7 +64,8 @@ class Cell extends Component<TableCellProps> {
   }
 
   render() {
-    const { children, styles, isStacked, header } = this.props
+    const { children, styles, header } = this.props
+    const isStacked = this.context.isStacked
 
     return (
       <View

--- a/packages/ui-table/src/Table/Cell/props.ts
+++ b/packages/ui-table/src/Table/Cell/props.ts
@@ -40,7 +40,7 @@ type TableCellOwnProps = {
    */
   header?: Renderable
   /**
-   * Control the text alignment in cell
+   * Controls the text alignment in cell.
    */
   textAlign?: 'start' | 'center' | 'end'
   children?: Renderable

--- a/packages/ui-table/src/Table/Cell/props.ts
+++ b/packages/ui-table/src/Table/Cell/props.ts
@@ -33,7 +33,11 @@ import type {
 } from '@instructure/shared-types'
 
 type TableCellOwnProps = {
-  isStacked?: boolean
+  /**
+   * Contains the column header for this cell.
+   * This gets rendered in `stacked` layout to identify the column the data
+   * belongs to.
+   */
   header?: Renderable
   /**
    * Control the text alignment in cell
@@ -54,17 +58,11 @@ type TableCellStyle = ComponentStyle<'cell'>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  isStacked: PropTypes.bool,
   header: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   textAlign: PropTypes.oneOf(['start', 'center', 'end'])
 }
 
-const allowedProps: AllowedPropKeys = [
-  'children',
-  'isStacked',
-  'header',
-  'textAlign'
-]
+const allowedProps: AllowedPropKeys = ['children', 'header', 'textAlign']
 
 export type { TableCellProps, TableCellStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-table/src/Table/ColHeader/props.ts
+++ b/packages/ui-table/src/Table/ColHeader/props.ts
@@ -32,7 +32,10 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableColHeaderOwnProps = {
-  isStacked?: boolean // needed because it needs the same API as `Table.RowHeader`
+  /**
+   * DEPRECATED. Use `TableContext` to read this value
+   */
+  isStacked?: boolean
   /**
    * A unique id for this column. The `id` is also used as option in combobox,
    * when sortable table is in stacked layout,
@@ -53,18 +56,18 @@ type TableColHeaderOwnProps = {
    */
   textAlign?: 'start' | 'center' | 'end'
   /**
-   * The string of sorting direction
+   * The sorting direction
    */
   sortDirection?: 'none' | 'ascending' | 'descending'
   /**
-   * Callback fired when column header is clicked. Parameters: `(event, { id })`
+   * Callback fired when column header is clicked.
    */
   onRequestSort?: (
     event: React.SyntheticEvent,
     param: { id: TableColHeaderOwnProps['id'] }
   ) => void
   /**
-   * The column header scope attribute. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope
+   * The column header scope attribute. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope
    */
   scope?: 'row' | 'col' | 'rowgroup' | 'colgroup' | 'auto'
   children?: React.ReactNode

--- a/packages/ui-table/src/Table/ColHeader/styles.ts
+++ b/packages/ui-table/src/Table/ColHeader/styles.ts
@@ -32,7 +32,6 @@ import type { TableColHeaderProps, TableColHeaderStyle } from './props'
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
 const generateStyle = (

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, Children } from 'react'
+import { Component, Children, ContextType } from 'react'
 
 import {
   omitProps,
@@ -47,6 +47,7 @@ import type { TableColHeaderProps } from '../ColHeader/props'
 import type { TableHeadProps } from './props'
 import type { ColHeaderChild, RowChild } from '../props'
 import { allowedProps, propTypes } from './props'
+import TableContext from '../TableContext'
 
 /**
 ---
@@ -57,10 +58,10 @@ id: Table.Head
 @withStyle(generateStyle, generateComponentTheme)
 class Head extends Component<TableHeadProps> {
   static readonly componentId = 'Table.Head'
-
+  static contextType = TableContext
+  declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
   static propTypes = propTypes
-
   static defaultProps = {
     children: null
   }
@@ -177,12 +178,15 @@ class Head extends Component<TableHeadProps> {
   }
 
   render() {
-    const { children, isStacked, styles } = this.props
-
-    return isStacked ? (
+    const { children, styles } = this.props
+    return this.context.isStacked ? (
       this.renderSelect()
     ) : (
-      <thead {...omitProps(this.props, Head.allowedProps)} css={styles?.head}>
+      // TODO remove 'hover' in the next version, its passed down for compatibility with custom components
+      <thead
+        {...omitProps(this.props, Head.allowedProps, ['hover'])}
+        css={styles?.head}
+      >
         {Children.map(children, (child) =>
           matchComponentTypes<RowChild>(child, [Row]) ? child : null
         )}

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -180,7 +180,7 @@ class Head extends Component<TableHeadProps> {
     return this.context.isStacked ? (
       this.renderSelect()
     ) : (
-      // TODO remove 'hover' exclude in the next version, its passed down for compatibility with custom components
+      // TODO remove 'hover' exclude in v11, its passed down for compatibility with custom components
       <thead
         {...omitProps(this.props, Head.allowedProps, ['hover'])}
         css={styles?.head}

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -92,15 +92,15 @@ class Head extends Component<TableHeadProps> {
   }
 
   /**
-   * This `Select` is used in `stacked` layout. Its populated by iterating trough
-   * the first child's children and reading there the
-   * `id, stackedSortByLabel, sortDirection, onRequestSort` props
+   * This `Select` is used in `stacked` layout. It's populated by iterating
+   * through the first child's children (by default `ColHeader`) and reading
+   * there the `id`, `stackedSortByLabel`, `sortDirection`, `onRequestSort` props
    */
   renderSelect() {
     const { children, renderSortLabel } = this.props
     const [firstRow] = Children.toArray(children) as RowChild[]
 
-    if (!firstRow || !firstRow.props.children) {
+    if (!firstRow?.props?.children) {
       return null
     }
 

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -25,11 +25,7 @@
 /** @jsx jsx */
 import { Component, Children, ContextType } from 'react'
 
-import {
-  omitProps,
-  matchComponentTypes,
-  callRenderProp
-} from '@instructure/ui-react-utils'
+import { omitProps, callRenderProp } from '@instructure/ui-react-utils'
 import { SimpleSelect } from '@instructure/ui-simple-select'
 import type { SimpleSelectProps } from '@instructure/ui-simple-select'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
@@ -41,11 +37,9 @@ import { withStyle, jsx } from '@instructure/emotion'
 import generateStyle from './styles'
 import generateComponentTheme from './theme'
 
-import { Row } from '../Row'
-import { ColHeader } from '../ColHeader'
 import type { TableColHeaderProps } from '../ColHeader/props'
 import type { TableHeadProps } from './props'
-import type { ColHeaderChild, RowChild } from '../props'
+import type { RowChild } from '../props'
 import { allowedProps, propTypes } from './props'
 import TableContext from '../TableContext'
 
@@ -66,18 +60,20 @@ class Head extends Component<TableHeadProps> {
     children: null
   }
 
+  /**
+   * Returns `true` if the first child's children have a `onRequestSort` prop
+   */
   get isSortable() {
-    const [row] = Children.toArray(this.props.children) as RowChild[]
+    const [firstRow] = Children.toArray(this.props.children) as RowChild[]
     let sortable = false
-
-    if (row) {
-      Children.forEach(row.props.children as ColHeaderChild[], (colHeader) => {
-        if (matchComponentTypes<ColHeaderChild>(colHeader, [ColHeader])) {
-          if (colHeader.props.onRequestSort) sortable = true
+    if (firstRow && firstRow.props && firstRow.props.children) {
+      Children.forEach(firstRow.props.children, (grandchild) => {
+        if (grandchild.props.onRequestSort) {
+          sortable = true
+          return
         }
       })
     }
-
     return sortable
   }
 
@@ -95,13 +91,19 @@ class Head extends Component<TableHeadProps> {
     this.props.makeStyles?.()
   }
 
+  /**
+   * This `Select` is used in `stacked` layout. Its populated by iterating trough
+   * the first child's children and reading there the
+   * `id, stackedSortByLabel, sortDirection, onRequestSort` props
+   */
   renderSelect() {
     const { children, renderSortLabel } = this.props
-    const [row] = Children.toArray(children) as RowChild[]
+    const [firstRow] = Children.toArray(children) as RowChild[]
 
-    if (!matchComponentTypes<RowChild>(row, [Row])) {
+    if (!firstRow || !firstRow.props.children) {
       return null
     }
+
     const options: {
       id: TableColHeaderProps['id']
       label:
@@ -114,21 +116,17 @@ class Head extends Component<TableHeadProps> {
     > = {}
     let selectedOption: TableColHeaderProps['id'] | undefined
     let count = 0
-
-    Children.forEach(row.props.children, (colHeader) => {
+    Children.forEach(firstRow.props.children, (grandchild) => {
       count += 1
-      if (matchComponentTypes<ColHeaderChild>(colHeader, [ColHeader])) {
-        const { id, stackedSortByLabel, sortDirection, onRequestSort } =
-          colHeader.props
-
+      if (!grandchild.props) return
+      const { id, stackedSortByLabel, sortDirection, onRequestSort } =
+        grandchild.props
+      if (id && onRequestSort) {
         const label = stackedSortByLabel || id
-
-        if (onRequestSort) {
-          options.push({ id, label })
-          clickHandlers[id] = onRequestSort
-          if (sortDirection !== 'none') {
-            selectedOption = id
-          }
+        options.push({ id, label })
+        clickHandlers[id] = onRequestSort
+        if (sortDirection !== 'none') {
+          selectedOption = id
         }
       }
     })
@@ -182,14 +180,12 @@ class Head extends Component<TableHeadProps> {
     return this.context.isStacked ? (
       this.renderSelect()
     ) : (
-      // TODO remove 'hover' in the next version, its passed down for compatibility with custom components
+      // TODO remove 'hover' exclude in the next version, its passed down for compatibility with custom components
       <thead
         {...omitProps(this.props, Head.allowedProps, ['hover'])}
         css={styles?.head}
       >
-        {Children.map(children, (child) =>
-          matchComponentTypes<RowChild>(child, [Row]) ? child : null
-        )}
+        {children}
       </thead>
     )
   }

--- a/packages/ui-table/src/Table/Head/props.ts
+++ b/packages/ui-table/src/Table/Head/props.ts
@@ -34,15 +34,25 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import { RowChild } from '../props'
 
 type TableHeadOwnProps = {
+  /**
+   * The sort `Select`'s label when using `stacked` layout and the table is
+   * sortable.
+   * If you don't want to display anything you should use `ScreenReaderContent`
+   * so screen readers can read the `Select`'s purpose
+   */
   renderSortLabel?: Renderable
   /**
+   * The header row(s).
    * Default type: `Table.Row`
    *
-   * Its first child is treated specially in `stacked` mode:
+   * Its first child is treated specially if the table is sortable and has
+   * `stacked` layout:
+   *
    * A `Select` is created which reads options from the first child's
-   * children, the code is looking for the following props: `id`,
-   * `stackedSortByLabel`,`sortDirection`, `onRequestSort`.
-   * These are used to sort the table in this mode.
+   * children, that tries to read the following props: `id`,
+   * `stackedSortByLabel`,`sortDirection`, `onRequestSort` (Available on
+   * `Table.ColHeader`).
+   * These are used to sort the table in this layout.
    */
   children?: RowChild
 }

--- a/packages/ui-table/src/Table/Head/props.ts
+++ b/packages/ui-table/src/Table/Head/props.ts
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 
-import React from 'react'
 import PropTypes from 'prop-types'
 
 import type {
@@ -32,13 +31,20 @@ import type {
   TableHeadTheme
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import { RowChild } from '../props'
 
 type TableHeadOwnProps = {
   renderSortLabel?: Renderable
   /**
-   * `Table.Row`
+   * Default type: `Table.Row`
+   *
+   * Its first child is treated specially in `stacked` mode:
+   * A `Select` is created which reads options from the first child's
+   * children, the code is looking for the following props: `id` (required),
+   * `stackedSortByLabel`,`sortDirection`, `onRequestSort` (required).
+   * These are used to sort the table in this mode.
    */
-  children?: React.ReactNode
+  children?: RowChild
 }
 type PropKeys = keyof TableHeadOwnProps
 

--- a/packages/ui-table/src/Table/Head/props.ts
+++ b/packages/ui-table/src/Table/Head/props.ts
@@ -34,8 +34,6 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableHeadOwnProps = {
-  hover?: boolean // needed because it needs the same API as `Table.Body`
-  isStacked?: boolean
   renderSortLabel?: Renderable
   /**
    * `Table.Row`
@@ -54,17 +52,10 @@ type TableHeadStyle = ComponentStyle<'head'>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node,
-  hover: PropTypes.bool,
-  isStacked: PropTypes.bool,
   renderSortLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 }
 
-const allowedProps: AllowedPropKeys = [
-  'children',
-  'hover',
-  'isStacked',
-  'renderSortLabel'
-]
+const allowedProps: AllowedPropKeys = ['children', 'renderSortLabel']
 
 export type { TableHeadProps, TableHeadStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-table/src/Table/Head/props.ts
+++ b/packages/ui-table/src/Table/Head/props.ts
@@ -40,8 +40,8 @@ type TableHeadOwnProps = {
    *
    * Its first child is treated specially in `stacked` mode:
    * A `Select` is created which reads options from the first child's
-   * children, the code is looking for the following props: `id` (required),
-   * `stackedSortByLabel`,`sortDirection`, `onRequestSort` (required).
+   * children, the code is looking for the following props: `id`,
+   * `stackedSortByLabel`,`sortDirection`, `onRequestSort`.
    * These are used to sort the table in this mode.
    */
   children?: RowChild

--- a/packages/ui-table/src/Table/Head/styles.ts
+++ b/packages/ui-table/src/Table/Head/styles.ts
@@ -31,8 +31,6 @@ import type { TableHeadStyle } from './props'
  * ---
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
- * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
 const generateStyle = (componentTheme: TableHeadTheme): TableHeadStyle => {

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -879,7 +879,7 @@ In some cases you might want to use custom components in a `Table`, e.g. a HOC f
 
 > Do not replace `Table.Body` and `Table.Head` with custom components
 
-Wrapper HOCs are simple:
+Wrapper HOCs are simple, just return the original component:
 
 ```javascript
 ---
@@ -998,7 +998,7 @@ If you want to use fully custom components you have to pay attention to the foll
 - A11y: Row header cells must have the `scope='row'` HTML attribute
 - A11y: Column header cells must have the `scope='col'` and `aria-sort` (if sortable) HTML attribute
 
-Basic custom table sample
+Basic fully custom table:
 
 ```javascript
 ---
@@ -1116,7 +1116,7 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
-#### Custom children with `stacked` layout
+#### Fully custom components with `stacked` layout
 
 This layout for small screens displays the table as a list. To accomplish this the headers are passed down to cells (in `TableContext`), so they can display what column they are rendering.
 In this layout for accessibility not render HTML table tags, just plain DOM elements (e.g. `div`) and use the appropriate ARIA role to signify that it's actually a `Table` (e.g. [`cell`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), [`row`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/row_role), [`rowheader`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)).  

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -875,12 +875,292 @@ render(
 
 ### Using Custom Components as Children
 
-In some cases you might want to use custom components in a `Table`, e.g. a HOC for `Table.Row` or `Table.Cell`. This is generally not recommended but sometimes it could be beneficial for codesplitting or writing cleaner code for larger and more complex Tables. In those cases you have to pay attention to always pass down the appropriate props manually.
+In some cases you might want to use custom components in a `Table`, e.g. a HOC for `Table.Row` or `Table.Cell`. This is generally not recommended, but sometimes it could be beneficial for codesplitting or writing cleaner code for larger and more complex Tables. In those cases you have to pay attention to the following:
+
+#### `Table.Body`, `Table.Head`
+
+Do not replace these components.
+
+#### Other components
+
+- Render them as the appropriate HTML Table tags (`tr`, `th`, ...)
+- Read the `hover` prop from `TableContext` to customize hover behaviour
+- A11y: Row header cells must have the `scope='row'` HTML attribute
+- A11y: Column header cells must have the `scope='col'` and `aria-sort` (if sortable) HTML attribute
+
+Basic custom table
 
 ```javascript
 ---
 type: example
 ---
+
+class CustomTableCell extends React.Component {
+  render() {
+    return <td>{this.props.children}</td>
+  }
+}
+
+class CustomTableRow extends React.Component {
+  static contextType = TableContext
+  state = { isHovered: false }
+
+  toggleHoverOff = () => {
+    this.setState({isHovered: false})
+  }
+  toggleHoverOn = () => {
+    this.setState({isHovered: true})
+  }
+  render() {
+    // super ugly way to change CSS om hover
+    let css = {backgroundColor: 'white'}
+    if (this.context.hover && this.state.isHovered) {
+      css = {backgroundColor: 'SeaGreen'}
+    }
+    return (
+      <tr style={css} onMouseOver={this.toggleHoverOn} onMouseOut={this.toggleHoverOff}>
+        {this.props.children}
+      </tr>
+    )
+  }
+}
+
+class Example extends React.Component {
+  state = {
+    layout: 'auto',
+    hover: false,
+  }
+
+  handleChange = (field, value) => {
+    this.setState({
+      [field]: value,
+    })
+  }
+
+  renderOptions () {
+    const { layout, hover } = this.state
+
+    return (
+      <Flex alignItems="start">
+        <Flex.Item margin="small">
+          <RadioInputGroup
+            name="Layout"
+            description="Layout"
+            value={layout}
+            onChange={(e, value) => this.handleChange('layout', value)}
+          >
+            <RadioInput label="auto" value="auto" />
+            <RadioInput label="fixed" value="fixed" />
+          </RadioInputGroup>
+        </Flex.Item>
+        <Flex.Item margin="small">
+          <Checkbox
+            label="hover"
+            checked={hover}
+            onChange={(e, value) => this.handleChange('hover', !hover)}
+          />
+        </Flex.Item>
+      </Flex>
+    )
+  }
+
+  render() {
+    const { layout, hover } = this.state
+
+    return (
+      <div>
+        {this.renderOptions()}
+        <Table
+          caption='Top rated movies'
+          layout={layout}
+          hover={hover}
+        >
+          <Table.Head>
+            <CustomTableRow>
+              <CustomTableCell scope='col'>Rank</CustomTableCell>
+              <CustomTableCell scope='col'>Title</CustomTableCell>
+              <CustomTableCell scope='col'>Year</CustomTableCell>
+              <CustomTableCell scope='col'>Rating</CustomTableCell>
+            </CustomTableRow>
+          </Table.Head>
+          <Table.Body>
+            <CustomTableRow>
+              <CustomTableCell scope='row'>1</CustomTableCell>
+              <CustomTableCell>The Godfather</CustomTableCell>
+              <CustomTableCell>1972</CustomTableCell>
+              <CustomTableCell>9.2</CustomTableCell>
+            </CustomTableRow>
+            <CustomTableRow>
+              <CustomTableCell scope='row'>2</CustomTableCell>
+              <CustomTableCell>The Godfather: Part II</CustomTableCell>
+              <CustomTableCell>1974</CustomTableCell>
+              <CustomTableCell>9.0</CustomTableCell>
+            </CustomTableRow>
+          </Table.Body>
+        </Table>
+      </div>
+    )
+  }
+}
+
+render(<Example />)
+```
+
+#### `stacked` layout
+
+This layout for small screens displays the table as a list. To accomplish this the headers are passed down to cells (in `TableContext`), so they can display what column they are rendering.
+For a11y in this case you should not render HTML table tags, just plain DOM elements (e.g. `div`) and use the appropriate ARIA role that it's actually a `Table` (e.g. [`cell`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), [`row`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/row_role), [`rowheader`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)).  
+Also you need the following props on the components:
+
+##### `Table.Row`
+
+- It should read the `headers` array from `TableContext` and pass its nth element to its nth child (if they have such prop).
+
+##### `Table.ColHeader` (the children of the first row in `Table.Head`)
+
+- If the table is sortable it needs an `id` and `onRequestSort`, `sortDirection` and `stackedSortByLabel` props to render a `Select` to choose how to sort the `Table`
+
+##### `Table.Cell`
+
+- It needs to have an optional `header` prop and should display its value so the user knows which column the cell's value belongs to.
+
+Custom table with `stacked` layout enabled
+
+```javascript
+---
+type: example
+---
+
+class CustomTableCell extends React.Component {
+  render() {
+    return <td>{this.props.children}</td>
+  }
+}
+
+class CustomTableRow extends React.Component {
+  static contextType = TableContext
+  state = { isHovered: false }
+
+  toggleHoverOff = () => {
+    this.setState({isHovered: false})
+  }
+  toggleHoverOn = () => {
+    this.setState({isHovered: true})
+  }
+  render() {return "TODO"// TODO
+    // super ugly way to change CSS om hover
+    let css = {backgroundColor: 'white'}
+    if (this.context.hover && this.state.isHovered) {
+      css = {backgroundColor: 'SeaGreen'}
+    }
+    const headers = this.context.headers
+    return (
+      <tr style={css} onMouseOver={this.toggleHoverOn} onMouseOut={this.toggleHoverOff}>
+        {React.Children.toArray(this.props.children)
+          .filter(React.isValidElement)
+          .map((child, index) => {
+            return React.cloneElement(child, {
+              key: child.props.name,
+              // used by `Cell` to render its column title in `stacked` layout
+              header: headers && headers[index]
+            })
+          })
+        }
+      </tr>
+    )
+  }
+}
+
+class Example extends React.Component {
+  state = {
+    layout: 'auto',
+    hover: false,
+  }
+
+  handleChange = (field, value) => {
+    this.setState({
+      [field]: value,
+    })
+  }
+
+  renderOptions () {
+    const { layout, hover } = this.state
+
+    return (
+      <Flex alignItems="start">
+        <Flex.Item margin="small">
+          <RadioInputGroup
+            name="customStackedLayout"
+            description="Layout"
+            value={layout}
+            onChange={(e, value) => this.handleChange('layout', value)}
+          >
+            <RadioInput label="auto" value="auto" />
+            <RadioInput label="fixed" value="fixed" />
+            <RadioInput label="stacked" value="stacked" />
+          </RadioInputGroup>
+        </Flex.Item>
+        <Flex.Item margin="small">
+          <Checkbox
+            label="hover"
+            checked={hover}
+            onChange={(e, value) => this.handleChange('hover', !hover)}
+          />
+        </Flex.Item>
+      </Flex>
+    )
+  }
+
+  render() {
+    const { layout, hover } = this.state
+
+    return (
+      <div>
+        {this.renderOptions()}
+        <Table
+          caption='Top rated movies'
+          layout={layout}
+          hover={hover}
+        >
+          <Table.Head>
+            <CustomTableRow>
+              <CustomTableCell scope='col'>Rank</CustomTableCell>
+              <CustomTableCell scope='col'>Title</CustomTableCell>
+              <CustomTableCell scope='col'>Year</CustomTableCell>
+              <CustomTableCell scope='col'>Rating</CustomTableCell>
+            </CustomTableRow>
+          </Table.Head>
+          <Table.Body>
+            <CustomTableRow>
+              <CustomTableCell scope='row'>1</CustomTableCell>
+              <CustomTableCell>The Godfather</CustomTableCell>
+              <CustomTableCell>1972</CustomTableCell>
+              <CustomTableCell>9.2</CustomTableCell>
+            </CustomTableRow>
+            <CustomTableRow>
+              <CustomTableCell scope='row'>2</CustomTableCell>
+              <CustomTableCell>The Godfather: Part II</CustomTableCell>
+              <CustomTableCell>1974</CustomTableCell>
+              <CustomTableCell>9.0</CustomTableCell>
+            </CustomTableRow>
+          </Table.Body>
+        </Table>
+      </div>
+    )
+  }
+}
+
+render(<Example />)
+```
+
+============
+Custom HOCs:
+
+```javascript
+---
+type: example
+---
+
 class CustomTableCell extends React.Component {
   render () {
     return (
@@ -944,7 +1224,7 @@ class Example extends React.Component {
 
   render() {
     const { layout, hover } = this.state
-
+    return <span>dfff</span>
     return (
       <div>
         {this.renderOptions()}

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -877,7 +877,9 @@ render(
 
 In some cases you might want to use custom components in a `Table`, e.g. a HOC for `Table.Row` or `Table.Cell`. This is generally not recommended, but sometimes it could be beneficial for codesplitting or writing cleaner code for larger and more complex Tables.
 
-Custom HOCs:
+> Do not replace `Table.Body` and `Table.Head` with custom components
+
+Wrapper HOCs are simple:
 
 ```javascript
 ---
@@ -987,20 +989,16 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
+#### Fully custom components
+
 If you want to use fully custom components you have to pay attention to the following:
-
-#### `Table.Body`, `Table.Head`
-
-Do not replace these components.
-
-#### Other components
 
 - Render them as the appropriate HTML Table tags (`tr`, `th`, ...)
 - Read the `hover` prop from `TableContext` to customize hover behaviour
 - A11y: Row header cells must have the `scope='row'` HTML attribute
 - A11y: Column header cells must have the `scope='col'` and `aria-sort` (if sortable) HTML attribute
 
-Basic custom table
+Basic custom table sample
 
 ```javascript
 ---
@@ -1118,25 +1116,25 @@ class Example extends React.Component {
 render(<Example />)
 ```
 
-#### Custom `stacked` layout
+#### Custom children with `stacked` layout
 
 This layout for small screens displays the table as a list. To accomplish this the headers are passed down to cells (in `TableContext`), so they can display what column they are rendering.
-For a11y in this case you should not render HTML table tags, just plain DOM elements (e.g. `div`) and use the appropriate ARIA role that it's actually a `Table` (e.g. [`cell`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), [`row`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/row_role), [`rowheader`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)).  
+In this layout for accessibility not render HTML table tags, just plain DOM elements (e.g. `div`) and use the appropriate ARIA role to signify that it's actually a `Table` (e.g. [`cell`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role), [`row`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/row_role), [`rowheader`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role)).  
 Also you need the following props on the components:
 
-##### Table.Row
+##### Table rows
 
 - It should read the `headers` array from `TableContext` and pass its nth element to its nth child (if they have such prop).
 
-##### Table.ColHeader (the children of the first row in `Table.Head`)
+##### The children of the first row in `Table.Head` (`Table.ColHeader` by default)
 
-- If the table is sortable it needs an `id` and `onRequestSort`, `sortDirection` and `stackedSortByLabel` props to render a `Select` to choose how to sort the `Table`
+- If the table is sortable the Table needs `id`, `onRequestSort`, `sortDirection` and `stackedSortByLabel` props to render a `Select` to choose how to sort the `Table` (see the props of `Table.ColHeader` for types)
 
-##### Table.Cell
+##### Table cells
 
-- It needs to have an optional `header` prop and should display its value so the user knows which column the cell's value belongs to.
+- It needs to have an optional `header` prop and should display its value so the user knows which column the cell's value belongs to (you can read whether the table is using `stacked` layout from `TableContext`.
 
-Custom table with `stacked` layout enabled
+Custom table with `stacked` layout support:
 
 ```javascript
 ---
@@ -1192,7 +1190,7 @@ class CustomTableRow extends React.Component {
           .map((child, index) => {
             return React.cloneElement(child, {
               key: child.props.name,
-              // used by `Cell` to render its column title in `stacked` layout
+              // used by `CustomTableCell` to render its column title in `stacked` layout
               header: headers && headers[index]
             })
           })

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -88,7 +88,7 @@ class Row extends Component<TableRowProps> {
               return safeCloneElement(child, {
                 key: child.props.name,
                 // Sent down for compatibility with custom components
-                // TODO DEPRECATED, remove in next version
+                // TODO DEPRECATED, remove in v11
                 isStacked,
                 // used by `Cell` to render its column title in `stacked` layout
                 header: headers && headers[index]

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, Children } from 'react'
+import { Component, Children, ContextType } from 'react'
 
 import { omitProps, safeCloneElement } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -35,6 +35,7 @@ import generateComponentTheme from './theme'
 
 import type { TableRowProps } from './props'
 import { allowedProps, propTypes } from './props'
+import TableContext from '../TableContext'
 
 /**
 ---
@@ -45,7 +46,8 @@ id: Table.Row
 @withStyle(generateStyle, generateComponentTheme)
 class Row extends Component<TableRowProps> {
   static readonly componentId = 'Table.Row'
-
+  static contextType = TableContext
+  declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
   static propTypes = propTypes
 
@@ -54,15 +56,23 @@ class Row extends Component<TableRowProps> {
   }
 
   componentDidMount() {
-    this.props.makeStyles?.()
+    this.props.makeStyles?.({
+      isStacked: this.context.isStacked,
+      hover: this.context.hover
+    })
   }
 
   componentDidUpdate() {
-    this.props.makeStyles?.()
+    this.props.makeStyles?.({
+      isStacked: this.context.isStacked,
+      hover: this.context.hover
+    })
   }
 
   render() {
-    const { children, styles, isStacked, headers } = this.props
+    const { children, styles } = this.props
+    const isStacked = this.context.isStacked
+    const headers = this.context.headers
 
     return (
       <View
@@ -76,6 +86,8 @@ class Row extends Component<TableRowProps> {
           .map((child: any, index) => {
             return safeCloneElement(child, {
               key: child.props.name,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
               isStacked,
               header: headers && headers[index]
             })

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component, Children, ContextType } from 'react'
+import { Component, Children, ContextType, isValidElement } from 'react'
 
 import { omitProps, safeCloneElement } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -83,14 +83,18 @@ class Row extends Component<TableRowProps> {
       >
         {Children.toArray(children)
           .filter(Boolean)
-          .map((child: any, index) => {
-            return safeCloneElement(child, {
-              key: child.props.name,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in next version
-              isStacked,
-              header: headers && headers[index]
-            })
+          .map((child, index) => {
+            if (isValidElement(child)) {
+              return safeCloneElement(child, {
+                key: child.props.name,
+                // Sent down for compatibility with custom components
+                // TODO DEPRECATED, remove in next version
+                isStacked,
+                // used by `Cell` to render its column title in `stacked` layout
+                header: headers && headers[index]
+              })
+            }
+            return child
           })}
       </View>
     )

--- a/packages/ui-table/src/Table/Row/props.ts
+++ b/packages/ui-table/src/Table/Row/props.ts
@@ -25,8 +25,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import type { TableCellProps } from '../Cell/props'
-
 import type {
   OtherHTMLAttributes,
   PropValidators,
@@ -35,9 +33,6 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableRowOwnProps = {
-  hover?: boolean
-  isStacked?: boolean
-  headers?: TableCellProps['header'][]
   /**
    * `Table.ColHeader`, `Table.RowHeader` or `Table.Cell`
    */
@@ -55,20 +50,10 @@ type TableRowProps = TableRowOwnProps &
 type TableRowStyle = ComponentStyle<'row'>
 
 const propTypes: PropValidators<PropKeys> = {
-  children: PropTypes.node,
-  hover: PropTypes.bool,
-  isStacked: PropTypes.bool,
-  headers: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.node, PropTypes.func])
-  )
+  children: PropTypes.node
 }
 
-const allowedProps: AllowedPropKeys = [
-  'children',
-  'hover',
-  'isStacked',
-  'headers'
-]
+const allowedProps: AllowedPropKeys = ['children']
 
 export type { TableRowProps, TableRowStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-table/src/Table/Row/props.ts
+++ b/packages/ui-table/src/Table/Row/props.ts
@@ -34,9 +34,14 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableRowOwnProps = {
   /**
-   * `Table.ColHeader`, `Table.RowHeader` or `Table.Cell`
+   * A row's children should be table cells. It should have the following
+   * props:
+   * - `isStacked:boolean`: whether its in stacked mode
+   * - `header:Renderable`: extra data to render in `stacked` layout
+   *
+   * By default `Table.ColHeader` or `Table.RowHeader` or `Table.Cell`
    */
-  children?: React.ReactNode
+  children?: React.ReactElement | React.ReactElement[]
 }
 
 type PropKeys = keyof TableRowOwnProps

--- a/packages/ui-table/src/Table/Row/props.ts
+++ b/packages/ui-table/src/Table/Row/props.ts
@@ -34,10 +34,8 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableRowOwnProps = {
   /**
-   * A row's children should be table cells. It should have the following
-   * props:
-   * - `isStacked:boolean`: whether its in stacked mode
-   * - `header:Renderable`: extra data to render in `stacked` layout
+   * A row's children should be table cells. Its children should have the
+   * `header` prop to render the column header in `stacked` layout
    *
    * By default `Table.ColHeader` or `Table.RowHeader` or `Table.Cell`
    */

--- a/packages/ui-table/src/Table/Row/styles.ts
+++ b/packages/ui-table/src/Table/Row/styles.ts
@@ -32,15 +32,14 @@ import type { TableRowProps, TableRowStyle } from './props'
  * Generates the style object from the theme and provided additional information
  * @param  {Object} componentTheme The theme variable object.
  * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
+ * @param  {Object} extraArgs the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
 const generateStyle = (
   componentTheme: TableRowTheme,
-  props: TableRowProps
+  _props: TableRowProps,
+  extraArgs: { isStacked: boolean; hover: boolean }
 ): TableRowStyle => {
-  const { hover, isStacked } = props
-
   return {
     row: {
       label: 'row',
@@ -54,7 +53,7 @@ const generateStyle = (
       borderBottomWidth: '0.0625rem',
       borderBottomColor: componentTheme.borderColor,
 
-      ...(hover && {
+      ...(extraArgs.hover && {
         borderLeft: '0.1875rem solid transparent',
         borderRight: '0.1875rem solid transparent',
 
@@ -64,7 +63,7 @@ const generateStyle = (
         }
       }),
 
-      ...(isStacked && { padding: componentTheme.padding })
+      ...(extraArgs.isStacked && { padding: componentTheme.padding })
     }
   }
 }

--- a/packages/ui-table/src/Table/RowHeader/index.tsx
+++ b/packages/ui-table/src/Table/RowHeader/index.tsx
@@ -23,7 +23,7 @@
  */
 
 /** @jsx jsx */
-import { Component } from 'react'
+import { Component, ContextType } from 'react'
 
 import { omitProps, callRenderProp } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -34,6 +34,7 @@ import generateStyle from './styles'
 import generateComponentTheme from './theme'
 import type { TableRowHeaderProps } from './props'
 import { allowedProps, propTypes } from './props'
+import TableContext from '../TableContext'
 
 /**
 ---
@@ -44,7 +45,8 @@ id: Table.RowHeader
 @withStyle(generateStyle, generateComponentTheme)
 class RowHeader extends Component<TableRowHeaderProps> {
   static readonly componentId = 'Table.RowHeader'
-
+  static contextType = TableContext
+  declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
   static propTypes = propTypes
 
@@ -62,8 +64,8 @@ class RowHeader extends Component<TableRowHeaderProps> {
   }
 
   render() {
-    const { children, isStacked, styles } = this.props
-
+    const { children, styles } = this.props
+    const isStacked = this.context.isStacked
     return (
       <View
         {...View.omitViewProps(

--- a/packages/ui-table/src/Table/RowHeader/props.ts
+++ b/packages/ui-table/src/Table/RowHeader/props.ts
@@ -33,7 +33,6 @@ import type {
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableRowHeaderOwnProps = {
-  isStacked?: boolean
   /**
    * Control the text alignment in row header
    */
@@ -53,11 +52,10 @@ type TableRowHeaderStyle = ComponentStyle<'rowHeader'>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  isStacked: PropTypes.bool,
   textAlign: PropTypes.oneOf(['start', 'center', 'end'])
 }
 
-const allowedProps: AllowedPropKeys = ['children', 'isStacked', 'textAlign']
+const allowedProps: AllowedPropKeys = ['children', 'textAlign']
 
 export type { TableRowHeaderProps, TableRowHeaderStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-table/src/Table/TableContext.ts
+++ b/packages/ui-table/src/Table/TableContext.ts
@@ -36,16 +36,14 @@ type TableContextType = {
    */
   hover: boolean
   /**
-   * Array of first row of UI elements. Used if `isStacked` is `true`.
+   * Array of first row of UI elements. Has value if `isStacked` is `true`.
    */
   headers?: Renderable[]
-  // TEST idea: allow children to add themselves here to prevent looking up stuff in children
-  // Likely it won't work because it will need to manage unmounting,
-  // and we would need to determine the order too
-  //headers2?: Renderable[],
-  //addHeader?: (header: Renderable) => void
 }
 
+/**
+ * React context created by the `Table` component to hold its data
+ */
 const TableContext = createContext<TableContextType>({
   isStacked: false,
   hover: false

--- a/packages/ui-table/src/Table/TableContext.ts
+++ b/packages/ui-table/src/Table/TableContext.ts
@@ -36,7 +36,7 @@ type TableContextType = {
    */
   hover: boolean
   /**
-   * Array of first row of UI elements. Has value if `isStacked` is `true`.
+   * Contents of the first row of cells. Has value if `isStacked` is `true`.
    */
   headers?: Renderable[]
 }

--- a/packages/ui-table/src/Table/TableContext.ts
+++ b/packages/ui-table/src/Table/TableContext.ts
@@ -21,38 +21,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from 'react'
-import PropTypes from 'prop-types'
 
-import type {
-  OtherHTMLAttributes,
-  PropValidators,
-  TableBodyTheme
-} from '@instructure/shared-types'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import { createContext } from 'react'
+import { Renderable } from '@instructure/shared-types'
 
-type TableBodyOwnProps = {
+type TableContextType = {
   /**
-   * `Table.Row`
+   * If `true` the table gets rendered in one column to be more readable on
+   * narrow screens.
    */
-  children?: React.ReactNode
+  isStacked: boolean
+  /**
+   * Highlight each row on hover.
+   */
+  hover: boolean
+  /**
+   * Array of first row of UI elements. Used if `isStacked` is `true`.
+   */
+  headers?: Renderable[]
 }
 
-type PropKeys = keyof TableBodyOwnProps
+const TableContext = createContext<TableContextType>({
+  isStacked: false,
+  hover: false
+})
 
-type AllowedPropKeys = Readonly<Array<PropKeys>>
-
-type TableBodyProps = TableBodyOwnProps &
-  WithStyleProps<TableBodyTheme, TableBodyStyle> &
-  OtherHTMLAttributes<TableBodyOwnProps>
-
-type TableBodyStyle = ComponentStyle<'body'>
-
-const propTypes: PropValidators<PropKeys> = {
-  children: PropTypes.node
-}
-
-const allowedProps: AllowedPropKeys = ['children']
-
-export type { TableBodyProps, TableBodyStyle }
-export { propTypes, allowedProps }
+export default TableContext
+export { TableContext }
+export type { TableContextType }

--- a/packages/ui-table/src/Table/TableContext.ts
+++ b/packages/ui-table/src/Table/TableContext.ts
@@ -39,6 +39,11 @@ type TableContextType = {
    * Array of first row of UI elements. Used if `isStacked` is `true`.
    */
   headers?: Renderable[]
+  // TEST idea: allow children to add themselves here to prevent looking up stuff in children
+  // Likely it won't work because it will need to manage unmounting,
+  // and we would need to determine the order too
+  //headers2?: Renderable[],
+  //addHeader?: (header: Renderable) => void
 }
 
 const TableContext = createContext<TableContextType>({

--- a/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
@@ -170,14 +170,16 @@ describe('<Table />', async () => {
   })
 
   // TODO fix code
-  it.skip('does not crash for text children', async () => {
+  it('does not crash for invalid children', async () => {
     render(
       <Table caption="Test table" layout="stacked">
         test1
         <span>test</span>
+        {/* @ts-ignore error is normal here */}
         <Table.Head>
           <span>test</span>
           test2
+          {/* @ts-ignore error is normal here */}
           <Table.Row>
             test3
             <span>test</span>
@@ -190,6 +192,7 @@ describe('<Table />', async () => {
         <Table.Body>
           test
           <span>test</span>
+          {/* @ts-ignore error is normal here */}
           <Table.Row>
             test
             <span>test</span>
@@ -200,10 +203,10 @@ describe('<Table />', async () => {
         </Table.Body>
       </Table>
     )
-    const stackedTable = screen.getByRole('table')
+    const table = screen.getByRole('table')
 
-    expect(stackedTable).toBeInTheDocument()
-    expect(stackedTable).not.toHaveTextContent('Foo')
+    expect(table).toBeInTheDocument()
+    expect(table).toHaveTextContent('Foo')
   })
 
   // see https://github.com/vitest-dev/eslint-plugin-vitest/issues/511

--- a/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
@@ -169,6 +169,43 @@ describe('<Table />', async () => {
     expect(stackedTable).not.toHaveTextContent('Foo')
   })
 
+  // TODO fix code
+  it.skip('does not crash for text children', async () => {
+    render(
+      <Table caption="Test table" layout="stacked">
+        test1
+        <span>test</span>
+        <Table.Head>
+          <span>test</span>
+          test2
+          <Table.Row>
+            test3
+            <span>test</span>
+            <Table.Cell>Foo</Table.Cell>
+          </Table.Row>
+          test4
+          <span>test</span>
+        </Table.Head>
+        test5
+        <Table.Body>
+          test
+          <span>test</span>
+          <Table.Row>
+            test
+            <span>test</span>
+            <Table.Cell>Foo</Table.Cell>
+            test
+            <span>test</span>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    )
+    const stackedTable = screen.getByRole('table')
+
+    expect(stackedTable).toBeInTheDocument()
+    expect(stackedTable).not.toHaveTextContent('Foo')
+  })
+
   // see https://github.com/vitest-dev/eslint-plugin-vitest/issues/511
   // eslint-disable-next-line vitest/valid-describe-callback
   describe('when table is sortable', async () => {

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -50,6 +50,7 @@ import type {
 } from './props'
 
 import { allowedProps, propTypes } from './props'
+import TableContext from './TableContext'
 
 /**
 ---
@@ -116,32 +117,43 @@ class Table extends Component<TableProps> {
     const headers = isStacked ? this.getHeaders() : undefined
 
     return (
-      <View
-        {...View.omitViewProps(
-          omitProps(this.props, Table.allowedProps),
-          Table
-        )}
-        as={isStacked ? 'div' : 'table'}
-        margin={margin}
-        elementRef={this.handleRef}
-        css={styles?.table}
-        role={isStacked ? 'table' : undefined}
-        aria-label={isStacked ? (caption as string) : undefined}
+      <TableContext.Provider
+        value={{
+          isStacked: isStacked,
+          hover: hover!,
+          headers: headers
+        }}
       >
-        {!isStacked && (
-          <caption>
-            <ScreenReaderContent>{caption}</ScreenReaderContent>
-          </caption>
-        )}
-        {Children.map(children, (child: any) => {
-          return safeCloneElement(child, {
-            key: child.props.name,
-            isStacked,
-            hover,
-            headers
-          })
-        })}
-      </View>
+        <View
+          {...View.omitViewProps(
+            omitProps(this.props, Table.allowedProps),
+            Table
+          )}
+          as={isStacked ? 'div' : 'table'}
+          margin={margin}
+          elementRef={this.handleRef}
+          css={styles?.table}
+          role={isStacked ? 'table' : undefined}
+          aria-label={isStacked ? (caption as string) : undefined}
+        >
+          {!isStacked && (
+            <caption>
+              <ScreenReaderContent>{caption}</ScreenReaderContent>
+            </caption>
+          )}
+          {Children.map(children, (child: any) => {
+            return safeCloneElement(child, {
+              key: child.props.name,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
+              hover,
+              // Sent down for compatibility with custom components
+              // TODO DEPRECATED, remove in next version
+              headers
+            })
+          })}
+        </View>
+      </TableContext.Provider>
     )
   }
 }

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -92,8 +92,7 @@ class Table extends Component<TableProps> {
   }
 
   getHeaders() {
-    const { children } = this.props
-    const [headChild] = Children.toArray(children)
+    const [headChild] = Children.toArray(this.props.children)
     if (!headChild || !isValidElement(headChild)) return undefined
     const [firstRow] = Children.toArray(headChild.props.children)
     if (!firstRow || !isValidElement(firstRow)) return undefined

--- a/packages/ui-table/src/Table/index.tsx
+++ b/packages/ui-table/src/Table/index.tsx
@@ -71,9 +71,6 @@ class Table extends Component<TableProps> {
   static RowHeader = RowHeader
   static Cell = Cell
 
-  state = {
-    rows: []
-  }
   ref: Element | null = null
 
   handleRef = (el: Element | null) => {
@@ -138,15 +135,7 @@ class Table extends Component<TableProps> {
           )}
           {Children.map(children, (child) => {
             if (isValidElement(child)) {
-              return safeCloneElement(child, {
-                key: child.props.name,
-                // Sent down for compatibility with custom components
-                // TODO DEPRECATED, remove in next version
-                hover,
-                // Sent down for compatibility with custom components
-                // TODO DEPRECATED, remove in next version
-                headers
-              })
+              return safeCloneElement(child, { key: child.props.name })
             }
             return child
           })}

--- a/packages/ui-table/src/Table/props.ts
+++ b/packages/ui-table/src/Table/props.ts
@@ -39,8 +39,6 @@ import type {
 
 import { Head } from './Head'
 import type { TableHeadProps } from './Head/props'
-import { Row } from './Row'
-import type { TableRowProps } from './Row/props'
 import { ColHeader } from './ColHeader'
 import type { TableColHeaderProps } from './ColHeader/props'
 import { RowHeader } from './RowHeader'
@@ -49,7 +47,7 @@ import { Cell } from './Cell'
 import type { TableCellProps } from './Cell/props'
 
 type HeadChild = React.ComponentElement<TableHeadProps, Head>
-type RowChild = React.ComponentElement<TableRowProps, Row>
+type RowChild = React.ReactElement<{ children: React.ReactElement }>
 type ColHeaderChild = React.ComponentElement<TableColHeaderProps, ColHeader>
 type RowHeaderChild = React.ComponentElement<TableRowHeaderProps, RowHeader>
 type CellChild = React.ComponentElement<TableCellProps, Cell>

--- a/packages/ui-table/src/Table/props.ts
+++ b/packages/ui-table/src/Table/props.ts
@@ -63,12 +63,13 @@ type TableOwnProps = {
    * `auto` lets the browser determine table column widths based on cell content,
    * while `fixed` forces columns of equal width (sets the
    * [tableLayout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout)
-   * CSS prop to `fixed`). `stacked` renders table in one
-   * column to be more readable on narrow screens
+   * CSS prop to `fixed`).
+   *
+   * `stacked` renders table in one column to be more readable on narrow screens
    */
   layout?: 'auto' | 'fixed' | 'stacked'
   /**
-   * `Table.Head` or `Table.Body` by default
+   * `Table.Head` or `Table.Body`
    */
   children?: React.ReactNode
 }

--- a/packages/ui-table/src/Table/props.ts
+++ b/packages/ui-table/src/Table/props.ts
@@ -37,20 +37,7 @@ import type {
   TableTheme
 } from '@instructure/shared-types'
 
-import { Head } from './Head'
-import type { TableHeadProps } from './Head/props'
-import { ColHeader } from './ColHeader'
-import type { TableColHeaderProps } from './ColHeader/props'
-import { RowHeader } from './RowHeader'
-import type { TableRowHeaderProps } from './RowHeader/props'
-import { Cell } from './Cell'
-import type { TableCellProps } from './Cell/props'
-
-type HeadChild = React.ComponentElement<TableHeadProps, Head>
 type RowChild = React.ReactElement<{ children: React.ReactElement }>
-type ColHeaderChild = React.ComponentElement<TableColHeaderProps, ColHeader>
-type RowHeaderChild = React.ComponentElement<TableRowHeaderProps, RowHeader>
-type CellChild = React.ComponentElement<TableCellProps, Cell>
 
 type TableOwnProps = {
   /**
@@ -118,10 +105,6 @@ export type {
   TableProps,
   TableStyle,
   // children
-  HeadChild,
-  RowChild,
-  ColHeaderChild,
-  RowHeaderChild,
-  CellChild
+  RowChild
 }
 export { propTypes, allowedProps }

--- a/packages/ui-table/src/Table/props.ts
+++ b/packages/ui-table/src/Table/props.ts
@@ -39,8 +39,6 @@ import type {
 
 import { Head } from './Head'
 import type { TableHeadProps } from './Head/props'
-import { Body } from './Body'
-import type { TableBodyProps } from './Body/props'
 import { Row } from './Row'
 import type { TableRowProps } from './Row/props'
 import { ColHeader } from './ColHeader'
@@ -51,7 +49,6 @@ import { Cell } from './Cell'
 import type { TableCellProps } from './Cell/props'
 
 type HeadChild = React.ComponentElement<TableHeadProps, Head>
-type BodyChild = React.ComponentElement<TableBodyProps, Body>
 type RowChild = React.ComponentElement<TableRowProps, Row>
 type ColHeaderChild = React.ComponentElement<TableColHeaderProps, ColHeader>
 type RowHeaderChild = React.ComponentElement<TableRowHeaderProps, RowHeader>
@@ -79,12 +76,14 @@ type TableOwnProps = {
   hover?: boolean
   /**
    * `auto` lets the browser determine table column widths based on cell content,
-   * while `fixed` forces columns of equal width. `stacked` renders table in one
+   * while `fixed` forces columns of equal width (sets the
+   * [tableLayout](https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout)
+   * CSS prop to `fixed`). `stacked` renders table in one
    * column to be more readable on narrow screens
    */
   layout?: 'auto' | 'fixed' | 'stacked'
   /**
-   * Build table via `Table.Head` and `Table.Body`
+   * `Table.Head` or `Table.Body` by default
    */
   children?: React.ReactNode
 }
@@ -122,7 +121,6 @@ export type {
   TableStyle,
   // children
   HeadChild,
-  BodyChild,
   RowChild,
   ColHeaderChild,
   RowHeaderChild,

--- a/packages/ui-table/src/index.ts
+++ b/packages/ui-table/src/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 export { Table } from './Table'
+export { TableContext } from './Table/TableContext'
 
 export type { TableProps } from './Table/props'
 export type { TableBodyProps } from './Table/Body/props'


### PR DESCRIPTION
- [x] use Context instead of passing down props
- [x] Allow custom children
- [x] write test for custom children
- [x] make sure that one can use falsey/null children
- [x] write example and docs for the new API

To test:

- Check out the new examples and play with them.   
- Try to add custom components as children that just wrap existing components.               
- Try to make fully new custom components.  
- Add stupid things as children to components (see one of the new tests), it should not result in an exception
