### PR TITLE
chore: fix npm release script when its running on a multi line commit message

### DIFF
--- a/.github/workflows/manual-release-from-pr.yml
+++ b/.github/workflows/manual-release-from-pr.yml
@@ -23,12 +23,12 @@ jobs:
           NPM_USERNAME: ${{secrets.NPM_USERNAME}}
         run: npm run release -- --prRelease
       - name: Get commit message
-        run: |
-          echo "commmit_message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
+        run: | # puts the first line of the last commit message to the commmit_message env var
+          echo "commmit_message=$(git log --format=%B -n 1 ${{ github.event.after }} | head -n 1)" >> $GITHUB_ENV
       - name: Set up git identity
         if: "startsWith(env.commmit_message, 'chore(release)')"
         run: git config --global user.name "instructure-ui-ci" && git config --global user.email "instructure-ui-ci@instructure.com"
-        # -a -m is needed to make the tag "annotated". Lerna needs annotated tags to work correctly with verisons
+        # -a -m is needed to make the tag "annotated". Lerna needs annotated tags to work correctly with versions
       - name: Add tag
         if: "startsWith(env.commmit_message, 'chore(release)')"
         run: git tag -a v$(./.github/workflows/calculateVersion.sh) -m v$(./.github/workflows/calculateVersion.sh)

--- a/.github/workflows/manual-release-to-npm.yml
+++ b/.github/workflows/manual-release-to-npm.yml
@@ -19,12 +19,12 @@ jobs:
           NPM_USERNAME: ${{secrets.NPM_USERNAME}}
         run: npm run release
       - name: Get commit message
-        run: |
-          echo "commmit_message=$(git log --format=%B -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
+        run: | # puts the first line of the last commit message to the commmit_message env var
+          echo "commmit_message=$(git log --format=%B -n 1 ${{ github.event.after }} | head -n 1)" >> $GITHUB_ENV
       - name: Set up git identity
         if: "startsWith(env.commmit_message, 'chore(release)')"
         run: git config --global user.name "instructure-ui-ci" && git config --global user.email "instructure-ui-ci@instructure.com"
-        # -a -m is needed to make the tag "annotated". Lerna needs annotated tags to work correctly with verisons
+        # -a -m is needed to make the tag "annotated". Lerna needs annotated tags to work correctly with versions
       - name: Add tag
         if: "startsWith(env.commmit_message, 'chore(release)')"
         run: git tag -a v$(./.github/workflows/calculateVersion.sh) -m v$(./.github/workflows/calculateVersion.sh)


### PR DESCRIPTION
The release script tried to put a multiline string into an env var which resulted in an error. Now only the first line of the commit message is kept.

This was causing an issue when trying to do a manual NPM release from a branch