### PR TITLE
docs(ui-table): add sort by to the table header label for headers tha…

### DIFF
--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -486,7 +486,14 @@ By default, the options in the `Select` for sorting in stacked layout are genera
                 sortDirection: id === sortBy ? direction : 'none'
               })}
             >
-              {text}
+              {id === sortBy ? (
+                text
+              ) : (
+                <>
+                  <span aria-hidden="true">{text}</span>
+                  <ScreenReaderContent>sort by {text}</ScreenReaderContent>
+                </>
+              )}
             </Table.ColHeader>
           ))}
         </Table.Row>
@@ -726,7 +733,14 @@ By default, the options in the `Select` for sorting in stacked layout are genera
               sortDirection: id === sortBy ? direction : 'none'
             })}
           >
-            {text}
+            {id === sortBy ? (
+              text
+            ) : (
+              <>
+                <span aria-hidden="true">{text}</span>
+                <ScreenReaderContent>sort by {text}</ScreenReaderContent>
+              </>
+            )}
           </Table.ColHeader>
         ))}
       </Table.Row>
@@ -980,7 +994,16 @@ that selection does not re-paginate or re-sort the table, and pagination does no
                         onRequestSort={onSort}
                         sortDirection={id === sortBy ? direction : 'none'}
                       >
-                        {text}
+                        {id === sortBy ? (
+                          text
+                        ) : (
+                          <>
+                            <span aria-hidden="true">{text}</span>
+                            <ScreenReaderContent>
+                              sort by {text}
+                            </ScreenReaderContent>
+                          </>
+                        )}
                       </Table.ColHeader>
                     ))}
                   </Table.Row>
@@ -1310,7 +1333,16 @@ that selection does not re-paginate or re-sort the table, and pagination does no
                       onRequestSort={onSort}
                       sortDirection={id === sortBy ? direction : 'none'}
                     >
-                      {text}
+                      {id === sortBy ? (
+                        text
+                      ) : (
+                        <>
+                          <span aria-hidden="true">{text}</span>
+                          <ScreenReaderContent>
+                            sort by {text}
+                          </ScreenReaderContent>
+                        </>
+                      )}
                     </Table.ColHeader>
                   ))}
                 </Table.Row>


### PR DESCRIPTION
…t are not being used to sort

INSTUI-4552

**ISSUE:**
- table header buttons - when not being used to sort -  do not have proper description so screen reader users will not know what will happen when they interact with that header

**TEST PLAN:**
- check the header titles in the two sortable table examples in Table with different screenreaders
- table header buttons - when not being used to sort - should annouce "sort by [header title]" instead of just [header title]
- (note: VoiceOver announces header titles twice in Chrome which is a known bug https://issues.chromium.org/issues/341800520)