### PR TITLE
chore: multiple navigation landmarks are removed from navigation panel

### DIFF
--- a/packages/__docs__/src/Nav/index.tsx
+++ b/packages/__docs__/src/Nav/index.tsx
@@ -449,7 +449,7 @@ class Nav extends Component<NavProps, NavState> {
             shouldNotWrap
           />
         </View>
-        <View role="navigation" margin="medium none none" display="block">
+        <View margin="medium none none" display="block">
           {hasMatches && matches}
         </View>
       </View>


### PR DESCRIPTION
Closes: INSTUI-4246

ISSUE:
On the main page, in the navigation panel, there are two navigation landmarks inside each other, which confuses users:

- a nav tag
- and a span with a role="navigation"

The role="navigation" was removed in accordance to LevelAccess' suggestion.

TEST PLAN:
- the menu starting with the "Getting started" option should not be announced as a navigation landmark.
