### PR TITLE
Fix docs theme not respecting theme change

### DIFF
--- a/packages/__docs__/src/ComponentTheme/index.tsx
+++ b/packages/__docs__/src/ComponentTheme/index.tsx
@@ -45,10 +45,7 @@ class ComponentTheme extends Component<ComponentThemeProps> {
     colorPrimitives: object
   ) {
     if (!value) {
-      return <code>$aposundefined$apos</code>
-    }
-    if (typeof value === 'object') {
-      return <code>{JSON.stringify(value)}</code>
+      return <code>ERROR - possible bug</code>
     }
     if (typeof value === 'object') {
       return <code>{JSON.stringify(value)}</code>

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -90,8 +90,11 @@ class Document extends Component<DocumentProps, DocumentState> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: typeof this.props) {
     this.props.makeStyles?.()
+    if (this.props.themeVariables?.key !== prevProps.themeVariables?.key) {
+      this.fetchGenerateComponentTheme()
+    }
   }
 
   handleDetailsTabChange: TabsProps['onRequestTabChange'] = (

--- a/packages/__docs__/src/Document/props.ts
+++ b/packages/__docs__/src/Document/props.ts
@@ -36,7 +36,7 @@ type DocDataType = DocData & { legacyGitBranch?: string }
 type DocumentOwnProps = {
   doc: DocDataType
   description: string
-  themeVariables?: BaseThemeVariables
+  themeVariables?: BaseThemeVariables & { key: string }
   repository?: string
   layout?: 'small' | 'medium' | 'large' | 'x-large'
 }


### PR DESCRIPTION
TEST_PLAN:
go to the docs app and navigate to any component's docs page. Check the default theme variables section. Change the theme. Observe that the color variables are changing.
Test Avatar (only functional component currently) and any other component with default theme colors



closes: INSTUI-4497