### PR TITLE
fix(ui-form-field): fix Select's focus selecting its leaf not instead of the input field

### DIFF
--- a/packages/ui-form-field/src/FormField/index.tsx
+++ b/packages/ui-form-field/src/FormField/index.tsx
@@ -68,6 +68,7 @@ class FormField extends Component<FormFieldProps> {
         label={this.props.label}
         vAlign={this.props.vAlign}
         as="label"
+        htmlFor={this.props.id}
         elementRef={this.handleRef}
         margin={this.props.margin}
       />


### PR DESCRIPTION
This is a fix for the bug introduced by the FormFieldLayout refactor PR 1863. Now the multiple select example should not delete the added Tag-s
[Is a revert from here: packages/ui-form-field/src/FormField/index.tsx](https://github.com/instructure/instructure-ui/pull/1863/files#diff-c3fa8d3879537cb2154a993c04dfa9d0bd50e05c64ad876325b046f34c25d59c)

To Test: Check the select examples. Clicking on the label should bring the input field in the focus