### PR TITLE
refactor(ui,ui-form-field,shared-types): add back FormFieldLabel, mark it as deprecated

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -606,6 +606,14 @@ export type FormFieldLayoutTheme = {
   spacing: any // TODO remove any
 }
 
+export type FormFieldLabelTheme = {
+  color: Colors['contrasts']['grey125125']
+  fontFamily: Typography['fontFamily']
+  fontWeight: Typography['fontWeightBold']
+  fontSize: Typography['fontSizeMedium']
+  lineHeight: Typography['lineHeightFit']
+}
+
 export type FormFieldMessageTheme = {
   colorHint: Colors['contrasts']['grey125125']
   colorError: Colors['contrasts']['red4570']

--- a/packages/ui-form-field/src/FormFieldLabel/__new-tests__/FormFieldLabel.test.tsx
+++ b/packages/ui-form-field/src/FormFieldLabel/__new-tests__/FormFieldLabel.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import { runAxeCheck } from '@instructure/ui-axe-check'
+import '@testing-library/jest-dom'
+
+import { FormFieldLabel } from '../index'
+
+describe('<FormFieldLabel />', () => {
+  let consoleWarningMock: ReturnType<typeof vi.spyOn>
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // Mocking console to prevent test output pollution and expect for messages
+    consoleWarningMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {}) as any
+    consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {}) as any
+  })
+
+  afterEach(() => {
+    consoleWarningMock.mockRestore()
+    consoleErrorMock.mockRestore()
+  })
+
+  it('should render', () => {
+    const { container } = render(<FormFieldLabel>Foo</FormFieldLabel>)
+
+    const formFieldLabel = container.querySelector(
+      "span[class$='-formFieldLabel']"
+    )
+
+    expect(formFieldLabel).toBeInTheDocument()
+    expect(formFieldLabel).toHaveTextContent('Foo')
+  })
+
+  it('should render as specified via the `as` prop', () => {
+    const { container } = render(<FormFieldLabel as="li">Foo</FormFieldLabel>)
+
+    const formFieldLabel = container.querySelector('li')
+
+    expect(formFieldLabel).toBeInTheDocument()
+    expect(formFieldLabel).toHaveTextContent('Foo')
+  })
+
+  it('should meet a11y standards', async () => {
+    const { container } = render(<FormFieldLabel>Foo</FormFieldLabel>)
+
+    const axeCheck = await runAxeCheck(container)
+
+    expect(axeCheck).toBe(true)
+  })
+})

--- a/packages/ui-form-field/src/FormFieldLabel/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLabel/index.tsx
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/** @jsx jsx */
+import { Component } from 'react'
+
+import {
+  omitProps,
+  getElementType,
+  deprecated
+} from '@instructure/ui-react-utils'
+import { withStyle, jsx } from '@instructure/emotion'
+
+import generateStyle from './styles'
+import generateComponentTheme from './theme'
+
+import { propTypes, allowedProps } from './props'
+import type { FormFieldLabelProps } from './props'
+
+/**
+---
+parent: FormField
+---
+
+This is a helper component that is used by most of the custom form
+components. In most cases it shouldn't be used directly.
+
+```js
+---
+type: example
+---
+<FormFieldLabel>Hello</FormFieldLabel>
+```
+
+ @deprecated since version 10. This is an internal component that will be
+ removed in the future
+**/
+@withStyle(generateStyle, generateComponentTheme)
+@deprecated('10', null, 'This component will be removed in a future version')
+class FormFieldLabel extends Component<FormFieldLabelProps> {
+  static readonly componentId = 'FormFieldLabel'
+
+  static propTypes = propTypes
+  static allowedProps = allowedProps
+  static defaultProps = {
+    as: 'span'
+  } as const
+
+  ref: Element | null = null
+
+  handleRef = (el: Element | null) => {
+    this.ref = el
+  }
+
+  componentDidMount() {
+    this.props.makeStyles?.()
+  }
+
+  componentDidUpdate() {
+    this.props.makeStyles?.()
+  }
+
+  render() {
+    const ElementType = getElementType(FormFieldLabel, this.props)
+
+    const { styles, children } = this.props
+
+    return (
+      <ElementType
+        {...omitProps(this.props, FormFieldLabel.allowedProps)}
+        css={styles?.formFieldLabel}
+        ref={this.handleRef}
+      >
+        {children}
+      </ElementType>
+    )
+  }
+}
+
+export default FormFieldLabel
+export { FormFieldLabel }

--- a/packages/ui-form-field/src/FormFieldLabel/props.ts
+++ b/packages/ui-form-field/src/FormFieldLabel/props.ts
@@ -22,19 +22,37 @@
  * SOFTWARE.
  */
 
-export { FormField } from './FormField'
-export { FormFieldLabel } from './FormFieldLabel'
-export { FormFieldMessage } from './FormFieldMessage'
-export { FormFieldMessages } from './FormFieldMessages'
-export { FormFieldLayout } from './FormFieldLayout'
-export { FormFieldGroup } from './FormFieldGroup'
+import PropTypes from 'prop-types'
 
