### PR TITLE
fix(ui-alerts): fix Alert border radius override and add new prop for…

### DIFF
--- a/packages/ui-alerts/src/Alert/__tests__/Alert.test.tsx
+++ b/packages/ui-alerts/src/Alert/__tests__/Alert.test.tsx
@@ -29,6 +29,7 @@ import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 import { Alert } from '../index'
 import type { AlertProps } from '../props'
+import { IconGroupLine } from '@instructure/ui-icons'
 
 describe('<Alert />', () => {
   let srdiv: HTMLDivElement | null
@@ -145,6 +146,14 @@ describe('<Alert />', () => {
 
     expect(liveRegion).toHaveTextContent('Success: Sample alert text.')
     expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('should render an icon when provided as the `renderIcon` prop', () => {
+    const { container } = render(<Alert renderCustomIcon={<IconGroupLine />} />)
+    const icon = container.querySelector('svg[class$="-svgIcon"]')
+
+    expect(icon).toHaveAttribute('name', 'IconGroup')
+    expect(icon).toBeInTheDocument()
   })
 
   describe('with `screenReaderOnly', () => {

--- a/packages/ui-alerts/src/Alert/index.tsx
+++ b/packages/ui-alerts/src/Alert/index.tsx
@@ -237,10 +237,11 @@ class Alert extends Component<AlertProps, AlertState> {
   }
 
   renderIcon() {
-    const Icon = this.variantUI[this.props.variant!]
+    const { renderCustomIcon, variant, styles } = this.props
+    const Icon = this.variantUI[variant!]
     return (
-      <div css={this.props.styles?.icon}>
-        <Icon />
+      <div css={styles?.icon}>
+        {renderCustomIcon ? callRenderProp(renderCustomIcon) : <Icon />}
       </div>
     )
   }

--- a/packages/ui-alerts/src/Alert/props.ts
+++ b/packages/ui-alerts/src/Alert/props.ts
@@ -109,6 +109,11 @@ type AlertOwnProps = {
    * If the alert should have a shadow.
    */
   hasShadow: boolean
+
+  /**
+   * An icon, or function that returns an icon. Setting it will override the variant's icon.
+   */
+  renderCustomIcon?: Renderable
 }
 
 type PropKeys = keyof AlertOwnProps
@@ -137,7 +142,8 @@ const propTypes: PropValidators<PropKeys> = {
   transition: PropTypes.oneOf(['none', 'fade']),
   open: PropTypes.bool,
   hasShadow: PropTypes.bool,
-  variantScreenReaderLabel: PropTypes.string
+  variantScreenReaderLabel: PropTypes.string,
+  renderCustomIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
 }
 
 const allowedProps: AllowedPropKeys = [
@@ -153,7 +159,8 @@ const allowedProps: AllowedPropKeys = [
   'onDismiss',
   'transition',
   'open',
-  'hasShadow'
+  'hasShadow',
+  'renderCustomIcon'
 ]
 
 type AlertState = {

--- a/packages/ui-alerts/src/Alert/styles.ts
+++ b/packages/ui-alerts/src/Alert/styles.ts
@@ -95,6 +95,9 @@ const generateStyle = (
       justifyContent: 'center',
       fontSize: '1.125rem',
       borderRight: `${componentTheme.borderWidth} ${componentTheme.borderStyle}`,
+      margin: -1,
+      borderStartStartRadius: componentTheme.borderRadius,
+      borderEndStartRadius: componentTheme.borderRadius,
       ...variantStyles[variant!].icon
     },
     closeButton: {


### PR DESCRIPTION
… custom icon

INSTUI-4572

**ISSUE:**
- overriding the border radius of Alert results the icon's border not changing
- the icon cannot be customized

**TEST PLAN:**

- go over the examples in Alert by overriding borderRadius e.g.:
```
themeOverride={{
    borderRadius: '1rem'
  }}
```
- the icons border radius should also change (previously is was unaffected)
- it should work in RTL too
- try adding a custom icon by using the renderCustomIcon prop e.g.:
```
renderCustomIcon={()=> <IconUserLine />}
```
- the icon should change