### PR TITLE
chore(ui-progress): improve accessibilty on documentation main page

### DIFF
--- a/packages/__docs__/src/Header/index.tsx
+++ b/packages/__docs__/src/Header/index.tsx
@@ -154,13 +154,8 @@ class Header extends Component<HeaderProps> {
     )
 
     return (
-      <View
-        role="banner"
-        as="div"
-        margin="none none medium"
-        padding="none medium"
-      >
-        <Heading level="h2" as="h1">
+      <View as="div" margin="none none medium" padding="none medium">
+        <Heading level="h2" as="div">
           <Link href="#index" isWithinText={false} display="block">
             <View display="block" textAlign="center">
               {corpLogo}

--- a/packages/__docs__/src/Hero/index.tsx
+++ b/packages/__docs__/src/Hero/index.tsx
@@ -29,7 +29,7 @@ import { Button, IconButton } from '@instructure/ui-buttons'
 import { Flex } from '@instructure/ui-flex'
 import { Img } from '@instructure/ui-img'
 import { Link } from '@instructure/ui-link'
-import { List } from '@instructure/ui-list'
+import { InlineList, List } from '@instructure/ui-list'
 import { Text } from '@instructure/ui-text'
 import { View } from '@instructure/ui-view'
 import {
@@ -290,7 +290,7 @@ class Hero extends Component<HeroProps> {
     )
 
     const sidebarContent = (
-      <View as="aside">
+      <View as="div">
         <View as="div">
           <Flex>
             <Flex.Item>
@@ -453,37 +453,42 @@ class Hero extends Component<HeroProps> {
                       LMS.
                     </Text>
                   </View>
-
-                  <View as="p" margin="0">
-                    <Button
-                      withBackground={false}
-                      color="primary-inverse"
-                      href="#usage"
-                      margin="0 x-small x-small 0"
-                      size={bigScreen ? 'large' : 'medium'}
-                    >
-                      Developer Quick Start
-                    </Button>
-                    <Button
-                      withBackground={false}
-                      color="primary-inverse"
-                      renderIcon={IconGithubSolid as any}
-                      href="https://github.com/instructure/instructure-ui"
-                      size={bigScreen ? 'large' : 'medium'}
-                      margin="0 x-small x-small 0"
-                    >
-                      Github
-                    </Button>
-                    <Button
-                      focusColor="inverse"
-                      color="success"
-                      href="#v10-upgrade-guide"
-                      size={bigScreen ? 'large' : 'medium'}
-                      margin="0 x-small x-small 0"
-                    >
-                      10.0 Upgrade Guide
-                    </Button>
-                  </View>
+                  <InlineList margin="0">
+                    <InlineList.Item>
+                      <Button
+                        withBackground={false}
+                        color="primary-inverse"
+                        href="#usage"
+                        margin="0 x-small x-small 0"
+                        size={bigScreen ? 'large' : 'medium'}
+                      >
+                        Developer Quick Start
+                      </Button>
+                    </InlineList.Item>
+                    <InlineList.Item>
+                      <Button
+                        withBackground={false}
+                        color="primary-inverse"
+                        renderIcon={IconGithubSolid as any}
+                        href="https://github.com/instructure/instructure-ui"
+                        size={bigScreen ? 'large' : 'medium'}
+                        margin="0 x-small x-small 0"
+                      >
+                        Github
+                      </Button>
+                    </InlineList.Item>
+                    <InlineList.Item>
+                      <Button
+                        focusColor="inverse"
+                        color="success"
+                        href="#v10-upgrade-guide"
+                        size={bigScreen ? 'large' : 'medium'}
+                        margin="0 x-small x-small 0"
+                      >
+                        10.0 Upgrade Guide
+                      </Button>
+                    </InlineList.Item>
+                  </InlineList>
                 </View>
               </ContentWrap>
             </View>

--- a/packages/ui-progress/tsconfig.build.json
+++ b/packages/ui-progress/tsconfig.build.json
@@ -17,7 +17,6 @@
     { "path": "../ui-testable/tsconfig.build.json" },
     { "path": "../ui-view/tsconfig.build.json" },
     { "path": "../ui-babel-preset/tsconfig.build.json" },
-    { "path": "../ui-test-locator/tsconfig.build.json" },
     { "path": "../ui-test-utils/tsconfig.build.json" },
     { "path": "../ui-themes/tsconfig.build.json" }
   ]


### PR DESCRIPTION
Closes: 
INSTUI-4263
INSTUI-4265
INSTUI-4272

ISSUES:
- Quick start/Github/Migration guide buttons are not in list tags but appear as list
- "What's new?" section is nested within navigation landmark despite not being a top-level landmark
- Instructure logo is nested within navigation landmark, but it isn't a top-level landmark
- Instructure side menu container incorrectly has a heading tag

TEST PLAN:
- check if Quick start/Github/Migration guide buttons are in list on the main page
- check if "What's new?" section is a div instead of an aside tag on the main page
- check if inside the navigation bar, the container of the Instructure logo does not have a banner role 
- check if container below the previous element is a div, not a h1 tag