### PR TITLE
fix(ui-top-nav-bar,ui-drilldown): fix Drilldown's and TopNavBar's key…

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -887,8 +887,20 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
   }
 
   handleToggle = (event: React.UIEvent | React.FocusEvent, shown: boolean) => {
-    const { onToggle } = this.props
+    const { onToggle, trigger } = this.props
 
+    if (trigger && shown && this.currentPage) {
+      const actionLabel = callRenderProp(this.currentPage.renderActionLabel)
+      // Use action ID if exists, otherwise first non-action option's ID
+      const targetId = actionLabel
+        ? this._headerActionId
+        : this.currentPage.children[0]?.props.id
+      setTimeout(() => {
+        this.setState({
+          highlightedOptionId: targetId
+        })
+      }, 10)
+    }
     this.setState({ isShowingPopover: shown })
 
     if (typeof onToggle === 'function') {
@@ -1481,7 +1493,7 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
           this.handleToggle(event, false)
         }}
         onShowContent={(event) => this.handleToggle(event, true)}
-        mountNode={mountNode}
+        mountNode={mountNode || this.ref}
         placement={placement}
         withArrow={withArrow}
         positionTarget={positionTarget}
@@ -1495,6 +1507,17 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
         onMouseOver={onMouseOver}
         offsetX={offsetX}
         offsetY={offsetY}
+        defaultFocusElement={() => {
+          if (!this.currentPage) return null
+          const actionLabel = callRenderProp(this.currentPage.renderActionLabel)
+          // Use action ID if exists, otherwise first non-action option's ID
+          const targetId = actionLabel
+            ? this._headerActionId
+            : this.currentPage.children[0]?.props.id
+
+          if (!targetId) return null
+          return this._popover?._contentElement?.querySelector(`#${targetId}`)
+        }}
         elementRef={(element) => {
           // setting ref for "Popover" version, the popover root
           // (if there is no trigger, we set it in handleDrilldownRef)

--- a/packages/ui-drilldown/src/Drilldown/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/props.ts
@@ -207,7 +207,7 @@ type DrilldownOwnProps = {
 
   /**
    * If a trigger is supplied, an element or a function returning an element
-   * to use as the mount node for the `<Drilldown />` (defaults to `document.body`)
+   * to use as the mount node for the `<Drilldown />` (defaults to the component itself)
    */
   mountNode?: PositionMountNode
 

--- a/packages/ui-top-nav-bar/src/TopNavBar/README.md
+++ b/packages/ui-top-nav-bar/src/TopNavBar/README.md
@@ -648,12 +648,10 @@ class PlaygroundExample extends React.Component {
 
                       {...item.submenu && {
                         renderSubmenu: this.generateSubmenu(item),
-                        'aria-label': `Open for ${item.label} menu`
                       }}
 
                       {...item.customPopoverConfig && {
                         customPopoverConfig: item.customPopoverConfig,
-                        'aria-label': `Open for ${item.label} menu`
                       }}
 
                       {...!item.submenu && !item.customPopoverConfig ? {
@@ -720,7 +718,7 @@ class PlaygroundExample extends React.Component {
                   <TopNavBar.Item
                     id="Info"
                     renderIcon={<IconQuestionLine />}
-                    aria-label="Open for info menu"
+                    aria-label="info menu"
                     renderSubmenu={this.generateSubmenu({
                       id: 'Info',
                       submenu: ['Contact', 'Map', 'Career'].map(item => ({

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/DesktopLayout/styles.ts
@@ -66,10 +66,9 @@ const generateStyle = (
       alignItems: 'stretch',
       justifyContent: 'space-between',
       height: componentTheme.desktopHeight,
-      position: 'relative',
       zIndex: componentTheme.desktopZIndex,
       maxWidth: '100%',
-      overflow: 'hidden',
+      overflow: 'visible',
       paddingInline: componentTheme.desktopInlinePadding,
       paddingBlock: 0,
       ...(hasBrandBlock && {
@@ -113,7 +112,6 @@ const generateStyle = (
       marginInline: componentTheme.desktopUserContainerInlineMargin,
 
       ...(hasUserSeparator && {
-        position: 'relative',
         paddingInlineStart: componentTheme.desktopUserSeparatorGap,
 
         '&::before': {

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/styles.ts
@@ -51,7 +51,8 @@ const generateStyle = (
       flexDirection: 'row',
       alignItems: 'stretch',
       // padding to prevent focus ring getting cropped by `overflow: hidden`
-      padding: '0 0.125rem'
+      padding: '0 0.125rem',
+      overflow: 'visible'
     },
     submenuOption: {
       label: 'topNavBarMenuItems__submenuOption',


### PR DESCRIPTION
…board navigation issues

INSTUI-4494

**ISSUES:**
- in Drilldown and TopnavBar, the first option is not focused when the Drilldown is opened with the keyboard
- the screen reader cannot return focus to the Drilldown trigger when user is on the first item of a Drilldown

TEST PLAN:

**with keyboard navigation only (no screenreader):**
- test the 'Admin' menu from the TopNavBar playground
- when opening the 'Admin" menu, the first option should be focused and highlighted (previously the first item was not highlighted)
- you should be able to close the menu with ESC and the focus should return to the 'Admin' button
- test the examples in DrillDown that have a trigger button the same way
- they should behave the same way as the 'Admin' dropdown (highlighting first available options, returning focus to the triggers)
- test the SmallViewPort version of the TopNavBar playground too, it should behave the same way (highlighting first avaliable option, returning focus to the trigger)

**with VoiceOver:**
- test the 'Admin' menu from the TopNavBar playground
- when opening the 'Admin" menu with Control + Options + Tab (or your custom VoiceOver command), the first option should be focused (previously the first item was not focused)
- you should be able navigate through the options with Control + Options + Right Arrow/Left Arrow
- When the focus is on the first item, keep pressing Control + Options + Left Arrow, you should be able to move back to the admin button (previously the focus jumped to the end of the page because the menu was mounted at the end of the document)
- test the examples in DrillDown that have a trigger button the same way
- they should behave the same way as the 'Admin' dropdown (focusing the first available option, returning focus to the triggers)
- test the SmallViewPort version of the TopNavBar playground too, it should behave the same way (focusing the first available option, returning focus to the trigger)

**with JAWS/NVDA:**
- test the 'Admin' menu from the TopNavBar playground
- when opening the 'Admin" menu with Enter, the first option should be focused (previously the first item was not focused)
- you should be able navigate through the options with Down Arrow/Up Arrow
- When the focus is on the first item, keep pressing Up Arrow, you should be able to move back to the admin button (previously the focus jumped to the end of the page because the menu was mounted at the end of the document)
- test the examples in DrillDown that have a trigger button the same way
- they should behave the same way as the 'Admin' dropdown (focusing the first available option, returning focus to the triggers)
- test the SmallViewPort version of the TopNavBar playground too, it should behave the same way (focusing the first available option, returning focus to the trigger)

**with iOS VoiceOver:**
- test the 'Admin' menu from the TopNavBar playground and the DrillDown examples with a trigger
- when opening menu with double tap, the first option should be focused (previously the first item was not focused)
- you should be able navigate through the options with swipes
- When the focus is on the first item, swipe left, you should be able to move back to the admin button (previously the focus jumped to the end of the page because the menu was mounted at the end of the document)
