### PR TITLE
feat(many): add missing inputRef prop to input components

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/__new-tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__new-tests__/Checkbox.test.tsx
@@ -105,6 +105,14 @@ describe('<Checkbox />', () => {
     expect(inputElem).toHaveAttribute('aria-checked', 'mixed')
   })
 
+  it('should provide an inputRef prop', async () => {
+    const inputRef = vi.fn()
+    renderCheckbox({ inputRef })
+    const input = screen.getByRole('checkbox')
+
+    expect(inputRef).toHaveBeenCalledWith(input)
+  })
+
   describe('events', () => {
     it('when clicked, fires onClick and onChange events', async () => {
       const onClick = vi.fn()

--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -102,6 +102,13 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     this.ref = el
   }
 
+  handleInputRef = (el: HTMLInputElement | null) => {
+    this._input = el
+    if (typeof this.props.inputRef === 'function') {
+      this.props.inputRef(el)
+    }
+  }
+
   componentDidMount() {
     if (this._input) {
       this._input.indeterminate = this.props.indeterminate!
@@ -323,9 +330,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             id={this.id}
             value={value}
             type="checkbox"
-            ref={(c) => {
-              this._input = c
-            }}
+            ref={this.handleInputRef}
             required={isRequired}
             disabled={disabled || readOnly}
             aria-checked={indeterminate ? 'mixed' : undefined}

--- a/packages/ui-checkbox/src/Checkbox/props.ts
+++ b/packages/ui-checkbox/src/Checkbox/props.ts
@@ -80,6 +80,10 @@ type CheckboxOwnProps = {
   inline?: boolean
   labelPlacement?: 'top' | 'start' | 'end'
   isRequired?: boolean
+  /**
+   * A function that provides a reference to the actual underlying input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type PropKeys = keyof CheckboxOwnProps
@@ -121,7 +125,8 @@ const propTypes: PropValidators<PropKeys> = {
   variant: PropTypes.oneOf(['simple', 'toggle']),
   inline: PropTypes.bool,
   labelPlacement: PropTypes.oneOf(['top', 'start', 'end']),
-  isRequired: PropTypes.bool
+  isRequired: PropTypes.bool,
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -144,7 +149,8 @@ const allowedProps: AllowedPropKeys = [
   'variant',
   'inline',
   'labelPlacement',
-  'isRequired'
+  'isRequired',
+  'inputRef'
 ]
 
 type CheckboxState = {

--- a/packages/ui-color-picker/src/ColorPicker/__new-tests__/ColorPicker.test.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/__new-tests__/ColorPicker.test.tsx
@@ -389,6 +389,14 @@ describe('<ColorPicker />', () => {
         expect(errorMessage).toBeInTheDocument()
       })
     })
+
+    it('should provide an inputRef prop', async () => {
+      const inputRef = vi.fn()
+      render(<SimpleExample inputRef={inputRef} />)
+      const input = screen.getByRole('textbox')
+
+      expect(inputRef).toHaveBeenCalledWith(input)
+    })
   })
 
   describe('complex mode', () => {

--- a/packages/ui-color-picker/src/ColorPicker/index.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/index.tsx
@@ -608,7 +608,8 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
   )
 
   render() {
-    const { disabled, isRequired, placeholderText, width, id } = this.props
+    const { disabled, isRequired, placeholderText, width, id, inputRef } =
+      this.props
 
     return (
       <div
@@ -633,6 +634,7 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
           onPaste={(event) => this.handleOnPaste(event)}
           onBlur={() => this.handleOnBlur()}
           messages={this.renderMessages()}
+          inputRef={inputRef}
         />
         {!this.isSimple && (
           <div

--- a/packages/ui-color-picker/src/ColorPicker/props.ts
+++ b/packages/ui-color-picker/src/ColorPicker/props.ts
@@ -234,6 +234,11 @@ type ColorPickerOwnProps = {
    * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
    */
   margin?: Spacing
+
+  /**
+   * A function that provides a reference to the input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type ColorPickerState = {
@@ -326,7 +331,8 @@ const propTypes: PropValidators<PropKeys> = {
   value: PropTypes.string,
   width: PropTypes.string,
   withAlpha: PropTypes.bool,
-  margin: PropTypes.string
+  margin: PropTypes.string,
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -350,7 +356,8 @@ const allowedProps: AllowedPropKeys = [
   'value',
   'width',
   'withAlpha',
-  'margin'
+  'margin',
+  'inputRef'
 ]
 
 export type {

--- a/packages/ui-radio-input/src/RadioInput/__new-tests__/RadioInput.test.tsx
+++ b/packages/ui-radio-input/src/RadioInput/__new-tests__/RadioInput.test.tsx
@@ -61,6 +61,21 @@ describe('<RadioInput />', () => {
     expect(input).toHaveAttribute('type', 'radio')
   })
 
+  it('should provide an inputRef prop', async () => {
+    const inputRef = vi.fn()
+    const { container } = render(
+      <RadioInput
+        label="fake label"
+        value="someValue"
+        name="someName"
+        inputRef={inputRef}
+      />
+    )
+    const input = container.querySelector('input')
+
+    expect(inputRef).toHaveBeenCalledWith(input)
+  })
+
   describe('events', () => {
     it('responds to onClick event', async () => {
       const onClick = vi.fn()

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -84,6 +84,13 @@ class RadioInput extends Component<RadioInputProps, RadioInputState> {
     this.props.makeStyles?.()
   }
 
+  handleInputRef = (el: HTMLInputElement | null) => {
+    this._input = el
+    if (typeof this.props.inputRef === 'function') {
+      this.props.inputRef(el)
+    }
+  }
+
   handleClick: React.MouseEventHandler<HTMLInputElement> = (e) => {
     if (this.props.disabled || this.props.readOnly) {
       e.preventDefault()
@@ -144,9 +151,7 @@ class RadioInput extends Component<RadioInputProps, RadioInputState> {
           <input
             {...props}
             id={this.id}
-            ref={(c: HTMLInputElement | null) => {
-              this._input = c
-            }}
+            ref={this.handleInputRef}
             value={value}
             name={name}
             checked={this.checked}

--- a/packages/ui-radio-input/src/RadioInput/props.ts
+++ b/packages/ui-radio-input/src/RadioInput/props.ts
@@ -72,6 +72,10 @@ type RadioInputOwnProps = {
    * event.target.value will contain the new value. It will always be a string.
    */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  /**
+   * A function that provides a reference to the actual underlying input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type PropKeys = keyof RadioInputOwnProps
@@ -107,7 +111,8 @@ const propTypes: PropValidators<PropKeys> = {
   context: PropTypes.oneOf(['success', 'warning', 'danger', 'off']),
   inline: PropTypes.bool,
   onClick: PropTypes.func,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -123,7 +128,8 @@ const allowedProps: AllowedPropKeys = [
   'context',
   'inline',
   'onClick',
-  'onChange'
+  'onChange',
+  'inputRef'
 ]
 
 export type { RadioInputProps, RadioInputState, RadioInputStyle }

--- a/packages/ui-range-input/src/RangeInput/__new-tests__/RangeInput.test.tsx
+++ b/packages/ui-range-input/src/RangeInput/__new-tests__/RangeInput.test.tsx
@@ -107,6 +107,23 @@ describe('<RangeInput />', () => {
     expect(input).toHaveValue('25')
   })
 
+  it('should provide an inputRef prop', async () => {
+    const inputRef = vi.fn()
+    const { container } = render(
+      <RangeInput
+        label="Opacity"
+        name="opacity"
+        max={100}
+        min={0}
+        defaultValue={42}
+        inputRef={inputRef}
+      />
+    )
+    const input = container.querySelector('input')
+
+    expect(inputRef).toHaveBeenCalledWith(input)
+  })
+
   describe('thumbVariant prop', () => {
     it('should throw deprecation warning by default', async () => {
       render(

--- a/packages/ui-range-input/src/RangeInput/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/index.tsx
@@ -86,6 +86,13 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
     this.ref = el
   }
 
+  handleInputRef = (el: HTMLInputElement | null) => {
+    this._input = el
+    if (typeof this.props.inputRef === 'function') {
+      this.props.inputRef(el)
+    }
+  }
+
   constructor(props: RangeInputProps) {
     super(props)
 
@@ -195,9 +202,7 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
         <div css={this.props.styles?.rangeInput}>
           <input
             css={this.props.styles?.rangeInputInput}
-            ref={(c) => {
-              this._input = c
-            }}
+            ref={this.handleInputRef}
             type="range"
             id={this.id}
             min={this.props.min}

--- a/packages/ui-range-input/src/RangeInput/props.ts
+++ b/packages/ui-range-input/src/RangeInput/props.ts
@@ -98,6 +98,11 @@ type RangeInputOwnProps = {
   thumbVariant?:
     | 'deprecated' // TODO: deprecated, remove in V9.
     | 'accessible'
+
+  /**
+   * A function that provides a reference to the actual underlying input element
+   */
+  inputRef?: (inputElement: HTMLInputElement | null) => void
 }
 
 type PropKeys = keyof RangeInputOwnProps
@@ -147,7 +152,8 @@ const propTypes: PropValidators<PropKeys> = {
     PropTypes.oneOf(['deprecated', 'accessible']),
     ['deprecated'],
     'The `deprecated` variant is not fully accessible and will be removed in V9. The connected theme variables will be removed as well: `handleShadowColor`, `handleFocusOutlineColor`, `handleFocusOutlineWidth`. Please use the `accessible` variant.'
-  )
+  ),
+  inputRef: PropTypes.func
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -167,7 +173,8 @@ const allowedProps: AllowedPropKeys = [
   'inline',
   'disabled',
   'readOnly',
-  'thumbVariant'
+  'thumbVariant',
+  'inputRef'
 ]
 
 export type { RangeInputProps, RangeInputState, RangeInputStyle }


### PR DESCRIPTION
INSTUI-4400

**ISSUE:**
- some components (e.g., RadioInput, Checkbox) that use an input field are missing the inputRef prop.

**TEST PLAN:**
- copy the code below to the preview
- click on each of the five "Focus' buttons
- the corresponding input field should get focused
- review the tests


```
class FocusExample extends React.Component {
  radioElement = null;
  checkboxElement = null;
  checkboxToggleElement = null;
  rangeInputElement = null;  
  colorElement = null;

  focusRadio = () => {
    if (this.radioElement) {
      this.radioElement.focus();
    }
  };

  focusCheckbox = () => {
    if (this.checkboxElement) {
      this.checkboxElement.focus();
    }
  };

  focusCheckboxToggle = () => {
    if (this.checkboxToggleElement) {
      this.checkboxToggleElement.focus();
    }
  };

  focusRangeInput = () => { 
    if (this.rangeInputElement) {
      this.rangeInputElement.focus();
    }
  };

  focusColor = () => {
    if (this.colorElement) {
      this.colorElement.focus();
    }
  };

  render() {
    return (
      <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
        <div>
          <RadioInput 
            
            label="RadioInput" 
            value="radio1" 
            name="radioGroup" 
            inputRef={(el) => { this.radioElement = el; }} 
          />
          <Button onClick={this.focusRadio}>Focus Radio</Button>
        </div>

        <div>
          <Checkbox 
            label="Checkbox" 
            value="checkbox1" 
            inputRef={(el) => { this.checkboxElement = el; }} 
          />
          <Button onClick={this.focusCheckbox}>Focus Checkbox</Button>
        </div>

         <div>
          <Checkbox 
            variant="toggle"
            label="Checkbox toggle" 
            value="checkboxtoggle1" 
            inputRef={(el) => { this.checkboxToggleElement = el; }} 
          />
          <Button onClick={this.focusCheckboxToggle}>Focus Checkbox</Button>
        </div>

        <div>
          <RangeInput
            label="RangeInput" 
            min="0" 
            max="100" 
            inputRef={(el) => { this.rangeInputElement = el; }} 
            thumbVariant="accessible"
          />
          <Button onClick={this.focusRangeInput}>Focus Range Input</Button>  
        </div>

        <div>
          <ColorPicker 
            label="ColorPicker" 
            defaultValue="#ff0000" 
            inputRef={(el) => { this.colorElement = el; }} 
          />
          <Button onClick={this.focusColor}>Focus Color Picker</Button>
        </div>
      </div>
    );
  }
}

render(<FocusExample />);
```