### PR TITLE
fix(ui-buttons): make Button have a focus ring in Safari

### DIFF
--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -36,6 +36,7 @@ import { isActiveElement } from '@instructure/ui-dom-utils'
 import { hasVisibleChildren } from '@instructure/ui-a11y-utils'
 import { View } from '@instructure/ui-view'
 import type { ViewProps } from '@instructure/ui-view'
+import { isSafari } from '@instructure/ui-utils'
 
 import { withStyle } from '@instructure/emotion'
 
@@ -278,7 +279,8 @@ class BaseButton extends Component<BaseButtonProps> {
       }
     }
     let tabIndexValue = tabIndex
-    if (onClick && as && needsZeroTabIndex) {
+    // In Safari, a button cannot get focus unless it has an explicit 0 tabindex
+    if ((onClick && as && needsZeroTabIndex) || (isSafari() && as)) {
       tabIndexValue = tabIndex || 0
     }
     return (


### PR DESCRIPTION
INSTUI-4527

**ISSUE:**
- In Safari, the same BaseButton or Button component doesn't show a focus ring, whereas the ring does appear in Chrome and other browsers - this is due to a missing 0 tabindex, which Safari needs
- Modal trigger button does not have a focus ring after closing the Modal due to this

**TEST PLAN:**
- make sure you have the latest Safari version
- open BaseButton and Button pages **in Safari**
- the first few examples should get a focus ring when they are clicked on - unlike in the latest InstUI release in Safari
- they should have a tabIndex=0 in Safari but not in other browsers
- open the first example of Modal **in Safari,** after closing it, the Modal should have a focus ring - unlike in the latest InstUI release in Safari