### PR TITLE
small fixes: tooltip close on esc; pagination indicator gap; pagination displayed as a html list for a11y

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -949,6 +949,10 @@ export type PaginationPageInputTheme = {
   inputWidth: string
 }
 
+export type PaginationTheme = {
+  pageIndicatorGap: Spacing['xSmall']
+}
+
 export type PillTheme = {
   fontFamily: Typography['fontFamily']
   padding: string | 0

--- a/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
+++ b/packages/ui-pagination/src/Pagination/PaginationButton/index.tsx
@@ -59,17 +59,20 @@ class PaginationButton extends Component<PaginationPageProps> {
 
     const props = omitProps(this.props, PaginationButton.allowedProps, exclude)
 
+    // wrapped in an unstyled <li> for better a11y
     return (
-      <BaseButton
-        color="primary"
-        withBackground={this.props.current}
-        withBorder={this.props.current}
-        {...props}
-        aria-current={this.props.current ? 'page' : undefined}
-        elementRef={this.handleRef}
-      >
-        {this.props.children}
-      </BaseButton>
+      <li style={{ all: 'unset' }}>
+        <BaseButton
+          color="primary"
+          withBackground={this.props.current}
+          withBorder={this.props.current}
+          {...props}
+          aria-current={this.props.current ? 'page' : undefined}
+          elementRef={this.handleRef}
+        >
+          {this.props.children}
+        </BaseButton>
+      </li>
     )
   }
 }

--- a/packages/ui-pagination/src/Pagination/__new-tests__/Pagination.test.tsx
+++ b/packages/ui-pagination/src/Pagination/__new-tests__/Pagination.test.tsx
@@ -123,7 +123,9 @@ describe('<Pagination />', () => {
     it('by default', async () => {
       const { container } = render(
         <Pagination variant="compact" labelNext="Next" labelPrev="Prev">
-          {buildPages(5)}
+          <ul>
+            {buildPages(5)}
+          </ul>
         </Pagination>
       )
 
@@ -134,7 +136,7 @@ describe('<Pagination />', () => {
     it('by default with more pages', async () => {
       const { container } = render(
         <Pagination variant="compact" labelNext="Next" labelPrev="Prev">
-          {buildPages(8)}
+          <ul>{buildPages(8)}</ul>
         </Pagination>
       )
       const axeCheck = await runAxeCheck(container)
@@ -151,7 +153,7 @@ describe('<Pagination />', () => {
           labelLast="Last"
           withFirstAndLastButton
         >
-          {buildPages(8)}
+          <ul>{buildPages(8)}</ul>
         </Pagination>
       )
       const axeCheck = await runAxeCheck(container)
@@ -169,7 +171,7 @@ describe('<Pagination />', () => {
           withFirstAndLastButton
           showDisabledButtons
         >
-          {buildPages(8)}
+          <ul>{buildPages(8)}</ul>
         </Pagination>
       )
       const axeCheck = await runAxeCheck(container)

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -36,6 +36,7 @@ import { PaginationArrowButton } from './PaginationArrowButton'
 import { PaginationPageInput } from './PaginationPageInput'
 
 import generateStyle from './styles'
+import generateComponentTheme from './theme'
 
 import type { PaginationPageProps } from './PaginationButton/props'
 import type { PaginationArrowDirections } from './PaginationArrowButton/props'
@@ -80,7 +81,7 @@ category: components
 ---
 **/
 @withDeterministicId()
-@withStyle(generateStyle, null)
+@withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Pagination extends Component<PaginationProps> {
   static readonly componentId = 'Pagination'
@@ -103,7 +104,7 @@ class Pagination extends Component<PaginationProps> {
     currentPage: 1,
     siblingCount: 1,
     boundaryCount: 1,
-    ellipsis: '...',
+    ellipsis: <li style={{all: 'unset'}}>...</li>,
     renderPageIndicator: (page: number) => page
   }
 
@@ -408,7 +409,7 @@ class Pagination extends Component<PaginationProps> {
         )
       )
     }
-    return pages
+    return (<ul css={this.props.styles?.pageIndicatorList}>{pages}</ul>)
   }
 
   renderPages(currentPageIndex: number) {

--- a/packages/ui-pagination/src/Pagination/props.ts
+++ b/packages/ui-pagination/src/Pagination/props.ts
@@ -197,7 +197,9 @@ type PaginationProps = PaginationOwnProps &
   OtherHTMLAttributes<PaginationOwnProps> &
   WithDeterministicIdProps
 
-type PaginationStyle = ComponentStyle<'pagination' | 'pages'>
+type PaginationStyle = ComponentStyle<
+  'pagination' | 'pages' | 'pageIndicatorList'
+>
 
 const propTypes: PropValidators<PropKeys> = {
   children: Children.oneOf([PaginationButton]),

--- a/packages/ui-pagination/src/Pagination/theme.ts
+++ b/packages/ui-pagination/src/Pagination/theme.ts
@@ -22,37 +22,24 @@
  * SOFTWARE.
  */
 
-import type { PaginationTheme } from '@instructure/shared-types'
-import type { PaginationStyle } from './props'
+import type { Theme } from '@instructure/ui-themes'
+import { PaginationTheme } from '@instructure/shared-types'
 
 /**
- * ---
- * private: true
- * ---
- * Generates the style object from the theme and provided additional information
- * @param  {Object} componentTheme The theme variable object.
- * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
- * @return {Object} The final style object, which will be used in the component
+ * Generates the theme object for the component from the theme and provided additional information
+ * @param  {Object} theme The actual theme object.
+ * @return {Object} The final theme object with the overrides and component variables
  */
-const generateStyle = (componentTheme: PaginationTheme): PaginationStyle => {
+const generateComponentTheme = (theme: Theme): PaginationTheme => {
+  const { spacing } = theme
+
+  const componentVariables: PaginationTheme = {
+    pageIndicatorGap: spacing.xSmall
+  }
+
   return {
-    pageIndicatorList: {
-      all: 'unset',
-      display: 'flex',
-      alignItems: 'center',
-      gap: componentTheme.pageIndicatorGap
-    },
-    pagination: {
-      label: 'pagination',
-      textAlign: 'center'
-    },
-    pages: {
-      label: 'pagination__pages',
-      display: 'inline-flex',
-      alignItems: 'center'
-    }
+    ...componentVariables
   }
 }
 
-export default generateStyle
+export default generateComponentTheme

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -181,7 +181,7 @@ class Popover extends Component<PopoverProps, PopoverState> {
       // manage its FocusRegion internally rather than registering it with
       // the FocusRegionManager via Dialog
       this._focusRegion = new FocusRegion(this._contentElement, {
-        shouldCloseOnEscape: false,
+        shouldCloseOnEscape: this.props.shouldCloseOnEscape,
         shouldCloseOnDocumentClick: false,
         onDismiss: this.hide
       })

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -175,6 +175,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         onBlur={this.handleBlur}
         elementRef={this.handleRef}
         shouldCloseOnDocumentClick={false}
+        shouldCloseOnEscape
       >
         <span id={this._id} css={styles?.tooltip} role="tooltip">
           {/* TODO: figure out how to add a ref to this */}


### PR DESCRIPTION
INSTUI-4347
INSTUI-4334
INSTUI-4353

test plan:

- check if pagination indicators have an 8px gap now
- inspect pagination indicators: should have a markup with `<ul>` and `<li>`
- voiceover should announce that the indicators are in a list
- tooltips should be dismissable with esc even when you hover on them (and any other way)