### PR TITLE
docs: add more documentation on how to do theme overrides

### DIFF
--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -110,8 +110,8 @@ type: example
     color='primary'
     margin="0 0 0 small"
     themeOverride={(_componentTheme, currentTheme) => ({
-      primaryBackground: currentTheme.colors.backgroundWarning,
-      primaryBorderColor: currentTheme.colors.backgroundLightest,
+      primaryBackground: currentTheme.colors.primitives.orange57,
+      primaryBorderColor: '#00AAA4',
       borderWidth: currentTheme.borders.widthLarge,
       borderStyle: 'dashed'
     })}

--- a/packages/ui-themes/README.md
+++ b/packages/ui-themes/README.md
@@ -21,6 +21,9 @@ npm install @instructure/ui-themes
 - application level theming:
 
   ```jsx
+  ---
+  type: code
+  ---
   import canvas from '@instructure/ui-themes'
 
   ReactDOM.render(
@@ -34,6 +37,9 @@ npm install @instructure/ui-themes
 - (DEPRECATED) global theming:
 
   ```js
+  ---
+  type: code
+  ---
   import canvas from '@instructure/ui-themes'
 
   canvas.use()
@@ -44,6 +50,9 @@ npm install @instructure/ui-themes
 - (DEPRECATED) globally:
 
   ```js
+  ---
+  type: code
+  ---
   import canvas from '@instructure/ui-themes'
 
   canvas.use({ overrides: { colors: { brand: 'red' } } })
@@ -52,6 +61,9 @@ npm install @instructure/ui-themes
 - application level:
 
   ```jsx
+  ---
+  type: code
+  ---
   import canvas from '@instructure/ui-themes'
   const themeOverrides = { colors: { brand: 'red' } }
 


### PR DESCRIPTION
Content mostly recovered from the deleted parts in the v9 version, but I also tried to make the examples more clear