### PR TITLE
chore: add expanded state to menu side navigation button

### DIFF
--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -613,6 +613,7 @@ class App extends Component<AppProps, AppState> {
               shape="circle"
               color="secondary"
               size="medium"
+              aria-expanded={true}
               ref={(button) => {
                 if (button) {
                   button.focus()


### PR DESCRIPTION
Closes: INSTUI-4249

ISSUE:
- the side navigation button is not announced as "expanded" when it is open.

TEST PLAN:
- click on the side navigation button in the documentation to open it
- the screen reader should announce it as "expanded" after the menu opens.