### PR TITLE
feat(ui-color-picker): add type=button to color preset's buttons for better form handling

### DIFF
--- a/packages/ui-color-picker/src/ColorPreset/index.tsx
+++ b/packages/ui-color-picker/src/ColorPreset/index.tsx
@@ -273,6 +273,7 @@ class ColorPreset extends Component<ColorPresetProps, ColorPresetState> {
         padding="0"
         cursor={this.props.disabled ? 'not-allowed' : 'auto'}
         as="button"
+        type="button"
         aria-label={screenReaderLabel}
         {...(selectOnClick
           ? { onClick: () => this.props.onSelect(color) }


### PR DESCRIPTION
TEST_PLAN:
Check if `ColorPreset`'s buttons have the `type="button"` attribute

INSTUI-4647