### PR TITLE
Refactor: remove jsdoc-api from the docs app

### DIFF
--- a/docs/contributor-docs/writing-docs.md
+++ b/docs/contributor-docs/writing-docs.md
@@ -12,15 +12,40 @@ This page documents how to add and maintain documentation.
 
 The documentation site is generated from the **source code** and the `.md` files. There are two types of `.md` files: `README.md` and `named-md-files.md`, under the `docs folder`.
 
-The **source code** is parsed with [JSDoc](https://jsdoc.app/) with the exeption of react components, which are parsed by [react-docgen](https://react-docgen.dev/) and it provides `type` information for the docs.
+The **source code** is parsed with the [TypeScript compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) with the exception of React components, which are parsed by [react-docgen](https://react-docgen.dev/). These tools parse out JSDoc comments, type information of React component props and types for functions.
+
+## Utility functions
+
+These are in the "utilities" menu in the left navigation bar. Their JSDoc needs to be above an exported function and needs to have a `@module` annotation to be included in the docs. Our parser can handle 1 export/file. No need to define types in JSDoc, they will be parsed from the function itself.
+
+The gray-matter YAML defines meta information like which part of the side navigation this will be in (`category`).
+
+```typescript
+---
+type: code
+---
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ * @module
+ * Documentation goes here
+ * @param p1 the param
+ */
+function myFunc(p1: int) {}
+
+export {myFunc}
+```
+
+## Markdown files
 
 The docs can be written in `markdown`, with some added flavor, so the docs can handle special code-display cases.
 
-## Special Mardown Rules
+### Special Markdown Rules
 
 The only special markdown part is the `codeblock`. It can be displayed in several different ways.
 
-### 1. code
+#### 1. code
 
 If a code example is needed with syntax highlighting:
 
@@ -48,7 +73,7 @@ console.log("my js example comes here")
 
 Most common languages can be used for syntax highlight, such as `jsx`, `bash` or `md`
 
-### 2. embed
+#### 2. embed
 
 The `type: embed` will render the containing code into the page. It must be valid `javascript`
 
@@ -76,7 +101,7 @@ type: embed
 
 **_Note:_** you can use any instUI components in the examples
 
-### 3. example
+#### 3. example
 
 The most complex type is the `type: example`. It will render as the `embed` did, but it also provides access to the code, which is editable and the changes reflect on the rendered view immediately.
 
@@ -216,7 +241,7 @@ render(<Example />);
 
 **_Note:_** you can use `funcional React` as well.
 
-### 4. Multi example
+#### 4. Multi example
 
 If an example should be shown in `class` and `function` form as well, it needs to be written as a `list` with two items. The first item will be the `class`, the second the `function`.
 
@@ -312,7 +337,7 @@ The above code will display like this:
 
 **_Note:_** beacuse of this feature, code examples can not be displayed by `lists`
 
-### 5. comment examples
+#### 5. comment examples
 
 `JSDoc` can parse `markdown` even in the comments of `js/ts files`. These `comment-based examples` can not contain `front-matter`:
 
@@ -348,7 +373,7 @@ type: code
 
 The compiler will strip the postfix and calculate the language and type from it as well.
 
-## Named files
+### Purely documentation files
 
 Under the docs folder, there are additional folders, which are containing `.md` files, which are for general documentation. These need a `frontmatter`:
 
@@ -378,7 +403,7 @@ The `category` is the category under which the doc will be palced in the menu tr
 
 ## Additional information
 
-There are automatically generated parts of the documentation, such as:
+These are automatically generated parts of the documentation, such as:
 
 - Table of content
 - Properties

--- a/package-lock.json
+++ b/package-lock.json
@@ -4149,19 +4149,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdoc/salty": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
-      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v12.0.0"
-      }
-    },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -7484,31 +7471,6 @@
         "json-stable-stringify": "*"
       }
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "license": "MIT"
@@ -8757,14 +8719,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/array-back": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -9780,27 +9734,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
-    "node_modules/cache-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "fs-then-native": "^2.0.0",
-        "mkdirp2": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cache-point/node_modules/array-back": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cachedir": {
       "version": "2.3.0",
       "dev": true,
@@ -9946,19 +9879,6 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/catharsis": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -10513,18 +10433,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/collect-all": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -14431,26 +14339,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/file-set": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^5.0.0",
-        "glob": "^7.1.6"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/file-set/node_modules/array-back": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "dev": true,
@@ -14982,14 +14870,6 @@
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "license": "MIT"
-    },
-    "node_modules/fs-then-native": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -17551,83 +17431,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/js2xmlparser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xmlcreate": "^2.0.4"
-      }
-    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsdoc": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
-      "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^14.1.1",
-        "bluebird": "^3.7.2",
-        "catharsis": "^0.9.0",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.2",
-        "klaw": "^3.0.0",
-        "markdown-it": "^14.1.0",
-        "markdown-it-anchor": "^8.6.7",
-        "marked": "^4.0.10",
-        "mkdirp": "^1.0.4",
-        "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
-        "underscore": "~1.13.2"
-      },
-      "bin": {
-        "jsdoc": "jsdoc.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/jsdoc-api": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-8.1.1.tgz",
-      "integrity": "sha512-yas9E4h8NHp1CTEZiU/DPNAvLoUcip+Hl8Xi1RBYzHqSrgsF+mImAZNtwymrXvgbrgl4bNGBU9syulM0JzFeHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "cache-point": "^2.0.0",
-        "collect-all": "^1.0.4",
-        "file-set": "^4.0.2",
-        "fs-then-native": "^2.0.0",
-        "jsdoc": "^4.0.3",
-        "object-to-spawn-args": "^2.0.1",
-        "temp-path": "^1.0.0",
-        "walk-back": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/jsdoc/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/jsdom": {
       "version": "24.1.0",
@@ -17942,16 +17751,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/klaw-sync": {
@@ -18841,16 +18640,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/lint-staged": {
       "version": "15.2.10",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
@@ -19656,61 +19445,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it-anchor": {
-      "version": "8.6.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-      "dev": true,
-      "license": "Unlicense",
-      "peerDependencies": {
-        "@types/markdown-it": "*",
-        "markdown-it": "*"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/marked-react": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/marked-react/-/marked-react-3.0.0.tgz",
@@ -19743,13 +19477,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -20188,11 +19915,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mkdirp2": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "10.7.3",
@@ -21424,14 +21146,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-to-spawn-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/object.assign": {
@@ -23176,16 +22890,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -23837,16 +23541,6 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/requizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
-      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.4",
@@ -24916,28 +24610,6 @@
         "component-emitter": "^2.0.0"
       }
     },
