### PR TITLE
Attempt to fix 'JSON5: invalid end of input' build error in CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13373,7 +13373,6 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -26847,9 +26846,9 @@
       }
     },
     "node_modules/path-unified": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.1.0.tgz",
-      "integrity": "sha512-/Oaz9ZJforrkmFrwkR/AcvjVsCAwGSJHO0X6O6ISj8YeFbATjIEBXLDcZfnK3MO4uvCBrJTdVIxdOc79PMqSdg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.2.0.tgz",
+      "integrity": "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==",
       "license": "MIT"
     },
     "node_modules/path/node_modules/inherits": {
@@ -29766,9 +29765,9 @@
       }
     },
     "node_modules/style-dictionary": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.1.2.tgz",
-      "integrity": "sha512-ZQz+Qs38jq0Qb7IOKuj2Rnm81AziQJDV1E2/TnnKpfLajWKr3VAf8xfrFT1gA3+pHmx+M2bfabDTuMUJYJM2Lg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.4.0.tgz",
+      "integrity": "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -29778,11 +29777,12 @@
         "@zip.js/zip.js": "^2.7.44",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
-        "commander": "^8.3.0",
+        "commander": "^12.1.0",
         "is-plain-obj": "^4.1.0",
         "json5": "^2.2.2",
         "patch-package": "^8.0.0",
-        "path-unified": "^0.1.0",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
         "tinycolor2": "^1.6.0"
       },
       "bin": {
@@ -29804,14 +29804,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/style-dictionary/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/style-dictionary/node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -29822,6 +29814,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-dictionary/node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/style-loader": {
@@ -50570,7 +50577,6 @@
         "@lerna/project": "^6.4.1",
         "dotenv": "^16.4.7",
         "find-up": "^7.0.0",
-        "fs-extra": "^11.2.0",
         "http-server": "^14.1.1",
         "jscodeshift": "^0.16.1",
         "karma-cli": "^2.0.0",
@@ -50578,7 +50584,7 @@
         "lodash.isplainobject": "^4.0.6",
         "mocha": "^10.7.3",
         "semver": "^7.6.3",
-        "style-dictionary": "4.1.2",
+        "style-dictionary": "4.4.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.1.0",
         "yargs": "^17.7.2"
@@ -50715,19 +50721,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/ui-scripts/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "packages/ui-scripts/node_modules/jscodeshift": {

--- a/packages/ui-scripts/lib/build/generate-all-tokens.js
+++ b/packages/ui-scripts/lib/build/generate-all-tokens.js
@@ -23,6 +23,7 @@
  */
 
 import path from 'path'
+import fs from 'fs'
 import { error } from '@instructure/command-utils'
 import { handleMapJSTokensToSource } from '../utils/handle-map-js-tokens-to-source.js'
 import { handleGenerateTokens } from '../utils/handle-generate-tokens.js'
@@ -90,7 +91,21 @@ export default {
         ? path.join(themePath, outputDir, themeKey)
         : path.join(themePath, outputDir)
       const sourcePath = path.join(outputPath, 'source.json')
-
+      // this is just a debug code to find the JSON error here that occurs only in CI
+      // eslint-disable-next-line no-console
+      console.log(
+        '!!!!! starting',
+        themeKey,
+        sourceTokens,
+        outputPath,
+        sourcePath,
+        fs.existsSync(sourcePath)
+      )
+      // eslint-disable-next-line no-console
+      console.log(
+        '!!!! styleDictionarySource',
+        JSON.stringify(styleDictionarySource)?.substring(0, 400)
+      )
       generators.push(
         handleGenerateTokens({
           themeKey,

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -26,7 +26,6 @@
     "@lerna/project": "^6.4.1",
     "dotenv": "^16.4.7",
     "find-up": "^7.0.0",
-    "fs-extra": "^11.2.0",
     "http-server": "^14.1.1",
     "jscodeshift": "^0.16.1",
     "karma-cli": "^2.0.0",
@@ -34,7 +33,7 @@
     "lodash.isplainobject": "^4.0.6",
     "mocha": "^10.7.3",
     "semver": "^7.6.3",
-    "style-dictionary": "4.1.2",
+    "style-dictionary": "4.4.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.1.0",
     "yargs": "^17.7.2"


### PR DESCRIPTION
The debug statements help to investigate flaky CI builds that fail.
Also remove `fse`, since the error seems to be that `styleDictionarySource` is not created  in some cases

Trying to fix errors like

```
scss
✔︎ /home/runner/work/instructure-ui/instructure-ui/packages/canvas-high-contrast-theme/tokens/scss/_variables.scss

scss
✔︎ /home/runner/work/instructure-ui/instructure-ui/packages/canvas-theme/tokens/scss/_variables.scss

scss
✔︎ /home/runner/work/instructure-ui/instructure-ui/packages/ui-theme-tokens/tokens/canvas/scss/_variables.scss

scss
✔︎ /home/runner/work/instructure-ui/instructure-ui/packages/ui-themes/tokens/canvas/scss/_variables.scss
/home/runner/work/instructure-ui/instructure-ui/node_modules/json5/lib/parse.js:1110
    const err = new SyntaxError(message)
                ^

SyntaxError: Failed to load or parse JSON or JS Object: JSON5: invalid end of input at 1:1
    at syntaxError (/home/runner/work/instructure-ui/instructure-ui/node_modules/json5/lib/parse.js:1110:17)
    at invalidEOF (/home/runner/work/instructure-ui/instructure-ui/node_modules/json5/lib/parse.js:1059:12)
    at Object.start (/home/runner/work/instructure-ui/instructure-ui/node_modules/json5/lib/parse.js:843:19)
    at Object.parse (/home/runner/work/instructure-ui/instructure-ui/node_modules/json5/lib/parse.js:32:32)
    at combineJSON (file:///home/runner/work/instructure-ui/instructure-ui/node_modules/style-dictionary/lib/utils/combineJSON.js:111:32)
    at StyleDictionary.extend (file:///home/runner/work/instructure-ui/instructure-ui/node_modules/style-dictionary/lib/StyleDictionary.js:302:28) {
  lineNumber: 1,
  columnNumber: 1
}

Node.js v22.15.0
node:child_process:957
    throw err;
    ^

Error: Command failed: npm run build:tokens
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:882:11)
    at execSync (node:child_process:954:15)
    at ChildProcess.<anonymous> (/home/runner/work/instructure-ui/instructure-ui/scripts/bootstrap.js:67:20)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 9206,
  stdout: null,
  stderr: null
}

Node.js v22.15.0
```