### PR TITLE
fix(ui-top-nav-bar): fix focus ring not showing when closing a dropdown

### DIFF
--- a/packages/ui-color-utils/tsconfig.build.json
+++ b/packages/ui-color-utils/tsconfig.build.json
@@ -9,6 +9,6 @@
   "references": [
     {
       "path": "../ui-babel-preset/tsconfig.build.json"
-    },
+    }
   ]
 }

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/index.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/index.tsx
@@ -435,7 +435,7 @@ class TopNavBarItem extends Component<TopNavBarItemProps, TopNavBarItemState> {
         this.handleItemRef(e as HTMLButtonElement | HTMLLinkElement)
       },
       withFocusOutline:
-        withFocusOutline || this.hasOpenPopover || this.state.isFocused
+        withFocusOutline || this.hasOpenPopover ? true : undefined
     }
   }
 


### PR DESCRIPTION
The issue was likely that TopNavBarItem did not enter the focused state because its rerendered a lot. This fix does not use the onFocus React event rather sets withFocusoutline to undefined so the focus ring is added via CSS

This PR also fixes a strange build error, that checkTSReferences was failing with a JSON parse error.

To test: Check the TopNavBar examples. Menu items should be in focus when their dropdown is open and when it gets closed (e.g. by pressing ESC) 

Fixes INSTUI-4587