### PR TITLE
fix(ui-pagination): remove padding from legacy Pagination

### DIFF
--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -461,7 +461,7 @@ class Pagination extends Component<PaginationProps> {
     }
 
     return (
-      <View display="inline-block" as="ul" margin="0">
+      <View display="inline-block" as="ul" margin="0" padding="0">
         {this.transferDisabledPropToChildren(visiblePages)}
       </View>
     )


### PR DESCRIPTION
<ul> padding was unset and so inherited from the browser's stylesheet

Context: https://instructure.slack.com/archives/C0JCJ63TR/p1740483851746669?thread_ts=1737474461.141169&cid=C0JCJ63TR
Easy change, tried to do it myself:)

You can easily test what has changed by removing the padding in the browser's DevTools.