### PR TITLE
fix(ui-radio-input): only radio button and label are clickable

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -273,27 +273,29 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
         onMouseOut={createChainedFunction(onMouseOut, this.handleMouseOut)}
         ref={this.handleRef}
       >
-        <input
-          {...props}
-          id={this.id}
-          value={value}
-          type="checkbox"
-          ref={(c) => {
-            this._input = c
-          }}
-          disabled={disabled || readOnly}
-          aria-checked={indeterminate ? 'mixed' : undefined}
-          css={styles?.input}
-          onChange={this.handleChange}
-          onKeyDown={createChainedFunction(onKeyDown, this.handleKeyDown)}
-          onFocus={createChainedFunction(onFocus, this.handleFocus)}
-          onBlur={createChainedFunction(onBlur, this.handleBlur)}
-          checked={this.checked}
-        />
-        <label htmlFor={this.id} css={styles?.control}>
-          {this.renderFacade()}
-          {this.renderMessages()}
-        </label>
+        <div css={styles?.container}>
+          <input
+            {...props}
+            id={this.id}
+            value={value}
+            type="checkbox"
+            ref={(c) => {
+              this._input = c
+            }}
+            disabled={disabled || readOnly}
+            aria-checked={indeterminate ? 'mixed' : undefined}
+            css={styles?.input}
+            onChange={this.handleChange}
+            onKeyDown={createChainedFunction(onKeyDown, this.handleKeyDown)}
+            onFocus={createChainedFunction(onFocus, this.handleFocus)}
+            onBlur={createChainedFunction(onBlur, this.handleBlur)}
+            checked={this.checked}
+          />
+          <label htmlFor={this.id} css={styles?.control}>
+            {this.renderFacade()}
+            {this.renderMessages()}
+          </label>
+        </div>
       </div>
     )
   }

--- a/packages/ui-checkbox/src/Checkbox/props.ts
+++ b/packages/ui-checkbox/src/Checkbox/props.ts
@@ -87,9 +87,12 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type CheckboxProps = CheckboxOwnProps &
   WithStyleProps<CheckboxFacadeTheme | ToggleFacadeTheme, CheckboxStyle> &
-  OtherHTMLAttributes<CheckboxOwnProps> & WithDeterministicIdProps
+  OtherHTMLAttributes<CheckboxOwnProps> &
+  WithDeterministicIdProps
 
-type CheckboxStyle = ComponentStyle<'checkbox' | 'input' | 'control'>
+type CheckboxStyle = ComponentStyle<
+  'checkbox' | 'input' | 'control' | 'container'
+>
 
 const propTypes: PropValidators<PropKeys> = {
   label: PropTypes.node.isRequired,

--- a/packages/ui-checkbox/src/Checkbox/styles.ts
+++ b/packages/ui-checkbox/src/Checkbox/styles.ts
@@ -57,6 +57,10 @@ const generateStyle = (
         width: 'auto'
       })
     },
+    // this container is added to reduce the clickable area of the checkbox to the actual checkbox and label
+    container: {
+      width: 'fit-content'
+    },
     input: {
       label: 'checkbox__input',
       padding: 0,

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -141,26 +141,28 @@ class RadioInput extends Component<RadioInputProps, RadioInputState> {
           this.ref = el
         }}
       >
-        <input
-          {...props}
-          id={this.id}
-          ref={(c: HTMLInputElement | null) => {
-            this._input = c
-          }}
-          value={value}
-          name={name}
-          checked={this.checked}
-          type="radio"
-          css={styles?.input}
-          disabled={disabled || readOnly}
-          aria-disabled={disabled || readOnly ? 'true' : undefined}
-          onChange={this.handleChange}
-          onClick={this.handleClick}
-        />
-        <label css={styles?.control} htmlFor={this.id}>
-          <span css={styles?.facade} aria-hidden="true" />
-          <span css={styles?.label}>{label}</span>
-        </label>
+        <div css={styles?.container}>
+          <input
+            {...props}
+            id={this.id}
+            ref={(c: HTMLInputElement | null) => {
+              this._input = c
+            }}
+            value={value}
+            name={name}
+            checked={this.checked}
+            type="radio"
+            css={styles?.input}
+            disabled={disabled || readOnly}
+            aria-disabled={disabled || readOnly ? 'true' : undefined}
+            onChange={this.handleChange}
+            onClick={this.handleClick}
+          />
+          <label css={styles?.control} htmlFor={this.id}>
+            <span css={styles?.facade} aria-hidden="true" />
+            <span css={styles?.label}>{label}</span>
+          </label>
+        </div>
       </div>
     )
   }

--- a/packages/ui-radio-input/src/RadioInput/props.ts
+++ b/packages/ui-radio-input/src/RadioInput/props.ts
@@ -87,7 +87,7 @@ type RadioInputProps = RadioInputOwnProps &
   WithDeterministicIdProps
 
 type RadioInputStyle = ComponentStyle<
-  'radioInput' | 'input' | 'control' | 'facade' | 'label'
+  'radioInput' | 'input' | 'control' | 'facade' | 'label' | 'container'
 >
 
 type RadioInputState = {

--- a/packages/ui-radio-input/src/RadioInput/styles.ts
+++ b/packages/ui-radio-input/src/RadioInput/styles.ts
@@ -273,6 +273,10 @@ const generateStyle = (
         ...(disabled && { cursor: 'not-allowed' })
       }
     },
+    // this container is added to reduce the clickable area to the size of the radio button and label
+    container: {
+      width: 'fit-content'
+    },
     input: {
       label: 'radioInput__input',
       ...inputStyles,


### PR DESCRIPTION
Closes: INSTUI-4197

**Test plan**

Go through all of the RadioInput/RadioInputGroup examples in the docs app:

- Check whether the design is not broken
- click events should be registered if you click on the radio group icon or label. If you click on the remaining area of the radio input, click should not be registered.