### PR TITLE
docs: fix regression in docs page themes section

### DIFF
--- a/packages/__docs__/src/Theme/index.tsx
+++ b/packages/__docs__/src/Theme/index.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { Component } from 'react'
+import { Children, Component } from 'react'
 import { withStyle } from '@instructure/emotion'
 
 import { px } from '@instructure/ui-utils'


### PR DESCRIPTION
test plan: 
- theme pages should load (e.g. `/#canvas`)