### PR TITLE
fix(ui-tree-browser): TreeBrowser collection descriptor is now read b…

### DIFF
--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/__tests__/TreeCollection.test.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/__tests__/TreeCollection.test.tsx
@@ -360,7 +360,9 @@ describe('<TreeCollection />', async () => {
       const collection = await TreeCollectionLocator.find()
       const childs = await collection.findAllItems()
       const childNameArr = childs.map((child) => {
-        return child.getDOMNode().ariaLabel
+        return child
+          .getDOMNode()
+          .querySelector('span[class$="treeButton__textName"]')?.textContent
       })
       expect(childNameArr.slice(1)).deep.equal([
         'A',
@@ -410,7 +412,9 @@ describe('<TreeCollection />', async () => {
       const collection = await TreeCollectionLocator.find()
       const childs = await collection.findAllItems()
       const childNameArr = childs.map((child) => {
-        return child.getDOMNode().ariaLabel
+        return child
+          .getDOMNode()
+          .querySelector('span[class$="treeButton__textName"]')?.textContent
       })
       expect(childNameArr.slice(1)).deep.equal([
         'Item A',

--- a/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
+++ b/packages/ui-tree-browser/src/TreeBrowser/TreeCollection/index.tsx
@@ -387,7 +387,9 @@ class TreeCollection extends Component<
         tabIndex={-1}
         /* eslint-disable-next-line jsx-a11y/role-has-required-aria-props */
         role="treeitem"
-        aria-label={this.props.name}
+        aria-label={`${this.props.name}${
+          this.props.descriptor ? ` ${this.props.descriptor}` : ''
+        }`}
         aria-level={level}
         aria-posinset={position}
         aria-setsize={this.props.numChildren}


### PR DESCRIPTION
…y screenreaders

Closes: INSTUI-4296

ISSUE:
When navigating through a TreeBrowser component, the descriptor of a collection is not read

TEST PLAN:

- In TreeBrowser page, go to the second example (Managing State) using the `Tab` key
- after reaching it, press `Control + Option + Shift + Down Arrow` (Mac) or `Down Arrow` (Windows) key to enter the tree
- **collections like "Math outcomes" and "Advanced Math" should be announced together with their respective descriptors (e.g. 1 Group 2 Outcomes, 1 Outcome)**