### PR TITLE
fix(ui-a11y-utils): fix focus region missing mouse down target

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -45,8 +45,7 @@ class FocusRegion {
   private readonly _id: string
   private _listeners: ReturnType<typeof addEventListener>[] = []
   private _active = false
-  private _documentClickTarget: Node | null = null
-  private _contextContainsTarget = false
+  private _documentMouseDownTarget: Node | null = null
 
   constructor(element: Element | Node | null, options: FocusRegionOptions) {
     this._options = options || {
@@ -83,11 +82,8 @@ class FocusRegion {
   }
 
   captureDocumentMousedown = (event: React.MouseEvent) => {
-    this._documentClickTarget = event.target as Node
-    this._contextContainsTarget = contains(
-      this._contextElement,
-      this._documentClickTarget
-    )
+    // FocusRegion can be activated after mousedown but before click so this is not guaranteed to fire.
+    this._documentMouseDownTarget = event.target as Node
   }
 
   handleDocumentClick = (event: React.PointerEvent) => {
@@ -95,7 +91,8 @@ class FocusRegion {
       this._options.shouldCloseOnDocumentClick &&
       event.button === 0 &&
       event.detail > 0 && // if event.detail is 0 then this is a keyboard and not a mouse press
-      !this._contextContainsTarget
+      this._documentMouseDownTarget !== null &&
+      !contains(this._contextElement, this._documentMouseDownTarget)
     ) {
       this.handleDismiss(event, true)
     }


### PR DESCRIPTION
We noticed a weird issue where sometimes a Modal got closed unexpectedly when we clicked on any Button.

## Minimal code to reproduce:
```tsx
import { Button } from '@instructure/ui-buttons';
import { Modal } from '@instructure/ui-modal';
import { SimpleSelect } from '@instructure/ui-simple-select';
import React from 'react';

export const App: React.FC = () => {
	const [modalOpen, setModalOpen] = React.useState(false);

	return (
		<>
			<Button onClick={() => setModalOpen(true)}>Open modal</Button>
			<Modal open={modalOpen} onDismiss={() => setModalOpen(false)} label="Modal">
				<div style={{ display: 'flex', gap: '20px' }}>
					<SimpleSelect renderLabel="Use only keyboard to open this select">
						<SimpleSelect.Option id="foo" value="foo">
							Foo
						</SimpleSelect.Option>
						<SimpleSelect.Option id="bar" value="bar">
							Bar
						</SimpleSelect.Option>
						<SimpleSelect.Option id="baz" value="baz">
							Baz
						</SimpleSelect.Option>
					</SimpleSelect>
					<Button>Click by mouse when select is open</Button>
				</div>
			</Modal>
		</>
	);
};
```

## Steps to reproduce
* Open modal
* Open select dropdown **using only keyboard**, do not interact with anything else
* Click on button inside modal while select is still open
* Modal is closed when it shouldn't be

## Root cause
Between a `mousedown` and `click` event we change the active `FocusRegion` from select dropdown to modal. The `mousedown` event is captured in FocusRegion belonging to select and `click` is captured in FocusRegion belonging to modal. That means in modal FocusRegion `captureDocumentMousedown` is never fired and `_contextContainsTarget` defaults to false. This triggers a dismiss event even though we clicked on a button within FocusRegion.