### PR TITLE
chore: screenreaders incorrectly annouce header elements as main land…

### DIFF
--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -748,7 +748,6 @@ class App extends Component<AppProps, AppState> {
           <div
             css={this.props.styles?.content}
             aria-label={key || docsData.library.name}
-            role="main"
             ref={this.handleContentRef}
           >
             {!showMenu && (


### PR DESCRIPTION
…mark

Closes: INSTUI-4245

ISSUE:
Screen readers announce font page header section items as part of the main landmark, even though they are not within the main section of the page. The role="main" attribute was removed and there is already another role="main" referring to the main section of the front page.

TEST PLAN:
- open the main page of the documentation in Mac and Windows https://instructure.design/ with a screen reader
- start navigating through the page starting with the header section items (e.g. Open Navigation button, Search) using the Tab key
- screenreader should not announce header section elements as main landmark element (e.g. main landmark: open navigation button)