### PR TITLE
fix(ui-tabs): tabpanel content is now accessible with keyboard naviga…

### DIFF
--- a/packages/ui-tabs/src/Tabs/Panel/index.tsx
+++ b/packages/ui-tabs/src/Tabs/Panel/index.tsx
@@ -108,6 +108,7 @@ class Panel extends Component<TabsPanelProps> {
         {...passthroughProps(props)}
         css={styles?.panel}
         role="tabpanel"
+        tabIndex={0}
         id={id}
         aria-labelledby={labelledBy}
         aria-hidden={this.isHidden ? 'true' : undefined}


### PR DESCRIPTION
…tion when it does not have focusable element

Closes: INSTUI-4294

ISUUE:
Tabpanel content in a Tab component is not accessible when tabpanel does not have focusable content (e.g. just plain text).

TEST PLAN:
On Mac with VoiceOver and Chrome/Safari:
- using the `Tab` key, go the Tab A of the first example in Tabs
- using the `Right Arrow Key`, navigate to Tab C, then press `Tab` to give focus to the tabpanel
- by pressing `Control + Option` and `Right Arrow` Key, start navigating through the tabpanel content
- **the tabpanel text should be read by VoiceOver**
- use `Shift + Tab` to return to Tab C in the tablist

On Windows with NVDA and Chrome/Firefox:
- keep pressing the `Tab` key, until you reach Tab A of the first example (blue rectagle is placed on Tab A) in Tabs
- using the `Right Arrow Key`, navigate to Tab C, then press `Tab` to give focus to the tabpanel
- **the tabpanel text should be read by NVDA**
- use `Shift + Tab` to return to Tab C in the tablist

On Windows with JAWS and Chrome/Firefox:
- keep pressing the `Tab` key, until you reach Tab A of the first example (red rectagle is placed on Tab A) in Tabs
- using the `Right Arrow Key`, navigate to Tab C, then press `Tab` to give focus to the tabpanel
- by pressing `Down Arrow Key`, start navigating through the tabpanel content
- **the tabpanel text should be read by JAWS**
- keep using `Down Arrow Key` until end of tab panel is announced then use `Shift + Tab` to return to Tab C in the tablist
