### PR TITLE
fix(ui-pagination): remove margin from legacy Pagination

### DIFF
--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -461,7 +461,7 @@ class Pagination extends Component<PaginationProps> {
     }
 
     return (
-      <View display="inline-block" as="ul">
+      <View display="inline-block" as="ul" margin="0">
         {this.transferDisabledPropToChildren(visiblePages)}
       </View>
     )


### PR DESCRIPTION
We left margin unset, so it was inheriting values from the browser's stylesheet.
Fix for this fix: https://github.com/instructure/instructure-ui/pull/1839