### PR TITLE
fix(many): fix focus ring not respecting theme overrides in Button and FileDrop

### DIFF
--- a/packages/__docs__/src/Params/index.tsx
+++ b/packages/__docs__/src/Params/index.tsx
@@ -49,13 +49,13 @@ class Params extends Component<ParamsProps> {
           <Table.Cell>
             <code>{param?.defaultValue}</code>
           </Table.Cell>
-          <Table.Cell>{this.renderDescription(param.description!)}</Table.Cell>
+          <Table.Cell>{this.renderDescription(param.description)}</Table.Cell>
         </Table.Row>
       )
     })
   }
 
-  renderDescription(description: string) {
+  renderDescription(description?: string) {
     return <div>{description && compileMarkdown(description)}</div>
   }
 

--- a/packages/__docs__/src/Returns/index.tsx
+++ b/packages/__docs__/src/Returns/index.tsx
@@ -25,6 +25,7 @@
 import { Component } from 'react'
 import { Table } from '@instructure/ui-table'
 import type { ReturnsProps } from './props'
+import Markdown from 'marked-react'
 
 class Returns extends Component<ReturnsProps> {
   render() {
@@ -41,7 +42,9 @@ class Returns extends Component<ReturnsProps> {
             <Table.Cell>
               <code>{this.props.types.type}</code>
             </Table.Cell>
-            <Table.Cell>{this.props.types.description}</Table.Cell>
+            <Table.Cell>
+              <Markdown>{this.props.types.description}</Markdown>
+            </Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>

--- a/packages/emotion/src/styleUtils/ThemeablePropValues.ts
+++ b/packages/emotion/src/styleUtils/ThemeablePropValues.ts
@@ -140,7 +140,7 @@ type Background = (typeof ThemeablePropValues.BACKGROUNDS)[BackgroundKeys]
 type BorderRadiiKeys = keyof typeof ThemeablePropValues.BORDER_RADII
 type BorderRadiiValues =
   (typeof ThemeablePropValues.BORDER_RADII)[BorderRadiiKeys]
-type BorderRadii = CSSShorthandValue<BorderRadiiValues>
+type BorderRadii = CSSShorthandValue<BorderRadiiValues | string> // TODO type better for actual values like '12px'
 
 // BORDER_WIDTHS
 type BorderWidthKeys = keyof typeof ThemeablePropValues.BORDER_WIDTHS

--- a/packages/emotion/src/styleUtils/__tests__/getShorthandPropValue.test.tsx
+++ b/packages/emotion/src/styleUtils/__tests__/getShorthandPropValue.test.tsx
@@ -93,4 +93,21 @@ describe('getShorthandPropValue', () => {
     const result = getShorthandPropValue(name, theme, values, 'border')
     expect(result).toEqual('0 0 auto 0.3rem')
   })
+
+  it('accepts CSS units if matchCSSUnits is true', () => {
+    const r1 = getShorthandPropValue(name, theme, '1px', 'border', true)
+    expect(r1).toEqual('1px')
+
+    const r2 = getShorthandPropValue(name, theme, 'sdfsdf', 'border', true)
+    expect(r2).toEqual('0')
+
+    const r3 = getShorthandPropValue(name, theme, '123', 'border', true)
+    expect(r3).toEqual('0')
+
+    const r4 = getShorthandPropValue(name, theme, 'medium 2rem', 'border', true)
+    expect(r4).toEqual('0.2rem 2rem')
+
+    const r5 = getShorthandPropValue(name, theme, '15px .2rem', 'border', true)
+    expect(r5).toEqual('15px .2rem')
+  })
 })

--- a/packages/emotion/src/styleUtils/getShorthandPropValue.ts
+++ b/packages/emotion/src/styleUtils/getShorthandPropValue.ts
@@ -29,55 +29,58 @@ import { logError as error } from '@instructure/console'
  * ---
  * category: utilities/themes
  * ---
- * Given a theme object, a string of space delimited prop values,
- * and a propName prefix, combines each prop value with the
- * propName prefix and replaces it with a corresponding value
- * from the theme object.
+ * Gets prop values from a theme object for the given values.
  * @module getShorthandPropValue
  *
- * @param {String} componentName - the name of the component (for error messages)
- * @param {Object} componentTheme - a theme object of keys and values
- * @param {String} propValue - a space delimited string of values
- * @param {String} propName - a prefix to combine with each propValue
- * @returns {String} a string with each value replaced with a value from the theme object
+ * @param componentName The name of the component (just for error messages)
+ * @param componentTheme A theme object of keys and values
+ * @param propValue A space delimited string of values e.g. `"small large none"`
+ * @param propName A prefix to combine with each propValue
+ * @param matchCSSUnits Match valid CSS strings too like `1rem`. It's a simple
+ * matcher, just checks whether the given string starts with a number and ends
+ * with a string, e.g. `4rem`, `.5em`, `2.6px`, `5foo`
+ * @returns A space-delimited string with the following values:
+ * - `0` for the `0` or `none` `propValue`
+ * - `auto` for the `auto` `propValue`
+ * - `100%` for the `circle` `propValue`
+ * - `999em` for the `pill` `propValue`
+ * - The value in the theme object for the `${propName}-{nth propValue}` key, e.g.
+ * `small` will be `0.2rem`
  */
 function getShorthandPropValue(
   componentName: string,
   componentTheme: Record<string, string | number>,
   propValue: string | undefined,
-  propName: string
+  propName: string,
+  matchCSSUnits: boolean = false
 ) {
   if (typeof propValue !== 'string' || isEmpty(componentTheme)) {
     return
   }
-
   return propValue
     .split(' ')
     .map((shortHandValue) => {
       if (shortHandValue === 'auto' || shortHandValue === '0') {
         return shortHandValue
-      }
-
-      if (shortHandValue === 'none') {
+      } else if (shortHandValue === 'none') {
         return '0'
-      }
-
-      if (shortHandValue === 'circle') {
+      } else if (shortHandValue === 'circle') {
         return '100%'
-      }
-
-      if (shortHandValue === 'pill') {
+      } else if (shortHandValue === 'pill') {
         return '999em'
+      } else if (matchCSSUnits) {
+        // try to match it as a CSS unit
+        // matches [number][string] like '4rem', '.5em', '2.6px'
+        if (shortHandValue.match(/^([+-]?(\d+\.?\d*|\.\d+))([a-zA-Z]+)$/)) {
+          return shortHandValue
+        }
       }
-
       const themeVariableName = camelize(`${propName}-${shortHandValue}`)
       const themeVariableValue = componentTheme[themeVariableName]
-
       error(
         typeof themeVariableValue !== 'undefined',
         `[${componentName}] '${themeVariableName}' is an invalid '${propName}' value.`
       )
-
       return themeVariableValue || '0'
     })
     .join(' ')

--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -308,9 +308,6 @@ class BaseButton extends Component<BaseButtonProps> {
         tabIndex={tabIndexValue}
         disabled={isDisabled || isReadOnly}
         css={styles?.baseButton}
-        focusRingBorderRadius={String(
-          (styles?.content as { borderRadius?: string | number })?.borderRadius
-        )}
         withFocusOutline={withFocusOutline}
       >
         <span css={styles?.content}>{this.renderChildren()}</span>

--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -359,6 +359,8 @@ const generateStyle = (
           appearance: 'none',
           textDecoration: 'none' /* for links styled as buttons */,
           touchAction: 'manipulation',
+          // This sets the focus ring's border radius displayed by the `View`
+          borderRadius: componentTheme.borderRadius,
 
           '&::-moz-focus-inner': {
             border: '0' /* removes default dotted focus outline in Firefox */

--- a/packages/ui-file-drop/src/FileDrop/index.tsx
+++ b/packages/ui-file-drop/src/FileDrop/index.tsx
@@ -369,16 +369,15 @@ class FileDrop extends Component<FileDropProps, FileDropState> {
           onDrop={this.handleChange}
         >
           <View
-            display="block"
-            position="relative"
-            withFocusOutline={this.state.isFocused}
-            borderRadius="large"
-            focusColor={focusColor}
-            height={height}
-            focusRingBorderRadius={String(
+            borderRadius={String(
               (styles?.fileDropLayout as { borderRadius?: string | number })
                 ?.borderRadius
             )}
+            display="block"
+            position="relative"
+            withFocusOutline={this.state.isFocused}
+            focusColor={focusColor}
+            height={height}
           >
             <span css={this.props.styles?.fileDropLabelContent}>
               <span css={this.props.styles?.fileDropLayout}>

--- a/packages/ui-react-utils/src/pickProps.ts
+++ b/packages/ui-react-utils/src/pickProps.ts
@@ -27,7 +27,7 @@
  * category: utilities/react
  * ---
  * Return a props object with only specified propTypes.
- * @module pickProps
+ *
  * @param props React component props
  * @param propTypesOrAllowedPropList React component propTypes or the list of allowed prop keys
  * @param include an optional array of prop names to include

--- a/packages/ui-view/src/View/props.ts
+++ b/packages/ui-view/src/View/props.ts
@@ -180,6 +180,7 @@ type ViewOwnProps = {
   /**
    * Accepts `small`, `medium`, `large`, `circle`, and `pill`. Border radius can be
    * assigned to individual corners in CSS shorthand style (e.g., `"medium large none pill"`).
+   * Also accepts valid CSS length values like `1rem` or `12px`
    */
   borderRadius?: BorderRadii
   /**
@@ -201,6 +202,9 @@ type ViewOwnProps = {
    */
   overscrollBehavior?: 'auto' | 'contain' | 'none'
   /**
+   * DEPRECATED, this prop does nothing. Use the focusOutlineOffset theme
+   * variable
+   *
    * Sets the radius of the focus border ring.
    *
    * For offset type, the given value is increased by the difference between the focus ring' offset and the focus ring's width.
@@ -252,7 +256,7 @@ const propTypes: PropValidators<PropKeys> = {
   children: PropTypes.node,
   textAlign: PropTypes.oneOf(['start', 'center', 'end']),
   borderWidth: ThemeablePropTypes.borderWidth,
-  borderRadius: ThemeablePropTypes.borderRadius,
+  borderRadius: PropTypes.string,
   borderColor: PropTypes.string,
   background: PropTypes.oneOf([
     'transparent',


### PR DESCRIPTION
This was already fixed in INSTUI-4375, but it broke with the focus rewrite. This PR introduces a more stable method to accomplish the same thing. Instead of a new prop, now the borderRadius prop on View accepts CSS units like '1rem'

To test:
- Set different `borderRadius` values in the `View` examples when it has a focus ring.
- Check if `focusOutlineWidth`, `focusOutlineOffset`, `focusOutlineInset` theme variables are working the same for `View` by overriding them and comparing the result on `master`
- Override the `borderRadius` theme variable in the `Button` and `FileDrop` examples. it should now respect the theme variable and not use the default value of the View.

Fixes INSTUI-4641