### PR TITLE
INSTUI-4241: fix(ui-toggle-details): do not put aria-expanded and aria-controls on  the toggle if there is nothing to toggle

### DIFF
--- a/packages/ui-expandable/src/Expandable/README.md
+++ b/packages/ui-expandable/src/Expandable/README.md
@@ -3,4 +3,30 @@ describes: Expandable
 ---
 
 `Expandable` handles the show/hide functionality for both [`ToggleDetails`](#ToggleDetails)
-and [`ToggleGroup`](#ToggleGroup).
+and [`ToggleGroup`](#ToggleGroup). `getToggleProps` and `getDetailsProps` are needed for the component to function properly, these add necessary ARIA tags and event listeners.
+
+### Basic example
+
+```javascript
+---
+type: example
+---
+<Expandable onToggle={(event, expanded) => console.log(event, expanded)}>
+  {({ expanded, getToggleProps, getDetailsProps }) => {
+    return (
+      <div>
+        <Button margin="small 0"
+                {...getToggleProps()}
+                display="block"
+                textAlign="start"
+        >
+          I am expanded? {expanded.toString()}
+        </Button>
+        {expanded ? <div {...getDetailsProps()}>
+          This is the content that will display under the Expandable
+        </div> : null}
+      </div>
+    )
+  }}
+</Expandable>
+```

--- a/packages/ui-expandable/src/Expandable/index.tsx
+++ b/packages/ui-expandable/src/Expandable/index.tsx
@@ -43,9 +43,7 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
   static propTypes = propTypes
   static allowedProps = allowedProps
   static defaultProps = {
-    defaultExpanded: false,
-    onToggle: function () {},
-    children: null
+    defaultExpanded: false
   }
 
   _contentId: string
@@ -92,7 +90,7 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
     if (!this.isControlled()) {
       this.setState(toggleExpanded)
     }
-    this.props.onToggle(event, !this.expanded)
+    this.props.onToggle?.(event, !this.expanded)
   }
 
   render() {
@@ -101,15 +99,12 @@ class Expandable extends Component<ExpandableProps, ExpandableState> {
     if (typeof render === 'function') {
       return render({
         expanded: this.expanded,
-        getToggleProps: (props = {} as any) => {
+        getToggleProps: (props = {}) => {
           return {
+            ...props,
             'aria-controls': this._contentId,
             'aria-expanded': this.expanded,
-            onClick: createChainedFunction(
-              this.handleToggle,
-              props.onClick
-            ) as React.MouseEventHandler,
-            ...props
+            onClick: createChainedFunction(this.handleToggle, props.onClick)!
           }
         },
         getDetailsProps: () => {

--- a/packages/ui-expandable/src/Expandable/props.ts
+++ b/packages/ui-expandable/src/Expandable/props.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React from 'react'
+import React, { JSX } from 'react'
 import PropTypes from 'prop-types'
 
 import { controllable } from '@instructure/ui-prop-types'
@@ -30,17 +30,18 @@ import { controllable } from '@instructure/ui-prop-types'
 import type { PropValidators } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
-type ExpandableToggleProps = <P extends Record<string, any>>(
-  props?: P & { onClick?: React.MouseEventHandler }
-) => {
+type ExpandableToggleProps = (props?: {
+  onClick?: React.MouseEventHandler
+  [key: string]: unknown
+}) => {
   'aria-controls': string
   'aria-expanded': boolean
   onClick: (event: React.MouseEvent) => void
-} & P
+  [key: string]: unknown
+}
 
 type RenderProps = {
   expanded: boolean
-
   /**
    * Props to be spread onto the trigger element
    */
@@ -65,17 +66,22 @@ type ExpandableOwnProps = {
    */
   defaultExpanded: boolean
 
-  onToggle: (event: React.MouseEvent, expanded: boolean) => void
+  /**
+   * Function invoked when this component is expanded/collapsed
+   */
+  onToggle?: (event: React.MouseEvent, expanded: boolean) => void
 
   /**
-   * @param {Object} renderProps
-   * @param {Boolean} renderProps.expanded
-   * @param {Function} renderProps.getToggleProps - Props to be spread onto the trigger element
-   * @param {Function} renderProps.getDetailsProps - Props to be spread onto the details element
+   * Must be a function that returns a JSX element. It receives and object which
+   * contains whether its expanded and objects that need to be spread on the
+   * trigger and details elements.
    */
   children?: RenderExpandable
 
   /**
+   * Must be a function that returns a JSX element. It receives and object which
+   * contains whether its expanded and objects that need to be spread on the
+   * trigger and details elements.
    * Identical to children
    */
   render?: RenderExpandable

--- a/packages/ui-toggle-details/src/ToggleDetails/__tests__/ToggleDetails.test.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/__tests__/ToggleDetails.test.tsx
@@ -23,7 +23,7 @@
  */
 
 import React from 'react'
-import { expect, mount, spy } from '@instructure/ui-test-utils'
+import { expect, mount, spy, find } from '@instructure/ui-test-utils'
 
 import { ToggleDetails } from '../index'
 import { ToggleDetailsLocator } from '../ToggleDetailsLocator'
@@ -74,6 +74,16 @@ describe('<ToggleDetails />', async () => {
     expect(toggle.getAttribute('aria-expanded')).to.equal('false')
   })
 
+  it('should not have aria attributes when it has no children', async () => {
+    await mount(
+      <ToggleDetails summary="Click me" data-test-id="td__0"></ToggleDetails>
+    )
+    const toggle = await find('[data-test-id="td__0"]')
+
+    expect(toggle.getAttribute('aria-controls')).to.not.exist()
+    expect(toggle.getAttribute('aria-expanded')).to.not.exist()
+  })
+
   it('should toggle on click events', async () => {
     await mount(<ToggleDetails summary="Click me">Details</ToggleDetails>)
 
@@ -100,7 +110,27 @@ describe('<ToggleDetails />', async () => {
 
     const { args } = onToggle.firstCall
 
-    expect((args[0] as any).type).to.equal('click')
+    expect(args[0].type).to.equal('click')
+    expect(args[1]).to.be.true()
+  })
+
+  it('should call onToggle on click events when it has no children', async () => {
+    const onToggle = spy((_event: React.MouseEvent) => {
+      _event.persist()
+    })
+
+    await mount(
+      <ToggleDetails
+        summary="Click me"
+        expanded={false}
+        onToggle={onToggle}
+        data-test-id="td__1"
+      ></ToggleDetails>
+    )
+    const toggleDetails = await find('[data-test-id="td__1"]')
+    await toggleDetails.click()
+    const { args } = onToggle.firstCall
+    expect(args[0].type).to.equal('click')
     expect(args[1]).to.be.true()
   })
 

--- a/packages/ui-toggle-details/src/ToggleDetails/index.tsx
+++ b/packages/ui-toggle-details/src/ToggleDetails/index.tsx
@@ -101,13 +101,16 @@ class ToggleDetails extends Component<ToggleDetailsProps> {
     expanded: boolean
   ) {
     const { variant } = this.props
-
+    // Do not put aria-controls and aria-expanded into the toggle if there
+    // is nothing to open
+    const tProps = this.props.children
+      ? toggleProps
+      : { onClick: toggleProps.onClick }
     const props = {
       ...omitProps(this.props, ToggleDetails.allowedProps),
-      ...toggleProps,
+      ...tProps,
       children: this.renderSummary(expanded)
-      // spread operator makes toggleProps loose Record<string, any>>
-    } as Record<string, any>
+    } as Record<string, unknown>
     const summary = this.renderSummary(expanded)
 
     if (variant === 'filled') {
@@ -152,11 +155,11 @@ class ToggleDetails extends Component<ToggleDetailsProps> {
   }
 
   renderDetails(expanded: boolean, detailsProps: { id: string }) {
-    const { children } = this.props
+    if (!this.props.children) return null
     const expandedStyles = expanded ? { display: 'block' } : { display: 'none' }
     return (
       <div {...detailsProps} css={[this.props.styles?.details, expandedStyles]}>
-        {children && expanded && this.renderContent()}
+        {expanded && this.renderContent()}
       </div>
     )
   }


### PR DESCRIPTION
Also do not render an empty div for the details in this case. Note that this might break tests since
they might find these DOM parts via these ARIA tags. Also the empty div took up a small space when expanded (0.375rem), this might cause layout changes

TEST PLAN:
Make a ToggleDetails without any children, it should have no aria tags. Should still listen to mouse events