### PR TITLE
chore(ui-tag)Remove maxWidth from tag

### DIFF
--- a/packages/shared-types/src/ComponentThemeVariables.ts
+++ b/packages/shared-types/src/ComponentThemeVariables.ts
@@ -1425,7 +1425,6 @@ export type TagTheme = {
   focusOutlineColor: Colors['contrasts']['blue4570']
   focusOutlineWidth: Border['widthMedium']
   focusOutlineStyle: Border['style']
-  maxWidth: string | 0
   iconMargin: Spacing['small']
   transitionTiming: string
   defaultBackgroundHover: Colors['contrasts']['grey1214']

--- a/packages/ui-tag/src/Tag/README.md
+++ b/packages/ui-tag/src/Tag/README.md
@@ -69,17 +69,6 @@ type: example
 </div>
 ```
 
-### Max-width
-
-```js
----
-type: example
----
-<Tag
-  text="Long string of text designed to trigger overflow"
-/>
-```
-
 ### Inline variant
 
 This variant is designed to look similar to the surrounding text.

--- a/packages/ui-tag/src/Tag/styles.ts
+++ b/packages/ui-tag/src/Tag/styles.ts
@@ -206,7 +206,6 @@ const generateStyle = (componentTheme: TagTheme, props: TagProps): TagStyle => {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      maxWidth: componentTheme.maxWidth,
       ...sizeVariants[size!].text
     },
     icon: {

--- a/packages/ui-tag/src/Tag/theme.ts
+++ b/packages/ui-tag/src/Tag/theme.ts
@@ -58,7 +58,6 @@ const generateComponentTheme = (theme: Theme): TagTheme => {
     focusOutlineColor: colors?.contrasts?.blue4570,
     focusOutlineWidth: borders.widthMedium,
     focusOutlineStyle: borders.style,
-    maxWidth: '10rem',
     iconMargin: spacing.xSmall,
     transitionTiming: '0.2s',
 


### PR DESCRIPTION
Remove maxWidth style variable from Tag:

The full text content of the Tag should always be visible on the documentation page:
https://instructure.design/#Tag/#Sizes
`<Tag
  text="Long string of text designed to trigger overflow"
/>`

