### PR TITLE
[v9] fix(ui-selectable): fix Select options not being selectable on iOS Safari with VoiceOver on

### DIFF
--- a/packages/ui-selectable/src/Selectable/__tests__/Selectable.test.tsx
+++ b/packages/ui-selectable/src/Selectable/__tests__/Selectable.test.tsx
@@ -802,14 +802,12 @@ describe('<Selectable />', async () => {
 
       expect(input.getAttribute('aria-expanded')).to.equal('false')
       expect(input.getAttribute('aria-controls')).to.not.exist()
-      expect(input.getAttribute('aria-owns')).to.not.exist()
 
       await subject.setProps({ isShowingOptions: true })
       expect(input.getAttribute('aria-expanded')).to.equal('true')
       expect(input.getAttribute('aria-controls')).to.equal(
         list.getAttribute('id')
       )
-      expect(input.getAttribute('aria-owns')).to.equal(list.getAttribute('id'))
     })
 
     it('should set appropriate props based on highlightedOptionId', async () => {

--- a/packages/ui-selectable/src/Selectable/index.tsx
+++ b/packages/ui-selectable/src/Selectable/index.tsx
@@ -200,7 +200,6 @@ class Selectable extends Component<SelectableProps> {
             )!,
             'aria-haspopup': 'listbox',
             'aria-expanded': isShowingOptions,
-            'aria-owns': isShowingOptions ? this._listId : undefined,
             'aria-controls': isShowingOptions ? this._listId : undefined,
             'aria-describedby': this._descriptionId,
             'aria-activedescendant': isShowingOptions


### PR DESCRIPTION
`aria-owns` seems to be misused here. It rearranges the DOM seen by the screenreader, so the subtree owned by the element will be its child. Backport of https://github.com/instructure/instructure-ui/pull/1668

TEST PLAN:
Test all examples of Select, SimpleSelect, Selectable with keyboard navigation and VoiceOver. Test on mobile devices with TalkBack/VoiceOver and Windows too if possible