### PR TITLE
fix(ui-top-nav-bar): fix TopNavBarBrand flashing an outline on hover

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarBrand/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarBrand/styles.ts
@@ -59,7 +59,6 @@ const generateStyle = (
       justifyContent: 'flex-start',
       alignItems: 'stretch',
       border: 0,
-      outline: 0,
       padding: 0,
       margin: 0,
       appearance: 'none',


### PR DESCRIPTION
The root cause was that now View uses the CSS outline prop to display its focus ring, but it was overridden here

To test: Check the TopNavBarBrand example in the docs app it should not flash an outline on hover

Fixes: INSTUI-4585