### PR TITLE
fix: docs screenreader alerts are no longer screenreader focusable

### DIFF
--- a/packages/__docs__/buildScripts/DataTypes.mts
+++ b/packages/__docs__/buildScripts/DataTypes.mts
@@ -213,17 +213,16 @@ export type ParsedDoc = {
   descriptions: Record<string, string>
   // Hold minimal information about each document that is needed for search
   // functionality
-  docs: Record<
-    string,
-    {
-      title: string
-      order?: string
-      category?: string
-      isWIP?: boolean
-      tags?: string
-    }
-  >
+  docs: ParsedDocSummary
 }
+
+export type ParsedDocSummary = Record<string,{
+  title: string
+  order?: string
+  category?: string
+  isWIP?: boolean
+  tags?: string
+}>
 
 type IconGlyph = {
   name: string

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -76,7 +76,8 @@ import type { AppProps, AppState, DocData, LayoutSize } from './props'
 import { propTypes, allowedProps } from './props'
 import type {
   LibraryOptions,
-  MainDocsData
+  MainDocsData,
+  ParsedDocSummary
 } from '../../buildScripts/DataTypes.mjs'
 import { logError } from '@instructure/console'
 
@@ -498,10 +499,11 @@ class App extends Component<AppProps, AppState> {
     const { library, docs, themes } = this.state.docsData!
     const { layout } = this.state
 
-    const themeDocs: Record<string, any> = {}
+    const themeDocs: ParsedDocSummary = {}
 
     Object.keys(themes).forEach((key) => {
       themeDocs[key] = {
+        title: key,
         category: 'themes'
       }
     })

--- a/packages/__docs__/src/Hero/props.ts
+++ b/packages/__docs__/src/Hero/props.ts
@@ -22,15 +22,16 @@
  * SOFTWARE.
  */
 import type { ComponentStyle, WithStyleProps } from '@instructure/emotion'
-import type { Colors, PropValidators } from '@instructure/shared-types'
+import type { PropValidators } from '@instructure/shared-types'
 import PropTypes from 'prop-types'
+import type { ParsedDocSummary } from '../../buildScripts/DataTypes.mjs'
 
 type HeroOwnProps = {
   name: string
   repository: string
   version: string
   layout: 'small' | 'medium' | 'large' | 'x-large'
-  docs: any
+  docs: ParsedDocSummary
 }
 
 type PropKeys = keyof HeroOwnProps
@@ -59,7 +60,7 @@ type HeroStyle = ComponentStyle<
 >
 
 type HeroTheme = {
-  backgroundColor: Colors['backgroundBrand']
+  backgroundColor: string
 }
 export type { HeroStyle, HeroTheme }
 export type { HeroProps }

--- a/packages/__docs__/src/Search/props.ts
+++ b/packages/__docs__/src/Search/props.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 import type { PropValidators } from '@instructure/shared-types'
+import type { ParsedDocSummary } from '../../buildScripts/DataTypes.mjs'
 import PropTypes from 'prop-types'
 
 type OptionType = {
@@ -29,13 +30,12 @@ type OptionType = {
   value: string
   label: string
   groupLabel: string
-  tags: string
+  tags?: string
   isWIP: string | boolean
-  category?: string
 }
 
 type SearchOwnProps = {
-  options: Record<string, OptionType>
+  options: ParsedDocSummary
 }
 
 type PropKeys = keyof SearchOwnProps
@@ -55,15 +55,7 @@ type SearchState = {
   highlightedOptionId: string | null
   selectedOptionId: string | null
   selectedOptionLabel: string
-  filteredOptions: {
-    id: string
-    value: string
-    label: string
-    groupLabel: string
-    tags: string
-    isWIP: string | boolean
-    category?: string
-  }[]
+  filteredOptions: OptionType[]
   announcement: string | null
 }
 

--- a/packages/ui-a11y-content/src/ScreenReaderContent/styles.ts
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/styles.ts
@@ -29,25 +29,23 @@ import type { ScreenReaderContentStyle } from './props'
  * private: true
  * ---
  * Generates the style object from the theme and provided additional information
- * @param  {Object} componentTheme The theme variable object.
- * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
- * @return {Object} The final style object, which will be used in the component
+ * @return The final style object, which will be used in the component
  */
 const generateStyle = (): ScreenReaderContentStyle => {
   return {
     screenReaderContent: {
       label: 'screenReaderContent',
-      width: '0.0625rem',
-      height: '0.0625rem',
-      margin: '-0.0625rem',
-      padding: 0,
+      width: '0.0625rem !important',
+      height: '0.0625rem !important',
+      margin: '-0.0625rem !important',
+      padding: '0 !important',
       position: 'absolute',
       top: 0,
       insetInlineStart: 0,
-      overflow: 'hidden',
-      clip: 'rect(0 0 0 0)',
-      border: 0
+      whiteSpace: 'nowrap',
+      overflow: 'hidden !important',
+      clip: 'rect(0 0 0 0) !important',
+      border: '0 !important'
     }
   }
 }

--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -153,6 +153,9 @@ class Alert extends Component<AlertProps, AlertState> {
 
     if (liveRegion) {
       liveRegion.setAttribute('aria-live', this.props.liveRegionPoliteness!)
+      // indicates what notifications the user agent will trigger when the
+      // accessibility tree within a live region is modified.
+      // additions: elements are added, text: Text content is added
       liveRegion.setAttribute('aria-relevant', 'additions text')
       liveRegion.setAttribute(
         'aria-atomic',

--- a/packages/ui-alerts/src/Alert/props.ts
+++ b/packages/ui-alerts/src/Alert/props.ts
@@ -53,11 +53,23 @@ type AlertOwnProps = {
    */
   liveRegion?: () => Element
   /**
-   * Choose the politeness level of screenreader alerts.
+   * Choose the politeness level of screenreader alerts, sets the value of
+   * `aria-live`.
+   *
+   * When regions are specified as `polite`, assistive technologies will notify
+   * users of updates but generally do not interrupt the current task,
+   * and updates take low priority.
+   *
+   * When regions are specified as `assertive`, assistive technologies will
+   * immediately notify the user, and could potentially clear the speech queue
+   * of previous updates.
    */
   liveRegionPoliteness?: 'polite' | 'assertive'
   /**
-   * If the screenreader alert should be atomic
+   * Value for the `aria-atomic` attribute.
+   * `aria-atomic` controls how much is read when a change happens. Should only
+   * the specific thing that changed be read or should the entire element be
+   * read.
    */
   isLiveRegionAtomic?: boolean
   /**

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/index.tsx
@@ -71,7 +71,7 @@ class DrawerContent extends Component<DrawerLayoutContentProps> {
 
   private _resizeListener?: ResizeObserver
 
-  private _debounced?: Debounced
+  private _debounced?: Debounced<NonNullable<typeof this.props.onSizeChange>>
 
   componentDidMount() {
     const rect = getBoundingClientRect(this.ref)

--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/props.ts
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerContent/props.ts
@@ -32,7 +32,7 @@ import type {
 } from '@instructure/shared-types'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
-type DrawerContentSize = { width: number; height: number }
+type DrawerContentSize = { width: number; height?: number }
 
 type DrawerLayoutContentOwnProps = {
   label: string

--- a/packages/ui-position/src/Position/index.tsx
+++ b/packages/ui-position/src/Position/index.tsx
@@ -161,7 +161,7 @@ class Position extends Component<PositionProps, PositionState> {
   }
 
   componentWillUnmount() {
-    ;(this.position as Debounced).cancel()
+    ;(this.position as Debounced<typeof this.position>).cancel()
     this.stopTracking()
     this._timeouts.forEach((timeout) => clearTimeout(timeout))
 

--- a/packages/ui-tabs/src/Tabs/index.tsx
+++ b/packages/ui-tabs/src/Tabs/index.tsx
@@ -86,7 +86,7 @@ class Tabs extends Component<TabsProps, TabsState> {
   private _tabList: Element | null = null
   private _focusable: Focusable | null = null
   private _tabListPosition?: RectType
-  private _debounced?: Debounced
+  private _debounced?: Debounced<typeof this.handleResize>
   private _resizeListener?: ResizeObserver
 
   ref: Element | null = null

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -78,7 +78,7 @@ class TextArea extends Component<TextAreaProps> {
   private _request?: RequestAnimationFrameType
   private _defaultId: string
   private _textareaResizeListener?: ResizeObserver
-  private _debounced?: Debounced
+  private _debounced?: Debounced<typeof this.grow>
   private _textarea: HTMLTextAreaElement | null = null
   private _container: HTMLDivElement | null = null
   private _height?: string

--- a/packages/ui-truncate-list/src/TruncateList/index.tsx
+++ b/packages/ui-truncate-list/src/TruncateList/index.tsx
@@ -63,7 +63,7 @@ class TruncateList extends Component<TruncateListProps, TruncateListState> {
 
   private _menuTriggerRef: HTMLLIElement | null = null
 
-  private _debouncedHandleResize?: Debounced
+  private _debouncedHandleResize?: Debounced<typeof this.handleResize>
   private _resizeListener?: ResizeObserver
 
   handleRef = (el: HTMLUListElement | null) => {

--- a/packages/ui-truncate-text/src/TruncateText/index.tsx
+++ b/packages/ui-truncate-text/src/TruncateText/index.tsx
@@ -68,7 +68,7 @@ class TruncateText extends Component<TruncateTextProps, TruncateTextState> {
 
   ref: Element | null = null
   private _text?: JSX.Element
-  private _debounced?: Debounced
+  private _debounced?: Debounced<typeof this.update>
   private _stage: HTMLSpanElement | null = null
   private _wasTruncated?: boolean
   private _resizeListener?: ResizeObserver


### PR DESCRIPTION
The issue is that our `ScreenReaderContent` class does not hide its text from Screenreader focus, and this is used by `Alert` to display it in an ARIA live region.
I've tried to fix the `ScreenReaderContent` class, but could not do it, so the solution way to add a timeout to the screenreader alerts, so users will not have time to go back with the focus

Also some better types in the docs app and the debounce utility

TEST PLAN:
Enter some text in the docs in the top search field with screenreader on. After this focus out, and find the beginning of the page. It should not read the search results again