-export { FormPropTypes } from './FormPropTypes'
-export type { FormMessageType, FormMessage } from './FormPropTypes'
+import type {
+  AsElementType,
+  PropValidators,
+  FormFieldLabelTheme,
+  OtherHTMLAttributes
+} from '@instructure/shared-types'
+import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
-export type { FormFieldOwnProps, FormFieldProps } from './FormField/props'
-export type { FormFieldLabelProps } from './FormFieldLabel/props'
-export type { FormFieldMessageProps } from './FormFieldMessage/props'
-export type { FormFieldMessagesProps } from './FormFieldMessages/props'
-export type { FormFieldLayoutProps } from './FormFieldLayout/props'
-export type { FormFieldGroupProps } from './FormFieldGroup/props'
+type FormFieldLabelOwnProps = {
+  children: React.ReactNode
+  as?: AsElementType
+}
+
+type PropKeys = keyof FormFieldLabelOwnProps
+
+type AllowedPropKeys = Readonly<Array<PropKeys>>
+
+type FormFieldLabelProps = FormFieldLabelOwnProps &
+  WithStyleProps<FormFieldLabelTheme, FormFieldLabelStyle> &
+  OtherHTMLAttributes<FormFieldLabelOwnProps>
+
+type FormFieldLabelStyle = ComponentStyle<'formFieldLabel'>
+
+const propTypes: PropValidators<PropKeys> = {
+  children: PropTypes.node.isRequired,
+  as: PropTypes.elementType
+}
+
+const allowedProps: AllowedPropKeys = ['as', 'children']
+
+export type { FormFieldLabelProps, FormFieldLabelStyle }
+export { propTypes, allowedProps }

--- a/packages/ui-form-field/src/FormFieldLabel/styles.ts
+++ b/packages/ui-form-field/src/FormFieldLabel/styles.ts
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
+
+import type { FormFieldLabelTheme } from '@instructure/shared-types'
+import type { FormFieldLabelProps, FormFieldLabelStyle } from './props'
+
+/**
+ * ---
+ * private: true
+ * ---
+ * Generates the style object from the theme and provided additional information
+ * @param  {Object} componentTheme The theme variable object.
+ * @param  {Object} props the props of the component, the style is applied to
+ * @param  {Object} state the state of the component, the style is applied to
+ * @return {Object} The final style object, which will be used in the component
+ */
+const generateStyle = (
+  componentTheme: FormFieldLabelTheme,
+  props: FormFieldLabelProps
+): FormFieldLabelStyle => {
+  const { children } = props
+
+  const hasContent = hasVisibleChildren(children)
+
+  const labelStyles = {
+    all: 'initial',
+    display: 'block',
+    ...(hasContent && {
+      color: componentTheme.color,
+      fontFamily: componentTheme.fontFamily,
+      fontWeight: componentTheme.fontWeight,
+      fontSize: componentTheme.fontSize,
+      lineHeight: componentTheme.lineHeight,
+      margin: 0,
+      textAlign: 'inherit'
+    })
+  }
+
+  return {
+    formFieldLabel: {
+      label: 'formFieldLabel',
+      ...labelStyles,
+
+      // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
+      '&:is(label)': labelStyles,
+      '&:-webkit-any(label)': labelStyles
+    }
+  }
+}
+
+export default generateStyle

--- a/packages/ui-form-field/src/FormFieldLabel/theme.ts
+++ b/packages/ui-form-field/src/FormFieldLabel/theme.ts
@@ -22,19 +22,35 @@
  * SOFTWARE.
  */
 
-export { FormField } from './FormField'
-export { FormFieldLabel } from './FormFieldLabel'
-export { FormFieldMessage } from './FormFieldMessage'
-export { FormFieldMessages } from './FormFieldMessages'
-export { FormFieldLayout } from './FormFieldLayout'
-export { FormFieldGroup } from './FormFieldGroup'
+import type { Theme, ThemeSpecificStyle } from '@instructure/ui-themes'
+import { FormFieldLabelTheme } from '@instructure/shared-types'
 
-export { FormPropTypes } from './FormPropTypes'
-export type { FormMessageType, FormMessage } from './FormPropTypes'
+/**
+ * Generates the theme object for the component from the theme and provided additional information
+ * @param  {Object} theme The actual theme object.
+ * @return {Object} The final theme object with the overrides and component variables
+ */
+const generateComponentTheme = (theme: Theme): FormFieldLabelTheme => {
+  const { colors, typography, key: themeName } = theme
 
-export type { FormFieldOwnProps, FormFieldProps } from './FormField/props'
-export type { FormFieldLabelProps } from './FormFieldLabel/props'
-export type { FormFieldMessageProps } from './FormFieldMessage/props'
-export type { FormFieldMessagesProps } from './FormFieldMessages/props'
-export type { FormFieldLayoutProps } from './FormFieldLayout/props'
-export type { FormFieldGroupProps } from './FormFieldGroup/props'
+  const themeSpecificStyle: ThemeSpecificStyle<FormFieldLabelTheme> = {
+    canvas: {
+      color: theme['ic-brand-font-color-dark']
+    }
+  }
+
+  const componentVariables: FormFieldLabelTheme = {
+    color: colors?.contrasts?.grey125125,
+    fontFamily: typography?.fontFamily,
+    fontWeight: typography?.fontWeightBold,
+    fontSize: typography?.fontSizeMedium,
+    lineHeight: typography?.lineHeightFit
+  }
+
+  return {
+    ...componentVariables,
+    ...themeSpecificStyle[themeName]
+  }
+}
+
+export default generateComponentTheme

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -148,6 +148,7 @@ export { Focusable } from '@instructure/ui-focusable'
 export type { FocusableProps } from '@instructure/ui-focusable'
 export {
   FormField,
+  FormFieldLabel,
   FormFieldMessage,
   FormFieldMessages,
   FormFieldLayout,
@@ -157,6 +158,7 @@ export {
 export type {
   FormFieldGroupProps,
   FormFieldMessageProps,
+  FormFieldLabelProps,
   FormFieldMessagesProps,
   FormFieldLayoutProps,
   FormFieldOwnProps,


### PR DESCRIPTION
Some of our users are still using it