### PR TITLE
fix(ui-calendar,ui-date-input): fix locale and timezone for simple api

### DIFF
--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -342,7 +342,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
   locale(): string {
     if (this.props.locale) {
       return this.props.locale
-    } else if (this.context && this.context.locale) {
+    } else if (this?.context?.locale) {
       return this.context.locale
     }
     return Locale.browserLocale()

--- a/packages/ui-date-input/src/DateInput/__new-tests__/DateInput.test.tsx
+++ b/packages/ui-date-input/src/DateInput/__new-tests__/DateInput.test.tsx
@@ -842,5 +842,31 @@ describe('<DateInput />', () => {
         expect(calendarDays).toHaveLength(42)
       })
     })
+    it('should change weekdays according to locale', async () => {
+      const onChange = jest.fn()
+      render(
+        <DateInput
+          renderLabel="Choose date"
+          assistiveText="Type a date or use arrow keys to navigate date picker."
+          width="20rem"
+          isInline
+          value={'2023-11-23'}
+          onChange={onChange}
+          currentDate="2023-12-23"
+          disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
+          disabledDateErrorMessage="disabled date"
+          invalidDateErrorMessage="invalid date"
+          locale="fr"
+        ></DateInput>
+      )
+      const dateInput = screen.getByLabelText('Choose date')
+
+      fireEvent.click(dateInput)
+
+      const frenchMonday = screen.getByText('lu')
+      await waitFor(() => {
+        expect(typeof frenchMonday).toBe('object')
+      })
+    })
   })
 })

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -341,6 +341,8 @@ class DateInput extends Component<DateInputProps, DateInputState> {
     const noChildrenProps = this.props.children
       ? {}
       : {
+          timezone: this.timezone(),
+          locale: this.locale(),
           disabledDates,
           currentDate,
           selectedDate: isValidDate ? value : undefined,

--- a/packages/ui-date-input/src/DateInput/index.tsx
+++ b/packages/ui-date-input/src/DateInput/index.tsx
@@ -265,7 +265,7 @@ class DateInput extends Component<DateInputProps, DateInputState> {
             this.timezone()
           )
             .subtract(1, 'day')
-            .format('MMMM D, YYYY')
+            .format('LL')
         })
         this.setState({ messages: [] })
       }
@@ -282,7 +282,7 @@ class DateInput extends Component<DateInputProps, DateInputState> {
             this.timezone()
           )
             .add(1, 'day')
-            .format('MMMM D, YYYY')
+            .format('LL')
         })
         this.setState({ messages: [] })
       }
@@ -354,9 +354,7 @@ class DateInput extends Component<DateInputProps, DateInputState> {
           ) => {
             // @ts-expect-error TODO
             onChange?.(e, {
-              value: `${momentDate.format('MMMM')} ${momentDate.format(
-                'D'
-              )}, ${momentDate.format('YYYY')}`
+              value: momentDate.format('LL')
             })
             this.handleHideCalendar(e, dateString)
           }


### PR DESCRIPTION
Closes: INSTUI-4236

Locale and timezone was not passed down to the calendar in "minimal configuration" mode.  Also fixes validation and formatting when locale has changed

TEST PLAN: pass locale to the `<DateInput local="fr"` and see if the weekdaylabels changed and different locale dates are validated correctly
