### PR TITLE
fix(ui-drawer-layout): drawer tray should trap focus in overlay mode if `shouldContainFocus` prop is set to true

### DIFF
--- a/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
+++ b/packages/ui-drawer-layout/src/DrawerLayout/DrawerTray/index.tsx
@@ -253,9 +253,7 @@ class DrawerTray extends Component<
                   label={label}
                   shouldReturnFocus={shouldReturnFocus}
                   shouldContainFocus={
-                    !this.state.transitioning &&
-                    shouldContainFocus &&
-                    shouldOverlayTray
+                    shouldContainFocus && shouldOverlayTray // only contain focus when it's in overlay mode
                   }
                   shouldCloseOnDocumentClick={
                     shouldCloseOnDocumentClick && shouldOverlayTray


### PR DESCRIPTION
INSTUI-4401

test plan:

- go to the drawer layout example and check if by default it traps the focus in overlay mode (set the window size to small)
- by default it shouldn't trap the focus in desktop mode
- if you set explicitly the `shouldContainFocus` prop in the DrawerLayout.Tray, it should follow that setting (but still respect viewport size)