### PR TITLE
fix(ui-source-code-editor): link label to input field programmatically

### DIFF
--- a/packages/ui-source-code-editor/src/SourceCodeEditor/README.md
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/README.md
@@ -231,7 +231,7 @@ class LanguageExamples extends React.Component {
         <Flex.Item padding="0 0 0 large" shouldGrow shouldShrink>
           <FormField label="SourceCodeEditor with syntax highlight">
             <SourceCodeEditor
-              label={`${this.state.currentLanguage} code editor`}
+              label={`${this.state.currentLanguage} SourceCodeEditor with syntax highlight`}
               language={this.state.currentLanguage}
               value={this.state.currentValue}
               onChange={(value) => {

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/__new-tests__/SourceCodeEditor.test.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/__new-tests__/SourceCodeEditor.test.tsx
@@ -44,5 +44,19 @@ describe('<SourceCodeEditor />', () => {
       expect(activeLine[1]).toHaveStyle({ color: '#0000ff' })
       expect(activeLine[2]).toHaveStyle({ color: '#116644' })
     })
+
+    it('should link editor element to label using aria-labelledby attribute', async () => {
+      const { container } = render(
+        <SourceCodeEditor
+          label="test"
+          language="jsx"
+          defaultValue="const a = 2;"
+        />
+      )
+      const editorElement = container.querySelector('[role="textbox"]')
+      const labelId = container.querySelector('[class$="-label"]')?.id
+
+      expect(editorElement).toHaveAttribute('aria-labelledby', labelId)
+    })
   })
 })

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
@@ -302,6 +302,7 @@ class SourceCodeEditor extends Component<SourceCodeEditorProps> {
     if (indentOnLoad) {
       this.indentAll()
     }
+    this.assignAriaLabel()
   }
 
   componentWillUnmount() {
@@ -644,6 +645,15 @@ class SourceCodeEditor extends Component<SourceCodeEditorProps> {
     }
   }
 
+  assignAriaLabel = () => {
+    if (this._containerRef) {
+      const editorDiv = this._containerRef.querySelector('[role="textbox"]')
+      if (editorDiv) {
+        editorDiv.setAttribute('aria-labelledby', `${this._id}`)
+      }
+    }
+  }
+
   render() {
     const { label, styles, ...restProps } = this.props
 
@@ -655,7 +665,7 @@ class SourceCodeEditor extends Component<SourceCodeEditorProps> {
           omitProps(restProps, SourceCodeEditor.allowedProps)
         )}
       >
-        <label css={styles?.label} htmlFor={this._id}>
+        <label css={styles?.label} id={this._id}>
           <ScreenReaderContent>{label}</ScreenReaderContent>
           <div
             ref={this.handleContainerRef}


### PR DESCRIPTION
Closes: INSTUI-4289

ISSUE: SourceCodeEditor label is not linked to the input field pragmatically. Therefore screenreader does not read the label when tabbed into the input field

TEST PLAN:
- open the first example in SourceCodeEditor
- with a screenreader go into the input field
- the screenreader should announce the label 'javascript SourceCodeEditor with syntax highlight" when entering the input field
- the input (textbox) element should have an "aria-labelledby" attribute pointing to the label element by id.