### PR TITLE
feat(ui-filedrop): add inputRef prop to make FileDrop focusable

### DIFF
--- a/packages/ui-file-drop/src/FileDrop/__new-tests__/FileDrop.test.tsx
+++ b/packages/ui-file-drop/src/FileDrop/__new-tests__/FileDrop.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+import { FileDrop } from '../index'
+
+describe('<FileDrop/>', () => {
+  it('should focus the input when focus is called', async () => {
+    let inputEl: any
+    render(
+      <FileDrop
+        renderLabel="filedrop"
+        inputRef={(el: HTMLInputElement | null) => {
+          inputEl = el
+        }}
+      />
+    )
+    const input = document.querySelector('input[class$="-fileDrop__input"]')
+
+    inputEl.focus()
+
+    expect(input).toHaveFocus()
+  })
+
+  it('should provide an inputRef prop', async () => {
+    const inputRef = vi.fn()
+    render(<FileDrop renderLabel="filedrop" inputRef={inputRef} />)
+    const input = document.querySelector('input[class$="-fileDrop__input"]')
+
+    expect(inputRef).toHaveBeenCalledWith(input)
+  })
+})

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -274,6 +274,9 @@ class FileDrop extends Component<FileDropProps, FileDropState> {
 
   handleRef = (el: HTMLInputElement) => {
     this.fileInputEl = el
+    if (typeof this.props.inputRef === 'function') {
+      this.props.inputRef(el)
+    }
   }
 
   handleBlur = () => {

--- a/packages/ui-file-drop/src/FileDrop/props.ts
+++ b/packages/ui-file-drop/src/FileDrop/props.ts
@@ -155,6 +155,10 @@ type FileDropOwnProps = {
    * CSS-like shorthand. For example: margin="small auto large".
    */
   margin?: Spacing
+  /**
+   * A function that provides a reference to the actual input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type FileDropState = {
@@ -210,7 +214,8 @@ const propTypes: PropValidators<PropKeys> = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   minWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  margin: ThemeablePropTypes.spacing
+  margin: ThemeablePropTypes.spacing,
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -236,7 +241,8 @@ const allowedProps: AllowedPropKeys = [
   'width',
   'maxWidth',
   'minWidth',
-  'margin'
+  'margin',
+  'inputRef'
 ]
 
 export type { FileDropProps, FileDropState, FileDropStyleProps, FileDropStyle }


### PR DESCRIPTION
Closes: INSTUI-4431

ISSUE: Filedrop input cannot be focused, it needs a inputRef prop like Select or TextInput

TEST PLAN:
- test the example below in the documentation preview
- fileDrop should accept inputRef prop
- by clicking on the Focus File Input button, the FileDrop should receive focus
- review the updated documentation and new tests

```
class Example extends React.Component {
  fileInputElement = null

  focusFileInput = () => {
    if (this.fileInputElement) {
      this.fileInputElement.focus()
    }
  };

  render() {
    return (
      <div>
        <FileDrop
          accept="image/*"
          onDropAccepted={([file]) => console.log(`File accepted ${file.name}`)}
          onDropRejected={([file]) => console.log(`File rejected ${file.name}`)}
          inputRef={(el) => {
            this.fileInputElement = el;
          }}
          renderLabel={
            <View as="div" padding="xx-large large" background="primary">
              <IconModuleLine size="large" />
              <Heading>Drop files here to add them to module</Heading>
              <Text color="brand">
                Drag and drop, or click to browse your computer
              </Text>
            </View>
          }
        />
        <button onClick={this.focusFileInput}>Focus File Input</button>
      </div>
    );
  }
}
render(<Example />)
```