### PR TITLE
chore(ui-avatar,ui-source-code-editor): fix docs a11y issues

### DIFF
--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -759,6 +759,7 @@ class App extends Component<AppProps, AppState> {
                     renderIcon={IconHamburgerSolid}
                     screenReaderLabel="Open Navigation"
                     shape="circle"
+                    aria-expanded={false}
                   />
                 </InstUISettingsProvider>
               </div>

--- a/packages/__docs__/src/Header/index.tsx
+++ b/packages/__docs__/src/Header/index.tsx
@@ -70,10 +70,15 @@ class Header extends Component<HeaderProps> {
     // then navigate to the index (instructure.design/#currentHash).
     // In every other case eg.: v6,v7 navigate to --> instructure.design/v6/#currentHash
     // Add `ghPagesPrefix` if we are not on https://instructure.design/
-    const ghPagesPrefix = window.location.origin === 'https://instructure.github.io'
-      ? '/instructure-ui'
-      : ''
-    const versionToNavigate = `${ghPagesPrefix}/${isSelectedLatestVersion ? window.location.hash : `${selectedVersion}/${window.location.hash}`}`
+    const ghPagesPrefix =
+      window.location.origin === 'https://instructure.github.io'
+        ? '/instructure-ui'
+        : ''
+    const versionToNavigate = `${ghPagesPrefix}/${
+      isSelectedLatestVersion
+        ? window.location.hash
+        : `${selectedVersion}/${window.location.hash}`
+    }`
     return window.location.replace(versionToNavigate)
   }
 
@@ -93,11 +98,13 @@ class Header extends Component<HeaderProps> {
           trigger={
             <CondensedButton>
               <Text size="large">
-                {(name && version) ? (
+                {name && version ? (
                   <span>
                     {name} {version}
                   </span>
-                ) : 'Documentation'}
+                ) : (
+                  'Documentation'
+                )}
               </Text>
               <IconMiniArrowDownLine size="x-small" />
             </CondensedButton>
@@ -157,6 +164,7 @@ class Header extends Component<HeaderProps> {
           <Link href="#index" isWithinText={false} display="block">
             <View display="block" textAlign="center">
               {corpLogo}
+              <ScreenReaderContent>Instructure logo</ScreenReaderContent>
             </View>
           </Link>
           <View display="block" textAlign="center">

--- a/packages/__docs__/src/Hero/index.tsx
+++ b/packages/__docs__/src/Hero/index.tsx
@@ -291,7 +291,7 @@ class Hero extends Component<HeroProps> {
 
     const sidebarContent = (
       <View as="aside">
-        <View as="div" background="secondary" padding="large">
+        <View as="div">
           <Flex>
             <Flex.Item>
               <IconAnnouncementLine inline={false} size="small" />

--- a/packages/ui-avatar/src/Avatar/README.md
+++ b/packages/ui-avatar/src/Avatar/README.md
@@ -151,6 +151,10 @@ type: example
 </div>
 ```
 
+### Accessibility
+
+Avatars use the `aria-hidden="true"` property and therefore are hidden from screenreaders. Make sure if you are using them stand-alone it's accompanied with [ScreenReaderContent](#ScreenReaderContent).
+
 ### Guidelines
 
 ```js

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/README.md
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/README.md
@@ -229,20 +229,22 @@ class LanguageExamples extends React.Component {
         </Flex.Item>
 
         <Flex.Item padding="0 0 0 large" shouldGrow shouldShrink>
-          <SourceCodeEditor
-            label={`${this.state.currentLanguage} code editor`}
-            language={this.state.currentLanguage}
-            value={this.state.currentValue}
-            onChange={(value) => {
-              this.setState({
-                currentValue: value
-              })
-            }}
-            lineNumbers
-            lineWrapping
-            highlightActiveLine
-            highlightActiveLineGutter
-          />
+          <FormField label="SourceCodeEditor with syntax highlight">
+            <SourceCodeEditor
+              label={`${this.state.currentLanguage} code editor`}
+              language={this.state.currentLanguage}
+              value={this.state.currentValue}
+              onChange={(value) => {
+                this.setState({
+                  currentValue: value
+                })
+              }}
+              lineNumbers
+              lineWrapping
+              highlightActiveLine
+              highlightActiveLineGutter
+            />
+          </FormField>
         </Flex.Item>
       </Flex>
     )


### PR DESCRIPTION
INSTUI-4248
INSTUI-4249
INSTUI-4250
INSTUI-4270
INSTUI-4289

test plan:
- docs landing page "what's new" section now has white bg for better contrast
- docs side nav open button now have `aria-expanded="false` so screenreaders announce that it's closed
- added screen reader label to instructure logo in sidenav
- ui-avatar has `aria-hidden` -> this is now mentioned in the README
- source code editor example for syntax highlight now has a label