### PR TITLE
fix(ui-source-code-editor): make scrollview in SourceCodeEditor keyboard accessible

### DIFF
--- a/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/index.tsx
@@ -295,6 +295,14 @@ class SourceCodeEditor extends Component<SourceCodeEditorProps> {
       parent: this._containerRef
     })
 
+    // from the a11y team:
+    // axe devtools and other automated a11y tests both flagging this issue,
+    // which can be observed while navigating with keyboard:
+    // Ensure elements that have scrollable content are accessible by keyboard
+    // To solve this problem, you need to fix at least (1) of the following:
+    // Element should have focusable content, Element should be focusable
+    this._editorView.scrollDOM.tabIndex = 0
+
     if (autofocus) {
       this.focus()
     }


### PR DESCRIPTION
INSTUI-4492

test plan:

- open sourcecodeeditor and make sure you can focus the editor view and scroll it via keyboard
- check dom: the `div` with class `cm-scroller` should have `tabIndex` 0 (and not -1)