### PR TITLE
chore(many): make meta package export everything which is exported in…

### DIFF
--- a/packages/ui-calendar/src/index.ts
+++ b/packages/ui-calendar/src/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 export { Calendar } from './Calendar'
+export { Day as CalendarDay } from './Calendar/Day'
 
 export type { CalendarProps } from './Calendar/props'
 export type { CalendarDayProps } from './Calendar/Day/props'

--- a/packages/ui-drawer-layout/src/index.ts
+++ b/packages/ui-drawer-layout/src/index.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-export { DrawerLayout, DrawerContent } from './DrawerLayout'
+export { DrawerLayout, DrawerContent, DrawerTray } from './DrawerLayout'
 
 export type { DrawerLayoutProps } from './DrawerLayout/props'
 export type { DrawerLayoutContentProps } from './DrawerLayout/DrawerContent/props'

--- a/packages/ui-drilldown/src/index.ts
+++ b/packages/ui-drilldown/src/index.ts
@@ -23,6 +23,10 @@
  */
 
 export { Drilldown } from './Drilldown'
+export { DrilldownGroup } from './Drilldown/DrilldownGroup'
+export { DrilldownOption } from './Drilldown/DrilldownOption'
+export { DrilldownPage } from './Drilldown/DrilldownPage'
+export { DrilldownSeparator } from './Drilldown/DrilldownSeparator'
 
 export type {
   DrilldownProps,

--- a/packages/ui-list/src/index.ts
+++ b/packages/ui-list/src/index.ts
@@ -24,6 +24,7 @@
 
 export { InlineList } from './InlineList'
 export { List, ListItem } from './List'
+export { InlineListItem } from './InlineList/InlineListItem'
 
 export type { InlineListProps } from './InlineList/props'
 export type { InlineListItemProps } from './InlineList/InlineListItem/props'

--- a/packages/ui-modal/src/index.ts
+++ b/packages/ui-modal/src/index.ts
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-export { Modal } from './Modal'
+export { Modal, ModalBody, ModalFooter, ModalHeader } from './Modal'
 
 export type { ModalProps } from './Modal/props'
 export type { ModalBodyProps } from './Modal/ModalBody/props'

--- a/packages/ui-motion/src/index.ts
+++ b/packages/ui-motion/src/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 export { Transition } from './Transition'
+export { BaseTransition } from './Transition/BaseTransition'
 export type { TransitionProps, TransitionType } from './Transition/props'
 export type { BaseTransitionStatesType } from './Transition/BaseTransition/props'
 export { transitionTypePropType } from './Transition/props'

--- a/packages/ui-navigation/src/index.ts
+++ b/packages/ui-navigation/src/index.ts
@@ -23,6 +23,7 @@
  */
 
 export { AppNav } from './AppNav'
+export { Item as AppNavItem } from './AppNav/Item'
 
 export type { AppNavProps } from './AppNav/props'
 export type { AppNavItemProps } from './AppNav/Item/props'

--- a/packages/ui-options/src/index.ts
+++ b/packages/ui-options/src/index.ts
@@ -23,6 +23,8 @@
  */
 
 export { Options } from './Options'
+export { Item as OptionItem } from './Options/Item'
+export { Separator as OptionSeparator } from './Options/Separator'
 
 export { optionsThemeGenerator } from './Options/theme'
 export { optionsItemThemeGenerator } from './Options/Item/theme'

--- a/packages/ui-pages/src/index.ts
+++ b/packages/ui-pages/src/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 export { Pages } from './Pages'
+export { Page as PagesPage } from './Pages/Page'
 
 export type { PagesProps } from './Pages/props'
 export type { PagesPageProps } from './Pages/Page/props'

--- a/packages/ui-rating/src/index.ts
+++ b/packages/ui-rating/src/index.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 export { Rating } from './Rating'
+export { RatingIcon } from './RatingIcon'
 
 export type { RatingProps } from './Rating/props'
 export type { RatingIconProps } from './RatingIcon/props'

--- a/packages/ui-select/src/index.ts
+++ b/packages/ui-select/src/index.ts
@@ -23,6 +23,8 @@
  */
 
 export { Select } from './Select'
+export { Group as SelectGroup } from './Select/Group'
+export { Option as SelectOption } from './Select/Option'
 
 export type { SelectProps, SelectOwnProps } from './Select/props'
 export type { SelectGroupProps } from './Select/Group/props'

--- a/packages/ui-simple-select/src/index.ts
+++ b/packages/ui-simple-select/src/index.ts
@@ -23,6 +23,8 @@
  */
 
 export { SimpleSelect } from './SimpleSelect'
+export { Group as SimpleSelectGroup } from './SimpleSelect/Group'
+export { Option as SimpleSelectOption } from './SimpleSelect/Option'
 
 export type { SimpleSelectProps } from './SimpleSelect/props'
 export type { SimpleSelectGroupProps } from './SimpleSelect/Group/props'

--- a/packages/ui-table/src/index.ts
+++ b/packages/ui-table/src/index.ts
@@ -23,6 +23,12 @@
  */
 export { Table } from './Table'
 export { TableContext } from './Table/TableContext'
+export { Body as TableBody } from './Table/Body'
+export { Cell as TableCell } from './Table/Cell'
+export { ColHeader as TableColHeader } from './Table/ColHeader'
+export { Head as TableHead } from './Table/Head'
+export { Row as TableRow } from './Table/Row'
+export { RowHeader as TableRowHeader } from './Table/RowHeader'
 
 export type { TableProps } from './Table/props'
 export type { TableBodyProps } from './Table/Body/props'

--- a/packages/ui-tabs/src/index.ts
+++ b/packages/ui-tabs/src/index.ts
@@ -23,6 +23,8 @@
  */
 
 export { Tabs } from './Tabs'
+export { Panel as TabsPanel } from './Tabs/Panel'
+export { Tab as TabsTab } from './Tabs/Tab'
 
 export type { TabsProps } from './Tabs/props'
 export type { TabsPanelProps } from './Tabs/Panel/props'

--- a/packages/ui-top-nav-bar/src/index.ts
+++ b/packages/ui-top-nav-bar/src/index.ts
@@ -23,6 +23,13 @@
  */
 
 export { TopNavBar } from './TopNavBar'
+export { TopNavBarActionItems } from './TopNavBar/TopNavBarActionItems'
+export { TopNavBarBrand } from './TopNavBar/TopNavBarBrand'
+export { TopNavBarBreadcrumb } from './TopNavBar/TopNavBarBreadcrumb'
+export { TopNavBarItem } from './TopNavBar/TopNavBarItem'
+export { TopNavBarLayout } from './TopNavBar/TopNavBarLayout'
+export { TopNavBarMenuItems } from './TopNavBar/TopNavBarMenuItems'
+export { TopNavBarUser } from './TopNavBar/TopNavBarUser'
 
 export type { TopNavBarProps, TopNavBarOwnProps } from './TopNavBar/props'
 export type {

--- a/packages/ui-tree-browser/src/index.ts
+++ b/packages/ui-tree-browser/src/index.ts
@@ -22,6 +22,9 @@
  * SOFTWARE.
  */
 export { TreeBrowser } from './TreeBrowser'
+export { TreeButton } from './TreeBrowser/TreeButton'
+export { TreeCollection } from './TreeBrowser/TreeCollection'
+export { TreeNode } from './TreeBrowser/TreeNode'
 
 export type { TreeBrowserProps } from './TreeBrowser/props'
 export type { TreeBrowserButtonProps } from './TreeBrowser/TreeButton/props'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -28,12 +28,24 @@ export {
   PresentationContent,
   ScreenReaderContent
 } from '@instructure/ui-a11y-content'
+export type {
+  AccessibleContentProps,
+  ScreenReaderContentProps,
+  PresentationContentProps
+} from '@instructure/ui-a11y-content'
 export { Alert } from '@instructure/ui-alerts'
+export type { AlertProps } from '@instructure/ui-alerts'
 export { Avatar } from '@instructure/ui-avatar'
-
+export type { AvatarProps } from '@instructure/ui-avatar'
 export { Badge } from '@instructure/ui-badge'
+export type { BadgeProps } from '@instructure/ui-badge'
 export { Billboard } from '@instructure/ui-billboard'
-export { Breadcrumb } from '@instructure/ui-breadcrumb'
+export type { BillboardProps } from '@instructure/ui-billboard'
+export { Breadcrumb, BreadcrumbLink } from '@instructure/ui-breadcrumb'
+export type {
+  BreadcrumbProps,
+  BreadcrumbLinkProps
+} from '@instructure/ui-breadcrumb'
 export {
   BaseButton,
   Button,
@@ -42,15 +54,33 @@ export {
   IconButton,
   ToggleButton
 } from '@instructure/ui-buttons'
+export type {
+  BaseButtonOwnProps,
+  ButtonProps,
+  BaseButtonProps,
+  ToggleButtonProps,
+  CloseButtonProps,
+  CondensedButtonProps,
+  IconButtonProps
+} from '@instructure/ui-buttons'
 export { Byline } from '@instructure/ui-byline'
-export { Calendar } from '@instructure/ui-calendar'
+export type { BylineProps } from '@instructure/ui-byline'
+export { Calendar, CalendarDay } from '@instructure/ui-calendar'
+export type { CalendarDayProps, CalendarProps } from '@instructure/ui-calendar'
 export {
   Checkbox,
   CheckboxGroup,
   CheckboxFacade,
   ToggleFacade
 } from '@instructure/ui-checkbox'
+export type {
+  CheckboxFacadeProps,
+  ToggleFacadeProps,
+  CheckboxGroupProps,
+  CheckboxProps
+} from '@instructure/ui-checkbox'
 export { CodeEditor } from '@instructure/ui-code-editor'
+export type { CodeEditorProps } from '@instructure/ui-code-editor'
 export {
   ColorPicker,
   ColorMixer,
@@ -58,75 +88,398 @@ export {
   ColorContrast,
   ColorIndicator
 } from '@instructure/ui-color-picker'
+export type {
+  ColorContrastProps,
+  ColorIndicatorProps,
+  ColorMixerProps,
+  ColorPickerProps,
+  ColorPresetProps
+} from '@instructure/ui-color-picker'
 export { DateInput, DateInput2 } from '@instructure/ui-date-input'
+export type {
+  DateInputProps,
+  DateInput2Props
+} from '@instructure/ui-date-input'
 export { DateTimeInput } from '@instructure/ui-date-time-input'
 export { Dialog } from '@instructure/ui-dialog'
-export { DrawerLayout, DrawerContent } from '@instructure/ui-drawer-layout'
-export { Drilldown } from '@instructure/ui-drilldown'
+export type { DialogProps } from '@instructure/ui-dialog'
+export {
+  DrawerLayout,
+  DrawerContent,
+  DrawerTray
+} from '@instructure/ui-drawer-layout'
+export type {
+  DrawerLayoutProps,
+  DrawerLayoutContentProps,
+  DrawerLayoutTrayProps
+} from '@instructure/ui-drawer-layout'
+export {
+  Drilldown,
+  DrilldownGroup,
+  DrilldownOption,
+  DrilldownPage,
+  DrilldownSeparator
+} from '@instructure/ui-drilldown'
+export type {
+  DrilldownGroupChild,
+  DrilldownGroupProps,
+  DrilldownOptionChild,
+  DrilldownOptionProps,
+  DrilldownPageChild,
+  DrilldownPageChildren,
+  DrilldownPageProps,
+  DrilldownProps,
+  DrilldownSeparatorChild,
+  DrilldownSeparatorProps
+} from '@instructure/ui-drilldown'
 export { Editable, InPlaceEdit } from '@instructure/ui-editable'
+export type { EditableProps, InPlaceEditProps } from '@instructure/ui-editable'
 export { Expandable } from '@instructure/ui-expandable'
+export type {
+  ExpandableProps,
+  RenderExpandable,
+  ExpandableToggleProps
+} from '@instructure/ui-expandable'
 export { FileDrop } from '@instructure/ui-file-drop'
+export type { FileDropProps } from '@instructure/ui-file-drop'
 export { Flex, FlexItem } from '@instructure/ui-flex'
+export type { FlexProps, FlexItemProps } from '@instructure/ui-flex'
 export { Focusable } from '@instructure/ui-focusable'
+export type { FocusableProps } from '@instructure/ui-focusable'
 export {
   FormField,
   FormFieldLabel,
   FormFieldMessage,
   FormFieldMessages,
   FormFieldLayout,
-  FormFieldGroup
+  FormFieldGroup,
+  FormPropTypes
+} from '@instructure/ui-form-field'
+export type {
+  FormFieldGroupProps,
+  FormFieldLabelProps,
+  FormFieldMessageProps,
+  FormFieldMessagesProps,
+  FormFieldLayoutProps,
+  FormFieldOwnProps,
+  FormFieldProps,
+  FormMessage,
+  FormMessageType
 } from '@instructure/ui-form-field'
 export { Grid, GridRow, GridCol } from '@instructure/ui-grid'
+export type {
+  GridProps,
+  GridRowProps,
+  GridColProps,
+  GridBreakpoints
+} from '@instructure/ui-grid'
 export { Heading } from '@instructure/ui-heading'
-export { ApplyLocale, TextDirectionContext } from '@instructure/ui-i18n'
+export type { HeadingProps } from '@instructure/ui-heading'
+export {
+  ApplyLocale,
+  TextDirectionContext,
+  ApplyLocaleContext,
+  textDirectionContextConsumer,
+  DateTime,
+  getTextDirection,
+  I18nPropTypes,
+  Locale,
+  DIRECTION
+} from '@instructure/ui-i18n'
+export type {
+  Moment,
+  TextDirectionContextConsumerProps,
+  ApplyLocaleProps
+} from '@instructure/ui-i18n'
 export * from '@instructure/ui-icons'
 export { Img } from '@instructure/ui-img'
+export type { ImgProps } from '@instructure/ui-img'
 export { Link } from '@instructure/ui-link'
-export { List, ListItem, InlineList } from '@instructure/ui-list'
+export type { LinkProps } from '@instructure/ui-link'
+export {
+  List,
+  ListItem,
+  InlineList,
+  InlineListItem
+} from '@instructure/ui-list'
+export type {
+  ListProps,
+  ListItemProps,
+  InlineListProps,
+  InlineListItemProps
+} from '@instructure/ui-list'
 export {
   Menu,
   MenuItem,
   MenuItemGroup,
   MenuItemSeparator
 } from '@instructure/ui-menu'
+export type {
+  MenuProps,
+  MenuItemProps,
+  MenuGroupProps,
+  MenuSeparatorProps
+} from '@instructure/ui-menu'
 export { MetricGroup, Metric } from '@instructure/ui-metric'
-export { Modal } from '@instructure/ui-modal'
-export { Transition } from '@instructure/ui-motion'
-export { AppNav } from '@instructure/ui-navigation'
+export type { MetricGroupProps, MetricProps } from '@instructure/ui-metric'
+export {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader
+} from '@instructure/ui-modal'
+export type {
+  ModalProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  ModalHeaderProps
+} from '@instructure/ui-modal'
+export {
+  Transition,
+  transitionTypePropType,
+  BaseTransition
+} from '@instructure/ui-motion'
+export type {
+  TransitionProps,
+  TransitionType,
+  BaseTransitionStatesType
+} from '@instructure/ui-motion'
+export { AppNav, AppNavItem } from '@instructure/ui-navigation'
+export type { AppNavProps, AppNavItemProps } from '@instructure/ui-navigation'
 export { NumberInput } from '@instructure/ui-number-input'
-export { Options } from '@instructure/ui-options'
+export type { NumberInputProps } from '@instructure/ui-number-input'
+export {
+  Options,
+  OptionSeparator,
+  OptionItem,
+  optionsThemeGenerator,
+  optionsItemThemeGenerator,
+  optionsSeparatorThemeGenerator
+} from '@instructure/ui-options'
+export type {
+  OptionsItemProps,
+  OptionsItemRenderProps,
+  OptionsProps,
+  OptionsSeparatorProps
+} from '@instructure/ui-options'
 export { Mask, Overlay } from '@instructure/ui-overlays'
-export { Pages } from '@instructure/ui-pages'
-export { Pagination } from '@instructure/ui-pagination'
+export type { MaskProps, OverlayProps } from '@instructure/ui-overlays'
+export { Pages, PagesPage } from '@instructure/ui-pages'
+export type { PagesPageProps, PagesProps } from '@instructure/ui-pages'
+export { Pagination, PaginationButton } from '@instructure/ui-pagination'
+export type {
+  PaginationNavigationProps,
+  PaginationPageProps,
+  PaginationProps
+} from '@instructure/ui-pagination'
 export { Pill } from '@instructure/ui-pill'
+export type { PillProps } from '@instructure/ui-pill'
 export { Popover } from '@instructure/ui-popover'
+export type { PopoverProps, PopoverOwnProps } from '@instructure/ui-popover'
 export { Portal } from '@instructure/ui-portal'
-export { Position } from '@instructure/ui-position'
+export type { PortalProps, PortalNode } from '@instructure/ui-portal'
+export {
+  Position,
+  PositionPropTypes,
+  calculateElementPosition,
+  executeMirrorFunction,
+  mirrorHorizontalPlacement,
+  mirrorPlacement,
+  parsePlacement
+} from '@instructure/ui-position'
+export type {
+  PositionConstraint,
+  PositionObject,
+  PositionProps,
+  PlacementPropValues,
+  PositionMountNode
+} from '@instructure/ui-position'
 export { ProgressBar, ProgressCircle } from '@instructure/ui-progress'
+export type {
+  ProgressBarProps,
+  ProgressCircleProps
+} from '@instructure/ui-progress'
 export { RadioInput, RadioInputGroup } from '@instructure/ui-radio-input'
+export type {
+  RadioInputProps,
+  RadioInputGroupProps
+} from '@instructure/ui-radio-input'
 export { RangeInput } from '@instructure/ui-range-input'
-export { Rating } from '@instructure/ui-rating'
-export { Responsive } from '@instructure/ui-responsive'
-export { Select } from '@instructure/ui-select'
+export type { RangeInputProps } from '@instructure/ui-range-input'
+export { Rating, RatingIcon } from '@instructure/ui-rating'
+export type { RatingIconProps, RatingProps } from '@instructure/ui-rating'
+export {
+  Responsive,
+  ResponsivePropTypes,
+  addElementQueryMatchListener,
+  addMediaQueryMatchListener,
+  parseQuery,
+  jsonToMediaQuery
+} from '@instructure/ui-responsive'
+export type {
+  ResponsiveProps,
+  ResponsivePropsObject,
+  BreakpointQueries,
+  QueriesMatching,
+  Query,
+  ResponsiveByBreakpointProps,
+  ValidQueryKey
+} from '@instructure/ui-responsive'
+export { Select, SelectGroup, SelectOption } from '@instructure/ui-select'
+export type {
+  SelectOwnProps,
+  SelectGroupProps,
+  SelectOptionProps,
+  SelectProps
+} from '@instructure/ui-select'
 export { Selectable } from '@instructure/ui-selectable'
-export { SideNavBar } from '@instructure/ui-side-nav-bar'
-export { SimpleSelect } from '@instructure/ui-simple-select'
+export type {
+  SelectableRender,
+  SelectableProps
+} from '@instructure/ui-selectable'
+export { SideNavBar, SideNavBarItem } from '@instructure/ui-side-nav-bar'
+export type {
+  SideNavBarProps,
+  SideNavBarItemProps
+} from '@instructure/ui-side-nav-bar'
+export {
+  SimpleSelect,
+  SimpleSelectOption,
+  SimpleSelectGroup
+} from '@instructure/ui-simple-select'
+export type {
+  SimpleSelectProps,
+  SimpleSelectGroupProps,
+  SimpleSelectOptionProps
+} from '@instructure/ui-simple-select'
 export { SourceCodeEditor } from '@instructure/ui-source-code-editor'
+export type { SourceCodeEditorProps } from '@instructure/ui-source-code-editor'
 export { Spinner } from '@instructure/ui-spinner'
+export type { SpinnerProps } from '@instructure/ui-spinner'
 export { InlineSVG, SVGIcon } from '@instructure/ui-svg-images'
-export { Table } from '@instructure/ui-table'
-export { Tabs } from '@instructure/ui-tabs'
+export type { InlineSVGProps, SVGIconProps } from '@instructure/ui-svg-images'
+export {
+  Table,
+  TableContext,
+  TableBody,
+  TableHead,
+  TableCell,
+  TableRow,
+  TableColHeader,
+  TableRowHeader
+} from '@instructure/ui-table'
+export type {
+  TableBodyProps,
+  TableCellProps,
+  TableProps,
+  TableColHeaderProps,
+  TableHeadProps,
+  TableRowHeaderProps,
+  TableRowProps
+} from '@instructure/ui-table'
+export { Tabs, TabsPanel, TabsTab } from '@instructure/ui-tabs'
+export type {
+  TabsTabProps,
+  TabsPanelProps,
+  TabsProps
+} from '@instructure/ui-tabs'
 export { Tag } from '@instructure/ui-tag'
+export type { TagProps } from '@instructure/ui-tag'
 export { Text } from '@instructure/ui-text'
+export type { TextProps } from '@instructure/ui-text'
 export { TextArea } from '@instructure/ui-text-area'
+export type { TextAreaProps } from '@instructure/ui-text-area'
 export { TextInput } from '@instructure/ui-text-input'
-export { canvas, canvasHighContrast } from '@instructure/ui-themes'
+export type { TextInputProps } from '@instructure/ui-text-input'
+export {
+  canvas,
+  canvasThemeLocal,
+  canvasHighContrast,
+  canvasHighContrastThemeLocal,
+  primitives,
+  additionalPrimitives,
+  dataVisualization
+} from '@instructure/ui-themes'
+export type {
+  ThemeMap,
+  BaseTheme,
+  Theme,
+  ThemeKeys,
+  ThemeSpecificStyle,
+  CanvasTheme,
+  CanvasBrandVariables,
+  CanvasHighContrastTheme,
+  Primitives,
+  AdditionalPrimitives,
+  DataVisualization,
+  UI
+} from '@instructure/ui-themes'
 export { TimeSelect } from '@instructure/ui-time-select'
+export type { TimeSelectProps } from '@instructure/ui-time-select'
 export { ToggleDetails, ToggleGroup } from '@instructure/ui-toggle-details'
+export type {
+  ToggleDetailsProps,
+  ToggleGroupProps
+} from '@instructure/ui-toggle-details'
 export { Tooltip } from '@instructure/ui-tooltip'
-export { TopNavBar } from '@instructure/ui-top-nav-bar'
+export type {
+  TooltipProps,
+  TooltipRenderChildrenArgs
+} from '@instructure/ui-tooltip'
+export {
+  TopNavBar,
+  TopNavBarActionItems,
+  TopNavBarBrand,
+  TopNavBarBreadcrumb,
+  TopNavBarItem,
+  TopNavBarLayout,
+  TopNavBarMenuItems,
+  TopNavBarUser
+} from '@instructure/ui-top-nav-bar'
+export type {
+  TopNavBarProps,
+  TopNavBarOwnProps,
+  TopNavBarActionItemsProps,
+  TopNavBarActionItemsOwnProps,
+  TopNavBarBrandProps,
+  TopNavBarBrandOwnProps,
+  TopNavBarItemProps,
+  TopNavBarItemOwnProps,
+  TopNavBarItemTooltipType,
+  TopNavBarLayoutProps,
+  CommonTopNavBarLayoutProps,
+  TopNavBarDesktopLayoutProps,
+  TopNavBarDesktopLayoutOwnProps,
+  DesktopLayoutOwnProps,
+  TopNavBarSmallViewportLayoutProps,
+  TopNavBarSmallViewportLayoutOwnProps,
+  SmallViewportLayoutOwnProps,
+  TopNavBarMenuItemsProps,
+  TopNavBarMenuItemsOwnProps,
+  TopNavBarUserProps,
+  TopNavBarUserOwnProps
+} from '@instructure/ui-top-nav-bar'
 export { Tray } from '@instructure/ui-tray'
-export { TreeBrowser } from '@instructure/ui-tree-browser'
+export type { TrayProps } from '@instructure/ui-tray'
+export {
+  TreeBrowser,
+  TreeNode,
+  TreeButton,
+  TreeCollection
+} from '@instructure/ui-tree-browser'
+export type {
+  TreeBrowserButtonProps,
+  TreeBrowserProps,
+  TreeBrowserCollectionProps,
+  TreeBrowserNodeProps
+} from '@instructure/ui-tree-browser'
 export { TruncateList } from '@instructure/ui-truncate-list'
+export type { TruncateListProps } from '@instructure/ui-truncate-list'
 export { TruncateText } from '@instructure/ui-truncate-text'
+export type { TruncateTextProps } from '@instructure/ui-truncate-text'
 export { View, ContextView } from '@instructure/ui-view'
+export type {
+  ViewProps,
+  ContextViewProps,
+  ViewOwnProps
+} from '@instructure/ui-view'


### PR DESCRIPTION
… components

Closes: INSTUI-4381

- added everything to the meta file which is exported in the ui-component-name/src/index.ts files
- also added sub component exports to some of the ui-component-name/src/index.ts files where the sub components props were exported but not the sub components themselves (eg, AppNavItem was missing from AppNav)
