### PR TITLE
INSTUI-4322 Make it possible to not use global theme registry. Deprecate global theme registry.

### DIFF
--- a/docs/guides/using-theme-overrides.md
+++ b/docs/guides/using-theme-overrides.md
@@ -27,23 +27,7 @@ type: embed
 
 ### How theming works in InstUI
 
-The theming system in InstUI has three levels:
-
-**The global theme**
-
-Global themes are useful when you have multiple React Application trees and you want to set up themes and overrides on a more global level than application level theming.
-This basically means you don't necessarily have to wrap each application tree with an [InstUISettingsProvider](/#InstUISettingsProvider) to use themes.
-InstUI leverages the [ThemeRegistry](/#ThemeRegistry) package to achieve global theming.
-
-```jsx
----
-type: code
----
-// app/init sets the global theme
-import canvas from '@instructure/ui-themes'
-
-canvas.use()
-```
+The theming system in InstUI has these levels:
 
 **The application level theme**
 
@@ -95,41 +79,27 @@ const generateStyle = (componentTheme) => {
 }
 ```
 
-### Global theme overrides
-
-In order to globally register and override themes, simply import the theme you wish to use and call `.use({ overrides })` on it:
-
-```js
----
-type: code
----
-import ReactDOM from "react-dom"
-import { canvas } from "@instructure/ui-themes"
-
-canvas.use({
-  overrides: {
-    colors: {
-      primitives: {
-        green45: "red"
-      }
-    }
-  }
-})
-
-ReactDOM.render(
-  <div>
-    ...your application code goes here...
-  </div>
-)
-```
-
-**Note**: globally overriding themes like this means that every InstUI component will use that theme, unless they are wrapped inside an `<InstUISettingsProvider/>`.
-
-You can see more examples [here](/#using-theme-overrides/#using-theme-overrides-examples).
-
 ### Application level theme overrides
 
 `<InstUISettingsProvider/>` accepts full theme objects and override objects too.
+
+```js
+---
+type: example
+---
+<InstUISettingsProvider theme={{
+    ...canvas,
+    ...{
+      typography: { fontFamily: 'monospace' }
+    }
+  }}>
+  <div>
+    <Heading level="h3" margin="small small">
+      I should have monospace font family from the override
+    </Heading>
+  </div>
+</InstUISettingsProvider>
+```
 
 #### Full themes
 
@@ -214,27 +184,27 @@ const Example = () => {
   return (
     <div>
       <h3>Common variables</h3>
-      <Flex gap="small large">
-        <Flex.Item size="50%">
+      <Flex gap="small">
+        <Flex.Item size="45%">
           <TextInput renderLabel="ic-brand-primary" value={icBrandPrimary} onChange={(e, v) => setIcBrandPrimary(v)}
-  messages={[{text:'used for border/background/shadow/focus colors in many places',type:'hint'}]} />
+  messages={[{text:'used for border/background/focus/shadow/.. colors in many places',type:'hint'}]} />
         </Flex.Item>
-        <Flex.Item size="50%">
+        <Flex.Item size="45%">
   <TextInput renderLabel="ic-brand-font-color-dark" value={icBrandFontColorDark} onChange={(e, v) => setIcBrandFontColorDark(v)}
   messages={[{text:'used in lots of places for text color',type:'hint'}]} />
         </Flex.Item>
     </Flex>
 
       <h3><code>Button</code> branding</h3>
-      <Flex gap="small large">
-        <Flex.Item size="50%">
+      <Flex gap="small">
+        <Flex.Item size="45%">
           <TextInput renderLabel="ic-brand-button--primary-bgd" value={icBrandButtonPrimaryBgd} onChange={(e, v) => setIcBrandButtonPrimaryBgd(v)}
   messages={[{text:"Used by 'primary' color buttons for background",type:'hint'}]} />
           <br/>
           <TextInput renderLabel="ic-brand-button--primary-text" value={icBrandButtonPrimaryText} onChange={(e, v) => setIcBrandButtonPrimaryText(v)}
   messages={[{text:"Used by 'primary' color buttons for text color",type:'hint'}]} />
         </Flex.Item>
-        <Flex.Item size="50%">
+        <Flex.Item size="45%">
           <TextInput renderLabel="ic-brand-button--secondary-bgd" value={icBrandButtonSecondaryBgd} onChange={(e, v) => setIcBrandButtonSecondaryBgd(v)}
   messages={[{text:'Unused in InstUI',type:'hint'}]} />
           <br/>
@@ -260,13 +230,17 @@ const Example = () => {
           'ic-brand-global-nav-menu-item__text-color--active': icBrandGlobalNavMenuItemTextColorActive
         }}}>
           <hr style={{width:'100%'}}/>
-          <Flex gap="small large">
-            <Flex.Item size="50%">
-              <Button color="primary">I'm a 'primary' color button</Button>
+          <Flex gap="large">
+            <Flex.Item size="45%">
+              <Badge count={15} countUntil={100} margin="0 medium 0 0">
+                <Button color="primary">I'm a 'primary' color button</Button>
+              </Badge>
               <TextInput renderLabel="TextInput" placeholder="ic-brand-primary sets focus color"/>
             </Flex.Item>
-            <Flex.Item size="50%">
-              <Button color="secondary">I'm a 'secondary' color button</Button>
+            <Flex.Item size="45%">
+              <Badge count={15} countUntil={100} margin="0 medium 0 0">
+                <Button color="secondary">I'm a 'secondary' color button</Button>
+              </Badge>
               <TextArea label="TextArea" placeholder="ic-brand-primary sets focus color"/>
             </Flex.Item>
           </Flex>
@@ -280,18 +254,18 @@ const Example = () => {
 
           <hr style={{width:'100%'}}/>
           <h3>Link colors used by <code>Link</code> and <code>Billboard</code>:</h3>
-          <Flex gap="small large">
-            <Flex.Item size="50%">
+          <Flex gap="small">
+            <Flex.Item size="45%">
               <TextInput renderLabel="ic-link-color" value={icLinkColor} onChange={(e, v) => setIcLinkColor(v)}
               messages={[{text:'Used for non-inverse Link and clickable Billboard',type:'hint'}]} />
             </Flex.Item>
-            <Flex.Item size="50%">
+            <Flex.Item size="45%">
               <TextInput renderLabel="ic-link-decoration" value={icLinkDecoration} onChange={(e, v) => setIcLinkDecoration(v)}
               messages={[{text:'Unused in InstUI',type:'hint'}]}/>
             </Flex.Item>
           </Flex>
           <hr style={{width:'100%'}}/>
-          <Flex gap="small large">
+          <Flex gap="small">
             <Flex.Item size="50%">
               <Link href="https://instructure.github.io/instructure-ui/">normal link</Link>
             </Flex.Item>
@@ -301,8 +275,8 @@ const Example = () => {
               </View>
             </Flex.Item>
           </Flex>
-          <Flex gap="small large">
-            <Flex.Item size="50%">
+          <Flex gap="small">
+            <Flex.Item size="40%">
               <Billboard
               margin="small"
               message="Billboard with link"
@@ -310,7 +284,7 @@ const Example = () => {
               hero={(size) => <IconGradebookLine size={size} />}
               />
             </Flex.Item>
-            <Flex.Item size="50%">
+            <Flex.Item size="40%">
               <Billboard
               margin="small"
               message="Billboard without link"
@@ -321,13 +295,13 @@ const Example = () => {
 
           <hr style={{width:'100%'}}/>
           <h3><code>SideNavBar</code> branding</h3>
-          <Flex gap="small large">
-            <Flex.Item size="50%">
+          <Flex gap="large small">
+            <Flex.Item size="45%">
               <TextInput renderLabel="ic-brand-global-nav-bgd" value={icBrandGlobalNavBgd} onChange={(e, v) => setIcBrandGlobalNavBgd(v)}/>
               <TextInput renderLabel="ic-global-nav-link-hover" value={icGlobalNavLinkHover} onChange={(e, v) => setIcGlobalNavLinkHover(v)}/>
               <TextInput renderLabel="ic-brand-global-nav-ic-icon-svg-fill" value={icBrandGlobalNavIcIconSvgFill} onChange={(e, v) => setIcBrandGlobalNavIcIconSvgFill(v)}/>
             </Flex.Item>
-            <Flex.Item size="50%">
+            <Flex.Item size="45%">
               <TextInput renderLabel="ic-brand-global-nav-menu-item__text-color" value={icBrandGlobalNavMenuItemTextColor} onChange={(e, v) => setIcBrandGlobalNavMenuItemTextColor(v)}/>
               <TextInput renderLabel="ic-brand-global-nav-menu-item__text-color--active" value={icBrandGlobalNavMenuItemTextColorActive} onChange={(e, v) => setIcBrandGlobalNavMenuItemTextColorActive(v)}/>
               <TextInput renderLabel="ic-brand-global-nav-ic-icon-svg-fill--active" value={icBrandGlobalNavIcIconSvgFillActive} onChange={(e, v) => setIcBrandGlobalNavIcIconSvgFillActive(v)}/>
@@ -386,3 +360,53 @@ const Example = () => {
 
 render(<Example/>)
 ```
+
+### (DEPRECATED) Global (window-level) theming
+
+**The global theme**
+
+> This feature is deprecated because it needs to use the [global object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) that pierces application borders, so it causes issues with running multiple versions of InstUI in a single page.
+
+Global themes are useful when you have multiple React Application trees, and you want to set up themes and overrides on a more global level than application level theming.
+This basically means you don't necessarily have to wrap each application tree with an [InstUISettingsProvider](/#InstUISettingsProvider) to use themes.
+InstUI leverages the [ThemeRegistry](/#ThemeRegistry) package to achieve global theming.
+
+```jsx
+---
+type: code
+---
+// app/init sets the global theme
+import canvas from '@instructure/ui-themes'
+
+canvas.use()
+```
+
+### (DEPRECATED) Global theme overrides
+
+In order to globally register and override themes, simply import the theme you wish to use and call `.use({ overrides })` on it:
+
+```js
+---
+type: code
+---
+import ReactDOM from "react-dom"
+import { canvas } from "@instructure/ui-themes"
+
+canvas.use({
+  overrides: {
+    colors: {
+      primitives: {
+        green45: "red"
+      }
+    }
+  }
+})
+
+ReactDOM.render(
+  <div>
+    ...your application code goes here...
+  </div>
+)
+```
+
+**Note**: globally overriding themes like this means that every InstUI component will use that theme, unless they are wrapped inside an `<InstUISettingsProvider/>`.

--- a/packages/__docs__/components.js
+++ b/packages/__docs__/components.js
@@ -130,4 +130,9 @@ export { Drilldown } from '@instructure/ui-drilldown'
 export { SourceCodeEditor } from '@instructure/ui-source-code-editor'
 export { TopNavBar } from '@instructure/ui-top-nav-bar'
 export { TruncateList } from '@instructure/ui-truncate-list'
-export { canvas, canvasHighContrast, instructure } from '@instructure/ui-themes'
+export {
+  canvas,
+  canvasHighContrast,
+  canvasThemeLocal,
+  canvasHighContrastThemeLocal
+} from '@instructure/ui-themes'

--- a/packages/__docs__/src/Theme/index.tsx
+++ b/packages/__docs__/src/Theme/index.tsx
@@ -279,7 +279,7 @@ class Theme extends Component<ThemeProps> {
           id={`${themeKey}ApplicationUsage`}
           content={`
 ### Usage (before mounting your application)
-##### Global theming
+##### (DEPRECATED) Global theming
 ${'```javascript\n \
 ---\n \
 type: code\n \

--- a/packages/emotion/src/getTheme.ts
+++ b/packages/emotion/src/getTheme.ts
@@ -37,15 +37,17 @@ import type {
  * ---
  * private: true
  * ---
- * Gives back the theme object for the the provider.
+ * Gives back the theme object for the provider.
  *
  * If a valid InstUI theme is given, it just returns the theme.
  *
  * If an override object is given, it returns the ancestor theme and
  * the overrides merged together.
  *
- * @param {object} themeOrOverride - A full theme or an override object
- * @returns {function} A function that returns with the theme object for the [ThemeProvider](https://emotion.sh/docs/theming#themeprovider-reactcomponenttype)
+ * @param themeOrOverride - A full theme or an override object
+ * @returns A function that returns with the theme object for the [ThemeProvider](https://emotion.sh/docs/theming#themeprovider-reactcomponenttype)
+ *    This function is called by Emotion on theme provider creation, where
+ *    `ancestorTheme` is a theme object from an ancestor `ThemeProvider`
  */
 const getTheme =
   (themeOrOverride: ThemeOrOverride) =>
@@ -71,7 +73,6 @@ const getTheme =
 
     // we need to clone the ancestor theme not to override it
     let currentTheme
-
     if (Object.keys(ancestorTheme).length === 0) {
       const globalTheme = ThemeRegistry.getCurrentTheme()
 

--- a/packages/emotion/src/useTheme.ts
+++ b/packages/emotion/src/useTheme.ts
@@ -36,9 +36,10 @@ import type { ThemeOrOverride } from './EmotionTypes'
  * A hook that will return the currently applied theme object from the nearest Context.
  * If there is no Context, then it tries to get the current theme from the global ThemeRegistry.
  * If there is no theme provided to the Context and ThemeRegistry it will return the default `canvas` theme.
- * @returns {object} the theme object
+ * @returns The theme object
  */
 const useTheme = () => {
+  // This reads the theme from Emotion's ThemeContext
   let theme = useEmotionTheme() as ThemeOrOverride
 
   if (isEmpty(theme)) {

--- a/packages/theme-registry/src/ThemeRegistry.ts
+++ b/packages/theme-registry/src/ThemeRegistry.ts
@@ -53,9 +53,14 @@ type Registry<T extends RegisteredTheme> = {
 }
 
 type RegisteredTheme<T extends BaseTheme = BaseTheme> = T & {
-  // DEPRECATED. Use InstUISettingsProvider instead
+  /**
+   * @deprecated since version 10
+   * @param arg the theme overrides
+   */
   use(arg?: { overrides: DeepPartial<BaseThemeVariables> }): void
-  // DEPRECATED. Read its variables dirrectly from the theme object.
+  /**
+   * @deprecated since version 10
+   */
   variables: BaseThemeVariables
 }
 
@@ -118,7 +123,8 @@ function validateRegistry(registry: Registry<RegisteredTheme<BaseTheme>>) {
 
 /**
  * Get the global theme registry.
- * @return {Registry}  the theme registry
+ * @deprecated since version 10
+ * @return The theme registry
  * @module getRegistry
  */
 function getRegistry(): Registry<RegisteredTheme> {
@@ -127,6 +133,7 @@ function getRegistry(): Registry<RegisteredTheme> {
 
 /**
  * Set the global theme registry.
+ * @deprecated since version 10
  * @param {Registry} registry - the registry to set/replace the current registry with.
  * @returns {void}
  * @module setRegistry
@@ -137,6 +144,7 @@ function setRegistry(registry: Registry<RegisteredTheme>): void {
 
 /**
  * Clear/reset the global theme registry.
+ * @deprecated since version 10
  * @module clearRegistry
  * @returns {void}
  */
@@ -146,6 +154,7 @@ function clearRegistry(): void {
 
 /**
  * Get the activated theme object.
+ * @deprecated since version 10
  * @return {RegisteredTheme} the default theme object
  * @module getCurrentTheme
  */
@@ -205,6 +214,11 @@ function makeTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
     key,
     description,
     ...rest,
+    /**
+     * Activate a global theme with the given overrides.
+     * @deprecated since version 10
+     * @param arg
+     */
     use(arg?: { overrides: DeepPartial<BaseThemeVariables> }): void {
       activateTheme(key, arg?.overrides || {})
     }
@@ -226,6 +240,7 @@ function makeTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
 
 /**
  * Registers the passed theme into the ThemeRegistry.
+ * @deprecated since version 10
  * @param {BaseTheme} theme - the theme object to register into the ThemeRegistry
  * @returns {RegisteredTheme} If the given theme is already in the ThemeRegistry then simply return that theme.
  * Otherwise, returns the theme with a wrapper around it, so it can be `.use()`-ed to activate the given theme from the registry.
@@ -253,6 +268,9 @@ function registerTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
   }
 }
 
+/**
+ * @deprecated since version 10
+ */
 const ThemeRegistry = {
   getRegistry,
   clearRegistry,

--- a/packages/theme-registry/src/ThemeRegistry.ts
+++ b/packages/theme-registry/src/ThemeRegistry.ts
@@ -26,6 +26,7 @@
  * ---
  * category: utilities/themes
  * ---
+ * DEPRECATED. This will be deleted, please use InstUISettingsProvider instead.
  * A global theme registry used for registering theme objects, setting globally available themes
  * and receiving the currently used theme.
  * @module ThemeRegistry
@@ -52,7 +53,9 @@ type Registry<T extends RegisteredTheme> = {
 }
 
 type RegisteredTheme<T extends BaseTheme = BaseTheme> = T & {
+  // DEPRECATED. Use InstUISettingsProvider instead
   use(arg?: { overrides: DeepPartial<BaseThemeVariables> }): void
+  // DEPRECATED. Read its variables dirrectly from the theme object.
   variables: BaseThemeVariables
 }
 
@@ -225,7 +228,8 @@ function makeTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
  * Registers the passed theme into the ThemeRegistry.
  * @param {BaseTheme} theme - the theme object to register into the ThemeRegistry
  * @returns {RegisteredTheme} If the given theme is already in the ThemeRegistry then simply return that theme.
- * Otherwise returns the theme with a wrapper around it, so it can be `.use()`-ed to activate the given theme from the registry.
+ * Otherwise, returns the theme with a wrapper around it, so it can be `.use()`-ed to activate the given theme from the registry.
+ * This function also adds a `variables` prop for backwards compatibility (deprecated).
  * @module registerTheme
  */
 function registerTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {

--- a/packages/theme-registry/src/__tests__/ThemeRegistry.test.ts
+++ b/packages/theme-registry/src/__tests__/ThemeRegistry.test.ts
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { BaseTheme } from '@instructure/shared-types'
+import type { BaseTheme } from '@instructure/shared-types'
 import { expect } from '@instructure/ui-test-utils'
 import { ThemeRegistry } from '../ThemeRegistry'
 const defaultRegistry = ThemeRegistry.getRegistry()

--- a/packages/ui-themes/README.md
+++ b/packages/ui-themes/README.md
@@ -18,14 +18,6 @@ npm install @instructure/ui-themes
 
 ##### Before mounting (rendering) your React application:
 
-- global theming:
-
-  ```js
-  import canvas from '@instructure/ui-themes'
-
-  canvas.use()
-  ```
-
 - application level theming:
 
   ```jsx
@@ -39,9 +31,17 @@ npm install @instructure/ui-themes
   )
   ```
 
+- (DEPRECATED) global theming:
+
+  ```js
+  import canvas from '@instructure/ui-themes'
+
+  canvas.use()
+  ```
+
 ##### To override the theme variables:
 
-- globally:
+- (DEPRECATED) globally:
 
   ```js
   import canvas from '@instructure/ui-themes'

--- a/packages/ui-themes/src/__new-tests__/themes.test.tsx
+++ b/packages/ui-themes/src/__new-tests__/themes.test.tsx
@@ -21,12 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { canvas, canvasHighContrast } from '..'
+import { canvas, canvasHighContrast, canvasThemeLocal } from '..'
 import '@testing-library/jest-dom'
+import { ThemeRegistry } from '@instructure/theme-registry'
 
 const themes = [canvas, canvasHighContrast]
 
 describe('themes are backwards compatible', () => {
+  it('Local themes are not affected by ".use()"', async () => {
+    canvas.use({
+      overrides: {
+        colors: {
+          primitives: {
+            white: 'blue'
+          }
+        }
+      }
+    })
+    expect(ThemeRegistry.getCurrentTheme()?.colors?.primitives?.white).toEqual(
+      'blue'
+    )
+    expect(canvasThemeLocal?.colors?.primitives?.white).toEqual('#FFFFFF')
+  })
+
   describe("should be able to access theme variables with 'theme.variables.x'", () => {
     for (const theme of themes) {
       it(`${theme.key}`, () => {

--- a/packages/ui-themes/src/index.ts
+++ b/packages/ui-themes/src/index.ts
@@ -32,8 +32,10 @@ import type {
   UI
 } from '@instructure/shared-types'
 
-import canvasHighContrast from './themes/canvasHighContrast'
-import canvas from './themes/canvas'
+import canvasHighContrast, {
+  canvasHighContrastThemeLocal
+} from './themes/canvasHighContrast'
+import canvas, { canvasThemeLocal } from './themes/canvas'
 
 import {
   primitives,
@@ -61,7 +63,9 @@ type ThemeSpecificStyle<ComponentTheme> = {
 
 export {
   canvas,
+  canvasThemeLocal,
   canvasHighContrast,
+  canvasHighContrastThemeLocal,
   primitives,
   additionalPrimitives,
   dataVisualization

--- a/packages/ui-themes/src/themes/canvas/index.ts
+++ b/packages/ui-themes/src/themes/canvas/index.ts
@@ -59,6 +59,11 @@ export type CanvasTheme = BaseTheme & {
   key: 'canvas'
 } & typeof sharedThemeTokens & { colors: Colors } & CanvasBrandVariables
 
+/**
+ * Canvas theme without the `use` function and `variables` prop.
+ * Not affected by global theme overrides (`.use()` function).
+ * Will be default in the next major version of InstUI
+ */
 const __theme: CanvasTheme = {
   key,
   ...sharedThemeTokens,
@@ -69,5 +74,4 @@ const __theme: CanvasTheme = {
 const theme = ThemeRegistry.registerTheme(__theme)
 
 export default theme
-// theme without the use() function and `variables` prop
 export { __theme as canvasThemeLocal }

--- a/packages/ui-themes/src/themes/canvas/index.ts
+++ b/packages/ui-themes/src/themes/canvas/index.ts
@@ -69,3 +69,5 @@ const __theme: CanvasTheme = {
 const theme = ThemeRegistry.registerTheme(__theme)
 
 export default theme
+// theme without the use() function and `variables` prop
+export { __theme as canvasThemeLocal }

--- a/packages/ui-themes/src/themes/canvasHighContrast/index.ts
+++ b/packages/ui-themes/src/themes/canvasHighContrast/index.ts
@@ -39,6 +39,8 @@ const __theme: CanvasHighContrastTheme = {
   ...sharedThemeTokens,
   colors
 }
-const theme = ThemeRegistry.registerTheme(__theme)
 
+const theme = ThemeRegistry.registerTheme(__theme)
 export default theme
+// theme without the use() function and `variables` prop
+export { __theme as canvasHighContrastThemeLocal }

--- a/packages/ui-themes/src/themes/canvasHighContrast/index.ts
+++ b/packages/ui-themes/src/themes/canvasHighContrast/index.ts
@@ -33,6 +33,12 @@ export type CanvasHighContrastTheme = BaseTheme & {
   key: 'canvas-high-contrast'
 } & typeof sharedThemeTokens & { colors: Colors }
 
+/**
+ * Canvas high contrast theme without the `use` function and `variables` prop.
+ * Not affected by global theme overrides (`.use()` function).
+ *
+ * Will be default in the next major version of InstUI
+ */
 const __theme: CanvasHighContrastTheme = {
   key,
   description: 'This theme meets WCAG 2.0 AA rules for color contrast.',

--- a/packages/ui-utils/src/isBaseTheme.ts
+++ b/packages/ui-utils/src/isBaseTheme.ts
@@ -39,6 +39,12 @@ const baseThemeProps: BaseThemeVariableKeys = [
   'typography'
 ]
 
+/**
+ * Checks if the given param is an object with all the keys needed for an
+ * Instructure theme.
+ * @param theme Anything. This function will throw an error if it's not a theme
+ * object.
+ */
 const isBaseTheme = (theme: any): theme is BaseTheme => {
   if (Array.isArray(theme) || typeof theme === 'function') {
     throw new Error()


### PR DESCRIPTION
The main goal of this PR is to make it possible to run InstUI v8/v9 in the same page as InstUI v10 when the host app uses the older version and a later initialized one v10.
Currently this causes the v10 app to look buggy because `ThemeRegistry` will return an incompatible v8 theme object:

in `canvas.ts`:
```
const theme = ThemeRegistry.registerTheme(__theme)
export default theme
```
in `ThemeRegistry.registerTheme`:
```
if (theme.key && registry.themes[theme.key]) {
    return registry.themes[theme.key] as RegisteredTheme<T>
  }
```

This PR makes it possible to get the theme directly circumventing `ThemeRegistry` and its theme cache. Also deprecates `ThemeRegistry` (which is used for global themes)


