### PR TITLE
feat(link): add textUnderlineOffset to Link component theme override

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -653,6 +653,7 @@ export type LinkTheme = {
   focusInverseIconOutlineColor: Colors['contrasts']['white1010']
   iconSize: string
   iconPlusTextMargin: Spacing['xxSmall']
+  textUnderlineOffset: string
 }
 
 export type InlineListItemTheme = {

--- a/packages/ui-link/src/Link/styles.ts
+++ b/packages/ui-link/src/Link/styles.ts
@@ -57,6 +57,7 @@ const generateStyle = (
     outlineStyle: componentTheme.focusOutlineStyle,
     borderRadius: componentTheme.focusOutlineBorderRadius,
     outlineOffset: '0.25rem',
+    textUnderlineOffset: componentTheme.textUnderlineOffset,
 
     // If TruncateText is used in Link with icon, align the icon and the text vertically
     ...(renderIcon &&

--- a/packages/ui-link/src/Link/theme.ts
+++ b/packages/ui-link/src/Link/theme.ts
@@ -71,7 +71,8 @@ const generateComponentTheme = (theme: Theme): LinkTheme => {
     focusInverseIconOutlineColor: colors?.contrasts?.white1010,
 
     iconSize: '1.125em', // make icon slightly larger than inherited font-size,
-    iconPlusTextMargin: spacing?.xxSmall
+    iconPlusTextMargin: spacing?.xxSmall,
+    textUnderlineOffset: 'auto'
   }
 
   return {


### PR DESCRIPTION
Added text-underline-offset option to theme override variables.
Default value is set to auto.

<img width="1031" alt="Screenshot 2024-12-09 at 15 14 24" src="https://github.com/user-attachments/assets/b125a051-1627-4e32-b8d3-a22e38b89a70">

<img width="1068" alt="Screenshot 2024-12-09 at 15 07 46" src="https://github.com/user-attachments/assets/f9ae1205-9ee3-44a5-9846-8f87c19b2b4e">
