### PR TITLE
INSTUI-4429 fix(ui-time-select): clear input field after setting an empty value

### DIFF
--- a/cypress/component/TimeSelect.cy.tsx
+++ b/cypress/component/TimeSelect.cy.tsx
@@ -26,8 +26,8 @@ import moment from 'moment-timezone'
 import 'cypress-real-events'
 
 import '../support/component'
-import { TimeSelect } from '../../packages/ui'
-import { DateTime } from '../../packages/ui-i18n'
+import { TimeSelect } from '@instructure/ui'
+import { DateTime } from '@instructure/ui-i18n'
 
 describe('<TimeSelect/>', () => {
   it('should render an input and list', async () => {
@@ -67,6 +67,34 @@ describe('<TimeSelect/>', () => {
       .then((spy) => {
         expect(spy.lastCall.args[1]).to.have.property('value')
         expect(spy.lastCall.args[1]).to.have.property('inputText', '00:00')
+      })
+  })
+
+  it('should fire onChange when input field is cleared and blurred and allowClearingSelection is true', async () => {
+    const onChange = cy.spy()
+    cy.mount(
+      <TimeSelect
+        renderLabel="Choose a time"
+        timezone="US/Eastern"
+        onChange={onChange}
+        allowClearingSelection={true}
+      />
+    )
+    cy.get('input[id^="Select_"]').as('input')
+
+    cy.get('@input').click()
+
+    cy.get('li[class$="-optionItem"]').eq(0).click()
+
+    cy.get('@input').click()
+    cy.get('@input').clear()
+    cy.get('@input').blur()
+
+    cy.wrap(onChange)
+      .should('have.been.called')
+      .then((spy) => {
+        expect(spy.lastCall.args[1]).to.have.property('value', '')
+        expect(spy.lastCall.args[1]).to.have.property('inputText', '')
       })
   })
 

--- a/docs/contributor-docs/v11-upgrade-guide.md
+++ b/docs/contributor-docs/v11-upgrade-guide.md
@@ -31,3 +31,4 @@ isWIP: true
 ## Changes
 
 - `ui-dom-utils`/`getComputedStyle` can now return `undefined`: In previous versions sometimes returned an empty object which could lead to runtime exceptions when one tried to call methods of `CSSStyleDeclaration` on it.
+- TO-DO: [TimeSelect](/#TimeSelect) as a controlled component can now return an '' instead of a valid date when its input field is cleared. In previous versions it always reverted to the last selected value when the input field was cleared and lost focus.

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -244,6 +244,11 @@ type TimeSelectOwnProps = {
      */
     valueAsISOString?: string
   ) => void
+  /**
+   * Whether to allow for the user to clear the selected option in the input field.
+   * If `false`, the input field will return the last selected option after the input is cleared and loses focus.
+   */
+  allowClearingSelection: boolean
 }
 
 const propTypes: PropValidators<PropKeys> = {
@@ -278,7 +283,8 @@ const propTypes: PropValidators<PropKeys> = {
   locale: PropTypes.string,
   timezone: PropTypes.string,
   allowNonStepInput: PropTypes.bool,
-  onInputChange: PropTypes.func
+  onInputChange: PropTypes.func,
+  allowClearingSelection: PropTypes.bool
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -313,7 +319,8 @@ const allowedProps: AllowedPropKeys = [
   'locale',
   'timezone',
   'allowNonStepInput',
-  'onInputChange'
+  'onInputChange',
+  'allowClearingSelection'
 ]
 
 type TimeSelectOptions = {
@@ -356,6 +363,10 @@ type TimeSelectState = {
    * fire onChange event when the popup closes?
    */
   fireChangeOnBlur?: TimeSelectOptions
+  /**
+   * Whether to selected option is cleared
+   */
+  isInputCleared: boolean
 }
 
 export type { TimeSelectProps, TimeSelectState, TimeSelectOptions }


### PR DESCRIPTION
ISSUE:
In the TimeSelect component, after explicitly setting a value, it cannot be cleared from the input field. When the value is deleted form the input filed and the input field loses focus, the last selected option is reapplied.
Also the onChange does not trigger when input field is cleared.

TEST PLAN:

test clearing values if allowClearingSelection is not set (should default to false)
- go to the "Controlled" TimeSelect example
- before selecting a new value, click the input field, delete its current value, and click elsewhere to ensure the input field loses focus
- the input value should go back to the initial value (11:59:00 PM) and onChange should not triggered (can be checked with a console.log)
- reload the same example
- select a new value from the dropdown
- after it' selected, click the input field, delete its current value, and click elsewhere to ensure the input field loses focus
- the input value should go back to the previously selected value and onChange should not triggered (can be checked with a console.log)

test clearing values if allowClearingSelection is true:
- go to the "Controlled" TimeSelect example
- set allowClearingSelection to true
- before selecting a new value, click the input field, delete its current value, and click elsewhere to ensure the input field loses focus
- the input field now should be cleared and have no option selected apart form the placeholder
- onChange should be triggered when input is cleared and loses focus (can be checked with a console.log)
- reload the same example and set allowClearingSelection to true
- select a different value than the current one
- click the input field, delete its current value, and click elsewhere to ensure the input field loses focus
- the input field now should be cleared and have no option selected apart form the placeholder
- onChange should be triggered when input is cleared and loses focus (can be checked with a console.log)

other:
- test of all the other examples in TimeSelect to see if they work as expected
- review the new test