### PR TITLE
fix(ui-date-input): fix DateInput2 to update messages properly

### DIFF
--- a/packages/ui-date-input/src/DateInput2/index.tsx
+++ b/packages/ui-date-input/src/DateInput2/index.tsx
@@ -184,9 +184,9 @@ const DateInput2 = ({
 
   useEffect(() => {
     // don't set input messages if there is an internal error set already
-    if (!inputMessages.length && !invalidDateErrorMessage) {
-      setInputMessages(messages || [])
-    }
+    if (inputMessages.find((m) => m.text === invalidDateErrorMessage)) return
+
+    setInputMessages(messages || [])
   }, [messages])
 
   useEffect(() => {

--- a/packages/ui-date-input/src/index.ts
+++ b/packages/ui-date-input/src/index.ts
@@ -25,3 +25,4 @@
 export { DateInput } from './DateInput'
 export { DateInput2 } from './DateInput2'
 export type { DateInputProps } from './DateInput/props'
+export type { DateInput2Props } from './DateInput2/props'


### PR DESCRIPTION
this was a minor but annoying bug that prevented the messages prop sometimes to work properly.

to test:
- check the basic and the `Date validation` (last) example with custom messages and valid + invalid dates. See if the messages appear/disappear as they should