### PR TITLE
fix(ui-select): fix select's dropdown border radius

### DIFF
--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -523,7 +523,8 @@ class Select extends Component<SelectProps> {
             optionsMaxHeight || this._optionHeight * visibleOptionsCount!,
           maxWidth: optionsMaxWidth || this.width,
           background: 'primary',
-          elementRef: (node: Element | null) => (this._listView = node)
+          elementRef: (node: Element | null) => (this._listView = node),
+          borderRadius: 'medium'
         }
       : { maxHeight: 0 }
 


### PR DESCRIPTION
TEST PLAN: check if the bottom of select's dropdown and the option list has the same border radius


closes: INSTUI-4442