### PR TITLE
chore: add 'Skip to main content' button to the main page

### DIFF
--- a/packages/__docs__/src/App/props.ts
+++ b/packages/__docs__/src/App/props.ts
@@ -51,6 +51,7 @@ type AppStyle = ComponentStyle<
   | 'hamburger'
   | 'inlineNavigation'
   | 'globalStyles'
+  | 'skipToMainButton'
 >
 
 type AppTheme = {

--- a/packages/__docs__/src/App/styles.ts
+++ b/packages/__docs__/src/App/styles.ts
@@ -76,6 +76,21 @@ const generateStyle = (componentTheme: AppTheme): AppStyle => {
       borderInlineEndWidth: componentTheme.navBorderWidth,
       borderInlineEndStyle: 'solid'
     },
+    skipToMainButton: {
+      label: 'skipToMainButton',
+      position: 'absolute',
+      left: '-9999px',
+      zIndex: 999,
+      marginTop: '6px',
+      opacity: 0,
+      height: '60px',
+      fontSize: '150%',
+      '&:focus': {
+        left: '11.5rem',
+        transform: 'translateX(-50%)',
+        opacity: 1
+      }
+    },
     globalStyles: {
       html: {
         height: '100%',

--- a/packages/__docs__/src/Hero/index.tsx
+++ b/packages/__docs__/src/Hero/index.tsx
@@ -52,6 +52,7 @@ import { Heading } from '../Heading'
 
 import type { HeroProps } from './props'
 import { propTypes, allowedProps } from './props'
+import React from 'react'
 
 @withStyle(generateStyle, generateComponentTheme)
 class Hero extends Component<HeroProps> {
@@ -61,12 +62,24 @@ class Hero extends Component<HeroProps> {
     docs: null
   }
 
+  _mainContent?: HTMLElement
+
   componentDidMount() {
     this.props.makeStyles?.()
   }
 
   componentDidUpdate() {
     this.props.makeStyles?.()
+  }
+
+  mainContentRef = (el: Element | null) => {
+    this._mainContent = el as HTMLElement
+  }
+
+  focusMainContent = () => {
+    if (this._mainContent) {
+      this._mainContent.focus()
+    }
   }
 
   render() {
@@ -191,7 +204,12 @@ class Hero extends Component<HeroProps> {
     const checkmark = <IconCheckMarkSolid inline={false} color="success" />
 
     const heroBodyContent = (
-      <View as="div">
+      <View
+        as="div"
+        elementRef={this.mainContentRef}
+        tabIndex={0}
+        aria-label="main content"
+      >
         <Heading as="h3" level="h2" margin="none none medium">
           Components everyone can count on
         </Heading>

--- a/packages/__docs__/src/Nav/index.tsx
+++ b/packages/__docs__/src/Nav/index.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import React, { Component } from 'react'
+import React, { Component, createRef } from 'react'
 
 import { IconSearchLine } from '@instructure/ui-icons'
 import { Link } from '@instructure/ui-link'
@@ -38,6 +38,7 @@ import type { NavProps, NavState } from './props'
 class Nav extends Component<NavProps, NavState> {
   _themeId: string
   searchTimeout: ReturnType<typeof setTimeout> | null
+  _textInput?: HTMLElement
   constructor(props: NavProps) {
     super(props)
 
@@ -198,6 +199,22 @@ class Nav extends Component<NavProps, NavState> {
     })
   }
 
+  textInputRef = (el: Element | null) => {
+    this._textInput = el as HTMLElement
+  }
+
+  focusTextInput = () => {
+    if (this._textInput) {
+      this._textInput.focus()
+    }
+  }
+
+  removeFocus = (event) => {
+    if (event.target && event.target.blur) {
+      event.target.blur()
+    }
+  }
+
   renderDocLink(docId: string) {
     const { docs, selected } = this.props
     const docSelected = docId === selected
@@ -223,7 +240,12 @@ class Nav extends Component<NavProps, NavState> {
             background="brand"
           />
         )}
-        <Link display="block" href={`#${docId}`} isWithinText={false}>
+        <Link
+          onClick={this.removeFocus}
+          display="block"
+          href={`#${docId}`}
+          isWithinText={false}
+        >
           {docs[docId].title}
         </Link>
       </View>
@@ -385,7 +407,12 @@ class Nav extends Component<NavProps, NavState> {
             borderWidth={isSelected ? 'none none none large' : 'none'}
             borderColor="brand"
           >
-            <Link display="block" isWithinText={false} href={`#${themeKey}`}>
+            <Link
+              display="block"
+              onClick={this.removeFocus}
+              isWithinText={false}
+              href={`#${themeKey}`}
+            >
               {themeKey}
             </Link>
           </View>
@@ -408,7 +435,14 @@ class Nav extends Component<NavProps, NavState> {
   render() {
     const sections = this.renderSections()
     const themes = this.renderThemes()
-    const icons = <NavToggle key={'icons'} summary={'Icons'} href="#icons" />
+    const icons = (
+      <NavToggle
+        key={'icons'}
+        summary={'Icons'}
+        href="#icons"
+        shouldBlur={true}
+      />
+    )
     const matches = [...sections, ...themes, icons]
     const hasMatches = matches.length > 0
     const errorMessage = [
@@ -432,6 +466,7 @@ class Nav extends Component<NavProps, NavState> {
                 : errorMessage
             }
             shouldNotWrap
+            elementRef={this.textInputRef}
           />
         </View>
         <View margin="medium none none" display="block">

--- a/packages/__docs__/src/NavToggle/index.tsx
+++ b/packages/__docs__/src/NavToggle/index.tsx
@@ -36,7 +36,8 @@ class NavToggle extends Component<NavToggleProps> {
   static allowedProps = allowedProps
   static defaultProps = {
     variant: 'section',
-    children: null
+    children: null,
+    shouldBlur: false
   }
   private _toggle: ToggleDetails | null = null
 
@@ -44,8 +45,15 @@ class NavToggle extends Component<NavToggleProps> {
     this._toggle?.focus()
   }
 
+  blurNavToggle = () => {
+    const { shouldBlur } = this.props
+    if (shouldBlur && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+  }
+
   render() {
-    const { summary, variant, ...props } = this.props
+    const { summary, variant, shouldBlur, ...props } = this.props
 
     const isSection = variant === 'section'
 
@@ -67,6 +75,8 @@ class NavToggle extends Component<NavToggleProps> {
         display="block"
         padding="x-small none"
         margin={isSection ? 'none' : 'none none none x-small'}
+        onClick={this.blurNavToggle}
+        as={'div'}
       >
         <InstUISettingsProvider>
           <ToggleDetails

--- a/packages/__docs__/src/NavToggle/props.ts
+++ b/packages/__docs__/src/NavToggle/props.ts
@@ -35,6 +35,7 @@ type NavToggleOwnProps = {
   summary: string
   variant?: 'section' | 'category'
   children?: React.ReactNode
+  shouldBlur?: boolean
 }
 type PropKeys = keyof NavToggleOwnProps
 
@@ -42,15 +43,21 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type NavToggleProps = PickPropsWithExceptions<
   ToggleDetailsProps,
-  'summary' | 'fluidWidth' | keyof NavToggleOwnProps
+  'summary' | 'shouldBlur' | 'fluidWidth' | keyof NavToggleOwnProps
 > &
   NavToggleOwnProps
 
 const propTypes: PropValidators<PropKeys> = {
   summary: PropTypes.string.isRequired,
   variant: PropTypes.oneOf(['section', 'category']),
-  children: PropTypes.node
+  children: PropTypes.node,
+  shouldBlur: PropTypes.bool
 }
-const allowedProps: AllowedPropKeys = ['children', 'summary', 'variant']
+const allowedProps: AllowedPropKeys = [
+  'children',
+  'summary',
+  'variant',
+  'shouldBlur'
+]
 export type { NavToggleProps }
 export { allowedProps, propTypes }


### PR DESCRIPTION
Closes: INSTUI-4240

ISUUE: main page does not have a a 'Skip to main content' button to avoid going through repetitive content. This current implementation is based on this recommendation: https://www.a11y-collective.com/blog/skip-to-main-content/

TEST PLAN:
test skipt to main button:
- go through the different types of docs page with screenreader with Tab
          1. main page
          2. document like /#Alert or /#focus-management
          3. changelog page /#CHANGELOG
          4. theme page like /#canvas-high-contrast
          5. icons page: /#icons
          6. error page /#iconsss

- the first focusable element on each page should be a 'Skip to main content' button
- the button should not be visible when not focused
- when the button is clicked, it should bring the focus to the main content
- the 'Skip to main content' button also should work when the side navigation is open

test skip to main button focus after page load:
- click a link from the navigation bar like Alert, Icons, canvas-high-contrast, Focus Management etc
- after page loads, nothing should be focused and the first tabbable element should be the 'Skip to main content' button

test clicking the hamburger Icon:
- click the hamburger icon
- the focus should be jumped to the search bar inside of the navigation
