### PR TITLE
fix(ui-alerts): stop passing onDismiss to div in Alert

### DIFF
--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -258,7 +258,9 @@ class Alert extends Component<AlertProps, AlertState> {
   }
 
   renderAlert() {
-    const { margin, styles, children, ...props } = this.props
+    // prevent onDismiss from being passed to the View component
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { margin, styles, children, onDismiss, ...props } = this.props
     return (
       <View
         {...passthroughProps({ ...props })}


### PR DESCRIPTION
The Alert component accepts onDismiss, but it's passing this down to a div element that doesn't
recognize it, which is causing the warning.
