### PR TITLE
fix(many): fix Tooltip focus issues and make Tooltip closeable inside of a Modal

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegionOptions.ts
+++ b/packages/ui-a11y-utils/src/FocusRegionOptions.ts
@@ -82,4 +82,8 @@ export type FocusRegionOptions = {
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
+  /**
+   * Whether or not the element is a Tooltip
+   */
+  isTooltip?: boolean
 }

--- a/packages/ui-dialog/src/Dialog/props.ts
+++ b/packages/ui-dialog/src/Dialog/props.ts
@@ -132,7 +132,11 @@ const propTypes: PropValidators<PropKeys> = {
   /**
    * provides a reference to the underlying html root element
    */
-  elementRef: PropTypes.func
+  elementRef: PropTypes.func,
+  /**
+   * Whether or not the element is a Tooltip
+   */
+  isTooltip: PropTypes.bool
 }
 
 const allowedProps: AllowedPropKeys = [

--- a/packages/ui-popover/src/Popover/index.tsx
+++ b/packages/ui-popover/src/Popover/index.tsx
@@ -183,7 +183,8 @@ class Popover extends Component<PopoverProps, PopoverState> {
       this._focusRegion = new FocusRegion(this._contentElement, {
         shouldCloseOnEscape: this.props.shouldCloseOnEscape,
         shouldCloseOnDocumentClick: false,
-        onDismiss: this.hide
+        onDismiss: this.hide,
+        isTooltip: true
       })
 
       if (this.shown) {

--- a/packages/ui-tooltip/src/Tooltip/index.tsx
+++ b/packages/ui-tooltip/src/Tooltip/index.tsx
@@ -159,7 +159,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
         defaultIsShowingContent={defaultIsShowingContent}
         on={on}
         shouldRenderOffscreen
-        shouldReturnFocus={true}
+        shouldReturnFocus={false}
         placement={placement}
         color={color === 'primary' ? 'primary-inverse' : 'primary'}
         mountNode={mountNode}


### PR DESCRIPTION
INSTUI-4459

- this fix https://github.com/instructure/instructure-ui/pull/1850 introduced some issues when trying to make Tooltip ESC closeable when inside of a modal without closing the Modal itself
- it resulted in the Tooltip disappearing when hovered over
- it also caused some focus issues in certain configurations

TEST PLAN:

**test the examples in Tooltip:**
- the Tooltip should remain visible when it is hovered over
- it should close on ESC, even when it is hovered over
- the Tooltip examples should work as expected, even with keyboard navigation

**test the Tooltip when inside of a modal:**
- open the TEST#1 code in the comments below
- the Tooltips should close on ESC without closing the modal, even when it is hovered over

**test the Tooltip with Tray:**
- open the TEST#2 code in the comments below
- open the Tray via keyboard
- Tab to the "Hello Instructure" button
- observe that the tooltip appears
- pressing space should close the tooltip and tray at the same time
- you should now be able to tab away from the tray triggering element
- you should be able to trigger the tray again and tab to different elements (before,
after closing the tray you couldn't tab anywhere)

**test the Tooltip with Buttons opening modals:**
- open the TEST#3 code in the comments below
- you should be able to close each Button with ESC and focus should return to the triggering button after closing the modal
-  (before the second button's modal couldn't be closed with ESC)

**test the Tooltip with a complex Dialog example:**
- go the second example in https://instructure.design/pr-preview/pr-1889/#focus-management
- place a Tooltip inside of the Popover
- with ESC, you should be able to gradually close the Tooltip, then the Popover then finally the Modal
