### PR TITLE
fix(ui-radio-input): fixing the issue of TalkBack reading the radio g…

### DIFF
--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -161,6 +161,7 @@ class RadioInputGroup extends Component<
         startAt={variant === 'toggle' ? 'small' : undefined}
         messagesId={this._messagesId}
         elementRef={this.handleRef}
+        role="radiogroup"
       >
         {this.renderChildren()}
       </FormFieldGroup>


### PR DESCRIPTION
…rop options incorrectly

Closes: INSTUI-4231

The issue: if RadioInputButton is wrapped in a FormFieldGroup, Android TalkBack cannot read the numbering of the elements correctly, e.g. it keeps reading every option as "1 out of 3". FormFieldGroup puts on extra HTML elements, which may be introducing ambiguity for TalkBack reading the correct sequence of items in a radio group. 

TEST PLAN:

- check the 4th example of the RadioInputGroup in the documentation. TalkBack should read the numbering of the elements correctly now eg: "1 out of 3", "2 out of 3", "3 out of 3"
- check if the examples on the RadioInputGroup page are read correctly by other screenreaders.