### PR TITLE
fix(ui-text-input): icon in SimpleSelect is vertically centered

### DIFF
--- a/packages/ui-text-input/src/TextInput/styles.ts
+++ b/packages/ui-text-input/src/TextInput/styles.ts
@@ -199,6 +199,8 @@ const generateStyle = (
       ...(!shouldNotWrap && { flexWrap: 'wrap' })
     },
     beforeElement: {
+      display: 'inline-flex',
+      alignItems: 'center',
       label: 'textInput__beforeElement',
       ...flexItemBase,
       paddingInlineStart: componentTheme.padding,


### PR DESCRIPTION
Closes: INSTUI-4226

TEST PLAN:

- copy the following code to the code editor of the documentation:
```
<SimpleSelect
  defaultValue="option-1"
  renderLabel="Option Icons"
  renderBeforeInput={<IconCommonsLine />}
>
  <SimpleSelect.Option id="opt1" value="option-1">
    Option one
  </SimpleSelect.Option>
</SimpleSelect>
```


- inspect the parent span of the svg element, and in Developer Tools>Styles, hover the mouse over align-items: center to check if the icon is vertically aligned
- previously the icon wasn't vertically centered
