### PR TITLE
feat(tooltip): make tooltip border color overridable

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -1445,6 +1445,7 @@ export type TooltipTheme = {
   fontWeight: Typography['fontWeightNormal']
   fontSize: Typography['fontSizeSmall']
   padding: Spacing['small']
+  borderColor: Colors['contrasts']['grey3045']
 }
 
 export type TopNavBarActionItemsTheme = {

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -176,6 +176,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         elementRef={this.handleRef}
         shouldCloseOnDocumentClick={false}
         shouldCloseOnEscape
+        themeOverride={{ borderColor: styles?.borderColor as string }}
       >
         <span id={this._id} css={styles?.tooltip} role="tooltip">
           {/* TODO: figure out how to add a ref to this */}

--- a/packages/ui-tooltip/src/Tooltip/props.ts
+++ b/packages/ui-tooltip/src/Tooltip/props.ts
@@ -186,7 +186,7 @@ type TooltipProps = PropsPassableToPopover &
   OtherHTMLAttributes<TooltipOwnProps> &
   WithDeterministicIdProps
 
-type TooltipStyle = ComponentStyle<'tooltip'>
+type TooltipStyle = ComponentStyle<'tooltip' | 'borderColor'>
 
 type TooltipState = {
   hasFocus: boolean

--- a/packages/ui-tooltip/src/Tooltip/styles.ts
+++ b/packages/ui-tooltip/src/Tooltip/styles.ts
@@ -45,7 +45,8 @@ const generateStyle = (componentTheme: TooltipTheme): TooltipStyle => {
       display: 'block',
       fontSize: componentTheme.fontSize,
       padding: componentTheme.padding
-    }
+    },
+    borderColor: componentTheme.borderColor
   }
 }
 

--- a/packages/ui-tooltip/src/Tooltip/theme.ts
+++ b/packages/ui-tooltip/src/Tooltip/theme.ts
@@ -31,13 +31,14 @@ import { TooltipTheme } from '@instructure/shared-types'
  * @return {Object} The final theme object with the overrides and component variables
  */
 const generateComponentTheme = (theme: Theme): TooltipTheme => {
-  const { typography, spacing } = theme
+  const { typography, spacing, colors } = theme
 
   const componentVariables: TooltipTheme = {
     fontFamily: typography?.fontFamily,
     fontWeight: typography?.fontWeightNormal,
     fontSize: typography?.fontSizeSmall,
-    padding: spacing?.small
+    padding: spacing?.small,
+    borderColor: colors?.contrasts?.grey3045
   }
 
   return {


### PR DESCRIPTION
On this pr I added the border color as overrideable property.
CLX ticket for the change requirement: https://instructure.atlassian.net/browse/CLX-233
Figma design with the new border color: https://www.figma.com/design/HJj54DmmepY3EWhVb8AYZ5/CEC-Design-System?node-id=1024-9289&node-type=frame&m=dev

Updated view for the Tooltip component:
<img width="2382" alt="Screenshot 2024-11-28 at 15 14 15" src="https://github.com/user-attachments/assets/e20844f8-9974-416c-97da-c9fb86c538fa">
Also I tried it out with red borders:
<img width="867" alt="Screenshot 2024-11-28 at 14 56 24" src="https://github.com/user-attachments/assets/b5c003d1-c68c-4d26-ac04-370f8341507e">


