### PR TITLE
fix(many): border colors are adjusted to meet a11y contrast standards

### DIFF
--- a/packages/shared-types/src/Colors.ts
+++ b/packages/shared-types/src/Colors.ts
@@ -30,6 +30,7 @@ type Primitives = {
   grey12: string
   grey14: string
   grey24: string
+  grey30: string
   grey45: string
   grey57: string
   grey70: string
@@ -195,6 +196,7 @@ type Contrasts = {
   grey1214: Primitives['grey12'] | Primitives['grey14']
   grey1424: Primitives['grey14'] | Primitives['grey24']
   grey2424: Primitives['grey24']
+  grey3045: Primitives['grey30'] | Primitives['grey45']
   grey4570: Primitives['grey45'] | Primitives['grey70']
   grey5782: Primitives['grey57'] | Primitives['grey82']
   grey100100: Primitives['grey100']

--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -345,6 +345,8 @@ export type ToggleFacadeTheme = {
   labelFontSizeMedium: Typography['fontSizeMedium']
   labelFontSizeLarge: Typography['fontSizeLarge']
   errorBorderColor: Colors['contrasts']['red4570']
+  uncheckedIconBorderColor: Colors['contrasts']['grey3045']
+  checkedIconBorderColor: Colors['contrasts']['green5782']
 }
 
 export type CodeEditorTheme = {
@@ -536,6 +538,8 @@ export type DrilldownTheme = {
   headerTitleFontWeight: Typography['fontWeightBold']
   headerActionColor: Colors['contrasts']['blue4570']
   labelInfoPadding: Spacing['small']
+  labelInfoColor: Colors['contrasts']['grey5782']
+  borderColor: Colors['contrasts']['grey3045']
 }
 
 export type FileDropTheme = {
@@ -714,6 +718,7 @@ export type MenuItemTheme = {
   activeBackground: Colors['contrasts']['blue4570']
   activeLabelColor: Colors['contrasts']['white1010']
   activeIconColor: Colors['contrasts']['white1010']
+  labelInfoColor: Colors['contrasts']['grey5782']
 }
 
 export type MenuGroupTheme = {
@@ -962,6 +967,10 @@ export type PillTheme = {
   borderWidth: Border['widthSmall']
   borderStyle: Border['style']
   borderRadius: string | 0
+}
+
+export type PopoverTheme = {
+  borderColor: Colors['contrasts']['grey3045']
 }
 
 export type PositionTheme = {
@@ -1423,6 +1432,10 @@ export type ToggleDetailsTheme = {
   filledPadding: Spacing['small']
 }
 
+export type ToggleGroupTheme = {
+  borderColor: Colors['contrasts']['grey3045']
+}
+
 export type TooltipTheme = {
   fontFamily: Typography['fontFamily']
   fontWeight: Typography['fontWeightNormal']
@@ -1749,6 +1762,7 @@ export interface ThemeVariables {
   Pages: PagesTheme
   PaginationPageInput: PaginationPageInputTheme
   'Pagination.PageInput': PaginationPageInputTheme
+  Popover: PopoverTheme
   Position: PositionTheme
   Pill: PillTheme
   ProgressBar: ProgressBarTheme
@@ -1785,6 +1799,8 @@ export interface ThemeVariables {
   TextArea: TextAreaTheme
   TextInput: TextInputTheme
   ToggleDetails: ToggleDetailsTheme
+  ToggleGroup: ToggleGroupTheme
+  'ToggleDetails.ToggleGroup': ToggleGroupTheme
   Tooltip: TooltipTheme
   TopNavBarBrand: TopNavBarBrandTheme
   'TopNavBar.Brand': TopNavBarBrandTheme

--- a/packages/ui-avatar/src/Avatar/theme.ts
+++ b/packages/ui-avatar/src/Avatar/theme.ts
@@ -38,7 +38,7 @@ const generateComponentTheme = (theme: Theme): AvatarTheme => {
     background: colors?.contrasts?.white1010,
     borderWidthSmall: borders?.widthSmall,
     borderWidthMedium: borders?.widthMedium,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     boxShadowColor: alpha('#2d3b45', 12),
     boxShadowBlur: '1rem',
     fontFamily: typography?.fontFamily,

--- a/packages/ui-buttons/src/BaseButton/theme.ts
+++ b/packages/ui-buttons/src/BaseButton/theme.ts
@@ -39,18 +39,18 @@ const generateComponentTheme = (theme: Theme): BaseButtonTheme => {
   const themeSpecificStyle: ThemeSpecificStyle<BaseButtonTheme> = {
     canvas: {
       primaryColor: theme['ic-brand-button--primary-text']!,
-      primaryBorderColor: theme['ic-brand-button--primary-bgd']!,
+      primaryBorderColor: darken(theme['ic-brand-button--primary-bgd']!),
       primaryBackground: theme['ic-brand-button--primary-bgd']!,
       primaryHoverBackground: darken(theme['ic-brand-button--primary-bgd']!),
       primaryActiveBackground: darken(theme['ic-brand-button--primary-bgd']!),
       primaryActiveBoxShadow: `${activeShadow} ${theme[
         'ic-brand-button--primary-bgd'
       ]!}`,
-      primaryGhostColor: theme['ic-brand-button--primary-bgd']!,
-      primaryGhostBorderColor: theme['ic-brand-button--primary-bgd']!,
+      primaryGhostColor: darken(theme['ic-brand-button--primary-bgd']!),
+      primaryGhostBorderColor: darken(theme['ic-brand-button--primary-bgd']!),
       primaryGhostBackground: 'transparent',
       primaryGhostHoverBackground: alpha(
-        theme['ic-brand-button--primary-bgd']!,
+        darken(theme['ic-brand-button--primary-bgd']!),
         10
       ),
       primaryGhostActiveBackground: 'transparent',
@@ -104,10 +104,10 @@ const generateComponentTheme = (theme: Theme): BaseButtonTheme => {
     primaryHoverBackground: colors?.contrasts?.blue5782,
     primaryActiveBackground: colors?.contrasts?.blue5782,
     primaryActiveBoxShadow: `${activeShadow} ${colors?.contrasts?.white1010}`,
-    primaryGhostColor: colors?.contrasts?.blue4570,
+    primaryGhostColor: colors?.contrasts?.blue5782,
     primaryGhostBorderColor: colors?.contrasts?.blue4570,
     primaryGhostBackground: 'transparent',
-    primaryGhostHoverBackground: alpha(colors?.contrasts?.blue4570, 10),
+    primaryGhostHoverBackground: colors?.contrasts?.blue1212,
     primaryGhostActiveBackground: 'transparent',
     primaryGhostActiveBoxShadow: `${activeShadow} ${alpha(
       colors?.contrasts?.blue1212,
@@ -123,7 +123,7 @@ const generateComponentTheme = (theme: Theme): BaseButtonTheme => {
     secondaryGhostColor: colors?.contrasts?.grey125125,
     secondaryGhostBorderColor: colors?.contrasts?.grey125125,
     secondaryGhostBackground: 'transparent',
-    secondaryGhostHoverBackground: alpha(colors?.contrasts?.grey125125, 10),
+    secondaryGhostHoverBackground: colors?.contrasts?.grey1111,
     secondaryGhostActiveBackground: 'transparent',
     secondaryGhostActiveBoxShadow: `${activeShadow} ${alpha(
       colors?.contrasts?.grey125125,

--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
@@ -47,7 +47,7 @@ const generateComponentTheme = (theme: Theme): CheckboxFacadeTheme => {
   const componentVariables: CheckboxFacadeTheme = {
     color: colors?.contrasts?.white1010,
     borderWidth: borders?.widthSmall,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     errorBorderColor: colors?.ui?.textError,
     borderRadius: borders?.radiusMedium,
     background: colors?.contrasts?.white1010,

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.ts
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.ts
@@ -157,13 +157,16 @@ const generateStyle = (
       '&::before': {
         content: '""',
         position: 'absolute',
-        top: componentTheme.borderWidth,
-        left: componentTheme.borderWidth,
-        height: `calc(100% - (${componentTheme.borderWidth} * 2))`,
-        width: `calc(100% - (${componentTheme.borderWidth} * 2))`,
+        height: `calc(100% - (${componentTheme.borderWidth} * 6))`,
+        width: `calc(100% - (${componentTheme.borderWidth} * 6))`,
         background: componentTheme.toggleBackground,
         boxShadow: componentTheme.toggleShadow,
-        borderRadius: '100%'
+        borderRadius: '100%',
+        border: `${componentTheme.borderWidth} solid ${
+          checked
+            ? componentTheme.checkedIconBorderColor
+            : componentTheme.uncheckedIconBorderColor
+        }`
       }
     },
 

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
@@ -56,7 +56,7 @@ const generateComponentTheme = (theme: Theme): ToggleFacadeTheme => {
     color: colors?.contrasts?.white1010,
     errorBorderColor: colors?.ui?.textError,
     background: colors?.contrasts?.grey1111,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     borderWidth: borders?.widthSmall,
     borderRadius: '4rem',
     marginEnd: spacing?.small,
@@ -64,7 +64,7 @@ const generateComponentTheme = (theme: Theme): ToggleFacadeTheme => {
     marginVertical: spacing?.xSmall,
     checkedBackground: colors?.contrasts?.green4570,
     uncheckedIconColor: colors?.contrasts?.grey125125,
-    checkedIconColor: colors?.contrasts?.green4570,
+    checkedIconColor: colors?.contrasts?.green5782,
     focusOutlineColor: colors?.contrasts?.blue4570,
     focusBorderWidth: borders?.widthMedium,
     focusBorderStyle: borders?.style,
@@ -77,7 +77,9 @@ const generateComponentTheme = (theme: Theme): ToggleFacadeTheme => {
     labelLineHeight: typography?.lineHeightCondensed,
     labelFontSizeSmall: typography?.fontSizeSmall,
     labelFontSizeMedium: typography?.fontSizeMedium,
-    labelFontSizeLarge: typography?.fontSizeLarge
+    labelFontSizeLarge: typography?.fontSizeLarge,
+    uncheckedIconBorderColor: colors?.contrasts?.grey5782,
+    checkedIconBorderColor: colors?.contrasts?.green5782
   }
 
   return {

--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -1377,6 +1377,7 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
           getDisabledOptionProps
         }) => (
           <View
+            borderWidth="small"
             as="div"
             elementRef={this.handleDrilldownRef}
             tabIndex={0}

--- a/packages/ui-drilldown/src/Drilldown/theme.ts
+++ b/packages/ui-drilldown/src/Drilldown/theme.ts
@@ -36,7 +36,9 @@ const generateComponentTheme = (theme: Theme): DrilldownTheme => {
   const componentVariables: DrilldownTheme = {
     headerTitleFontWeight: typography.fontWeightBold,
     headerActionColor: colors?.contrasts?.blue4570,
-    labelInfoPadding: spacing?.small
+    labelInfoPadding: spacing?.small,
+    labelInfoColor: colors?.contrasts?.grey5782,
+    borderColor: colors?.contrasts?.grey3045
   }
 
   return {

--- a/packages/ui-menu/src/Menu/MenuItem/styles.ts
+++ b/packages/ui-menu/src/Menu/MenuItem/styles.ts
@@ -143,7 +143,8 @@ const generateStyle = (
       height: '100%',
       float: 'right',
       clear: 'right',
-      paddingRight: '1.75rem'
+      paddingRight: '1.75rem',
+      color: componentTheme.labelInfoColor
     },
     label: {
       label: 'menuItem__label',

--- a/packages/ui-menu/src/Menu/MenuItem/theme.ts
+++ b/packages/ui-menu/src/Menu/MenuItem/theme.ts
@@ -58,7 +58,9 @@ const generateComponentTheme = (theme: Theme): MenuItemTheme => {
 
     activeBackground: colors?.contrasts?.blue4570,
     activeLabelColor: colors?.contrasts?.white1010,
-    activeIconColor: colors?.contrasts?.white1010
+    activeIconColor: colors?.contrasts?.white1010,
+
+    labelInfoColor: colors?.contrasts?.grey5782
   }
 
   return {

--- a/packages/ui-number-input/src/NumberInput/theme.ts
+++ b/packages/ui-number-input/src/NumberInput/theme.ts
@@ -47,7 +47,7 @@ const generateComponentTheme = (theme: Theme): NumberInputTheme => {
 
     borderWidth: borders?.widthSmall,
     borderStyle: borders?.style,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     borderRadius: borders?.radiusMedium,
 
     color: colors?.contrasts?.grey125125,

--- a/packages/ui-options/src/Options/Item/theme.ts
+++ b/packages/ui-options/src/Options/Item/theme.ts
@@ -64,7 +64,7 @@ const generateComponentTheme = (theme: Theme): OptionsItemTheme => {
     descriptionFontWeight: typography.fontWeightNormal,
     descriptionLineHeight: typography.lineHeight,
     descriptionPaddingStart: '0.25em',
-    descriptionColor: colors?.contrasts?.grey4570
+    descriptionColor: colors?.contrasts?.grey5782
   }
 
   return {

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -55,10 +55,14 @@ import type { ViewProps, ContextViewProps } from '@instructure/ui-view'
 import type { PositionProps } from '@instructure/ui-position'
 import type { DialogProps } from '@instructure/ui-dialog'
 
+import { withStyle } from '@instructure/emotion'
+
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
+
 import type { PopoverProps, PopoverState } from './props'
 import { allowedProps, propTypes } from './props'
 import type { Renderable } from '@instructure/shared-types'
-
 /**
 ---
 category: components
@@ -67,6 +71,7 @@ tags: overlay, portal, dialog
 **/
 @withDeterministicId()
 @textDirectionContextConsumer()
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Popover extends Component<PopoverProps, PopoverState> {
   static readonly componentId = 'Popover'
@@ -558,6 +563,7 @@ class Popover extends Component<PopoverProps, PopoverState> {
       }
 
       const { placement } = this.state
+      const { styles } = this.props
 
       if (this.props.withArrow) {
         viewProps = {
@@ -570,7 +576,11 @@ class Popover extends Component<PopoverProps, PopoverState> {
               : placement
         } as Partial<ContextViewProps> & { ref: any }
 
-        return <ContextView {...viewProps}>{content}</ContextView>
+        return (
+          <ContextView {...viewProps} borderColor={styles?.borderColor}>
+            {content}
+          </ContextView>
+        )
       } else {
         viewProps = {
           ...viewProps,
@@ -579,7 +589,11 @@ class Popover extends Component<PopoverProps, PopoverState> {
           ...(color === 'primary-inverse' && { borderColor: 'transparent' })
         } as Partial<ViewProps> & { ref: any }
 
-        return <View {...viewProps}>{content}</View>
+        return (
+          <View {...viewProps} borderColor={styles?.borderColor}>
+            {content}
+          </View>
+        )
       }
     } else {
       return null

--- a/packages/ui-popover/src/Popover/props.ts
+++ b/packages/ui-popover/src/Popover/props.ts
@@ -28,7 +28,7 @@ import { element } from '@instructure/ui-prop-types'
 import { ThemeablePropTypes } from '@instructure/emotion'
 import { PositionPropTypes } from '@instructure/ui-position'
 
-import type { Shadow, Stacking } from '@instructure/emotion'
+import type { Shadow, Stacking, WithStyleProps } from '@instructure/emotion'
 
 import type {
   PlacementPropValues,
@@ -41,7 +41,8 @@ import type {
   PropValidators,
   LiveRegion,
   UIElement,
-  Renderable
+  Renderable,
+  PopoverTheme
 } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
@@ -278,7 +279,8 @@ type PopoverOwnProps = {
 
 type PopoverProps = PopoverOwnProps &
   TextDirectionContextConsumerProps &
-  WithDeterministicIdProps
+  WithDeterministicIdProps &
+  WithStyleProps<PopoverTheme, PopoverStyle>
 
 type PopoverState = {
   placement: PopoverOwnProps['placement']
@@ -290,6 +292,8 @@ type PopoverState = {
 type PropKeys = keyof PopoverOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
+
+type PopoverStyle = { borderColor: string }
 
 const propTypes: PropValidators<PropKeys> = {
   isShowingContent: PropTypes.bool,
@@ -388,5 +392,5 @@ const allowedProps: AllowedPropKeys = [
   'elementRef'
 ]
 
-export type { PopoverOwnProps, PopoverProps, PopoverState }
+export type { PopoverOwnProps, PopoverProps, PopoverState, PopoverStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-popover/src/Popover/styles.ts
+++ b/packages/ui-popover/src/Popover/styles.ts
@@ -22,12 +22,8 @@
  * SOFTWARE.
  */
 
-import type { DrilldownTheme } from '@instructure/shared-types'
-import type {
-  DrilldownProps,
-  DrilldownStyleProps,
-  DrilldownStyle
-} from './props'
+import type { PopoverTheme } from '@instructure/shared-types'
+import type { PopoverStyle } from './props'
 
 /**
  * ---
@@ -39,58 +35,9 @@ import type {
  * @param  {Object} state the state of the component, the style is applied to
  * @return {Object} The final style object, which will be used in the component
  */
-const generateStyle = (
-  componentTheme: DrilldownTheme,
-  _props: DrilldownProps,
-  state: DrilldownStyleProps
-): DrilldownStyle => {
-  const { hasHighlightedOption } = state
-
+const generateStyle = (componentTheme: PopoverTheme): PopoverStyle => {
   return {
-    drilldown: {
-      label: 'drilldown',
-      overflow: 'visible', // needed for focus ring!
-      borderColor: componentTheme.borderColor,
-
-      ...(hasHighlightedOption && {
-        '&:focus::before': {
-          display: 'none'
-        }
-      })
-    },
-    container: {
-      label: 'drilldown__container'
-    },
-    headerBack: {
-      label: 'drilldown__headerBack',
-      minHeight: '1.25em'
-    },
-    headerTitle: {
-      label: 'drilldown__headerTitle',
-      fontWeight: componentTheme.headerTitleFontWeight
-    },
-    optionContainer: {
-      label: 'drilldown__optionContainer',
-      alignItems: 'center',
-      display: 'flex',
-      height: '100%'
-    },
-    optionLabelInfo: {
-      label: 'drilldown__optionLabelInfo',
-      display: 'flex',
-      flexShrink: 0,
-      height: '100%',
-      alignItems: 'center',
-      paddingInlineStart: componentTheme.labelInfoPadding,
-      color: componentTheme.labelInfoColor
-    },
-    optionContent: {
-      label: 'drilldown__optionContent',
-      flexGrow: 1
-    },
-
-    // we use it in the index file
-    headerActionColor: componentTheme.headerActionColor
+    borderColor: componentTheme.borderColor
   }
 }
 

--- a/packages/ui-popover/src/Popover/theme.ts
+++ b/packages/ui-popover/src/Popover/theme.ts
@@ -23,39 +23,21 @@
  */
 
 import type { Theme } from '@instructure/ui-themes'
-import { TableColHeaderTheme } from '@instructure/shared-types'
+import { PopoverTheme } from '@instructure/shared-types'
 
 /**
  * Generates the theme object for the component from the theme and provided additional information
  * @param  {Object} theme The actual theme object.
  * @return {Object} The final theme object with the overrides and component variables
  */
-const generateComponentTheme = (theme: Theme): TableColHeaderTheme => {
-  const { typography, colors, borders, spacing } = theme
+const generateComponentTheme = (theme: Theme): PopoverTheme => {
+  const { colors } = theme
 
-  const componentVariables: TableColHeaderTheme = {
-    fontSize: typography?.fontSizeMedium,
-    fontFamily: typography?.fontFamily,
-
-    color: colors?.contrasts?.grey125125,
-    background: colors?.contrasts?.white1010,
-
-    borderColor: colors?.contrasts?.grey1214,
-
-    lineHeight: typography?.lineHeightCondensed,
-    padding: `${spacing?.xSmall} ${spacing?.small}`,
-
-    focusOutlineColor: colors?.contrasts?.blue4570,
-    focusOutlineWidth: borders?.widthMedium,
-    focusOutlineStyle: borders?.style,
-
-    unSortedIconColor: colors?.contrasts?.grey3045,
-    sortedIconColor: colors?.contrasts?.blue4570
+  const componentVariables: PopoverTheme = {
+    borderColor: colors?.contrasts?.grey3045
   }
-
   return {
     ...componentVariables
   }
 }
-
 export default generateComponentTheme

--- a/packages/ui-progress/src/ProgressBar/theme.ts
+++ b/packages/ui-progress/src/ProgressBar/theme.ts
@@ -93,7 +93,7 @@ const generateComponentTheme = (theme: Theme): ProgressBarTheme => {
     trackColor: colors?.contrasts?.white1010,
     trackColorInverse: 'transparent',
     trackBottomBorderWidth: borders?.widthSmall,
-    trackBottomBorderColor: colors?.contrasts?.grey1214,
+    trackBottomBorderColor: colors?.contrasts?.grey3045,
     trackBottomBorderColorInverse: colors?.contrasts?.white1010
   }
 

--- a/packages/ui-progress/src/ProgressCircle/theme.ts
+++ b/packages/ui-progress/src/ProgressCircle/theme.ts
@@ -126,7 +126,7 @@ const generateComponentTheme = (theme: Theme): ProgressCircleTheme => {
     trackColor: colors?.contrasts?.white1010,
     trackColorInverse: 'transparent',
 
-    trackBorderColor: colors?.contrasts?.grey125125,
+    trackBorderColor: colors?.contrasts?.grey3045,
     trackBorderColorInverse: colors?.contrasts?.white1010,
 
     // variables are split out for inverse to allow

--- a/packages/ui-radio-input/src/RadioInput/theme.ts
+++ b/packages/ui-radio-input/src/RadioInput/theme.ts
@@ -60,7 +60,7 @@ const generateComponentTheme = (theme: Theme): RadioInputTheme => {
 
     background: colors?.contrasts?.white1010,
     borderWidth: borders?.widthSmall,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     hoverBorderColor: colors?.contrasts?.grey125125,
     controlSize: '0.1875rem',
 

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/theme.ts
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/theme.ts
@@ -40,7 +40,7 @@ const generateComponentTheme = (theme: Theme): SourceCodeEditorTheme => {
     color: colors?.contrasts?.grey125125,
     gutterBackground: colors?.contrasts?.grey1111,
     borderWidth: borders?.widthSmall,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     borderRadius: borders?.radiusMedium,
     focusBorderColor: colors?.contrasts?.blue4570,
     horizontalPadding: spacing?.xSmall,

--- a/packages/ui-table/src/Table/Row/theme.ts
+++ b/packages/ui-table/src/Table/Row/theme.ts
@@ -47,7 +47,7 @@ const generateComponentTheme = (theme: Theme): TableRowTheme => {
     color: colors?.contrasts?.grey125125,
     background: colors?.contrasts?.white1010,
 
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     hoverBorderColor: colors?.contrasts?.blue4570,
 
     padding: `${spacing?.xSmall} 0`

--- a/packages/ui-tabs/src/Tabs/Panel/theme.ts
+++ b/packages/ui-tabs/src/Tabs/Panel/theme.ts
@@ -46,7 +46,7 @@ const generateComponentTheme = (theme: Theme): TabsPanelTheme => {
     lineHeight: typography?.lineHeight,
     color: colors?.contrasts?.grey125125,
     background: colors?.contrasts?.white1010,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     borderWidth: borders?.widthSmall,
     borderStyle: borders?.style,
     defaultOverflowY: 'auto'

--- a/packages/ui-tabs/src/Tabs/Tab/theme.ts
+++ b/packages/ui-tabs/src/Tabs/Tab/theme.ts
@@ -54,7 +54,7 @@ const generateComponentTheme = (theme: Theme): TabsTabTheme => {
 
     secondaryColor: colors?.contrasts?.grey125125,
     secondarySelectedBackground: colors?.contrasts?.white1010,
-    secondarySelectedBorderColor: colors?.contrasts?.grey1214,
+    secondarySelectedBorderColor: colors?.contrasts?.grey3045,
 
     zIndex: stacking?.above
   }

--- a/packages/ui-text-area/src/TextArea/theme.ts
+++ b/packages/ui-text-area/src/TextArea/theme.ts
@@ -51,10 +51,10 @@ const generateComponentTheme = (theme: Theme): TextAreaTheme => {
 
     borderWidth: borders?.widthSmall,
     borderStyle: borders?.style,
-    borderTopColor: colors?.contrasts?.grey1214,
-    borderRightColor: colors?.contrasts?.grey1214,
-    borderBottomColor: colors?.contrasts?.grey1214,
-    borderLeftColor: colors?.contrasts?.grey1214,
+    borderTopColor: colors?.contrasts?.grey3045,
+    borderRightColor: colors?.contrasts?.grey3045,
+    borderBottomColor: colors?.contrasts?.grey3045,
+    borderLeftColor: colors?.contrasts?.grey3045,
     borderRadius: borders?.radiusMedium,
 
     padding: spacing?.small,

--- a/packages/ui-text-input/src/TextInput/theme.ts
+++ b/packages/ui-text-input/src/TextInput/theme.ts
@@ -46,7 +46,7 @@ const generateComponentTheme = (theme: Theme): TextInputTheme => {
 
     borderWidth: borders?.widthSmall,
     borderStyle: borders?.style,
-    borderColor: colors?.contrasts?.grey1214,
+    borderColor: colors?.contrasts?.grey3045,
     borderRadius: borders?.radiusMedium,
 
     color: colors?.contrasts?.grey125125,

--- a/packages/ui-themes/src/sharedThemeTokens/colors/primitives.ts
+++ b/packages/ui-themes/src/sharedThemeTokens/colors/primitives.ts
@@ -32,6 +32,7 @@ export const primitives: Primitives = {
   grey12: '#E8EAEC',
   grey14: '#D7DADE',
   grey24: '#9EA6AD',
+  grey30: '#8D959F',
   grey45: '#6A7883',
   grey57: '#586874',
   grey70: '#4A5B68',

--- a/packages/ui-themes/src/themes/canvas/colors.ts
+++ b/packages/ui-themes/src/themes/canvas/colors.ts
@@ -39,6 +39,7 @@ const contrasts: Contrasts = {
   grey1214: primitives.grey12,
   grey1424: primitives.grey14,
   grey2424: primitives.grey24,
+  grey3045: primitives.grey30,
   grey4570: primitives.grey45,
   grey5782: primitives.grey57,
   grey100100: primitives.grey100,

--- a/packages/ui-themes/src/themes/canvasHighContrast/colors.ts
+++ b/packages/ui-themes/src/themes/canvasHighContrast/colors.ts
@@ -39,6 +39,7 @@ const contrasts: Contrasts = {
   grey1214: primitives.grey14,
   grey1424: primitives.grey24,
   grey2424: primitives.grey24,
+  grey3045: primitives.grey45,
   grey4570: primitives.grey70,
   grey5782: primitives.grey82,
   grey100100: primitives.grey100,

--- a/packages/ui-toggle-details/src/ToggleGroup/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleGroup/index.tsx
@@ -45,11 +45,17 @@ import { testable } from '@instructure/ui-testable'
 import type { ToggleGroupProps } from './props'
 import { allowedProps, propTypes } from './props'
 
+import { withStyle } from '@instructure/emotion'
+
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
+
 /**
 ---
 category: components
 ---
 **/
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class ToggleGroup extends Component<ToggleGroupProps> {
   static readonly componentId = 'ToggleGroup'
@@ -97,6 +103,10 @@ class ToggleGroup extends Component<ToggleGroupProps> {
     this._shouldTransition = true
   }
 
+  componentDidUpdate() {
+    this.props.makeStyles?.(this.state)
+  }
+
   renderIcon(expanded: boolean) {
     const Icon = expanded ? this.props.iconExpanded : this.props.icon
     return Icon ? callRenderProp(Icon) : null
@@ -130,11 +140,13 @@ class ToggleGroup extends Component<ToggleGroupProps> {
   }
 
   renderDetails(detailsProps: { id: string }) {
+    const { styles } = this.props
     return (
       <View
         {...detailsProps}
         display="block"
         borderWidth="small none none none"
+        borderColor={styles?.borderColor}
       >
         {this.props.transition && this._shouldTransition ? (
           <Transition transitionOnMount in type="fade">
@@ -149,7 +161,7 @@ class ToggleGroup extends Component<ToggleGroupProps> {
 
   render() {
     const Element = getElementType(ToggleGroup, this.props)
-
+    const { styles } = this.props
     return (
       <Expandable {...pickProps(this.props, Expandable.allowedProps)}>
         {({ expanded, getToggleProps, getDetailsProps }) => {
@@ -162,6 +174,7 @@ class ToggleGroup extends Component<ToggleGroupProps> {
               display="block"
               borderRadius="medium"
               background="primary"
+              borderColor={styles?.borderColor}
             >
               <Flex
                 padding={

--- a/packages/ui-toggle-details/src/ToggleGroup/props.ts
+++ b/packages/ui-toggle-details/src/ToggleGroup/props.ts
@@ -31,8 +31,11 @@ import {
   AsElementType,
   OtherHTMLAttributes,
   PropValidators,
-  Renderable
+  Renderable,
+  ToggleGroupTheme
 } from '@instructure/shared-types'
+
+import type { WithStyleProps } from '@instructure/emotion'
 
 type ToggleGroupOwnProps = {
   /**
@@ -91,8 +94,11 @@ type PropKeys = keyof ToggleGroupOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
+type ToggleGroupStyle = { borderColor: string }
+
 type ToggleGroupProps = ToggleGroupOwnProps &
-  OtherHTMLAttributes<ToggleGroupOwnProps>
+  OtherHTMLAttributes<ToggleGroupOwnProps> &
+  WithStyleProps<ToggleGroupTheme, ToggleGroupStyle>
 
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node.isRequired,
@@ -126,5 +132,5 @@ const allowedProps: AllowedPropKeys = [
   'border'
 ]
 
-export type { ToggleGroupProps }
+export type { ToggleGroupProps, ToggleGroupStyle }
 export { propTypes, allowedProps }

--- a/packages/ui-toggle-details/src/ToggleGroup/styles.ts
+++ b/packages/ui-toggle-details/src/ToggleGroup/styles.ts
@@ -22,12 +22,8 @@
  * SOFTWARE.
  */
 
-import type { DrilldownTheme } from '@instructure/shared-types'
-import type {
-  DrilldownProps,
-  DrilldownStyleProps,
-  DrilldownStyle
-} from './props'
+import type { ToggleGroupTheme } from '@instructure/shared-types'
+import type { ToggleGroupProps, ToggleGroupStyle } from './props'
 
 /**
  * ---
@@ -40,57 +36,11 @@ import type {
  * @return {Object} The final style object, which will be used in the component
  */
 const generateStyle = (
-  componentTheme: DrilldownTheme,
-  _props: DrilldownProps,
-  state: DrilldownStyleProps
-): DrilldownStyle => {
-  const { hasHighlightedOption } = state
-
+  componentTheme: ToggleGroupTheme,
+  _props: ToggleGroupProps
+): ToggleGroupStyle => {
   return {
-    drilldown: {
-      label: 'drilldown',
-      overflow: 'visible', // needed for focus ring!
-      borderColor: componentTheme.borderColor,
-
-      ...(hasHighlightedOption && {
-        '&:focus::before': {
-          display: 'none'
-        }
-      })
-    },
-    container: {
-      label: 'drilldown__container'
-    },
-    headerBack: {
-      label: 'drilldown__headerBack',
-      minHeight: '1.25em'
-    },
-    headerTitle: {
-      label: 'drilldown__headerTitle',
-      fontWeight: componentTheme.headerTitleFontWeight
-    },
-    optionContainer: {
-      label: 'drilldown__optionContainer',
-      alignItems: 'center',
-      display: 'flex',
-      height: '100%'
-    },
-    optionLabelInfo: {
-      label: 'drilldown__optionLabelInfo',
-      display: 'flex',
-      flexShrink: 0,
-      height: '100%',
-      alignItems: 'center',
-      paddingInlineStart: componentTheme.labelInfoPadding,
-      color: componentTheme.labelInfoColor
-    },
-    optionContent: {
-      label: 'drilldown__optionContent',
-      flexGrow: 1
-    },
-
-    // we use it in the index file
-    headerActionColor: componentTheme.headerActionColor
+    borderColor: componentTheme.borderColor
   }
 }
 

--- a/packages/ui-toggle-details/src/ToggleGroup/theme.ts
+++ b/packages/ui-toggle-details/src/ToggleGroup/theme.ts
@@ -23,39 +23,21 @@
  */
 
 import type { Theme } from '@instructure/ui-themes'
-import { TableColHeaderTheme } from '@instructure/shared-types'
+import { ToggleGroupTheme } from '@instructure/shared-types'
 
 /**
  * Generates the theme object for the component from the theme and provided additional information
  * @param  {Object} theme The actual theme object.
  * @return {Object} The final theme object with the overrides and component variables
  */
-const generateComponentTheme = (theme: Theme): TableColHeaderTheme => {
-  const { typography, colors, borders, spacing } = theme
+const generateComponentTheme = (theme: Theme): ToggleGroupTheme => {
+  const { colors } = theme
 
-  const componentVariables: TableColHeaderTheme = {
-    fontSize: typography?.fontSizeMedium,
-    fontFamily: typography?.fontFamily,
-
-    color: colors?.contrasts?.grey125125,
-    background: colors?.contrasts?.white1010,
-
-    borderColor: colors?.contrasts?.grey1214,
-
-    lineHeight: typography?.lineHeightCondensed,
-    padding: `${spacing?.xSmall} ${spacing?.small}`,
-
-    focusOutlineColor: colors?.contrasts?.blue4570,
-    focusOutlineWidth: borders?.widthMedium,
-    focusOutlineStyle: borders?.style,
-
-    unSortedIconColor: colors?.contrasts?.grey3045,
-    sortedIconColor: colors?.contrasts?.blue4570
+  const componentVariables: ToggleGroupTheme = {
+    borderColor: colors?.contrasts?.grey3045
   }
-
   return {
     ...componentVariables
   }
 }
-
 export default generateComponentTheme

--- a/packages/ui-view/src/ContextView/props.ts
+++ b/packages/ui-view/src/ContextView/props.ts
@@ -74,7 +74,10 @@ type ContextViewProps = ContextViewOwnProps &
 
 type ContextViewStyle = ComponentStyle<
   'contextView' | 'contextView__content' | 'contextView__arrow'
-> & { arrowSize: string | 0; arrowBorderWidth: string | 0 }
+> & {
+  arrowSize: string | 0
+  arrowBorderWidth: string | 0
+}
 
 const propTypes: PropValidators<PropKeys> = {
   /**

--- a/packages/ui-view/src/ContextView/styles.ts
+++ b/packages/ui-view/src/ContextView/styles.ts
@@ -308,9 +308,7 @@ const generateStyle = (
       ...arrowBaseStyles,
       display: 'block',
       borderWidth: `calc(${componentTheme?.arrowSize} + ${componentTheme?.arrowBorderWidth})`,
-      borderColor:
-        borderColor ||
-        arrowBackGroundVariants[background!],
+      borderColor: borderColor || arrowBackGroundVariants[background!],
       ...arrowPlacementVariant.main,
       ...getArrowCorrections(placement!, componentTheme),
       '&::after': {

--- a/packages/ui-view/src/ContextView/styles.ts
+++ b/packages/ui-view/src/ContextView/styles.ts
@@ -308,7 +308,9 @@ const generateStyle = (
       ...arrowBaseStyles,
       display: 'block',
       borderWidth: `calc(${componentTheme?.arrowSize} + ${componentTheme?.arrowBorderWidth})`,
-      borderColor: borderColor || arrowBackGroundVariants[background!],
+      borderColor:
+        borderColor ||
+        arrowBackGroundVariants[background!],
       ...arrowPlacementVariant.main,
       ...getArrowCorrections(placement!, componentTheme),
       '&::after': {


### PR DESCRIPTION
Closes: INSTUI-4319

TEST PLAN:
- please check if all the necessary adjustments were made (except Drilldown/Menu/MenuItem selected row background color and ColorPicker IconButton border color - these will be moved to a new pull request): https://www.figma.com/design/8Ai2uBfoktyApNWHMBZFMu/%E2%9C%85-%5BDelivered%5D-Required%2C-error%2C-A11y-handover?node-id=1-2094&node-type=canvas&t=NuZAJJEIZDK8MBgS-0
- check if colors are changed in 'canvas-high-contrast' theme in the docs
