### PR TITLE
fix(ui-tag): Non-interactive components are announced as "clickable" by screen readers

### DIFF
--- a/packages/ui-progress/tsconfig.build.json
+++ b/packages/ui-progress/tsconfig.build.json
@@ -17,7 +17,6 @@
     { "path": "../ui-testable/tsconfig.build.json" },
     { "path": "../ui-view/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
-    { "path": "../ui-test-locator/tsconfig.build.json" },
     { "path": "../ui-test-utils/tsconfig.build.json" },
     { "path": "../ui-themes/tsconfig.build.json" }
   ]

--- a/packages/ui-tag/src/Tag/index.tsx
+++ b/packages/ui-tag/src/Tag/index.tsx
@@ -122,7 +122,7 @@ class Tag extends Component<TagProps> {
         as={onClick ? 'button' : 'span'}
         margin={margin}
         type={onClick ? 'button' : undefined}
-        onClick={onClick ?? this.handleClick}
+        {...(onClick && { onClick: this.handleClick })}
         disabled={disabled || readOnly}
         display={undefined}
         title={title || (typeof text === 'string' ? text : undefined)}


### PR DESCRIPTION
Remove onClick prop from Tag when callback is not provided.
Fix Progress dependency mismatch (test-locator)

Closes: INSTUI-4332


Test:
Check Tag component in the doc App with Safari and VoiceOver.
Tag should not announced as clickable (select with: control+shift+option+arrow buttons)