### PR TITLE
fix(ui-tabs): remove scrollbar from tabs

### DIFF
--- a/packages/ui-tabs/src/Tabs/styles.ts
+++ b/packages/ui-tabs/src/Tabs/styles.ts
@@ -74,7 +74,8 @@ const generateStyle = (
         '&::-webkit-scrollbar-thumb': {
           backgroundColor: 'transparent'
         }
-      })
+      }),
+      scrollbarWidth: 'none'
     }
   }
 


### PR DESCRIPTION
INSTUI-4562

Test:

1. Check if a vertical scrollbar is not present on a Tabs component with props `variant` set to `secondary` and `tabOverflow` set to `scroll`