### PR TITLE
refactor(ui-test-locator,ui-test-queries): export types needed for locator functions

### DIFF
--- a/packages/__examples__/.storybook/stories/stories.ts
+++ b/packages/__examples__/.storybook/stories/stories.ts
@@ -84,6 +84,8 @@ const additionalExamples: AdditionalExample[] = [
   }
 ]
 
+// Note: require.context causes Webpack to have huge compile times (and often
+// fail with out of memory errors) when switching to `pnpm`
 const examplesContext = require.context(
   '../../../', // bug: This causes start:watch to recompile endlessly in SB 6.2+
   true,

--- a/packages/ui-test-locator/src/index.ts
+++ b/packages/ui-test-locator/src/index.ts
@@ -23,3 +23,20 @@
  */
 
 export { locator } from './utils/locator'
+
+// these types must be exported because they are used by the locator
+export type {
+  QueriesHelpersEventsType,
+  QueryTypes,
+  HelperTypes,
+  CutFirstArg,
+  EventMapTypes,
+  ObjWithCutFirstArg,
+  QueryArguments,
+  QueryFunction,
+  SelectorOptions,
+  FireEvent,
+  FireEventMethod,
+  FireEventInit,
+  AxeCheckOptions
+} from '@instructure/ui-test-queries'

--- a/packages/ui-test-locator/src/utils/locator.ts
+++ b/packages/ui-test-locator/src/utils/locator.ts
@@ -28,10 +28,12 @@ import {
   querySelectorAllWithin,
   firstOrNull
 } from '@instructure/ui-test-queries'
-import { SelectorOptions } from '@instructure/ui-test-queries/src/utils/selectors'
-import { QueryArguments } from '@instructure/ui-test-queries/src/utils/parseQueryArguments'
-import { QueriesHelpersEventsType } from '@instructure/ui-test-queries/src/utils/bindElementToUtilities'
-import { ObjWithCutFirstArg } from '@instructure/ui-test-queries/src/utils/bindElementToMethods'
+import type {
+  SelectorOptions,
+  QueryArguments,
+  QueriesHelpersEventsType,
+  ObjWithCutFirstArg
+} from '@instructure/ui-test-queries'
 
 export function locator<K, T extends Record<string, K>>(
   containerSelector: string,
@@ -84,10 +86,8 @@ export function locator<K, T extends Record<string, K>>(
     return find(element, `:withLabel("${selector}")`, options)
   }
 
-  const methods: Record<
-    keyof T,
-    (...args: QueryArguments) => Promise<K>
-  > = {} as any
+  const methods: Record<keyof T, (...args: QueryArguments) => Promise<K>> =
+    {} as any
   Object.keys(customMethods).forEach((methodKey: keyof T) => {
     methods[methodKey] = async (...args: QueryArguments) => {
       const { element, selector, options } = parseQueryArguments(...args)
@@ -110,3 +110,15 @@ export function locator<K, T extends Record<string, K>>(
     ...methods
   }
 }
+// these types must be exported because they are used by the query functions
+export type {
+  QueriesHelpersEventsType,
+  ObjWithCutFirstArg,
+  QueryArguments,
+  QueryFunction,
+  SelectorOptions,
+  FireEvent,
+  FireEventMethod,
+  FireEventInit,
+  AxeCheckOptions
+} from '@instructure/ui-test-queries'

--- a/packages/ui-test-queries/src/index.ts
+++ b/packages/ui-test-queries/src/index.ts
@@ -71,5 +71,17 @@ export {
   findFrame,
   debug
 }
-
-export type { QueriesHelpersEventsType } from './utils/bindElementToUtilities'
+// these types must be exported because they are used by the exported functions
+export type {
+  QueriesHelpersEventsType,
+  QueryTypes,
+  HelperTypes,
+  CutFirstArg
+} from './utils/bindElementToUtilities'
+export type { EventMapTypes } from './utils/bindElementToEvents'
+export type { ObjWithCutFirstArg } from './utils/bindElementToMethods'
+export type { QueryArguments } from './utils/parseQueryArguments'
+export type { QueryFunction } from './utils/queries'
+export type { SelectorOptions } from './utils/selectors'
+export type { FireEvent, FireEventMethod, FireEventInit } from './utils/events'
+export type { AxeCheckOptions } from '@instructure/ui-axe-check'

--- a/packages/ui-test-queries/src/utils/bindElementToUtilities.ts
+++ b/packages/ui-test-queries/src/utils/bindElementToUtilities.ts
@@ -38,11 +38,11 @@ export type CutFirstArg<F> = F extends (_: any, ...tail: infer TT) => infer R
   ? (...args: TT) => R
   : never
 
-type QueryTypes = {
-  [K in Extract<keyof typeof queries, string>]: typeof queries[K]
+export type QueryTypes = {
+  [K in Extract<keyof typeof queries, string>]: (typeof queries)[K]
 }
-type HelperTypes = {
-  [K in Extract<keyof typeof helpers, string>]: CutFirstArg<typeof helpers[K]>
+export type HelperTypes = {
+  [K in Extract<keyof typeof helpers, string>]: CutFirstArg<(typeof helpers)[K]>
 }
 
 export type QueriesHelpersEventsType = QueryTypes & HelperTypes & EventMapTypes

--- a/packages/ui-test-queries/src/utils/queries.ts
+++ b/packages/ui-test-queries/src/utils/queries.ts
@@ -24,13 +24,15 @@
 
 import { firstOrNull } from './firstOrNull'
 import { getQueryResult } from './queryResult'
-import { parseQueryArguments, QueryArguments } from './parseQueryArguments'
+import { parseQueryArguments } from './parseQueryArguments'
 import {
   querySelectorAll,
   querySelectorFrames,
-  querySelectorParents,
-  SelectorOptions
+  querySelectorParents
 } from './selectors'
+
+import type { QueryArguments } from './parseQueryArguments'
+import type { SelectorOptions } from './selectors'
 
 export type QueryFunction = (
   element: Element,


### PR DESCRIPTION
This is an early preparation to use `pnpm`. When migrating to it, TS compilation fails because it cannot infer the types of locator functions properly, likely if someone would use our locators they could not if they use `pnpm`

TEST PLAN:
Just check the code that its not exporting something that it should not have