### PR TITLE
RadioInput: Better docs for name and value props

### DIFF
--- a/packages/ui-radio-input/src/RadioInput/props.ts
+++ b/packages/ui-radio-input/src/RadioInput/props.ts
@@ -35,13 +35,27 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
 type RadioInputOwnProps = {
+  /**
+   * The label displayed next to the checkbox
+   */
   label: React.ReactNode
+  /**
+   * This maps to the low level HTML attribute
+   * [with the same name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#value)
+   */
   value?: string | number
   id?: string
+  /**
+   * The [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group)
+   * defines which group it belongs to, it's managed by the `RadioInputGroup`
+   * this component belongs to.
+   *
+   * Do not set it manually.
+   */
   name?: string
   checked?: boolean
   /**
-   * Whether or not to disable the input
+   * Whether to disable the input
    */
   disabled?: boolean
   /**

--- a/packages/ui-radio-input/src/RadioInputGroup/README.md
+++ b/packages/ui-radio-input/src/RadioInputGroup/README.md
@@ -6,6 +6,8 @@ A RadioInputGroup is a group of RadioInput components. It will handle setting
 the name property on the RadioInput components for you and will set the selected item
 based on the `value` property.
 
+The `name` prop sets the [same low level HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group) which **must be unique across the DOM** otherwise groups with the same name will interfere with each other.
+
 Adjust the size of the radio button and label text via the `size` prop. The default size is
 `medium`.
 

--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -152,7 +152,6 @@ class RadioInputGroup extends Component<
         {...omitProps(this.props, RadioInputGroup.allowedProps)}
         {...pickProps(this.props, FormFieldGroup.allowedProps)}
         description={description}
-        // TODO: split out toggle variant into its own component
         layout={
           layout === 'columns' && variant === 'toggle' ? 'stacked' : layout
         } // toggles already display in cols

--- a/packages/ui-radio-input/src/RadioInputGroup/props.ts
+++ b/packages/ui-radio-input/src/RadioInputGroup/props.ts
@@ -36,6 +36,13 @@ import type {
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
 type RadioInputGroupOwnProps = {
+  /**
+   * This prop sets the
+   * [same low level HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group)
+   *
+   * **Must be unique across the DOM** otherwise groups will interfere with
+   * each other
+   */
   name: string
 
   description: React.ReactNode
@@ -48,7 +55,7 @@ type RadioInputGroupOwnProps = {
   /**
    * the selected value (must be accompanied by an `onChange` prop)
    */
-  value?: string | number // TODO: controllable( PropTypes.oneOfType([PropTypes.string, PropTypes.number]) )
+  value?: string | number
 
   /**
    * when used with the `value` prop, the component will not control its own state
@@ -70,7 +77,7 @@ type RadioInputGroupOwnProps = {
    */
   messages?: FormMessage[]
 
-  variant?: 'simple' | 'toggle' // TODO: split toggle out to its own component
+  variant?: 'simple' | 'toggle'
 
   size?: 'small' | 'medium' | 'large'
 
@@ -87,7 +94,8 @@ type PropKeys = keyof RadioInputGroupOwnProps
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type RadioInputGroupProps = RadioInputGroupOwnProps &
-  OtherHTMLAttributes<RadioInputGroupOwnProps> & WithDeterministicIdProps
+  OtherHTMLAttributes<RadioInputGroupOwnProps> &
+  WithDeterministicIdProps
 
 type RadioInputGroupState = {
   value?: string | number


### PR DESCRIPTION
choosing a bad name for your `RadioInputGroup` can cause them to interfere with each other, e.g. try out this code:

```jsx
<div>
  <RadioInputGroup name="abc">
    <RadioInput label="Off" value="off"/>
    <RadioInput label="Allow" value="allow" />
    <RadioInput label="On" value="on" />
  </RadioInputGroup>
  This is a different group but because they have the same name both are broken
  <RadioInputGroup name="abc">
    <RadioInput label="Off" value="off"/>
    <RadioInput label="Allow" value="allow" />
    <RadioInput label="On" value="on" />
  </RadioInputGroup>
</div>
```