### PR TITLE
fix(ui-form-field): Remove hardcoded colors and use theme provided ones

### DIFF
--- a/packages/ui-form-field/src/FormFieldMessage/theme.ts
+++ b/packages/ui-form-field/src/FormFieldMessage/theme.ts
@@ -40,9 +40,9 @@ const generateComponentTheme = (theme: Theme): FormFieldMessageTheme => {
   }
 
   const componentVariables: FormFieldMessageTheme = {
-    colorHint: colors?.contrasts?.grey125125,
-    colorError: colors?.contrasts?.red4570,
-    colorSuccess: colors?.contrasts?.green4570,
+    colorHint: colors?.ui?.textBody,
+    colorError: colors?.ui?.textError,
+    colorSuccess: colors?.ui?.textSuccess,
 
     fontFamily: typography?.fontFamily,
     fontWeight: typography?.fontWeightNormal,


### PR DESCRIPTION
The form field message component used hardcoded colors for the different message types, independently from the theme currently used. Now it will use the theme-provided colors.