### PR TITLE
fix(ui-menu): make Menu.Item apply target prop

### DIFF
--- a/packages/ui-menu/src/Menu/MenuItem/index.tsx
+++ b/packages/ui-menu/src/Menu/MenuItem/index.tsx
@@ -237,7 +237,8 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
   }
 
   render() {
-    const { disabled, controls, onKeyDown, onKeyUp, type, href } = this.props
+    const { disabled, controls, onKeyDown, onKeyUp, type, href, target } =
+      this.props
 
     const props = omitProps(this.props, MenuItem.allowedProps)
     const ElementType = this.elementType
@@ -247,6 +248,7 @@ class MenuItem extends Component<MenuItemProps, MenuItemState> {
         tabIndex={-1} // note: tabIndex can be overridden by Menu or MenuItemGroup components
         {...props}
         href={href}
+        target={target}
         role={this.role}
         aria-labelledby={this.labelId}
         aria-disabled={disabled ? 'true' : undefined}


### PR DESCRIPTION
Closes: INSTUI-4425

ISUUE:
- Menu.Item does not apply the target prop to the link, so the link always opens in the same tab

TEST PLAN:
- go the Menu component's example
- try the second menu item's (Default (Grid view)) with different target props like "_blank", "_self" or insert an iframe inside the View (above the first Menu.Item) and set the target to "myFrame":
```
        <iframe name="myFrame" src="about:blank" width="600" height="400"></iframe>
```
- **the link should open according to the given target prop: "_blank" - new tab, "_self" - same tab, "myFrame" - in the iframe**