### PR TITLE
fix(ui-date-input,ui-avatar): add ref support to functional components

### DIFF
--- a/packages/ui-avatar/src/Avatar/__new-tests__/Avatar.test.tsx
+++ b/packages/ui-avatar/src/Avatar/__new-tests__/Avatar.test.tsx
@@ -29,6 +29,7 @@ import { runAxeCheck } from '@instructure/ui-axe-check'
 import '@testing-library/jest-dom'
 import Avatar from '../index'
 import { IconGroupLine } from '@instructure/ui-icons'
+import { View } from '@instructure/ui-view'
 
 describe('<Avatar />', () => {
   describe('for a11y', () => {
@@ -72,12 +73,17 @@ describe('<Avatar />', () => {
       expect(getComputedStyle(initials).color).toBe('rgb(43, 122, 188)')
     })
 
-    it('should return the underlying component', async () => {
+    it('refs should return the underlying component', async () => {
       const elementRef = vi.fn()
+      const ref: React.Ref<View> = { current: null }
       const { container } = render(
-        <Avatar name="Avatar Name" elementRef={elementRef} />
+        <>
+          <Avatar id="av1" name="Avatar Name" elementRef={elementRef} />
+          <Avatar id="av2" name="Avatar Name2" ref={ref} />
+        </>
       )
-      expect(elementRef).toHaveBeenCalledWith(container.firstChild)
+      expect(ref.current!.props.id).toBe('av2')
+      expect(elementRef).toHaveBeenCalledWith(container.querySelector('#av1'))
     })
   })
 

--- a/packages/ui-avatar/src/Avatar/index.tsx
+++ b/packages/ui-avatar/src/Avatar/index.tsx
@@ -23,7 +23,13 @@
  */
 
 import { useStyle } from '@instructure/emotion'
-import { useState, SyntheticEvent, useEffect } from 'react'
+import {
+  useState,
+  SyntheticEvent,
+  useEffect,
+  forwardRef,
+  ForwardedRef
+} from 'react'
 
 import { View } from '@instructure/ui-view'
 import { callRenderProp, passthroughProps } from '@instructure/ui-react-utils'
@@ -37,125 +43,130 @@ import generateComponentTheme from './theme'
 category: components
 ---
 **/
-
-const Avatar = ({
-  size = 'medium',
-  color = 'default',
-  hasInverseColor = false,
-  showBorder = 'auto',
-  shape = 'circle',
-  display = 'inline-block',
-  onImageLoaded = (_event: SyntheticEvent) => {},
-  src,
-  name,
-  renderIcon,
-  alt,
-  as,
-  margin,
-  themeOverride,
-  elementRef,
-  ...rest
-}: AvatarProps) => {
-  const [loaded, setLoaded] = useState(false)
-
-  const styles = useStyle({
-    generateStyle,
-    generateComponentTheme,
-    params: {
-      loaded,
-      size,
-      color,
-      hasInverseColor,
-      shape,
+const Avatar = forwardRef(
+  (
+    {
+      size = 'medium',
+      color = 'default',
+      hasInverseColor = false,
+      showBorder = 'auto',
+      shape = 'circle',
+      display = 'inline-block',
+      onImageLoaded = (_event: SyntheticEvent) => {},
       src,
-      showBorder,
-      themeOverride
-    },
-    componentId: 'Avatar',
-    displayName: 'Avatar'
-  })
+      name,
+      renderIcon,
+      alt,
+      as,
+      margin,
+      themeOverride,
+      elementRef,
+      ...rest
+    }: AvatarProps,
+    ref: ForwardedRef<View>
+  ) => {
+    const [loaded, setLoaded] = useState(false)
 
-  useEffect(() => {
-    // in case the image is unset in an update, show icons/initials again
-    if (loaded && !src) {
-      setLoaded(false)
-    }
-  }, [loaded, src])
-
-  const makeInitialsFromName = () => {
-    if (!name || typeof name !== 'string') {
-      return
-    }
-    const currentName = name.trim()
-    if (currentName.length === 0) {
-      return
-    }
-
-    if (currentName.match(/\s+/)) {
-      const names = currentName.split(/\s+/)
-      return (names[0][0] + names[names.length - 1][0]).toUpperCase()
-    } else {
-      return currentName[0].toUpperCase()
-    }
-  }
-
-  const handleImageLoaded = (event: SyntheticEvent) => {
-    setLoaded(true)
-    onImageLoaded(event)
-  }
-
-  const renderInitials = () => {
-    return (
-      <span css={styles?.initials} aria-hidden="true">
-        {makeInitialsFromName()}
-      </span>
-    )
-  }
-
-  const renderContent = () => {
-    if (!renderIcon) {
-      return renderInitials()
-    }
-
-    return <span css={styles?.iconSVG}>{callRenderProp(renderIcon)}</span>
-  }
-
-  return (
-    <View
-      {...passthroughProps({
+    const styles = useStyle({
+      generateStyle,
+      generateComponentTheme,
+      params: {
+        loaded,
         size,
         color,
         hasInverseColor,
-        showBorder,
         shape,
-        display,
         src,
-        name,
-        renderIcon,
-        alt,
-        as,
-        margin,
-        ...rest
-      })}
-      aria-label={alt ? alt : undefined}
-      role={alt ? 'img' : undefined}
-      as={as}
-      elementRef={elementRef}
-      margin={margin}
-      css={styles?.avatar}
-      display={display}
-    >
-      <img // This is visually hidden and is here for loading purposes only
-        src={src}
-        css={styles?.loadImage}
-        alt={alt}
-        onLoad={handleImageLoaded}
-        aria-hidden="true"
-      />
-      {!loaded && renderContent()}
-    </View>
-  )
-}
+        showBorder,
+        themeOverride
+      },
+      componentId: 'Avatar',
+      displayName: 'Avatar'
+    })
+
+    useEffect(() => {
+      // in case the image is unset in an update, show icons/initials again
+      if (loaded && !src) {
+        setLoaded(false)
+      }
+    }, [loaded, src])
+
+    const makeInitialsFromName = () => {
+      if (!name || typeof name !== 'string') {
+        return
+      }
+      const currentName = name.trim()
+      if (currentName.length === 0) {
+        return
+      }
+
+      if (currentName.match(/\s+/)) {
+        const names = currentName.split(/\s+/)
+        return (names[0][0] + names[names.length - 1][0]).toUpperCase()
+      } else {
+        return currentName[0].toUpperCase()
+      }
+    }
+
+    const handleImageLoaded = (event: SyntheticEvent) => {
+      setLoaded(true)
+      onImageLoaded(event)
+    }
+
+    const renderInitials = () => {
+      return (
+        <span css={styles?.initials} aria-hidden="true">
+          {makeInitialsFromName()}
+        </span>
+      )
+    }
+
+    const renderContent = () => {
+      if (!renderIcon) {
+        return renderInitials()
+      }
+
+      return <span css={styles?.iconSVG}>{callRenderProp(renderIcon)}</span>
+    }
+
+    return (
+      <View
+        {...passthroughProps({
+          size,
+          color,
+          hasInverseColor,
+          showBorder,
+          shape,
+          display,
+          src,
+          name,
+          renderIcon,
+          alt,
+          as,
+          margin,
+          ...rest
+        })}
+        ref={ref}
+        aria-label={alt ? alt : undefined}
+        role={alt ? 'img' : undefined}
+        as={as}
+        elementRef={elementRef}
+        margin={margin}
+        css={styles?.avatar}
+        display={display}
+      >
+        <img // This is visually hidden and is here for loading purposes only
+          src={src}
+          css={styles?.loadImage}
+          alt={alt}
+          onLoad={handleImageLoaded}
+          aria-hidden="true"
+        />
+        {!loaded && renderContent()}
+      </View>
+    )
+  }
+)
 
 export default Avatar
 export { Avatar }

--- a/packages/ui-date-input/src/DateInput2/__new-tests__/DateInput2.test.tsx
+++ b/packages/ui-date-input/src/DateInput2/__new-tests__/DateInput2.test.tsx
@@ -29,6 +29,7 @@ import '@testing-library/jest-dom'
 import { IconHeartLine } from '@instructure/ui-icons'
 
 import { DateInput2 } from '../index'
+import { TextInput } from '@instructure/ui-text-input'
 
 const LABEL_TEXT = 'Choose a date'
 
@@ -122,6 +123,28 @@ describe('<DateInput2 />', () => {
 
     expect(calendarIcon).toBeInTheDocument()
     expect(calendarLabel).toBeInTheDocument()
+  })
+
+  it('refs should return the underlying component', async () => {
+    const inputRef = vi.fn()
+    const ref: React.Ref<TextInput> = { current: null }
+    const { container } = render(
+      <DateInput2
+        id="dateInput2"
+        inputRef={inputRef}
+        ref={ref}
+        renderLabel={LABEL_TEXT}
+        screenReaderLabels={{
+          calendarIcon: 'Calendar',
+          nextMonthButton: 'Next month',
+          prevMonthButton: 'Previous month'
+        }}
+      />
+    )
+    const dateInput = container.querySelector('input')
+    expect(inputRef).toHaveBeenCalledWith(dateInput)
+    expect(ref.current!.props.id).toBe('dateInput2')
+    expect(dateInput).toBeInTheDocument()
   })
 
   it('should render a custom calendar icon with screen reader label', async () => {


### PR DESCRIPTION
This is needed for things that try to access the `ref` prop, like our [Transition](https://github.com/instructure/instructure-ui/blob/7226e21d53f5e36820440205bfc2e269281e47bd/packages/ui-motion/src/Transition/BaseTransition/index.ts#L342) or [Position](https://github.com/instructure/instructure-ui/blob/7226e21d53f5e36820440205bfc2e269281e47bd/packages/ui-position/src/Position/index.tsx#L295) package.
Also we have a page asking users to add the `ref` prop, see https://instructure.design/#accessing-the-dom
Finally in React 19 this code will be much simpler, see https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop 

To test: check is `Transition`, `Position` works with `Avatar` and `DateInput2`


Fixes INSTUI-4520