### PR TITLE
chore: announce search results in side navigation

### DIFF
--- a/packages/__docs__/src/Nav/props.ts
+++ b/packages/__docs__/src/Nav/props.ts
@@ -59,6 +59,7 @@ type NavState = {
   expandedSections: Record<string, any>
   userToggling: boolean
   queryStr?: string
+  announcement: string | null
 }
 export type { NavProps, NavState }
 export { allowedProps, propTypes }


### PR DESCRIPTION
INSTUI-4243

**ISSUE:**
- search results in documentation's side navigation are not announced

**TEST PLAN:**
- navigate to the "Find…" search bar in the side navigation using different screen readers
- type a search term (e.g., "color" or "select")
- the screen reader should:
  - announce the number of results available
  - clearly indicate when no results are available