### PR TITLE
fix(ui-side-nav-bar): make screenreaders announce Badge text in SideN…

### DIFF
--- a/packages/ui-side-nav-bar/src/SideNavBar/SideNavBarItem/index.tsx
+++ b/packages/ui-side-nav-bar/src/SideNavBar/SideNavBarItem/index.tsx
@@ -89,9 +89,7 @@ class SideNavBarItem extends Component<SideNavBarItemProps> {
         css={this.props.styles?.navigationItem}
         aria-label={this.props.minimized ? (label as string) : undefined}
       >
-        <div css={this.props.styles?.icon} aria-hidden="true">
-          {icon}
-        </div>
+        <div css={this.props.styles?.icon}>{icon}</div>
         {!this.props.minimized ? (
           <div css={this.props.styles?.label}>{label}</div>
         ) : null}


### PR DESCRIPTION
…avBar

INSTUI-4292

ISSUE:
- in Safari with VoiceOver, and with NVDA and JAWS, the Badge count in SideNavBar example was not announced, it worked only in Chrome with VoiceOver

TEST PLAN:
- go over the SideNavBar example with Voiceover in Safari and Chrome, it should announce the text "You have 99 unread messages."
- go over the SideNavBar example with NVDA and JAWS, they should announce the text "You have 99 unread messages."