### PR TITLE
fix(ui-top-nav-bar): truncate TopNavBar menu items properly

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/styles.ts
@@ -51,8 +51,7 @@ const generateStyle = (
       flexDirection: 'row',
       alignItems: 'stretch',
       // padding to prevent focus ring getting cropped by `overflow: hidden`
-      padding: '0 0.125rem',
-      overflow: 'visible'
+      padding: '0 0.125rem'
     },
     submenuOption: {
       label: 'topNavBarMenuItems__submenuOption',


### PR DESCRIPTION
INSTUI-4577

**ISSUE:**
- INSTUI-4494 introduced a bug with truncating TopNavBar menuitems while trying to fix misaligned VoiceOver screenreader focus on Chrome

**TEST PLAN:**
- check the examples in TopNavBar: in examples under the titles such as 'smallViewport mode' , 'TopNavBar.MenuItems'  and 'Color override example for more complex customization', the menuitems should truncate e.g.  '7 more', '2 more' compared to the latest release.