### PR TITLE
fix(ui-utils): fix 'no matching export' build error

### DIFF
--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -37,4 +37,12 @@ export { within } from './within'
 export { camelize } from './camelize'
 export { pascalize } from './pascalize'
 export { isBaseTheme } from './isBaseTheme'
-export * from './getBrowser'
+export {
+  getBrowser,
+  isSafari,
+  isEdge,
+  isIE,
+  isFirefox,
+  isChromium,
+  isAndroidOrIOS
+} from './getBrowser'


### PR DESCRIPTION
This seems to occur rarely with e.g. Vite 2. Sadly we could not reproduce it

fixes INSTUI-4470