### PR TITLE
fix(ui-byline): remove figure and figcaption

### DIFF
--- a/packages/ui-byline/src/Byline/__new-tests__/Byline.test.tsx
+++ b/packages/ui-byline/src/Byline/__new-tests__/Byline.test.tsx
@@ -128,13 +128,6 @@ describe('<Byline />', () => {
     expect(axeCheck).toBe(true)
   })
 
-  it(`should render a figure by default`, () => {
-    renderByline()
-    const figureElement = screen.getByRole('figure')
-
-    expect(figureElement).toBeInTheDocument()
-  })
-
   describe('when passing down props to View', () => {
     const customAllowedProps: { [key: string]: string } = { margin: 'small' }
     const customIgnoredProps = ['elementRef', 'children']

--- a/packages/ui-byline/src/Byline/index.tsx
+++ b/packages/ui-byline/src/Byline/index.tsx
@@ -82,12 +82,11 @@ class Byline extends Component<BylineProps> {
         {...passthroughProps}
         elementRef={this.handleRef}
         css={this.props.styles?.byline}
-        as="figure"
         margin={this.props.margin}
         maxWidth={this.props.styles?.maxWidth}
       >
         <div css={this.props.styles?.figure}>{this.props.children}</div>
-        <figcaption css={this.props.styles?.caption}>
+        <div css={this.props.styles?.caption}>
           {this.props.title && (
             <span css={this.props.styles?.title}>{this.props.title}</span>
           )}
@@ -96,7 +95,7 @@ class Byline extends Component<BylineProps> {
               {this.props.description}
             </div>
           )}
-        </figcaption>
+        </div>
       </View>
     )
   }


### PR DESCRIPTION
INSTUI-4549

Test plan:

1. Go through a Byline example in the docs app with NVDA and VoiceOver, make sure no figure of figcaption is read by SR apps.