### PR TITLE
fix(ui-color-picker): add hex to aria-label

### DIFF
--- a/packages/ui-color-picker/src/ColorPreset/__new-tests__/ColorPreset.test.tsx
+++ b/packages/ui-color-picker/src/ColorPreset/__new-tests__/ColorPreset.test.tsx
@@ -110,11 +110,7 @@ describe('<ColorPreset />', () => {
 
       testColors.forEach((testColor, index) => {
         const tooltip = tooltips[index]
-        const indicator = indicators[index]
 
-        expect(tooltip.getAttribute('id')).toBe(
-          indicator.getAttribute('aria-describedby')
-        )
         expect(tooltip).toHaveTextContent(testColor)
       })
     })

--- a/packages/ui-color-picker/src/ColorPreset/index.tsx
+++ b/packages/ui-color-picker/src/ColorPreset/index.tsx
@@ -266,7 +266,11 @@ class ColorPreset extends Component<ColorPresetProps, ColorPresetState> {
       cursor={this.props.disabled ? 'not-allowed' : 'auto'}
       as="button"
       {...(selectOnClick ? { onClick: () => this.props.onSelect(color) } : {})}
-      {...(this.isSelectedColor(color) ? { 'aria-label': 'selected' } : {})}
+      {...{
+        'aria-label': `${color}${
+          this.isSelectedColor(color) ? ' selected' : ''
+        }`
+      }}
     >
       <div>
         <ColorIndicator color={color} shape="rectangle" role="presentation" />
@@ -282,9 +286,25 @@ class ColorPreset extends Component<ColorPresetProps, ColorPresetState> {
     </View>
   )
 
-  renderIndicatorTooltip = (child: React.ReactElement, color: string) => (
-    <Tooltip renderTip={<div>{color}</div>}>{child}</Tooltip>
-  )
+  renderIndicatorTooltip = (child: React.ReactElement, color: string) => {
+    return (
+      <Tooltip
+        renderTip={<div>{color}</div>}
+        elementRef={(element) => {
+          if (
+            element &&
+            element.firstElementChild instanceof HTMLButtonElement
+          ) {
+            // The tooltip and the button's aria-label has the same text content. This is redundant for screenreaders.
+            // Aria-describedby is removed to bypass reading the tooltip twice
+            element.firstElementChild.removeAttribute('aria-describedby')
+          }
+        }}
+      >
+        {child}
+      </Tooltip>
+    )
+  }
 
   renderSettingsMenu = (color: string, index: number) => (
     <Drilldown


### PR DESCRIPTION
INSTUI-4273

**Test:**

1. you have to test `ColorPreset` and `ColorContrast` separately, go to the docs page examples
2. try it with JAWS, NVDA and VoiceOver
3. go through the colors, the hex content of the color should be read only once
4. if you select one color, the hex content and a 'selected' text should be read
5. check if you notice other accessibility/screenreader issues
6. check the components with Accessibility Insights chrome extension
