### PR TITLE
fix(ui-source-code-editor): prevent Vite from erroring out during the…

### DIFF
--- a/packages/ui-source-code-editor/src/SourceCodeEditor/SearchPanel.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/SearchPanel.tsx
@@ -144,8 +144,10 @@ export default function customSearch(searchConfig: SearchConfig | undefined) {
           dom.style.padding = '8px'
           const reactVersionMajor = Number(React.version.split('.')[0])
           if (reactVersionMajor >= 18) {
+            const module = 'react-dom/client'
             // webpack tries to evaluate imports compile time which would lead to an error on older react versions
-            import(/* webpackIgnore: true */ 'react-dom/client')
+            // Vite errors out during build in React v16/17
+            import(/* webpackIgnore: true */ /* @vite-ignore */ module)
               .then((r) => {
                 const root = r.createRoot(dom)
                 root.render(


### PR DESCRIPTION
… build in React 16/17

Closes: INSTUI-4382

ISSUE: Vite errors out during build for an unused dependency imported with import(). Possible solution: https://github.com/vitejs/vite/issues/6582#issuecomment-1888725805

TEST PLAN:
- without the annotations, it throws a 'Failed to resolve import "react-dom/client" from...' error in console on React 17: https://stackblitz.com/edit/sb1-5rw3ux?file=src%2FApp.jsx
- with the new annotation it should not throw a 'Failed to resolve import "react-dom/client" from...' error in console on React 17: https://stackblitz.com/edit/sb1-wtz7pc?file=src%2FApp.jsx
- with the new annotation it should not throw with webpack on React 17: https://stackblitz.com/edit/sb1-byvu2b?file=src%2Futils%2FrenderUtils.js
