### PR TITLE
fix(ui-table): match fontWeight in style to theme variable

### DIFF
--- a/packages/ui-table/src/Table/RowHeader/styles.ts
+++ b/packages/ui-table/src/Table/RowHeader/styles.ts
@@ -46,7 +46,7 @@ const generateStyle = (
       label: 'rowHeader',
       fontSize: componentTheme.fontSize,
       fontFamily: componentTheme.fontFamily,
-      fontWeight: 'bold',
+      fontWeight: componentTheme.fontWeight,
       color: componentTheme.color,
       background: componentTheme.background,
       boxSizing: 'border-box',

--- a/packages/ui-table/src/Table/RowHeader/theme.ts
+++ b/packages/ui-table/src/Table/RowHeader/theme.ts
@@ -36,7 +36,7 @@ const generateComponentTheme = (theme: Theme): TableRowHeaderTheme => {
   const componentVariables: TableRowHeaderTheme = {
     fontSize: typography?.fontSizeMedium,
     fontFamily: typography?.fontFamily,
-    fontWeight: typography?.fontWeightNormal,
+    fontWeight: typography?.fontWeightBold,
 
     color: colors?.contrasts?.grey125125,
     background: colors?.contrasts?.white1010,


### PR DESCRIPTION
INSTUI-4462

**Test**

1. try overriding the fontWeight in a `Table.RowHeader` in our docs application
2. observe if it changes