### PR TITLE
fix(ui-a11y-utils): make Modal stay open when button is clicked in ce…

### DIFF
--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -45,7 +45,8 @@ class FocusRegion {
   private readonly _id: string
   private _listeners: ReturnType<typeof addEventListener>[] = []
   private _active = false
-  private _documentMouseDownTarget: Node | null = null
+  private _documentClickTarget: Node | null = null
+  private _contextContainsTarget = false
 
   constructor(element: Element | Node | null, options: FocusRegionOptions) {
     this._options = options || {
@@ -83,8 +84,11 @@ class FocusRegion {
   }
 
   captureDocumentMousedown = (event: React.MouseEvent) => {
-    // FocusRegion can be activated after mousedown but before click so this is not guaranteed to fire.
-    this._documentMouseDownTarget = event.target as Node
+    this._documentClickTarget = event.target as Node
+    this._contextContainsTarget = contains(
+      this._contextElement,
+      this._documentClickTarget
+    )
   }
 
   handleDocumentClick = (event: React.PointerEvent) => {
@@ -92,8 +96,7 @@ class FocusRegion {
       this._options.shouldCloseOnDocumentClick &&
       event.button === 0 &&
       event.detail > 0 && // if event.detail is 0 then this is a keyboard and not a mouse press
-      this._documentMouseDownTarget !== null &&
-      !contains(this._contextElement, this._documentMouseDownTarget)
+      !this._contextContainsTarget
     ) {
       this.handleDismiss(event, true)
     }


### PR DESCRIPTION
…rtain configurations

INSTUI-4483

**ISSUES:**
- Modal closes when a button that rerenders the modal’s content is clicked and when shouldCloseOnDocumentClick is set to true
- Modal closes when RadioInputButton is clicked in Firefox
- the likely culprit is this previous fix: https://github.com/instructure/instructure-ui/pull/1806  because reverting those changes makes the bugs disappear

**TEST PLAN:**

**check change revert:**
- make sure all the changes here are reverted: https://github.com/instructure/instructure-ui/pull/1806/files

**test clicking on button that rerenders modal content:**
- open the TEST#1 code in the comments below
- open the Modal
- click on the Change content button
- the content should be changed and the Modal should remain open
- the same code with same steps should result in closing the Modal in the latest release

**test clicking on Checkbox in Firefox:**
- **In Firefox** preview, open the TEST#2 code in the comments below 
- open the Modal
- click on checked checkbox
- the Modal should remain open
- the same code with same steps should result in closing the Modal in the latest release **in Firefox**

