### PR TITLE
fix(ui-checkbox): remove pointer cursor from disabled checkbox toggle

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.ts
+++ b/packages/ui-checkbox/src/Checkbox/ToggleFacade/styles.ts
@@ -39,7 +39,7 @@ const generateStyle = (
   componentTheme: ToggleFacadeTheme,
   props: ToggleFacadeProps
 ): ToggleFacadeStyle => {
-  const { size, checked, focused, labelPlacement, invalid } = props
+  const { disabled, size, checked, focused, labelPlacement, invalid } = props
 
   const labelPlacementVariants = {
     start: {
@@ -91,7 +91,11 @@ const generateStyle = (
       position: 'relative',
       borderRadius: '3rem',
       verticalAlign: 'middle',
-      boxShadow: `inset 0 0 0 ${componentTheme.borderWidth} ${(invalid && !checked) ? componentTheme.errorBorderColor : componentTheme.borderColor}`,
+      boxShadow: `inset 0 0 0 ${componentTheme.borderWidth} ${
+        invalid && !checked
+          ? componentTheme.errorBorderColor
+          : componentTheme.borderColor
+      }`,
       height: componentTheme.toggleSize,
       width: `calc(${componentTheme.toggleSize} * 1.5)`,
       ...labelPlacementVariants[labelPlacement!].facade,
@@ -99,6 +103,11 @@ const generateStyle = (
       ...(checked && {
         background: componentTheme.checkedBackground,
         boxShadow: 'none'
+      }),
+
+      ...(disabled && {
+        cursor: 'not-allowed',
+        pointerEvents: 'none'
       }),
 
       '&::before': {


### PR DESCRIPTION
INSTUI-4553

Test:

1. Check if pointer cursor disappears when hovering over a disabled checkbox (toggle variant)

Example code to use:
`<Checkbox disabled label="Toggle Checkbox" variant="toggle" />`