### PR TITLE
fix(ui-modal): save modal from unnecessary rerender

### DIFF
--- a/packages/ui-modal/src/Modal/ModalBody/styles.ts
+++ b/packages/ui-modal/src/Modal/ModalBody/styles.ts
@@ -53,9 +53,12 @@ const generateStyle = (
       label: 'modalBody',
       boxSizing: 'border-box',
       flex: '1 1 auto',
-      overflowY: 'auto',
       '&:focus': {
         outline: 'none'
+      },
+      // ModalBody is set to scrollable above 20rem height
+      '@media (min-height: 20rem)': {
+        overflowY: 'auto'
       },
       ...backgroundStyle
     }

--- a/packages/ui-modal/src/Modal/ModalHeader/props.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/props.ts
@@ -36,7 +36,6 @@ type ModalHeaderOwnProps = {
   children?: React.ReactNode
   variant?: 'default' | 'inverse'
   spacing?: 'default' | 'compact'
-  smallViewPort?: boolean
 }
 
 type ModalHeaderStyleProps = {
@@ -56,8 +55,7 @@ type ModalHeaderStyle = ComponentStyle<'modalHeader'>
 const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node,
   variant: PropTypes.oneOf(['default', 'inverse']),
-  spacing: PropTypes.oneOf(['default', 'compact']),
-  smallViewPort: PropTypes.bool
+  spacing: PropTypes.oneOf(['default', 'compact'])
 }
 
 const allowedProps: AllowedPropKeys = ['children', 'variant', 'spacing']

--- a/packages/ui-modal/src/Modal/ModalHeader/styles.ts
+++ b/packages/ui-modal/src/Modal/ModalHeader/styles.ts
@@ -44,7 +44,7 @@ const generateStyle = (
   props: ModalHeaderProps,
   state: ModalHeaderStyleProps
 ): ModalHeaderStyle => {
-  const { variant, spacing, smallViewPort } = props
+  const { variant, spacing } = props
   const { withCloseButton } = state
 
   const sizeVariants = {
@@ -83,9 +83,13 @@ const generateStyle = (
       borderBottomWidth: '0.0625rem',
       borderBottomStyle: 'solid',
       borderBottomColor: componentTheme.borderColor,
-      ...(smallViewPort ? { position: 'relative' } : {}),
       ...sizeVariants[spacing!],
-      ...inverseStyle
+      ...inverseStyle,
+
+      // Position is set to relative for small viewports to ensure proper close button positioning during scrolling
+      '@media (max-height: 20rem)': {
+        position: 'relative'
+      }
     }
   }
 }

--- a/packages/ui-modal/src/Modal/styles.ts
+++ b/packages/ui-modal/src/Modal/styles.ts
@@ -111,7 +111,15 @@ const generateStyle = (
     },
     joinedHeaderAndBody: {
       borderRadius: componentTheme.borderRadius,
-      overflowY: 'scroll'
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+
+      // ModalHeader and ModalBody is set to scrollable above 20rem height instead of just the ModalBody
+      '@media (max-height: 20rem)': {
+        overflowY: 'auto',
+        maxHeight: '20rem'
+      }
     }
   }
 }


### PR DESCRIPTION
INSTUI-4575

**Test**

1. Zoom in while a Modal is set to open and check if it gets rerendered unnecessarily
2. Below 20 rem height ModalHeader and ModalBody should get a common vertical scrollbar
3. Above 20 rem height only the ModalBody should be scrollable