### PR TITLE
fix(ui-date-input): correctly format the DateInput2 placeholder in every timezone

### DIFF
--- a/packages/ui-date-input/src/DateInput2/index.tsx
+++ b/packages/ui-date-input/src/DateInput2/index.tsx
@@ -214,7 +214,7 @@ const DateInput2 = ({
     return date ? [formatDate(date), date.toISOString()] : ['', '']
   }
 
-  const formatDate = (date: Date): string => {
+  const formatDate = (date: Date, timeZone: string = getTimezone()): string => {
     // use formatter function if provided
     if (typeof dateFormat !== 'string' && dateFormat?.formatter) {
       return dateFormat.formatter(date)
@@ -222,13 +222,13 @@ const DateInput2 = ({
     // if dateFormat set to a locale, use that, otherwise default to the user's locale
     return date.toLocaleDateString(
       typeof dateFormat === 'string' ? dateFormat : getLocale(),
-      { timeZone: getTimezone(), calendar: 'gregory', numberingSystem: 'latn' }
+      { timeZone, calendar: 'gregory', numberingSystem: 'latn' }
     )
   }
 
   const getDateFromatHint = () => {
     const exampleDate = new Date('2024-09-01')
-    const formattedDate = formatDate(exampleDate)
+    const formattedDate = formatDate(exampleDate, 'UTC') // exampleDate is in UTC so format it as such
 
     // Create a regular expression to find the exact match of the number
     const regex = (n: string) => {


### PR DESCRIPTION
INSTUI-4498

test plan

- go to the dateinput2 docs page and set the first example to every possible timezone offset (e.g. `Etc/GMT+4`, `Etc/GMT+5`, `Etc/GMT-10`, etc.) -> the placeholder should never break