### PR TITLE
[v8] Fix condensedButton warning when color is set to 'secondary'

### DIFF
--- a/packages/ui-buttons/src/CondensedButton/props.ts
+++ b/packages/ui-buttons/src/CondensedButton/props.ts
@@ -121,7 +121,7 @@ const propTypes: PropValidators<PropKeys> = {
   elementRef: PropTypes.func,
   as: PropTypes.elementType,
   interaction: PropTypes.oneOf(['enabled', 'disabled', 'readonly']),
-  color: PropTypes.oneOf(['primary', 'primary-inverse']),
+  color: PropTypes.oneOf(['primary', 'primary-inverse', 'secondary']),
   margin: ThemeablePropTypes.spacing,
   cursor: PropTypes.string,
   href: PropTypes.string,


### PR DESCRIPTION

port of https://github.com/instructure/instructure-ui/pull/1580 from v9

TEST PLAN:
set CondensedButton's color prop to secondary. There should be no failed prop type warning in the console