### PR TITLE
fix(ui-date-time-input): fix DateTimeInput displaying wrong value of its value is changed in a onChange callback

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -351,7 +351,14 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
       newState.message = { text: text, type: 'error' }
     }
     if (this.areDifferentDates(this.state.iso, newState.iso)) {
-      this.props.onChange?.(e, newState.iso?.toISOString())
+      if (typeof this.props.onChange === 'function') {
+        const newDate = newState.iso?.toISOString()
+        // Timeout is needed here because users might change value in the
+        // onChange event lister, which might not execute properly
+        window.setTimeout(() => {
+          this.props.onChange?.(e, newDate)
+        }, 0)
+      }
     }
     this.setState(newState)
   }
@@ -439,12 +446,12 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
       // Please note that this causes one hour of time difference in the affected timezones/dates and to
       // fully solve this bug we need to change to something like luxon which handles this properly
       if (currDate.clone().format('HH') === '23') {
-        arr.push(currDate.clone().add({hours: 1}))
+        arr.push(currDate.clone().add({ hours: 1 }))
       } else {
         arr.push(currDate.clone())
       }
 
-      currDate.add({days: 1})
+      currDate.add({ days: 1 })
     }
     return arr.map((date) => {
       const dateStr = date.toISOString()

--- a/packages/ui-date-time-input/src/DateTimeInput/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/index.tsx
@@ -277,7 +277,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     event.persist()
     // timeout is needed here because handleDayClick could be called in the same
     // frame, and it updates calendarSelectedDate which is read in here.
-    window.setTimeout(() => {
+    setTimeout(() => {
       if ((event as React.KeyboardEvent).key === 'Enter') {
         // user pressed enter, use the selected value in the calendar
         this.updateStateBasedOnDateInput(this.state.calendarSelectedDate, event)
@@ -355,7 +355,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
         const newDate = newState.iso?.toISOString()
         // Timeout is needed here because users might change value in the
         // onChange event lister, which might not execute properly
-        window.setTimeout(() => {
+        setTimeout(() => {
           this.props.onChange?.(e, newDate)
         }, 0)
       }
@@ -375,7 +375,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
     // happens on the target before the relatedTarget gets focus.
     // The timeout gives it a moment for that to happen
     if (typeof this.props.onBlur === 'function') {
-      window.setTimeout(() => {
+      setTimeout(() => {
         this.props.onBlur?.(e)
       }, 0)
     }


### PR DESCRIPTION
Closes: INSTUI-4406

I could only reproduce it in CodeSandbox, but according to React documentation setState is not synchronous so the results are not deterministic.

TEST PLAN:
Enter '2' to the date input here: https://codesandbox.io/p/sandbox/stupefied-almeida-d8qxtr observe that the DateTimeInput's message field displays the correct date. 
Change the dependency to InstUI 10.9.0, reload the preview and do the same. DateTimeInput's value should be wrong