### PR TITLE
fix(ui-select,ui-form-field): fix iOS VoiceOver with Select and SimpleSelect announcing 'readonly' and 'textinput'

### DIFF
--- a/packages/ui-form-field/src/FormFieldLayout/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/index.tsx
@@ -108,9 +108,10 @@ class FormFieldLayout extends Component<FormFieldLayoutProps> {
     }
     for (const msg of this.props.messages) {
       if (msg.text) {
-        if (typeof msg.text === 'string') {
-          return msg.text.length > 0
+        if (typeof msg.text === 'string' && msg.text.length > 0) {
+          return true
         }
+      } else {
         // this is more complicated (e.g. an array, a React component,...)
         // but we don't try to optimize here for these cases
         return true

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -697,10 +697,15 @@ class Select extends Component<SelectProps> {
     // popup buttons rather than comboboxes.
     const overrideProps: Partial<TextInputProps> = !isEditable
       ? {
-          // Given that Safari with Voiceover does not support proper combobox
-          // handling, a button role is set as a workaround.
+          // We need role="combobox" for the 'open list' button shortcut to work
+          // with desktop screenreaders.
+          // But desktop Safari with Voiceover does not support proper combobox
+          // handling, a 'button' role is set as a workaround.
           // See https://bugs.webkit.org/show_bug.cgi?id=236881
-          role: utils.isSafari() ? 'button' : 'combobox',
+          // Also on iOS Chrome with role='combobox' it announces unnecessarily
+          // that its 'read-only' and that this is a 'textfield', see INSTUI-4500
+          role:
+            utils.isSafari() || utils.isAndroidOrIOS() ? 'button' : 'combobox',
           title: inputValue,
           'aria-autocomplete': undefined,
           'aria-readonly': true


### PR DESCRIPTION
Also fix formFieldLayout spacing issue if there are multiple messages and the first one is an empty string

To test:
Check Select read-only, SimpleSelect, TimeSelect examples with VoiceOver on iOS and Desktop

Fixes INSTUI-4500