### PR TITLE
fix(ui-form-field): do not pass vAlign prop to underlying html element

### DIFF
--- a/packages/ui-form-field/src/FormFieldLayout/props.ts
+++ b/packages/ui-form-field/src/FormFieldLayout/props.ts
@@ -142,11 +142,8 @@ const allowedProps: AllowedPropKeys = [
   'width',
   'inputContainerRef',
   'elementRef',
-  'margin'
-
-  // added vAlign because FormField and FormFieldGroup passes it, but not adding
-  // it to allowedProps to prevent it from getting passed through accidentally
-  //'vAlign'
+  'margin',
+  'vAlign'
 ]
 
 type FormFieldStyleProps = {


### PR DESCRIPTION
INSTUI-4477

this bug was introduced when this line was removed: https://github.com/instructure/instructure-ui/pull/1863/files#diff-13252981104c2c32508f00c654a221b51e4b11acfc1ea64c9e1242e603fcb01cL183

test plan:

- check out branch locally (!) and open the textinput docs and see that there's no react warning error