-    "node_modules/stream-connect": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stream-connect/node_modules/array-back": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/stream-each": {
       "version": "1.2.3",
       "license": "MIT",
@@ -24949,14 +24621,6 @@
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/stream-via": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/stream/node_modules/component-emitter": {
       "version": "2.0.0",
@@ -25746,11 +25410,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/temp-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/temp/node_modules/mkdirp": {
       "version": "0.5.6",
@@ -27000,18 +26659,6 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
-    "node_modules/typical": {
-      "version": "2.6.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "license": "BSD-2-Clause",
@@ -27041,13 +26688,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -28239,14 +27879,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/walk-back": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/walk-up-path": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
@@ -29118,13 +28750,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/xmlcreate": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "license": "MIT",
@@ -29373,7 +28998,6 @@
         "globby": "^14.1.0",
         "gray-matter": "^4.0.3",
         "html-webpack-plugin": "^5.6.3",
-        "jsdoc-api": "^8.1.1",
         "mkdirp": "^3.0.1",
         "raw-loader": "^4.0.2",
         "react-docgen": "^8.0.0",

--- a/packages/__docs__/buildScripts/DataTypes.mts
+++ b/packages/__docs__/buildScripts/DataTypes.mts
@@ -53,6 +53,7 @@ type YamlMetaInfo = {
   description: string
   id?: string
   title?: string
+  // if `true` it will be not in the sidebar but reachable by the URL
   isWIP?: boolean
   order?: string
   parent?: string
@@ -62,36 +63,32 @@ type YamlMetaInfo = {
 }
 
 type JsDocResult = {
-  // the comment section above the function
-  comment?: string,
-  // metadata about the parsed file like filename
-  meta?: any,
   // the comment without the comment characters ("/*" etc)
   description?: string,
-  kind?: string,
+  // If it's a function it will be the function's name, otherwise
+  // it's either the string after the '@module' annotation or the variable's name
   name?: string,
   // function params. undefined if the comment is e.g. above imports
   params?: {
-    description?: string
-    defaultValue?: string | number | boolean
     name: string
-    type?: { names: string[] }
+    type?: string
+    defaultValue?: string
     optional?: boolean
+    // the description of the param
+    description?: string
   }[],
+  genericParameters?: {
+    name: string
+    defaultValue?: string
+    constraint?: string
+  }[]
   // function return value. undefined if the comment is e.g. above imports
-  returns?: JSDocFunctionReturns[],
-  //e.g. "module:debounce", "module:FocusRegion"
-  longname: string,
-  access?: string,
-  undocumented?: boolean,
-  title?: string
+  returns?: JSDocFunctionReturns,
 }
 
 type JSDocFunctionReturns = {
-  description: string
-  type: {
-    names: string[]
-  }
+  description?: string
+  type?: string
 }
 
 type LibraryOptions = {

--- a/packages/__docs__/buildScripts/processFile.mts
+++ b/packages/__docs__/buildScripts/processFile.mts
@@ -32,7 +32,7 @@ export function processFile(
   fullPath: string,
   projectRoot: string,
   library: LibraryOptions
-): ProcessedFile {
+): ProcessedFile | undefined {
   // eslint-disable-next-line no-console
   console.info(`Processing ${fullPath}`)
   const source = fs.readFileSync(fullPath)
@@ -42,11 +42,10 @@ export function processFile(
   const doc = parseDoc(fullPath, source, (err: Error) => {
     console.warn('Error when parsing ', fullPath, ":\n", err.stack)
   })
+  if (!doc) {
+    return
+  }
   const docData: ProcessedFile = { ...doc, ...pathInfo } as ProcessedFile
-  // TODO docblock is always undefined. Either show this or delete.
-  docData.methods = docData.methods
-    ? docData.methods.filter((method) => method.docblock !== null)
-    : undefined
   let docId: string
   const lowerPath = docData.relativePath.toLowerCase()
   if (docData.id) {

--- a/packages/__docs__/buildScripts/utils/getClientProps.mts
+++ b/packages/__docs__/buildScripts/utils/getClientProps.mts
@@ -44,9 +44,6 @@ export function getClientProps(docs: ProcessedFile[], library: LibraryOptions) {
     .filter((doc) => !doc.private)
     .forEach((doc) => {
       const { category, id, parent, describes } = doc
-      if (doc.undocumented) {
-        return
-      }
       // warn if the ID already exists with a different path
       if (docIDs[id] && docIDs[id] !== doc.srcPath) {
         warning(

--- a/packages/__docs__/buildScripts/utils/getJSDoc.mts
+++ b/packages/__docs__/buildScripts/utils/getJSDoc.mts
@@ -22,43 +22,214 @@
  * SOFTWARE.
  */
 
-// @ts-ignore no typing :(
-import jsdoc from 'jsdoc-api'
+import * as ts from 'typescript'
 import type { JsDocResult } from '../DataTypes.mjs'
+import {
+  ArrowFunction,
+  FunctionDeclaration,
+  FunctionExpression, JSDoc,
+  JSDocTag, NamedDeclaration,
+  TypeChecker,
+  VariableDeclaration
+} from 'typescript'
+import fs from 'fs'
 
-export function getJSDoc(source: Buffer, error: (err: Error) => void) {
-  // note: JSDoc seems to be abandoned, we should use TypeScript:
-  // https://stackoverflow.com/questions/47429792/is-it-possible-to-get-comments-as-nodes-in-the-ast-using-the-typescript-compiler
-  let doc: Partial<JsDocResult> = {}
-  try {
-    // JSDoc only creates these sections if the file has a @module or @namespace annotation
-    let sections: JsDocResult[] = jsdoc
-      .explainSync({
-        // note: Do not use cache:true here, its buggy
-        configure: './jsdoc.config.json',
-        source
-      })
-      sections = sections.filter((section) => {
-        return (
-          section.undocumented !== true &&
-          section.access !== 'private' &&
-          section.kind !== 'package'
-        )
-      })
-    const module =
-      sections.filter((section) => section.kind === 'module')[0] ||
-      sections[0] ||
-      {}
-    if (process.platform === 'win32' && module.description) {
-      // JSDoc bug https://github.com/jsdoc/jsdoc/issues/2067
-      module.description = module.description.replace(/\r/g, "\r\n")
+/**
+ * Only exported variables whose docs contains "@module" will be included
+ */
+const moduleTag = 'module'
+
+/**
+ * Returns the part after the JSDoc tag, e.g. for
+ * "@param abc def" it returns "abc def"
+ */
+function jsDocTagCommentToString(tag: JSDocTag | JSDoc) {
+  return tag.comment ?
+    typeof tag.comment == 'string' ?
+      tag.comment :
+      tag.comment.map(comment => comment.text).join(' ') :
+    ''
+}
+
+/**
+ * Find the `@returns` tag to get the return description
+ */
+function extractReturnDescription(node: ts.Node) {
+  const allTags = ts.getJSDocTags(node)
+  for (const tag of allTags) {
+    if (ts.isJSDocReturnTag(tag)) {
+      return jsDocTagCommentToString(tag)
     }
-    doc = {
-      ...module,
-      undocumented: sections.length <= 0
-    }
-  } catch (err: any) {
-    error(err)
   }
-  return doc
+  return undefined
+}
+
+function extractFunctionData(node: FunctionDeclaration | FunctionExpression | ArrowFunction,
+                             typeChecker: TypeChecker): JsDocResult | undefined {
+  // main description
+  let description = ''
+  // arrow function's name is the parent name, e.g. const asd = () => 4
+  const symbol = typeChecker.getSymbolAtLocation(node.name || (node.parent as VariableDeclaration).name)
+  if (symbol) {
+    const docs = symbol.getDocumentationComment(typeChecker)
+    description = ts.displayPartsToString(docs)
+  }
+  // Extract generic type parameters and their constraints
+  const genericParameters = node.typeParameters?.map(typeParam => {
+    return {
+      name: typeParam.name.text,
+      defaultValue: typeParam.default?.getText(),
+      constraint: ts.getEffectiveConstraintOfTypeParameter(typeParam)?.getText()
+    }
+  })
+  // Extract parameter types
+  const parameters: JsDocResult['params'] = node.parameters.map(param => {
+    const paramSymbol = typeChecker.getSymbolAtLocation(param.name)
+    return {
+      name: param.name.getText(),
+      type: typeChecker.typeToString(typeChecker.getTypeAtLocation(param.name)),
+      defaultValue: param.initializer?.getText(),
+      optional: param.questionToken !== undefined || param.initializer !== undefined,
+      description: paramSymbol ? ts.displayPartsToString(paramSymbol.getDocumentationComment(typeChecker)) : undefined
+    }
+  })
+  // Extract return type
+  const signature = typeChecker.getSignatureFromDeclaration(node)
+  const returnsType = signature
+    ? typeChecker.typeToString(typeChecker.getReturnTypeOfSignature(signature))
+    : 'unknown'
+  const returnsDesc = extractReturnDescription(node)
+  return {
+    // arrow function's name is the parents name
+    name: node.name ? node.name.getText() : (node.parent as NamedDeclaration).name?.getText(),
+    description: description,
+    ...(parameters.length > 0 && {params: parameters}),
+    ...((genericParameters && genericParameters.length > 0) && {genericParameters: genericParameters}),
+    ...((returnsDesc || returnsType) && {
+      returns: {
+        description: returnsDesc,
+        type: returnsType
+      }
+    })
+  }
+}
+
+function parseNode(node: ts.Node, typeChecker: TypeChecker): JsDocResult | undefined {
+  // Only exported functions with the @module annotation are needed
+  // TODO we also have a private prop in the YML, do we need both?
+  const allTags = ts.getJSDocTags(node)
+  let hasModuleAnnotation = false
+  let moduleName: string | undefined = undefined
+  for (const tag of allTags) {
+    if (!ts.isJSDoc(tag) && tag.tagName.text === moduleTag) {
+      hasModuleAnnotation = true
+      moduleName = jsDocTagCommentToString(tag)
+    }
+  }
+  if (!hasModuleAnnotation) {
+    return
+  }
+
+  let result: JsDocResult | undefined = undefined
+  if (ts.isVariableStatement(node)) { // e.g. const x = function(){}, y = 5
+    for (const d of node.declarationList.declarations) {
+      if (d.initializer) {
+        if (ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer)) {
+          result = extractFunctionData(d.initializer, typeChecker)
+        }
+      }
+    }
+  }
+  // e.g. function focusable(el: Element)
+  if (ts.isFunctionDeclaration(node)) {
+    result = extractFunctionData(node, typeChecker)
+  }
+  // if it's not a function, then try to parse types from the JSDoc comment
+  else if (!result) {
+    let description = ''
+    const params: JsDocResult['params'] = []
+    const docs = ts.getJSDocCommentsAndTags(node)
+    for (const doc of docs) {
+      description = jsDocTagCommentToString(doc)
+      if (ts.isJSDoc(doc)) {
+        if (doc.tags) {
+          for (const tag of doc.tags) {
+            if (ts.isJSDocParameterTag(tag)) {
+              params.push({
+                name: tag.name.getText(),
+                // Remove curly braces
+                type: tag.typeExpression?.getText().replace(/^{|}$/g, ''),
+                description: jsDocTagCommentToString(tag)
+              })
+            }
+          }
+        }
+      }
+    }
+    const nodeName = moduleName || (node as NamedDeclaration)?.name?.getText()
+    const returnsDesc = extractReturnDescription(node)
+    const returnsType = ts.getJSDocReturnType(node)?.getText()
+    result = {
+      name: nodeName,
+      description: description,
+      ...(params.length > 0 && {params: params}),
+      //genericParameters: todo,
+      ...((returnsDesc || returnsType) && {
+        returns: {
+          description: returnsDesc,
+          type: returnsType
+        }
+      })
+    }
+  }
+  return result
+}
+
+export function getJSDoc(filePath: string, _error: (err: Error) => void): JsDocResult | undefined {
+
+  function visit(node: ts.Node) {
+    // export declaration (e.g. export {abd, def})
+    if (ts.isExportDeclaration(node) &&
+               node.exportClause &&
+               ts.isNamedExports(node.exportClause)) {
+      for (const e of node.exportClause.elements) {
+        // TODO while this node can have the JSDoc comments, its types are at its
+        // original location. This is not parsed currently
+        const symbol = typeChecker.getSymbolAtLocation(e.name)
+        if (symbol) {
+          const originalSymbol = typeChecker.getAliasedSymbol(symbol)
+          // will fail if the jsdoc is here, needs to be stitched together
+          if (originalSymbol.valueDeclaration) {
+            const res = parseNode(originalSymbol.valueDeclaration, typeChecker)
+            if (res) {
+              result?.push(res)
+            }
+          }
+        }
+      }
+    }
+    // direct export, e.g. export function(...)
+    else if ((ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isVariableStatement(node) ||
+      ts.isEnumDeclaration(node)) &&
+      node.modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword)) {
+      const res = parseNode(node, typeChecker)
+      if (res) {
+        result?.push(res)
+      }
+    }
+  }
+  // bail quickly if it does not have the module annotation
+  const content = fs.readFileSync(filePath, 'utf-8')
+  if (!content.includes( '@' + moduleTag)) {
+    return undefined
+  }
+
+  const program = ts.createProgram([filePath], {})
+  const typeChecker = program.getTypeChecker()
+  const result: JsDocResult[] = []
+  const sourceFile = program.getSourceFile(filePath)
+  ts.forEachChild(sourceFile!, visit)
+  return result.pop() // TODO users of this cannot handle more than 1 export/file :(
 }

--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -14,6 +14,7 @@
     "prestart": "npm run build:scripts:ts && node lib/build-docs.mjs",
     "start": "npm run prestart && ui-scripts bundle && ui-scripts server -p 8001",
     "start:watch": "npm run prestart && ui-scripts bundle --watch -p 9090",
+    "start-watch-just-app": "ui-scripts bundle --watch -p 9090",
     "bundle": "npm run prestart && ui-scripts bundle",
     "lint": "ui-scripts lint",
     "lint:fix": "ui-scripts lint --fix",
@@ -135,7 +136,6 @@
     "globby": "^14.1.0",
     "gray-matter": "^4.0.3",
     "html-webpack-plugin": "^5.6.3",
-    "jsdoc-api": "^8.1.1",
     "mkdirp": "^3.0.1",
     "raw-loader": "^4.0.2",
     "react-docgen": "^8.0.0",
@@ -144,7 +144,6 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "//dependency-comments": {
-    "jsdoc-api": "v9 removes explainSync, its async only",
     "chokidar": "4.0.1 seems to have issues watching an array of paths. Check later if fixed..."
   }
 }

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -76,7 +76,7 @@ class Document extends Component<DocumentProps, DocumentState> {
     const generateTheme = doc?.componentInstance?.generateComponentTheme
     const generateThemeFunctional =
       functionalComponentThemes[
-      doc.id as keyof typeof functionalComponentThemes
+        doc.id as keyof typeof functionalComponentThemes
       ]
     if (
       generateTheme &&
@@ -173,9 +173,9 @@ class Document extends Component<DocumentProps, DocumentState> {
   {...props}
   themeOverride={{
     ${
-              // get random theme variable
-              themeVariableKeys[Math.floor(Math.random() * themeVariableKeys.length)]
-              }: 'custom value'
+      // get random theme variable
+      themeVariableKeys[Math.floor(Math.random() * themeVariableKeys.length)]
+    }: 'custom value'
   }}
 />`}
           />
@@ -288,14 +288,18 @@ import { ${importName} } from '${esPath}'
   }
 
   renderParams(doc: DocDataType) {
-    const { id, params } = doc
+    const { id, params, genericParameters } = doc
 
     return params ? (
       <View margin="small 0" display="block">
         <Heading level="h2" as="h3" id={`${id}Parameters`} margin="0 0 small 0">
           Parameters
         </Heading>
-        <Params params={params} layout={this.props.layout} />
+        <Params
+          params={params}
+          genericParameters={genericParameters}
+          layout={this.props.layout}
+        />
       </View>
     ) : null
   }

--- a/packages/__docs__/src/Params/index.tsx
+++ b/packages/__docs__/src/Params/index.tsx
@@ -27,6 +27,7 @@ import { Table } from '@instructure/ui-table'
 import { compileMarkdown } from '../compileMarkdown'
 import type { ParamsProps } from './props'
 import { propTypes } from './props'
+import { Heading } from '@instructure/ui-heading'
 
 class Params extends Component<ParamsProps> {
   static propTypes = propTypes
@@ -38,12 +39,12 @@ class Params extends Component<ParamsProps> {
   renderRows() {
     return this.props.params?.map((param) => {
       return (
-        <Table.Row key={param?.name}>
+        <Table.Row key={param.name}>
           <Table.Cell>
-            <code>{param?.name}</code>
+            <code>{param.name}</code>
           </Table.Cell>
           <Table.Cell>
-            <code>{this.renderType(param?.type)}</code>
+            <code>{param?.type}</code>
           </Table.Cell>
           <Table.Cell>
             <code>{param?.defaultValue}</code>
@@ -54,33 +55,78 @@ class Params extends Component<ParamsProps> {
     })
   }
 
-  renderType(type?: { names: string[] }) {
-    return type ? type.names.join(' | ') : null
-  }
-
   renderDescription(description: string) {
     return <div>{description && compileMarkdown(description)}</div>
   }
 
-  render() {
-    const { layout } = this.props
+  renderGenericRows() {
+    return this.props.genericParameters?.map((param) => {
+      return (
+        <Table.Row key={param.name}>
+          <Table.Cell>
+            <code>{param.name}</code>
+          </Table.Cell>
+          <Table.Cell>
+            <code>{param?.defaultValue}</code>
+          </Table.Cell>
+          <Table.Cell>{param?.constraint}</Table.Cell>
+        </Table.Row>
+      )
+    })
+  }
 
+  render() {
+    const { layout, genericParameters } = this.props
+    let genericParamsTable = <></>
+    if (genericParameters) {
+      genericParamsTable = (
+        <>
+          <Heading
+            level="h3"
+            as="h4"
+            id="genericParameters"
+            margin="0 0 small 0"
+          >
+            Generic type Parameters
+          </Heading>
+          <Table
+            caption="Parameters"
+            margin="0 0 large"
+            layout={layout === 'small' ? 'stacked' : 'auto'}
+          >
+            <Table.Head>
+              <Table.Row>
+                <Table.ColHeader id="genericParam">Param</Table.ColHeader>
+                <Table.ColHeader id="genericDefault">Default</Table.ColHeader>
+                <Table.ColHeader id="genericConstraint">
+                  Constraint
+                </Table.ColHeader>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>{this.renderGenericRows()}</Table.Body>
+          </Table>
+        </>
+      )
+    }
     return (
-      <Table
-        caption="Parameters"
-        margin="0 0 large"
-        layout={layout === 'small' ? 'stacked' : 'auto'}
-      >
-        <Table.Head>
-          <Table.Row>
-            <Table.ColHeader id="Param">Param</Table.ColHeader>
-            <Table.ColHeader id="Type">Type</Table.ColHeader>
-            <Table.ColHeader id="Default">Default</Table.ColHeader>
-            <Table.ColHeader id="Description">Description</Table.ColHeader>
-          </Table.Row>
-        </Table.Head>
-        <Table.Body>{this.renderRows()}</Table.Body>
-      </Table>
+      <>
+        <Table
+          caption="Parameters"
+          margin="0 0 large"
+          layout={layout === 'small' ? 'stacked' : 'auto'}
+        >
+          <Table.Head>
+            <Table.Row>
+              <Table.ColHeader id="Param">Param</Table.ColHeader>
+              <Table.ColHeader id="Type">Type</Table.ColHeader>
+              <Table.ColHeader id="Default">Default</Table.ColHeader>
+              <Table.ColHeader id="Description">Description</Table.ColHeader>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>{this.renderRows()}</Table.Body>
+        </Table>
+        {genericParamsTable}
+      </>
     )
   }
 }

--- a/packages/__docs__/src/Params/props.ts
+++ b/packages/__docs__/src/Params/props.ts
@@ -27,6 +27,7 @@ import type { DocDataType } from '../Document/props'
 
 type ParamsOwnProp = {
   params: DocDataType['params']
+  genericParameters: DocDataType['genericParameters']
   layout?: 'small' | 'medium' | 'large' | 'x-large'
 }
 type PropKeys = keyof ParamsOwnProp
@@ -34,8 +35,9 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 type ParamsProps = ParamsOwnProp
 const propTypes: PropValidators<PropKeys> = {
   params: PropTypes.array.isRequired,
+  genericParameters: PropTypes.array,
   layout: PropTypes.oneOf(['small', 'medium', 'large', 'x-large'])
 }
-const allowedProps: AllowedPropKeys = ['layout', 'params']
+const allowedProps: AllowedPropKeys = ['layout', 'params', 'genericParameters']
 export type { ParamsProps }
 export { propTypes, allowedProps }

--- a/packages/__docs__/src/Returns/index.tsx
+++ b/packages/__docs__/src/Returns/index.tsx
@@ -23,38 +23,10 @@
  */
 
 import { Component } from 'react'
-
 import { Table } from '@instructure/ui-table'
-
-import { compileMarkdown } from '../compileMarkdown'
-
 import type { ReturnsProps } from './props'
 
-import type { JSDocFunctionReturns } from '../../buildScripts/DataTypes.mts'
-
 class Returns extends Component<ReturnsProps> {
-  renderRows() {
-    return this.props.types.map((type, index) => {
-      const key = `${type.type}-${index}`
-      return (
-        <Table.Row key={key}>
-          <Table.Cell>
-            <code>{this.renderType(type.type)}</code>
-          </Table.Cell>
-          <Table.Cell>{this.renderDescription(type.description)}</Table.Cell>
-        </Table.Row>
-      )
-    })
-  }
-
-  renderType(type: JSDocFunctionReturns['type']) {
-    return type ? type.names.join(', ') : null
-  }
-
-  renderDescription(description: string) {
-    return <div>{description && compileMarkdown(description)}</div>
-  }
-
   render() {
     return (
       <Table caption="Returns" margin="0 0 large">
@@ -64,7 +36,14 @@ class Returns extends Component<ReturnsProps> {
             <Table.ColHeader id="Description">Description</Table.ColHeader>
           </Table.Row>
         </Table.Head>
-        <Table.Body>{this.renderRows()}</Table.Body>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <code>{this.props.types.type}</code>
+            </Table.Cell>
+            <Table.Cell>{this.props.types.description}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     )
   }

--- a/packages/__docs__/src/Returns/props.ts
+++ b/packages/__docs__/src/Returns/props.ts
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types'
 import type { JSDocFunctionReturns } from '../../buildScripts/DataTypes.mts'
 
 type ReturnsOwnProps = {
-  types: JSDocFunctionReturns[]
+  types: JSDocFunctionReturns
 }
 
 type PropKeys = keyof ReturnsOwnProps

--- a/packages/theme-registry/src/ThemeRegistry.ts
+++ b/packages/theme-registry/src/ThemeRegistry.ts
@@ -22,16 +22,6 @@
  * SOFTWARE.
  */
 
-/**
- * ---
- * category: utilities/themes
- * ---
- * DEPRECATED. This will be deleted, please use InstUISettingsProvider instead.
- * A global theme registry used for registering theme objects, setting globally available themes
- * and receiving the currently used theme.
- * @module ThemeRegistry
- */
-
 import { error } from '@instructure/console'
 import { mergeDeep } from '@instructure/ui-utils'
 import { isBaseTheme } from '@instructure/ui-utils'
@@ -79,7 +69,6 @@ if (globalThis[GLOBAL_THEME_REGISTRY]) {
 /**
  * Creates and returns a new empty registry.
  * @returns {Registry} the empty registry object
- * @module makeRegistry
  * @private
  */
 function makeRegistry(): Registry<RegisteredTheme> {
@@ -125,7 +114,6 @@ function validateRegistry(registry: Registry<RegisteredTheme<BaseTheme>>) {
  * Get the global theme registry.
  * @deprecated since version 10
  * @return The theme registry
- * @module getRegistry
  */
 function getRegistry(): Registry<RegisteredTheme> {
   return globalThis[GLOBAL_THEME_REGISTRY]
@@ -136,7 +124,6 @@ function getRegistry(): Registry<RegisteredTheme> {
  * @deprecated since version 10
  * @param {Registry} registry - the registry to set/replace the current registry with.
  * @returns {void}
- * @module setRegistry
  */
 function setRegistry(registry: Registry<RegisteredTheme>): void {
   globalThis[GLOBAL_THEME_REGISTRY] = registry
@@ -145,7 +132,6 @@ function setRegistry(registry: Registry<RegisteredTheme>): void {
 /**
  * Clear/reset the global theme registry.
  * @deprecated since version 10
- * @module clearRegistry
  * @returns {void}
  */
 function clearRegistry(): void {
@@ -155,8 +141,7 @@ function clearRegistry(): void {
 /**
  * Get the activated theme object.
  * @deprecated since version 10
- * @return {RegisteredTheme} the default theme object
- * @module getCurrentTheme
+ * @return the default theme object
  */
 function getCurrentTheme(): RegisteredTheme | undefined {
   const registry = getRegistry()
@@ -174,7 +159,6 @@ function getCurrentTheme(): RegisteredTheme | undefined {
  * @param {String} themeKey - the default theme key
  * @param {DeepPartial<BaseThemeVariables>} overrides - the overrides for the theme variables
  * @returns {RegisteredTheme} the registered theme object
- * @module activateTheme
  * @private
  */
 function activateTheme(
@@ -205,7 +189,6 @@ function activateTheme(
 /**
  * Wraps a theme and provides a method to activate the theme.
  * @returns the wrapped theme object
- * @module makeTheme
  * @private
  */
 function makeTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
@@ -245,7 +228,6 @@ function makeTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
  * @returns {RegisteredTheme} If the given theme is already in the ThemeRegistry then simply return that theme.
  * Otherwise, returns the theme with a wrapper around it, so it can be `.use()`-ed to activate the given theme from the registry.
  * This function also adds a `variables` prop for backwards compatibility (deprecated).
- * @module registerTheme
  */
 function registerTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
   const registry = getRegistry()
@@ -269,6 +251,14 @@ function registerTheme<T extends BaseTheme>(theme: T): RegisteredTheme<T> {
 }
 
 /**
+ * ---
+ * category: utilities/themes
+ * ---
+ * @module ThemeRegistry
+ *
+ * DEPRECATED. This will be deleted, please use `InstUISettingsProvider` instead.
+ * A global theme registry used for registering theme objects, setting globally available themes
+ * and receiving the currently used theme.
  * @deprecated since version 10
  */
 const ThemeRegistry = {

--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -38,6 +38,18 @@ import { ScreenReaderFocusRegion } from './ScreenReaderFocusRegion'
 import { KeyboardFocusRegion } from './KeyboardFocusRegion'
 import { FocusRegionOptions } from './FocusRegionOptions'
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Class for focus operations, manages [ScreenReaderFocusRegion](#ScreenReaderFocusRegion)
+ * and [KeyboardFocusRegion](#KeyboardFocusRegion) for the given DOM element.
+ * - Scoping focus within a given context (DOM node),
+ * - Mark active element for focus later
+ * - Return focus to the marked element
+ * @module FocusRegion
+ */
 class FocusRegion {
   private _contextElement: Node | Element | null = null
   private _options: FocusRegionOptions
@@ -230,18 +242,4 @@ class FocusRegion {
 }
 
 export default FocusRegion
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Class for focus operations, manages [ScreenReaderFocusRegion](#ScreenReaderFocusRegion)
-   * and [KeyboardFocusRegion](#KeyboardFocusRegion) for the given DOM element.
-   * - Scoping focus within a given context (DOM node),
-   * - Mark active element for focus later
-   * - Return focus to the marked element
-   * @module FocusRegion
-   */
-  FocusRegion
-}
+export { FocusRegion }

--- a/packages/ui-a11y-utils/src/FocusRegionManager.ts
+++ b/packages/ui-a11y-utils/src/FocusRegionManager.ts
@@ -35,6 +35,17 @@ type Entry = {
 }
 let ENTRIES: Entry[] = []
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Class for focus operations, manages multiple [FocusRegion](#FocusRegion)s.
+ * - Scoping focus within a given context,
+ * - Mark active element for focus later
+ * - Return focus to the marked element
+ * @module FocusManager
+ */
 class FocusRegionManager {
   static focusRegion = (
     element: Element | Node,
@@ -172,17 +183,4 @@ class FocusRegionManager {
 }
 
 export default FocusRegionManager
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Class for focus operations, manages multiple [FocusRegion](#FocusRegion)s.
-   * - Scoping focus within a given context,
-   * - Mark active element for focus later
-   * - Return focus to the marked element
-   * @module FocusManager
-   */
-  FocusRegionManager
-}
+export { FocusRegionManager }

--- a/packages/ui-a11y-utils/src/KeyboardFocusRegion.ts
+++ b/packages/ui-a11y-utils/src/KeyboardFocusRegion.ts
@@ -44,6 +44,17 @@ import { scopeTab } from './scopeTab'
 import type { UIElement } from '@instructure/shared-types'
 import { FocusRegionOptions } from './FocusRegionOptions'
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Class for focus operations.
+ * - Scoping focus within a given context (DOM node),
+ * - Mark active element for focus later
+ * - Return focus to the marked element
+ * @module KeyboardFocusRegion
+ */
 class KeyboardFocusRegion {
   private readonly _options: FocusRegionOptions
   private _focusLaterElement: Element | null = null
@@ -343,17 +354,4 @@ class KeyboardFocusRegion {
 }
 
 export default KeyboardFocusRegion
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Class for focus operations.
-   * - Scoping focus within a given context (DOM node),
-   * - Mark active element for focus later
-   * - Return focus to the marked element
-   * @module KeyboardFocusRegion
-   */
-  KeyboardFocusRegion
-}
+export { KeyboardFocusRegion }

--- a/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.ts
+++ b/packages/ui-a11y-utils/src/ScreenReaderFocusRegion.ts
@@ -29,6 +29,16 @@ function isElement(elem: Node): elem is Element {
   return elem instanceof Element
 }
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Utility that hides all DOM elements outside of a specified node. Used,
+ * for example, in overlay components where we want to restrict the screen
+ * readers to the overlay content.
+ * @module ScreenReaderFocusRegion
+ */
 class ScreenReaderFocusRegion {
   private _parents: HTMLElement[] = []
   private _nodes: Element[] = []
@@ -213,16 +223,4 @@ class ScreenReaderFocusRegion {
 }
 
 export default ScreenReaderFocusRegion
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Utility that hides all DOM elements outside of a specified node. Used,
-   * for example, in overlay components where we want to restrict the screen
-   * readers to the overlay content.
-   * @module ScreenReaderFocusRegion
-   */
-  ScreenReaderFocusRegion
-}
+export { ScreenReaderFocusRegion }

--- a/packages/ui-a11y-utils/src/hasVisibleChildren.ts
+++ b/packages/ui-a11y-utils/src/hasVisibleChildren.ts
@@ -28,6 +28,15 @@ import { matchComponentTypes } from '@instructure/ui-react-utils'
 import { ScreenReaderContent } from '@instructure/ui-a11y-content'
 import type { ScreenReaderContentProps } from '@instructure/ui-a11y-content'
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ * Returns `true` if any of the children are not wrapped with [ScreenReaderContent](#ScreenReaderContent).
+ * @module hasVisibleChildren
+ * @param children - A React component's children prop
+ * @return whether any of the children are visible
+ */
 function hasVisibleChildren(children: ReactNode) {
   let visible = false
   Children.forEach(children, (child) => {
@@ -44,15 +53,4 @@ function hasVisibleChildren(children: ReactNode) {
 }
 
 export default hasVisibleChildren
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   * Returns `true` if any of the children are not wrapped with [ScreenReaderContent](#ScreenReaderContent).
-   * @module hasVisibleChildren
-   * @param {ReactChildren} children - A react component's children prop
-   * @return {boolean} whether any of the children are visible
-   */
-  hasVisibleChildren
-}
+export { hasVisibleChildren }

--- a/packages/ui-a11y-utils/src/scopeTab.ts
+++ b/packages/ui-a11y-utils/src/scopeTab.ts
@@ -31,6 +31,18 @@ import {
 } from '@instructure/ui-dom-utils'
 import type { UIElement } from '@instructure/shared-types'
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Scope tab in order to trap focus within a specified
+ * element.
+ * @module scopeTab
+ * @param element
+ * @param event the DOM Event that was fired
+ * @param onLeavingFinalTabbable function executed when leaving final tabbable instead of the default behavior
+ */
 function scopeTab(
   element: UIElement | undefined,
   event: React.KeyboardEvent,
@@ -74,18 +86,4 @@ function scopeTab(
 }
 
 export default scopeTab
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Scope tab in order to trap focus within a specified
-   * element.
-   * @module scopeTab
-   * @param {ReactElement|DOMNode} element
-   * @param {Event} event the DOM Event that was fired
-   * @param {function} function executed when leaving final tabbable instead of the default behavior
-   */
-  scopeTab
-}
+export { scopeTab }

--- a/packages/ui-color-utils/src/conversions.ts
+++ b/packages/ui-color-utils/src/conversions.ts
@@ -22,14 +22,6 @@
  * SOFTWARE.
  */
 
-/**
- * ---
- * category: utilities
- * ---
- * Color conversion utilities to transform between `TinyColor` colors (https://github.com/bgrins/TinyColor)
- * @module conversions
- */
-
 import Color from 'tinycolor2'
 import type { ColorInputWithoutInstance } from 'tinycolor2'
 
@@ -37,7 +29,6 @@ import type { ColorInputWithoutInstance } from 'tinycolor2'
  * Converts any valid `TinyColor` colors to hex string
  * @param {ColorInputWithoutInstance} rgb a color string
  * @returns {String} a hex string like `#FF0000`
- * @module color2hex
  */
 const colorToHex = (rgb: ColorInputWithoutInstance): string => {
   return Color(rgb).toHexString().toUpperCase()
@@ -47,7 +38,6 @@ const colorToHex = (rgb: ColorInputWithoutInstance): string => {
  * Transforms any `TinyColor` to 8 length HEX (alpha included)
  * @param {ColorInputWithoutInstance} color representation from `TinyColor`
  * @returns {String} An 8 length hex string like `#FF0000FF`
- * @module colorToHex8
  */
 const colorToHex8 = (color: ColorInputWithoutInstance): string => {
   return Color(color).toHex8String().toUpperCase()
@@ -58,7 +48,6 @@ const colorToHex8 = (color: ColorInputWithoutInstance): string => {
  * also exported as `hexToRgb` for backward compatiblity reasons
  * @param {ColorInputWithoutInstance} color representation from `TinyColor`
  * @returns {Color.ColorFormats.RGBA} A `TinyColor` RGBA type
- * @module colorToRGB
  */
 const colorToRGB = (
   color: ColorInputWithoutInstance
@@ -70,7 +59,6 @@ const colorToRGB = (
  * Transforms any `TinyColor` to HSVA object ( {h:number, s:number, v:number, a:number} )
  * @param {ColorInputWithoutInstance} color representation from `TinyColor`
  * @returns {Color.ColorFormats.HSVA} A `TinyColor` HSVA type
- * @module colorToHsva
  */
 const colorToHsva = (
   color: ColorInputWithoutInstance
@@ -82,7 +70,6 @@ const colorToHsva = (
  * Transforms any `TinyColor` to HSLA object ( {h:number, s:number, l:number, a:number} )
  * @param {ColorInputWithoutInstance} color representation from `TinyColor`
  * @returns {Color.ColorFormats.HSLA} A `TinyColor` HSLA type
- * @module colorToHsla
  */
 const colorToHsla = (
   color: ColorInputWithoutInstance

--- a/packages/ui-dom-utils/src/contains.ts
+++ b/packages/ui-dom-utils/src/contains.ts
@@ -26,17 +26,6 @@ import { findDOMNode } from './findDOMNode'
 import { canUseDOM } from './canUseDOM'
 import { UIElement } from '@instructure/shared-types'
 
-/**
- * ---
- * category: utilities/DOM
- * ---
- *
- * Determine if an element contains another DOM node
- * @module containsWithDOM
- * @param { Node | Window | React.ReactElement | function | null } context - component or DOM node
- * @param { Node | Window | React.ReactElement | function | null } el - component or DOM node which we want to determine if contained within the context
- * @returns { boolean } if the element is contained within the context
- */
 function containsWithDOM(context: UIElement, el: UIElement) {
   const container = context && findDOMNode(context)
   const node = el && findDOMNode(el)
@@ -62,6 +51,17 @@ function containsFallback(context: UIElement, el: UIElement) {
   return false
 }
 
+/**
+ * ---
+ * category: utilities/DOM
+ * ---
+ *
+ * Determine if an element contains another DOM node
+ * @module containsWithDOM
+ * @param { Node | Window | React.ReactElement | function | null } context - component or DOM node
+ * @param { Node | Window | React.ReactElement | function | null } el - component or DOM node which we want to determine if contained within the context
+ * @returns { boolean } if the element is contained within the context
+ */
 const contains = canUseDOM ? containsWithDOM : containsFallback
 export default contains
 export { contains }

--- a/packages/ui-dom-utils/src/findFocusable.ts
+++ b/packages/ui-dom-utils/src/findFocusable.ts
@@ -63,6 +63,21 @@ function hasQuerySelectorAll(el?: UIElement): el is Element | Document {
   return true
 }
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Given an element, finds and returns all visible, focusable children.
+ * Focusable elements include input, select, textarea, button, and object.
+ * Anchor tags are also focusable if they include an href or
+ * tabindex attribute (including tabindices less than zero).
+ * @module findFocusable
+ * @param { Node | Window | React.ReactElement | React.Component | function | null } el component or DOM node
+ * @param { function } filter a function to filter the matching nodes
+ * @param { boolean } shouldSearchRootNode should the root node be included in the search
+ * @returns { Array } array of all tabbable children
+ */
 function findFocusable(
   el?: UIElement,
   filter?: (el: Element) => boolean,
@@ -126,20 +141,5 @@ function focusable(element: Element & { disabled?: boolean }) {
 
 export default findFocusable
 export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Given an element, finds and returns all visible, focusable children.
-   * Focusable elements include input, select, textarea, button, and object.
-   * Anchor tags are also focusable if they include an href or
-   * tabindex attribute (including tabindices less than zero).
-   * @module findFocusable
-   * @param { Node | Window | React.ReactElement | React.Component | function | null } el - component or DOM node
-   * @param { function } filter - a function to filter the matching nodes
-   * @param { boolean } shouldSearchRootNode - should the root node be included in the search
-   * @returns { Array } array of all tabbable children
-   */
   findFocusable
 }

--- a/packages/ui-dom-utils/src/findTabbable.ts
+++ b/packages/ui-dom-utils/src/findTabbable.ts
@@ -25,6 +25,22 @@
 import { findFocusable } from './findFocusable'
 import { UIElement } from '@instructure/shared-types'
 
+/**
+ * ---
+ * category: utilities/a11y
+ * ---
+ *
+ * Given an element, finds and returns all visible, tabbable children.
+ * Tabbable elements include input, select, textarea, button, and object.
+ * Anchor tags are also tabbable if they include an href or zero or positive
+ * tabindex attribute (to include elements with negative tabindex attributes,
+ * use findFocusable).
+ *
+ * @module findTabbable
+ * @param { Node | Window | React.ReactElement | React.Component | function | null } el - component or DOM node
+ * @param { boolean } shouldSearchRootNode - should the root node be included in the search
+ * @returns { Array } array of all tabbable children
+ */
 function findTabbable(el?: UIElement, shouldSearchRootNode?: boolean) {
   return findFocusable(
     el,
@@ -41,22 +57,4 @@ function isInvalidTabIndex(tabIndex: unknown) {
 }
 
 export default findTabbable
-export {
-  /**
-   * ---
-   * category: utilities/a11y
-   * ---
-   *
-   * Given an element, finds and returns all visible, tabbable children.
-   * Tabbable elements include input, select, textarea, button, and object.
-   * Anchor tags are also tabbable if they include an href or zero or positive
-   * tabindex attribute (to include elements with negative tabindex attributes,
-   * use findFocusable).
-   *
-   * @module findTabbable
-   * @param { Node | Window | React.ReactElement | React.Component | function | null } el - component or DOM node
-   * @param { boolean } shouldSearchRootNode - should the root node be included in the search
-   * @returns { Array } array of all tabbable children
-   */
-  findTabbable
-}
+export { findTabbable }

--- a/packages/ui-form-field/src/FormPropTypes.ts
+++ b/packages/ui-form-field/src/FormPropTypes.ts
@@ -46,13 +46,6 @@ type FormMessageType =
  */
 type FormMessageChild = React.ReactNode
 
-/**
- * ---
- * category: utilities/form
- * ---
- * Custom prop types for React components.
- * @module FormPropTypes
- */
 const FormPropTypes = {
   message: PropTypes.shape({
     type: formMessageTypePropType,

--- a/packages/ui-i18n/src/I18nPropTypes.ts
+++ b/packages/ui-i18n/src/I18nPropTypes.ts
@@ -69,13 +69,4 @@ const I18nPropTypes = {
 }
 
 export default I18nPropTypes
-export {
-  /**
-   * ---
-   * category: utilities/i18n
-   * ---
-   * @module I18nPropTypes
-   * Custom I18n prop types for React components.
-   */
-  I18nPropTypes
-}
+export { I18nPropTypes }

--- a/packages/ui-position/src/PositionPropTypes.ts
+++ b/packages/ui-position/src/PositionPropTypes.ts
@@ -168,15 +168,4 @@ export type Size = Pick<RectType, 'width' | 'height'>
 export type Overflow = Pick<RectType, 'top' | 'bottom' | 'left' | 'right'>
 
 export default PositionPropTypes
-export {
-  /**
-   * ---
-   * category: utilities/position
-   * ---
-   * Custom prop types for `ui-position` components.
-   * @module PositionPropTypes
-   */
-  PositionPropTypes,
-  placementPropValues,
-  mirrorMap
-}
+export { PositionPropTypes, placementPropValues, mirrorMap }

--- a/packages/ui-position/src/calculateElementPosition.ts
+++ b/packages/ui-position/src/calculateElementPosition.ts
@@ -69,6 +69,28 @@ type Options = {
   over?: boolean
 }
 
+/**
+ * ---
+ * category: utilities/position
+ * ---
+ *
+ * Calculate the coordinates to attach an element
+ * to a designated target with specified constraints
+ * @module
+ * @param element - component or DOM node
+ * @param target - the target DOM node
+ * @param options - constraints for the positioning
+ * @param options.placement - designates where the element will be attached
+ *  ('top', 'bottom', 'left', 'right', 'top left' etc.)
+ * @param options.container - DOM node where the element is contained
+ * @param options.over - whether or not you want the element to position over the target
+ * @param options.constrain - if the element should be constrained to 'window',
+ *  'scroll-parent', 'parent', or 'none'
+ * @param options.offsetX - the horizontal offset for the positioned element
+ * @param options.offsetY - the vertical offset for the positioned element
+ * @returns object containing style with the calculated position in the 'transform'
+ *  property
+ */
 function calculateElementPosition(
   element?: PositionElement,
   target?: PositionElement,
@@ -616,29 +638,4 @@ function formatPlacement(placement: PlacementValuesWithoutOffscreenArray) {
 }
 
 export default calculateElementPosition
-export {
-  /**
-   * ---
-   * category: utilities/position
-   * ---
-   *
-   * Calculate the coordinates to attach an element
-   * to a designated target with specified constraints
-   * @module
-   * @param {ReactComponent|DomNode} el - component or DOM node
-   * @param {DomNode} target - the target DOM node
-   * @param {Object} options - constraints for the positioning
-   * @param {string} options.placement - designates where the element will be attached
-   *  ('top', 'bottom', 'left', 'right', 'top left' etc.)
-   * @param {DomNode} options.container - DOM node where the element is contained
-   * @param {boolean} options.over - whether or not you want the element to position over the target
-   * @param {string} options.constrain - if the element should be constrained to 'window',
-   *  'scroll-parent', 'parent', or 'none'
-   * @param {string|number} options.offsetX - the horizontal offset for the positioned element
-   * @param {string|number} options.offsetY - the vertical offset for the positioned element
-   * @returns {Object} object containing style with the calculated position in the 'transform'
-   *  property
-   */
-  calculateElementPosition,
-  parsePlacement
-}
+export { calculateElementPosition, parsePlacement }

--- a/packages/ui-prop-types/src/Children.ts
+++ b/packages/ui-prop-types/src/Children.ts
@@ -378,12 +378,4 @@ const getDisplayName = (Component: string | ComponentType): string => {
 }
 
 export default Children
-export {
-  /**
-   * ---
-   * category: utilities/PropTypes
-   * ---
-   * @module Children
-   */
-  Children
-}
+export { Children }

--- a/packages/ui-react-utils/src/deprecated.ts
+++ b/packages/ui-react-utils/src/deprecated.ts
@@ -36,6 +36,31 @@ export interface DeprecatedDecorator {
   changedPackageWarning: (...args: any[]) => string
 }
 
+/**
+ * ---
+ * category: utilities/react
+ * ---
+ * Deprecate React component props. Warnings will display in the console when deprecated
+ * props are used. Include the version number when the deprecated component will be removed.
+ *
+ * ```js-code
+ *  class Example extends Component {
+ *    static propTypes = {
+ *      currentProp: PropTypes.func
+ *    }
+ *  }
+ *  export default deprecated('7.0.0', {
+ *    deprecatedProp: 'currentProp',
+ *    nowNonExistentProp: true
+ *  })(Example)
+ * ```
+ *
+ * @param {string} version
+ * @param {object} oldProps (if this argument is null or undefined, the entire component is deprecated)
+ * @param {string} message
+ * @return {function} React component with deprecated props behavior
+ * @module deprecated
+ */
 const deprecated = (() => {
   if (process.env.NODE_ENV === 'production') {
     const deprecated: DeprecatedDecorator = function () {
@@ -54,31 +79,6 @@ const deprecated = (() => {
       oldProps?: Record<string, any>,
       message = ''
     ) => {
-      /**
-       * ---
-       * category: utilities/react
-       * ---
-       * Deprecate React component props. Warnings will display in the console when deprecated
-       * props are used. Include the version number when the deprecated component will be removed.
-       *
-       * ```js-code
-       *  class Example extends Component {
-       *    static propTypes = {
-       *      currentProp: PropTypes.func
-       *    }
-       *  }
-       *  export default deprecated('7.0.0', {
-       *    deprecatedProp: 'currentProp',
-       *    nowNonExistentProp: true
-       *  })(Example)
-       * ```
-       *
-       * @param {string} version
-       * @param {object} oldProps (if this argument is null or undefined, the entire component is deprecated)
-       * @param {string} message
-       * @return {function} React component with deprecated props behavior
-       * @module deprecated
-       */
       class DeprecatedComponent extends ComposedComponent {}
 
       DeprecatedComponent.prototype.componentDidMount = function () {

--- a/packages/ui-react-utils/src/experimental.ts
+++ b/packages/ui-react-utils/src/experimental.ts
@@ -25,6 +25,28 @@ import { decorator } from '@instructure/ui-decorator'
 import { logWarn as warn } from '@instructure/console'
 import { ComponentClass } from 'react'
 
+/**
+ * ---
+ * category: utilities/react
+ * ---
+ * Flag React component and component props as experimental.
+ * Warnings will display in the console when experimental components/props
+ * props are used.
+ *
+ * ```js-code
+ *  class Example extends Component {
+ *    static propTypes = {
+ *      currentProp: PropTypes.func
+ *    }
+ *  }
+ *  export default experimental(['experimentalProp'])(Example)
+ * ```
+ *
+ * @module experimental
+ * @param {array} experimentalProps (if this argument is null or undefined, the entire component is flagged)
+ * @param {string} message
+ * @return {function} React component flagged as experimental
+ */
 const experimental =
   process.env.NODE_ENV == 'production'
     ? () => (ReactComponent: ComponentClass<any>) => ReactComponent
@@ -102,28 +124,4 @@ function warnExperimentalComponent(name: string, message = '') {
 }
 
 export default experimental
-export {
-  /**
-   * ---
-   * category: utilities/react
-   * ---
-   * Flag React component and component props as experimental.
-   * Warnings will display in the console when experimental components/props
-   * props are used.
-   *
-   * ```js-code
-   *  class Example extends Component {
-   *    static propTypes = {
-   *      currentProp: PropTypes.func
-   *    }
-   *  }
-   *  export default experimental(['experimentalProp'])(Example)
-   * ```
-   *
-   * @module experimental
-   * @param {array} experimentalProps (if this argument is null or undefined, the entire component is flagged)
-   * @param {string} message
-   * @return {function} React component flagged as experimental
-   */
-  experimental
-}
+export { experimental }

--- a/packages/ui-responsive/src/ResponsivePropTypes.ts
+++ b/packages/ui-responsive/src/ResponsivePropTypes.ts
@@ -70,13 +70,4 @@ const ResponsivePropTypes = {
 }
 
 export default ResponsivePropTypes
-export {
-  /**
-   * ---
-   * category: utilities/layout
-   * ---
-   * Custom prop types for `ui-responsive` components.
-   * @module ResponsivePropTypes
-   */
-  ResponsivePropTypes
-}
+export { ResponsivePropTypes }

--- a/packages/ui-utils/src/deepEqual.ts
+++ b/packages/ui-utils/src/deepEqual.ts
@@ -24,12 +24,5 @@
 
 import deepEqual from 'fast-deep-equal'
 
-/**
- * ---
- * category: utilities
- * ---
- * A wrapper for [fast-deep-equal](https://www.npmjs.com/package/fast-deep-equal)
- * @module deepEqual
- */
 export default deepEqual
 export { deepEqual }


### PR DESCRIPTION
Changes:   
- It uses the [TypeScript compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) instead of `JSDoc-api` JSDoc is outdated and its meant for JavaScript projects.  We use this to parse everything thats not a React component or a Markdown file. (the `utilities` menu in the sidebar).  
-  It gets type information for **functions** from the TypeScript types, so it can be deleted in the jsdoc (the `{Object}` part in `@param {Object} bla`).
- For non-function or complex utilities it gets the info from the JSDoc so we need to keep it (e.g. `withStyle`, `contains`).
- Removed `DateTime` and `conversions` and some custom PropTypes from the doc since they were parsed in a special way and contained no useful info.
- note that it cannot parse types if the jsdoc is at the export e.g.
   ```
   function myFunc() ...
   
   export {
   /**
   * here is the doc. The parser doesnt know the types, do not use this pattern
   */
   myFunc
   }
   ```

To test: 
- check all the functions in the `utilities` submenu, they should display equal or more information