### PR TITLE
fix(ui-pagination): make Pagination wrap on smaller screen sizes and prevent scrollbars

### DIFF
--- a/cypress/component/Pagination.cy.tsx
+++ b/cypress/component/Pagination.cy.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React from 'react'
-import { Pagination, ScreenReaderContent } from '../../packages/ui'
+import { Pagination, ScreenReaderContent } from '@instructure/ui'
 
 import '../support/component'
 import 'cypress-real-events'
@@ -65,6 +65,56 @@ describe('<Pagination/>', () => {
         ).height
         expect(heightWithNoLabel).to.equal(heightWithHiddenLabel)
         cy.wrap($paginationWithLabel).should('contain', 'I am a hidden label')
+      })
+    })
+  })
+
+  it('should wrap at a small viewport width', () => {
+    cy.mount(
+      <Pagination
+        as="nav"
+        margin="small"
+        variant="compact"
+        currentPage={4}
+        totalPageNumber={100000}
+        siblingCount={3}
+        boundaryCount={2}
+      />
+    )
+
+    cy.viewport(1000, 800)
+
+    cy.get('[role="navigation"]').within(() => {
+      cy.get('button').then(($items) => {
+        const firstItem = $items[0]
+        const firstItemTop = firstItem.getBoundingClientRect().top
+
+        let hasWrapped = false
+        $items.each((index, item) => {
+          const itemTop = item.getBoundingClientRect().top
+          if (index > 0 && itemTop > firstItemTop) {
+            hasWrapped = true
+          }
+        })
+        expect(hasWrapped).to.be.false
+      })
+    })
+
+    cy.viewport(300, 800)
+
+    cy.get('[role="navigation"]').within(() => {
+      cy.get('button').then(($items) => {
+        const firstItem = $items[0]
+        const firstItemTop = firstItem.getBoundingClientRect().top
+
+        let hasWrapped = false
+        $items.each((index, item) => {
+          const itemTop = item.getBoundingClientRect().top
+          if (index > 0 && itemTop > firstItemTop) {
+            hasWrapped = true
+          }
+        })
+        expect(hasWrapped).to.be.true
       })
     })
   })

--- a/packages/ui-pagination/src/Pagination/index.tsx
+++ b/packages/ui-pagination/src/Pagination/index.tsx
@@ -105,7 +105,8 @@ class Pagination extends Component<PaginationProps> {
     siblingCount: 1,
     boundaryCount: 1,
     ellipsis: '…',
-    renderPageIndicator: (page: number) => page
+    renderPageIndicator: (page: number) => page,
+    margin: 'space8'
   }
 
   static Page = PaginationButton

--- a/packages/ui-pagination/src/Pagination/props.ts
+++ b/packages/ui-pagination/src/Pagination/props.ts
@@ -118,9 +118,9 @@ type PaginationOwnProps = {
   variant?: 'full' | 'compact' | 'input'
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Spacing token values can be found here: [Spacing Tokens](https://instructure.design/#layout-spacing/%23Tokens)
+   *
+   * Apply these values via familiar CSS-like shorthand. For example: `margin="space8 0 space12"`.
    */
   margin?: Spacing
 

--- a/packages/ui-pagination/src/Pagination/styles.ts
+++ b/packages/ui-pagination/src/Pagination/styles.ts
@@ -41,7 +41,9 @@ const generateStyle = (componentTheme: PaginationTheme): PaginationStyle => {
       all: 'unset',
       display: 'flex',
       alignItems: 'center',
-      gap: componentTheme.pageIndicatorGap
+      gap: componentTheme.pageIndicatorGap,
+      flexWrap: 'wrap',
+      justifyContent: 'center'
     },
     pagination: {
       label: 'pagination',


### PR DESCRIPTION
INSTUI-4461

**ISSUE:** 
- on smaller screen sizes the Pagination has a horizontal scrollbar
- in some cases it has a vertical scrollbar and page buttons and their focus ring aren't fully visible when the parent has no padding

**TEST PLAN:**

**test no horizontal scrollbars:**
- open the examples in Pagination
- click Inspect then switch to mobile device view
- when exceeding the width of the container, the pagination numbers should wrap instead of a horizontal scrollbars appearing, and the new lines should be centered (similarly to the the legacy examples)

**test no vertical scrollbars:**
- go to the first example, click Inspect and on the Styles tab remove the preview parent element's (class="css-kinttp-preview") padding
- while the parent's padding removed, try when no margin prop is provided
- while the parent's padding removed when no margin prop is provided, the component should have NO vertical scrollbars (make sure you hover over the component and try scrolling with the mouse too)
- while the parent's padding removed and when no margin prop is provided, the click on the page buttons and make sure the buttons including their focus rings should remain fully visible (e.g. their top or bottom edges should not covered by the parent checkerboard container)

