### PR TITLE
fix(ui-table): fix table crashing in stacked layout when using falsy children

### DIFF
--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -117,7 +117,7 @@ class Head extends Component<TableHeadProps> {
     let count = 0
     Children.forEach(firstRow.props.children, (grandchild) => {
       count += 1
-      if (!grandchild.props) return
+      if (!grandchild?.props) return // grandchild can be false
       const { id, stackedSortByLabel, sortDirection, onRequestSort } =
         grandchild.props
       if (id && onRequestSort) {

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -2014,7 +2014,7 @@ Custom table with `stacked` layout support:
           onMouseOver={this.toggleHoverOn}
           onMouseOut={this.toggleHoverOff}
         >
-          {Children.toArray(this.props.children)
+          {React.Children.toArray(this.props.children)
             .filter(React.isValidElement)
             .map((child, index) => {
               return React.cloneElement(child, {
@@ -2144,7 +2144,7 @@ Custom table with `stacked` layout support:
         onMouseOver={() => setIsHovered(true)}
         onMouseOut={() => setIsHovered(false)}
       >
-        {Children.toArray(children)
+        {React.Children.toArray(children)
           .filter(React.isValidElement)
           .map((child, index) => {
             return React.cloneElement(child, {

--- a/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/__new-tests__/Table.test.tsx
@@ -155,10 +155,27 @@ describe('<Table />', async () => {
     render(
       <Table caption="Test table" layout="stacked">
         <Table.Head>
+          {/* @ts-expect-error error is normal here */}
           <Table.Row>
             <Table.Cell>Foo</Table.Cell>
+            {}
+            {false}
           </Table.Row>
         </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.RowHeader>1</Table.RowHeader>
+            <Table.Cell>The Shawshank Redemption</Table.Cell>
+            <Table.Cell>1994</Table.Cell>
+            <Table.Cell>9.3</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.RowHeader>2</Table.RowHeader>
+            <Table.Cell>The Godfather</Table.Cell>
+            <Table.Cell>1972</Table.Cell>
+            <Table.Cell>9.2</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     )
     const stackedTable = screen.getByRole('table')
@@ -167,7 +184,7 @@ describe('<Table />', async () => {
     expect(stackedTable).not.toHaveTextContent('Foo')
   })
 
-  it('does not crash for invalid children', async () => {
+  it('does not crash for invalid children in stacked layout', async () => {
     render(
       <Table caption="Test table" layout="stacked">
         test1


### PR DESCRIPTION
- fix table crashing in stacked layout when using falsy children
- a `Table` example that was using `Children` instead of `React.Children`
- CodeSandboxes crashing because missing imports.
- Make CodeSandbox examples nicer by only importing samples when needed

Fixes INSTUI-4534

To test:
1. try this code in this PR, it should not crash:
```
<Table caption="Test table" layout="stacked">
        <Table.Head>
          {/* @ts-expect-error error is normal here */}
          <Table.Row>
            <Table.Cell>Foo</Table.Cell>
            {}
            {false}
          </Table.Row>
        </Table.Head>
        <Table.Body>
          <Table.Row>
            <Table.RowHeader>1</Table.RowHeader>
            <Table.Cell>The Shawshank Redemption</Table.Cell>
            <Table.Cell>1994</Table.Cell>
            <Table.Cell>9.3</Table.Cell>
          </Table.Row>
          <Table.Row>
            <Table.RowHeader>2</Table.RowHeader>
            <Table.Cell>The Godfather</Table.Cell>
            <Table.Cell>1972</Table.Cell>
            <Table.Cell>9.2</Table.Cell>
          </Table.Row>
        </Table.Body>
      </Table>
```
2. Try to insert invalid children into other places (e.g. text, `{false}`), it should never crash.
3. Open some of our example codes in CodeSandbox, it should only import sample media (e.g. `lorem`) when its used, they should not crash