### PR TITLE
fix(ui-pagination): fix pagination with numberinput when onBlur it calls  onPage change every time, even where there are no changes

### DIFF
--- a/packages/ui-pagination/src/Pagination/PaginationPageInput/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationPageInput/index.tsx
@@ -164,7 +164,9 @@ class PaginationPageInput extends Component<
   }
 
   handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    this.setNewPage(event, Math.round(this.state.number))
+    if (Math.round(this.state.number) !== this.currentPage) {
+      this.setNewPage(event, Math.round(this.state.number))
+    }
   }
 
   getNumberWithinRange(n: number) {


### PR DESCRIPTION
TEST_PLAN: check if on an input type Pagination with a simple config if the onPageChange callback fires when the input field is blurred, only if the value has actually changed
Closes: INSTUI-4239