### PR TITLE
fix(ui-alerts): trigger onDismiss for SR-only alerts

### DIFF
--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -125,7 +125,10 @@ class Alert extends Component<AlertProps, AlertState> {
     this.clearTimeouts()
     this.removeScreenreaderAlert()
     this.setState({ open: false }, () => {
-      if (this.props.onDismiss && this.props.transition === 'none') {
+      if (
+        this.props.onDismiss &&
+        (this.props.transition === 'none' || this.props.screenReaderOnly)
+      ) {
         this.props.onDismiss()
       }
     })


### PR DESCRIPTION
- `onDismiss` was not being fired on `screenReaderOnly` alerts, unless `transition: 'none'` was specified alongside.

- Default transition value is `'fade'`. This change makes `screenReaderOnly` alerts an implicit `transition: 'none'` when executing `onDismiss`.

Credits for finding this bug: @meister245