### PR TITLE
fix(ui-date-input): make DateInput2 date parsing work in every locale and timezone

### DIFF
--- a/packages/ui-i18n/src/Locale.ts
+++ b/packages/ui-i18n/src/Locale.ts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+// TODO: there is an improved replacement for this helper at `ui-i18n/src/getLocale.ts`
+// all uses of this should be updated and this helper deleted
 import { canUseDOM } from '@instructure/ui-dom-utils'
 
 const defaultLocale = 'en-US'

--- a/packages/ui-i18n/src/getLocale.ts
+++ b/packages/ui-i18n/src/getLocale.ts
@@ -21,21 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { useContext } from 'react'
+import { ApplyLocaleContext } from '.'
 
-export { ApplyLocale } from './ApplyLocale'
-export { ApplyLocaleContext } from './ApplyLocale/ApplyLocaleContext'
+// TODO: this is a better replacement for `ui-i18n/src/Locale.ts` which should be deleted in the future
+export function getLocale(defaultLocale = 'en-US') {
+  const localeContext = useContext(ApplyLocaleContext)
+  if (localeContext.locale) {
+    return localeContext.locale
+  }
 
-export { textDirectionContextConsumer } from './textDirectionContextConsumer'
-export { DateTime } from './DateTime'
-export { getTextDirection } from './getTextDirection'
-export { I18nPropTypes } from './I18nPropTypes'
-
-export { Locale } from './Locale' // TODO delete this and only keep the ones below
-export { getLocale } from './getLocale'
-export { getTimezone } from './getTimezone'
-
-export { DIRECTION, TextDirectionContext } from './TextDirectionContext'
-
-export type { Moment } from './DateTime'
-export type { TextDirectionContextConsumerProps } from './textDirectionContextConsumer'
-export type { ApplyLocaleProps } from './ApplyLocale/props'
+  if (typeof navigator !== 'undefined') {
+    if (navigator.languages && navigator.languages.length) {
+      return navigator.languages[0]
+    }
+    if (navigator.language) {
+      return navigator.language
+    }
+  }
+  try {
+    // This is generally reliable if Intl is supported
+    return new Intl.DateTimeFormat().resolvedOptions().locale
+  } catch (e) {
+    console.warn(
+      'Intl.DateTimeFormat().resolvedOptions().locale failed, using fallback.'
+    )
+    // Fall through to default
+  }
+  return defaultLocale
+}

--- a/packages/ui-i18n/src/getTimezone.ts
+++ b/packages/ui-i18n/src/getTimezone.ts
@@ -21,21 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { useContext } from 'react'
+import { ApplyLocaleContext } from '.'
 
-export { ApplyLocale } from './ApplyLocale'
-export { ApplyLocaleContext } from './ApplyLocale/ApplyLocaleContext'
+// TODO: this is a better replacement for `ui-i18n/src/Locale.ts` which should be deleted in the future
+export function getTimezone() {
+  const localeContext = useContext(ApplyLocaleContext)
+  if (localeContext.timezone) {
+    return localeContext.timezone
+  }
 
-export { textDirectionContextConsumer } from './textDirectionContextConsumer'
-export { DateTime } from './DateTime'
-export { getTextDirection } from './getTextDirection'
-export { I18nPropTypes } from './I18nPropTypes'
-
-export { Locale } from './Locale' // TODO delete this and only keep the ones below
-export { getLocale } from './getLocale'
-export { getTimezone } from './getTimezone'
-
-export { DIRECTION, TextDirectionContext } from './TextDirectionContext'
-
-export type { Moment } from './DateTime'
-export type { TextDirectionContextConsumerProps } from './textDirectionContextConsumer'
-export type { ApplyLocaleProps } from './ApplyLocale/props'
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}


### PR DESCRIPTION
INSTUI-4571

test plan:

- check all examples for dateinput2, they should work as expected
- input a date manually (with keyboard) for each example and blur the input -> it should parse the date successfully
- placeholder hints should not have any number in them, just `D`, `M` and `Y` letters
- use chrome devtools and change your location (3 dots -> more tools -> sensors -> location)
- check the component examples again with different locales
- check if manually changing locale and timezone works as expected