### PR TITLE
fix(ui-progress,ui-side-nav-bar): improve a11y for Progress and SideNavBar examples

### DIFF
--- a/packages/ui-form-field/src/FormField/README.md
+++ b/packages/ui-form-field/src/FormField/README.md
@@ -9,7 +9,7 @@ components. In most cases it shouldn't be used directly.
 ---
 type: example
 ---
-<FormField id="foo" label="Opacity" width="200px">
-  <input style={{display: 'block', width: '100%'}}/>
+<FormField id="_foo123" label="Opacity" width="200px">
+  <input style={{display: 'block', width: '100%'}} id="_foo123"/>
 </FormField>
 ```

--- a/packages/ui-form-field/src/FormField/props.ts
+++ b/packages/ui-form-field/src/FormField/props.ts
@@ -36,7 +36,8 @@ import type { FormMessage } from '../FormPropTypes'
 type FormFieldOwnProps = {
   label: React.ReactNode
   /**
-   * the id of the input (to link it to its label for a11y)
+   * the id of the input (to link it to its label for a11y).
+   * Applied as the `for` HTML prop on the label.
    */
   id: string
   /**

--- a/packages/ui-progress/src/ProgressBar/README.md
+++ b/packages/ui-progress/src/ProgressBar/README.md
@@ -353,3 +353,14 @@ The `shouldAnimate` prop makes the progress bar animate the transition between v
 
   render(<Example />)
   ```
+
+```js
+---
+type: embed
+---
+<Guidelines>
+  <Figure recommendation="a11y" title="Accessibility">
+    <Figure.Item>If the progress bar conveys more information than just an approximate progress of a task (for example "5 or 23 items downloaded") then show this information as text too.</Figure.Item>
+  </Figure>
+</Guidelines>
+```

--- a/packages/ui-progress/src/ProgressCircle/README.md
+++ b/packages/ui-progress/src/ProgressCircle/README.md
@@ -206,3 +206,14 @@ type: example
   valueNow={33}
 />
 ```
+
+```js
+---
+type: embed
+---
+<Guidelines>
+  <Figure recommendation="a11y" title="Accessibility">
+    <Figure.Item>If the progress bar conveys more information than just an approximate progress of a task (for example "5 or 23 items downloaded") then show this information as text too.</Figure.Item>
+  </Figure>
+</Guidelines>
+```

--- a/packages/ui-side-nav-bar/src/SideNavBar/README.md
+++ b/packages/ui-side-nav-bar/src/SideNavBar/README.md
@@ -43,7 +43,15 @@ type: example
         href="#"
       />
       <SideNavBar.Item
-        icon={<Badge count={99}><IconInboxLine /></Badge>}
+        icon={<Badge count={99}
+                     formatOutput={function (formattedCount) {
+                       return (
+                         <AccessibleContent alt={`You have ${formattedCount} unread messages.`}>
+                           {formattedCount}
+                         </AccessibleContent>
+                       )
+                     }}
+        ><IconInboxLine /></Badge>}
         label="Inbox"
         href="#"
       />


### PR DESCRIPTION
Closes: INSTUI-4292, INSTUI-4283, INSTUI-4255

TEST PLAN:
Just check the new text and the associated INSTUI issue, with 4255 screen readers should read the label too in the example