### PR TITLE
fix(ui-time-select): make allowClearingSelection an optional prop

### DIFF
--- a/packages/ui-time-select/src/TimeSelect/index.tsx
+++ b/packages/ui-time-select/src/TimeSelect/index.tsx
@@ -341,7 +341,7 @@ class TimeSelect extends Component<TimeSelectProps, TimeSelectState> {
           ? this.state.selectedOptionId
           : undefined,
         fireChangeOnBlur: undefined,
-        isInputCleared: this.props.allowClearingSelection && value === ''
+        isInputCleared: this.props.allowClearingSelection! && value === ''
       })
     }
     this.setState({

--- a/packages/ui-time-select/src/TimeSelect/props.ts
+++ b/packages/ui-time-select/src/TimeSelect/props.ts
@@ -248,7 +248,7 @@ type TimeSelectOwnProps = {
    * Whether to allow for the user to clear the selected option in the input field.
    * If `false`, the input field will return the last selected option after the input is cleared and loses focus.
    */
-  allowClearingSelection: boolean
+  allowClearingSelection?: boolean
 }
 
 const propTypes: PropValidators<PropKeys> = {


### PR DESCRIPTION
This was never intended as a required prop.