### PR TITLE
fix(ui-top-nav-bar): ensure Drilldown overflows correctly in small vi…

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/styles.ts
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/styles.ts
@@ -74,7 +74,6 @@ const generateStyle = (
     maxWidth: '100%',
     paddingBlock: 0,
     paddingInline: componentTheme.smallViewportInlinePadding,
-    position: 'relative',
     zIndex: componentTheme.smallViewportZIndex,
     display: 'flex',
     justifyContent: 'space-between',


### PR DESCRIPTION
…ewports in TopNavBar

INSTUI-4607

**ISSUE:**
- in small viewports, the Drilldown in TopNavbar does not overflow the menubar due to this recent fix where Drilldown mountNode was modified https://github.com/instructure/instructure-ui/pull/1975

**TEST PLAN:**
- open OpenTopNavBar Fullscreen example in narrow viewport to make the button with the question icon to appear on the right end
- click on in, the drilldown should be fully visible