### PR TITLE
fix(ui-select): prevent scrolling when last item is hovered in Chrome

### DIFF
--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -133,6 +133,7 @@ tags: autocomplete, typeahead, combobox, dropdown, search, form
 @testable()
 class Select extends Component<SelectProps> {
   static readonly componentId = 'Select'
+  private readonly SCROLL_TOLERANCE = 0.5
 
   static allowedProps = allowedProps
   static propTypes = propTypes
@@ -527,7 +528,10 @@ class Select extends Component<SelectProps> {
           display: 'block',
           overflowY: 'auto',
           maxHeight:
-            optionsMaxHeight || this._optionHeight * visibleOptionsCount!,
+            optionsMaxHeight ||
+            this._optionHeight * visibleOptionsCount! -
+              // in Chrome, we need to prevent scrolling when the bottom area of last item is hovered
+              (utils.isChromium() ? this.SCROLL_TOLERANCE : 0),
           maxWidth: optionsMaxWidth || this.width,
           background: 'primary',
           elementRef: (node: Element | null) => (this._listView = node),


### PR DESCRIPTION
INSTUI-4361

**ISSUE:**
- in Chrome, Select starts scrolling when the bottom area of the last visible item is hovered and `scrollToHighlightedOption` is true

**TEST PLAN:**
- open the examples in Select in Chrome
- open the listbox and start hovering around the bottom edge of the last item and the listbox
- it should not scroll to the next item (like it does in the current version)