### PR TITLE
fix(ui-text-input): better IconButton positioning inside TextInput when wrapped inside a Popover

### DIFF
--- a/packages/ui-text-input/src/TextInput/styles.ts
+++ b/packages/ui-text-input/src/TextInput/styles.ts
@@ -208,11 +208,11 @@ const generateStyle = (
     afterElement: {
       // the next couple lines (until the `label`) is needed so the IconButton looks OK inside the TextInput
       // explanation: if the content inside is not a button or a popover (which could contain a button) it should have some padding on the right
-      '& > :not(button):not([data-cid$="Popover"])': {
+      '& > :not(button):not([data-position^="Popover"])': {
         marginRight: componentTheme.padding
       },
       marginTop: '1px',
-      marginBottom: '1px',
+      marginBottom: '2px',
       display: 'flex',
       alignItems: 'center',
       ...sizeVariants[size!],


### PR DESCRIPTION
INSTUI-4628

the issue was caused by the previous solutions reliance on the `data-cid` prop which is not present in prod

test plan:
- check DateInput2 -> icon button should not have a padding on the right
- check the code