### PR TITLE
feat(ui-color-picker,ui-color-utils): add callback for contrast validation information and export validation methods

### DIFF
--- a/packages/ui-color-picker/src/ColorContrast/README.md
+++ b/packages/ui-color-picker/src/ColorContrast/README.md
@@ -32,13 +32,23 @@ type: example
       super(props)
       this.state = {
         selectedForeGround: '#0CBF94',
-        selectedBackGround: '#35423A'
+        selectedBackGround: '#35423A',
+        validationLevel: 'AA'
       }
     }
 
     render() {
       return (
         <div>
+          <RadioInputGroup
+            onChange={(_e, value) => this.setState({ validationLevel: value })}
+            name="example1"
+            defaultValue="AA"
+            description="validationLevel"
+          >
+            <RadioInput key="AA" value="AA" label="AA" />
+            <RadioInput key="AAA" value="AAA" label="AAA" />
+          </RadioInputGroup>
           <ColorPreset
             label="Background"
             colors={[
@@ -86,6 +96,8 @@ type: example
             normalTextLabel="Normal text"
             largeTextLabel="Large text"
             graphicsTextLabel="Graphics text"
+            validationLevel={this.state.validationLevel}
+            onContrastChange={(contrastData) => console.log(contrastData)}
           />
         </div>
       )
@@ -99,9 +111,19 @@ type: example
   const Example = () => {
     const [selectedForeGround, setSelectedForeGround] = useState('#0CBF94')
     const [selectedBackGround, setSelectedBackGround] = useState('#35423A')
+    const [validationLevel, setValidationLevel] = useState('AA')
 
     return (
       <div>
+        <RadioInputGroup
+          onChange={(_e, value) => setValidationLevel(value)}
+          name="example1"
+          defaultValue="AA"
+          description="validationLevel"
+        >
+          <RadioInput key="AA" value="AA" label="AA" />
+          <RadioInput key="AAA" value="AAA" label="AAA" />
+        </RadioInputGroup>
         <ColorPreset
           label="Background"
           colors={[
@@ -149,6 +171,8 @@ type: example
           normalTextLabel="Normal text"
           largeTextLabel="Large text"
           graphicsTextLabel="Graphics text"
+          validationLevel={validationLevel}
+          onContrastChange={(contrastData) => console.log(contrastData)}
         />
       </div>
     )

--- a/packages/ui-color-picker/src/ColorContrast/props.ts
+++ b/packages/ui-color-picker/src/ColorContrast/props.ts
@@ -83,6 +83,46 @@ type ColorContrastOwnProps = {
    * Otherwise, it is required.
    */
   withoutColorPreview?: boolean
+  /**
+   * Triggers a callback whenever the contrast changes, due to a changing color input.
+   * Communicates the contrast and the success/fail state of the contrast, depending on
+   * the situation:
+   *
+   * isValidNormalText true if at least 4.5:1
+   *
+   * isValidLargeText true if at least 3:1
+   *
+   * isValidGraphicsText true if at least 3:1
+   */
+  onContrastChange?: (conrastData: {
+    contrast: number
+    isValidNormalText: boolean
+    isValidLargeText: boolean
+    isValidGraphicsText: boolean
+    firstColor: string
+    secondColor: string
+  }) => null
+  /**
+   * According to WCAG 2.2
+   *
+   * AA level (https://www.w3.org/TR/WCAG22/#contrast-minimum)
+   *
+   * text: 4.5:1
+   *
+   * large text: 3:1
+   *
+   * non-text: 3:1 (https://www.w3.org/TR/WCAG22/#non-text-contrast)
+   *
+   *
+   * AAA level (https://www.w3.org/TR/WCAG22/#contrast-enhanced)
+   *
+   * text: 7:1
+   *
+   * large text: 4.5:1
+   *
+   * non-text: 3:1 (https://www.w3.org/TR/WCAG22/#non-text-contrast)
+   */
+  validationLevel?: 'AA' | 'AAA'
 }
 
 type PropKeys = keyof ColorContrastOwnProps
@@ -106,6 +146,8 @@ type ColorContrastStyle = ComponentStyle<
   | 'firstColorPreview'
   | 'secondColorPreview'
   | 'label'
+  | 'onContrastChange'
+  | 'validationLevel'
 >
 
 const propTypes: PropValidators<PropKeys> = {
@@ -120,7 +162,9 @@ const propTypes: PropValidators<PropKeys> = {
   normalTextLabel: PropTypes.string.isRequired,
   secondColor: PropTypes.string.isRequired,
   secondColorLabel: PropTypes.string,
-  successLabel: PropTypes.string.isRequired
+  successLabel: PropTypes.string.isRequired,
+  onContrastChange: PropTypes.func,
+  validationLevel: PropTypes.oneOf(['AA', 'AAA'])
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -135,8 +179,16 @@ const allowedProps: AllowedPropKeys = [
   'normalTextLabel',
   'secondColor',
   'secondColorLabel',
-  'successLabel'
+  'successLabel',
+  'onContrastChange',
+  'validationLevel'
 ]
 
-export type { ColorContrastProps, ColorContrastStyle }
+type ColorContrastState = {
+  contrast: number
+  isValidNormalText: boolean
+  isValidLargeText: boolean
+  isValidGraphicsText: boolean
+}
+export type { ColorContrastProps, ColorContrastStyle, ColorContrastState }
 export { propTypes, allowedProps }

--- a/packages/ui-color-picker/src/ColorPicker/index.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/index.tsx
@@ -548,6 +548,9 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
               secondColorLabel={
                 this.props.colorMixerSettings.colorContrast.secondColorLabel
               }
+              onContrastChange={
+                this.props.colorMixerSettings.colorContrast.onContrastChange
+              }
             />
           </div>
         )}

--- a/packages/ui-color-picker/src/ColorPicker/props.ts
+++ b/packages/ui-color-picker/src/ColorPicker/props.ts
@@ -32,7 +32,6 @@ import type {
   OtherHTMLAttributes,
   PropValidators
 } from '@instructure/shared-types'
-
 type ContrastStrength = 'min' | 'mid' | 'max'
 
 type ColorPickerOwnProps = {
@@ -100,6 +99,14 @@ type ColorPickerOwnProps = {
       graphicsTextLabel: string
       firstColorLabel: string
       secondColorLabel: string
+      onContrastChange?: (conrastData: {
+        contrast: number
+        isValidNormalText: boolean
+        isValidLargeText: boolean
+        isValidGraphicsText: boolean
+        firstColor: string
+        secondColor: string
+      }) => null
     }
   }
 
@@ -288,7 +295,8 @@ const propTypes: PropValidators<PropKeys> = {
       largeTextLabel: PropTypes.string.isRequired,
       graphicsTextLabel: PropTypes.string.isRequired,
       firstColorLabel: PropTypes.string.isRequired,
-      secondColorLabel: PropTypes.string.isRequired
+      secondColorLabel: PropTypes.string.isRequired,
+      onContrastChange: PropTypes.func
     })
   }),
   children: PropTypes.func,

--- a/packages/ui-color-utils/src/contrastWithAlpha.ts
+++ b/packages/ui-color-utils/src/contrastWithAlpha.ts
@@ -22,39 +22,29 @@
  * SOFTWARE.
  */
 
-export { alpha } from './alpha'
-export { darken } from './darken'
-export { lighten } from './lighten'
-export { contrast } from './contrast'
-export { isValid } from './isValid'
-export { overlayColors } from './overlayColors'
-export { contrastWithAlpha } from './contrastWithAlpha'
-export { validateContrast } from './validateContrast'
-export {
-  color2hex,
-  colorToHex8,
-  colorToHsva,
-  colorToHsla,
-  colorToRGB
-} from './conversions'
+import { colorToRGB, colorToHex8 } from './conversions'
+import { overlayColors } from './overlayColors'
+import { contrast } from './contrast'
 
-import {
-  color2hex,
-  colorToHex8,
-  colorToHsva,
-  colorToHsla,
-  colorToRGB
-} from './conversions'
+/**
+ * ---
+ * category: utilities
+ * ---
+ * Calculates two, not necesseraly opaque color's contrast on top of each other.
+ * The method assumes that the bottom color is on top of a white background (only important if it isn't opaque)
+ * @module contrastWithAlpha
+ * @param {String} color1
+ * @param {String} color2
+ * @param {Number} decimalPlaces
+ * @returns {Number} color contrast ratio
+ */
+const contrastWithAlpha = (color1: string, color2: string): number => {
+  const c1RGBA = colorToRGB(color1)
+  const c2RGBA = colorToRGB(color2)
+  const c1OnWhite = overlayColors({ r: 255, g: 255, b: 255, a: 1 }, c1RGBA)
+  const c2OnC1OnWhite = overlayColors(c1OnWhite, c2RGBA)
 
-// TODO remove when we get rid of babel-plugin-transform-imports
-// This default export is needed because babel-plugin-transform-imports will
-// fail if the exported name is not the same as the filename
-export default {
-  color2hex: color2hex,
-  colorToHex8: colorToHex8,
-  colorToHsva: colorToHsva,
-  colorToHsla: colorToHsla,
-  colorToRGB: colorToRGB
+  return contrast(colorToHex8(c1OnWhite), colorToHex8(c2OnC1OnWhite), 2)
 }
 
-export type { RGBType, HSVType, HSLType, RGBAType } from './colorTypes'
+export { contrastWithAlpha }

--- a/packages/ui-color-utils/src/overlayColors.ts
+++ b/packages/ui-color-utils/src/overlayColors.ts
@@ -22,39 +22,37 @@
  * SOFTWARE.
  */
 
-export { alpha } from './alpha'
-export { darken } from './darken'
-export { lighten } from './lighten'
-export { contrast } from './contrast'
-export { isValid } from './isValid'
-export { overlayColors } from './overlayColors'
-export { contrastWithAlpha } from './contrastWithAlpha'
-export { validateContrast } from './validateContrast'
-export {
-  color2hex,
-  colorToHex8,
-  colorToHsva,
-  colorToHsla,
-  colorToRGB
-} from './conversions'
+import type { RGBAType } from './colorTypes'
 
-import {
-  color2hex,
-  colorToHex8,
-  colorToHsva,
-  colorToHsla,
-  colorToRGB
-} from './conversions'
+/**
+ * @typedef {Object} RGBAResult
+ * @property {Number} r - Red component as a string
+ * @property {Number} g - Green component as a string
+ * @property {Number} b - Blue component as a string
+ * @property {Number} a - Alpha component as a string
+ */
 
-// TODO remove when we get rid of babel-plugin-transform-imports
-// This default export is needed because babel-plugin-transform-imports will
-// fail if the exported name is not the same as the filename
-export default {
-  color2hex: color2hex,
-  colorToHex8: colorToHex8,
-  colorToHsva: colorToHsva,
-  colorToHsla: colorToHsla,
-  colorToRGB: colorToRGB
+/**
+ * ---
+ * category: utilities
+ * ---
+ * Place two RGBA colors on top of each other. The second one (c2) goes on top.
+ * The method calculates what color would be visible. If the second color (c2) is opaque, the result
+ * will be c2, if fully transparent, c1. If anything in between, it calculates the real color.
+ * Alpha is always set to 1 after the calculation
+ * @module overlayColors
+ * @param {RGBAType} c1
+ * @param {RGBAType} c2
+ * @returns {RGBAType} color as rgb string
+ */
+const overlayColors = (c1: RGBAType, c2: RGBAType): RGBAType => {
+  const alpha = 1 - (1 - c1.a) * (1 - c2.a)
+  return {
+    r: (c2.r * c2.a) / alpha + (c1.r * c1.a * (1 - c2.a)) / alpha,
+    g: (c2.g * c2.a) / alpha + (c1.g * c1.a * (1 - c2.a)) / alpha,
+    b: (c2.b * c2.a) / alpha + (c1.b * c1.a * (1 - c2.a)) / alpha,
+    a: 1
+  }
 }
 
-export type { RGBType, HSVType, HSLType, RGBAType } from './colorTypes'
+export { overlayColors }

--- a/packages/ui-color-utils/src/validateContrast.ts
+++ b/packages/ui-color-utils/src/validateContrast.ts
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+interface ValidatedContrasts {
+  isValidNormalText: boolean
+  isValidLargeText: boolean
+  isValidGraphicsText: boolean
+}
+
+/**
+ * @typedef {Object} ValidatedContrasts
+ * @property {Boolean} isValidNormalText - Is the contrast high enough for normal text size?
+ * @property {Boolean} isValidLargeText - Is the contrast high enough for large text size?
+ * @property {Boolean} isValidGraphicsText - Is the contrast high enough for graphics text?
+ */
+
+/**
+ * ---
+ * category: utilities
+ * ---
+ * Decides if the given contrast is sufficient for different text sizes and situations.
+ *
+ * According to WCAG 2.2
+ *
+ * AA level (https://www.w3.org/TR/WCAG22/#contrast-minimum)
+ *
+ * text: 4.5:1
+ *
+ * large text: 3:1
+ *
+ * non-text: 3:1 (https://www.w3.org/TR/WCAG22/#non-text-contrast)
+ *
+ *
+ * AAA level (https://www.w3.org/TR/WCAG22/#contrast-enhanced)
+ *
+ * text: 7:1
+ *
+ * large text: 4.5:1
+ *
+ * non-text: 3:1 (https://www.w3.org/TR/WCAG22/#non-text-contrast)
+ * @module validateContrast
+ * @param {Number} contrast
+ * @returns {ValidatedContrasts} validation object
+ */
+const validateContrast = (
+  contrast: number,
+  validationLevel?: 'AA' | 'AAA'
+): ValidatedContrasts => {
+  return {
+    isValidNormalText: contrast >= (validationLevel === 'AAA' ? 7 : 4.5),
+    isValidLargeText: contrast >= (validationLevel === 'AAA' ? 4.5 : 3),
+    isValidGraphicsText: contrast >= 3
+  }
+}
+
+export { validateContrast }


### PR DESCRIPTION
TEST_PLAN:
check if contrast calculation works as before for ColorContrast.
Test if you pass the onContrastChange callback, to ColorContrast or ColorPicker, it really gets called when the color changes.

Check if preciously internally used methods work as before in color utils

Check if validationLevel prop does what it says

Closes: INSTUI-4360