### PR TITLE
[v9] feat(ui-file-drop): add inputRef prop to make FileDrop focusable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42682,10 +42682,65 @@
         "@instructure/ui-babel-preset": "9.10.2",
         "@instructure/ui-test-locator": "9.10.2",
         "@instructure/ui-test-utils": "9.10.2",
-        "@instructure/ui-themes": "9.10.2"
+        "@instructure/ui-themes": "9.10.2",
+        "@testing-library/jest-dom": "^6.4.6",
+        "@testing-library/react": "^15.0.7",
+        "vitest": "^2.0.2"
       },
       "peerDependencies": {
         "react": ">=16.8 <=18"
+      }
+    },
+    "packages/ui-file-drop/node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui-file-drop/node_modules/@testing-library/react": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.7.tgz",
+      "integrity": "sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui-file-drop/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "packages/ui-flex": {

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -41,7 +41,10 @@
     "@instructure/ui-babel-preset": "9.10.2",
     "@instructure/ui-test-locator": "9.10.2",
     "@instructure/ui-test-utils": "9.10.2",
-    "@instructure/ui-themes": "9.10.2"
+    "@instructure/ui-themes": "9.10.2",
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^15.0.7",
+    "vitest": "^2.0.2"
   },
   "peerDependencies": {
     "react": ">=16.8 <=18"

--- a/packages/ui-file-drop/src/FileDrop/__new-tests__/FileDrop.test.tsx
+++ b/packages/ui-file-drop/src/FileDrop/__new-tests__/FileDrop.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+import { FileDrop } from '../index'
+
+describe('<FileDrop/>', () => {
+  it('should focus the input when focus is called', async () => {
+    let inputEl: any
+    render(
+      <FileDrop
+        renderLabel="filedrop"
+        inputRef={(el: HTMLInputElement | null) => {
+          inputEl = el
+        }}
+      />
+    )
+    const input = document.querySelector('input[class$="-fileDrop__input"]')
+
+    inputEl.focus()
+
+    expect(input).toHaveFocus()
+  })
+
+  it('should provide an inputRef prop', async () => {
+    const inputRef = vi.fn()
+    render(<FileDrop renderLabel="filedrop" inputRef={inputRef} />)
+    const input = document.querySelector('input[class$="-fileDrop__input"]')
+
+    expect(inputRef).toHaveBeenCalledWith(input)
+  })
+})

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -275,6 +275,9 @@ class FileDrop extends Component<FileDropProps, FileDropState> {
 
   handleRef = (el: HTMLInputElement) => {
     this.fileInputEl = el
+    if (typeof this.props.inputRef === 'function') {
+      this.props.inputRef(el)
+    }
   }
 
   handleBlur = () => {

--- a/packages/ui-file-drop/src/FileDrop/props.ts
+++ b/packages/ui-file-drop/src/FileDrop/props.ts
@@ -155,6 +155,10 @@ type FileDropOwnProps = {
    * CSS-like shorthand. For example: margin="small auto large".
    */
   margin?: Spacing
+  /**
+   * A function that provides a reference to the actual input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type FileDropState = {
@@ -210,7 +214,8 @@ const propTypes: PropValidators<PropKeys> = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   minWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  margin: ThemeablePropTypes.spacing
+  margin: ThemeablePropTypes.spacing,
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -236,7 +241,8 @@ const allowedProps: AllowedPropKeys = [
   'width',
   'maxWidth',
   'minWidth',
-  'margin'
+  'margin',
+  'inputRef'
 ]
 
 export type { FileDropProps, FileDropState, FileDropStyleProps, FileDropStyle }


### PR DESCRIPTION
Closes: INSTUI-4441

ISSUE: Filedrop input cannot be focused, it needs a inputRef prop like Select or TextInput.
Backport of https://github.com/instructure/instructure-ui/pull/1853

TEST PLAN:
- test the example below in the documentation preview
- fileDrop should accept inputRef prop
- by clicking on the Focus File Input button, the FileDrop should receive focus
- review the updated documentation and new tests

```
class Example extends React.Component {
  fileInputElement = null

  focusFileInput = () => {
    if (this.fileInputElement) {
      this.fileInputElement.focus()
    }
  };

  render() {
    return (
      <div>
        <FileDrop
          accept="image/*"
          onDropAccepted={([file]) => console.log(`File accepted ${file.name}`)}
          onDropRejected={([file]) => console.log(`File rejected ${file.name}`)}
          inputRef={(el) => {
            this.fileInputElement = el;
          }}
          renderLabel={
            <View as="div" padding="xx-large large" background="primary">
              <IconModuleLine size="large" />
              <Heading>Drop files here to add them to module</Heading>
              <Text color="brand">
                Drag and drop, or click to browse your computer
              </Text>
            </View>
          }
        />
        <button onClick={this.focusFileInput}>Focus File Input</button>
      </div>
    );
  }
}
render(<Example />)
```