### PR TITLE
fix(ui-options): fix isAndroidOrIOS missing error for some bundlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35965,6 +35965,7 @@
         "@instructure/ui-prop-types": "10.15.1",
         "@instructure/ui-react-utils": "10.15.1",
         "@instructure/ui-testable": "10.15.1",
+        "@instructure/ui-utils": "10.15.1",
         "@instructure/ui-view": "10.15.1",
         "prop-types": "^15.8.1"
       },

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -40,6 +40,7 @@
     "@instructure/ui-icons": "10.15.1",
     "@instructure/ui-prop-types": "10.15.1",
     "@instructure/ui-react-utils": "10.15.1",
+    "@instructure/ui-utils": "10.15.1",
     "@instructure/ui-testable": "10.15.1",
     "@instructure/ui-view": "10.15.1",
     "prop-types": "^15.8.1"

--- a/packages/ui-options/tsconfig.build.json
+++ b/packages/ui-options/tsconfig.build.json
@@ -17,6 +17,7 @@
     { "path": "../ui-icons/tsconfig.build.json" },
     { "path": "../ui-prop-types/tsconfig.build.json" },
     { "path": "../ui-react-utils/tsconfig.build.json" },
+    { "path": "../ui-utils/tsconfig.build.json" },
     { "path": "../ui-testable/tsconfig.build.json" },
     { "path": "../ui-view/tsconfig.build.json" }
   ]


### PR DESCRIPTION
Some bundlers or package managers (`pnpm`? `vite`?) error out with an error that `isAndroidOrIOS` is missing from the build. Its added to `ui-options` in a transitive dependency (`ui-react-utils` -> `ui-utils`), which should work, but it does not. This is an attempt to fix this issue