### PR TITLE
fix(ui-date-input): fix messages prop sometimes not populating in DateInput2

### DIFF
--- a/packages/ui-date-input/src/DateInput2/index.tsx
+++ b/packages/ui-date-input/src/DateInput2/index.tsx
@@ -183,8 +183,8 @@ const DateInput2 = ({
   const [showPopover, setShowPopover] = useState<boolean>(false)
 
   useEffect(() => {
-    // don't set input messages if there is an error set already
-    if (!inputMessages) {
+    // don't set input messages if there is an internal error set already
+    if (!inputMessages.length && !invalidDateErrorMessage) {
       setInputMessages(messages || [])
     }
   }, [messages])


### PR DESCRIPTION
test plan:

- check the custom validation example for dateinput2