### PR TITLE
fix(ui-file-drop): underlying HTML input's 'files' prop is now populated when dropping a file

### DIFF
--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -231,6 +231,12 @@ class FileDrop extends Component<FileDropProps, FileDropState> {
     const [accepted, rejected] = this.parseFiles(fileList)
     e.preventDefault()
     this.enterCounter = 0
+    // When dropping a file the browser does not populate the input's
+    // 'files' property, so we need to do it manually. This will also populate
+    // the input's 'value' prop, which contains the first file's path
+    if (accepted.length > 0 && 'dataTransfer' in e) {
+      this.fileInputEl!.files = e.dataTransfer!.files
+    }
     onDrop && onDrop(accepted, rejected, e as React.DragEvent)
     if (rejected.length > 0 && onDropRejected) {
       onDropRejected(rejected, e)


### PR DESCRIPTION
By default browsers do not populate the input's `files` and `value` prop when a file is dropped (its populated when clicking on the control). This PR populates `files` prop when dropping (and the `value` prop which is calculated from this one)

To test:
Drop files into a `FileDrop` example, you should see the `files` object populated in devtool's "Properties" tab or in the console.
Test it with Chrome, Safari, FF

Fixes INSTUI-4476