### PR TITLE
chore: fix Github actions build failing with webpack-cli error

### DIFF
--- a/.github/workflows/deploy-docs-to-netlify.yml
+++ b/.github/workflows/deploy-docs-to-netlify.yml
@@ -6,6 +6,10 @@ jobs:
     name: Deploy docs to Netlify.
     steps:
       - uses: actions/checkout@v4
+      - name: Install Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install netlify-cli
         run: npm install --save-dev netlify-cli@13.2.2
       - name: Install packages.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
+      - name: Install Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - run: npm ci && npm run bootstrap
       - name: Build docs-app
         run: npm run build:docs

--- a/.github/workflows/manual-deploy-docs.yml
+++ b/.github/workflows/manual-deploy-docs.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy docs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - name: Install Node 22
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '22'
       - name: Install netlify-cli
         run: npm install --save-dev netlify-cli@13.2.2
       - name: Install packages.

--- a/.github/workflows/manual-release-to-npm.yml
+++ b/.github/workflows/manual-release-to-npm.yml
@@ -8,6 +8,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install packages
         run: npm ci
       - name: Set up project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Tag release commit
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up git identity
@@ -49,13 +49,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy docs to Netlify
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - name: Install Node 22
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: '22'
       - name: Install netlify-cli
         run: npm install --save-dev netlify-cli@13.2.2
       - name: Install packages.


### PR DESCRIPTION
Fixes docs-app: `[webpack-cli] TypeError [ERR_INVALID_ARG_TYPE]: The \"paths[0]\" argument must be of type string. Received undefined` in Github actions. 

This became needed when we started using ESM Webpack config files