### PR TITLE
fix(ui-modal): set inverseBackground to grey100100

### DIFF
--- a/packages/ui-modal/src/Modal/ModalHeader/theme.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/theme.ts
@@ -39,7 +39,7 @@ const generateComponentTheme = (theme: Theme): ModalHeaderTheme => {
     padding: spacing?.medium,
     paddingCompact: spacing?.small,
 
-    inverseBackground: colors?.contrasts?.grey125125,
+    inverseBackground: colors?.contrasts?.grey100100,
     inverseBorderColor: colors?.contrasts?.grey125125
   }
 


### PR DESCRIPTION
INSTUI-4528

**Test**

1. Create a Modal with the `variant` prop set to `inverse`
2. Observe if the background color (of all Modal parts: Modal, Modal.Header, Modal.Footer) is `grey100100`