### PR TITLE
fix(many): hide required asterisks from screenreaders

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/CheckboxFacade/theme.ts
@@ -48,7 +48,7 @@ const generateComponentTheme = (theme: Theme): CheckboxFacadeTheme => {
     color: colors?.contrasts?.white1010,
     borderWidth: borders?.widthSmall,
     borderColor: colors?.contrasts?.grey3045,
-    errorBorderColor: colors?.ui?.textError,
+    errorBorderColor: colors?.contrasts?.red5782,
     borderRadius: borders?.radiusMedium,
     background: colors?.contrasts?.white1010,
     marginRight: spacing?.xSmall,

--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/theme.ts
@@ -54,7 +54,7 @@ const generateComponentTheme = (theme: Theme): ToggleFacadeTheme => {
 
   const componentVariables: ToggleFacadeTheme = {
     color: colors?.contrasts?.white1010,
-    errorBorderColor: colors?.ui?.textError,
+    errorBorderColor: colors?.contrasts?.red5782,
     background: colors?.contrasts?.grey1111,
     borderColor: colors?.contrasts?.grey3045,
     borderWidth: borders?.widthSmall,

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -231,7 +231,13 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
         >
           {label}
           {isRequired && label && (
-            <span css={this.invalid ? styles?.requiredInvalid : {}}> *</span>
+            <span
+              css={this.invalid ? styles?.requiredInvalid : {}}
+              aria-hidden={true}
+            >
+              {' '}
+              *
+            </span>
           )}
         </ToggleFacade>
       )
@@ -248,7 +254,13 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
         >
           {label}
           {isRequired && label && (
-            <span css={this.invalid ? styles?.requiredInvalid : {}}> *</span>
+            <span
+              css={this.invalid ? styles?.requiredInvalid : {}}
+              aria-hidden={true}
+            >
+              {' '}
+              *
+            </span>
           )}
         </CheckboxFacade>
       )

--- a/packages/ui-number-input/src/NumberInput/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/index.tsx
@@ -246,7 +246,13 @@ class NumberInput extends Component<NumberInputProps, NumberInputState> {
       <React.Fragment>
         {rawLabel}
         {isRequired && (
-          <span css={this.invalid ? styles?.requiredInvalid : {}}> *</span>
+          <span
+            css={this.invalid ? styles?.requiredInvalid : {}}
+            aria-hidden={true}
+          >
+            {' '}
+            *
+          </span>
         )}
       </React.Fragment>
     ) : (

--- a/packages/ui-radio-input/src/RadioInputGroup/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/index.tsx
@@ -165,7 +165,13 @@ class RadioInputGroup extends Component<
       <React.Fragment>
         {description}
         {isRequired && description && (
-          <span css={this.invalid ? styles?.invalidAsterisk : {}}> *</span>
+          <span
+            css={this.invalid ? styles?.invalidAsterisk : {}}
+            aria-hidden={true}
+          >
+            {' '}
+            *
+          </span>
         )}
       </React.Fragment>
     ) : (

--- a/packages/ui-text-area/src/TextArea/index.tsx
+++ b/packages/ui-text-area/src/TextArea/index.tsx
@@ -358,7 +358,13 @@ class TextArea extends Component<TextAreaProps> {
       <React.Fragment>
         {this.props.label}
         {required && (
-          <span css={this.invalid ? styles?.requiredInvalid : {}}> *</span>
+          <span
+            css={this.invalid ? styles?.requiredInvalid : {}}
+            aria-hidden={true}
+          >
+            {' '}
+            *
+          </span>
         )}
       </React.Fragment>
     ) : (

--- a/packages/ui-text-input/src/TextInput/index.tsx
+++ b/packages/ui-text-input/src/TextInput/index.tsx
@@ -333,7 +333,13 @@ class TextInput extends Component<TextInputProps, TextInputState> {
       <React.Fragment>
         {rawLabel}
         {isRequired && (
-          <span css={this.invalid ? styles?.requiredInvalid : {}}> *</span>
+          <span
+            css={this.invalid ? styles?.requiredInvalid : {}}
+            aria-hidden={true}
+          >
+            {' '}
+            *
+          </span>
         )}
       </React.Fragment>
     ) : (


### PR DESCRIPTION
INSTUI-4374

also fixed 2 instances where the wrong color token was used

test plan:
- check if screen readers ignore the required asterisk in field labels