### PR TITLE
fix(ui-testable): handle ref forwarding in testable decorator

### DIFF
--- a/packages/ui-testable/src/testable.ts
+++ b/packages/ui-testable/src/testable.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { ComponentClass, ComponentState } from 'react'
+import React, { ComponentClass, ComponentState } from 'react'
 
 import { decorator } from '@instructure/ui-decorator'
 import { findDOMNode } from '@instructure/ui-dom-utils'
@@ -124,7 +124,21 @@ const testable =
             })
           }
         }
-        return TestableComponent
+
+        // Forward refs properly
+        const ForwardedComponent = React.forwardRef((props: any, ref: any) => {
+          // Filter out the ref from props to avoid the warning
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { ref: propRef, ...restProps } = props
+          // Pass the ref through to the component if it has a ref prop
+          const componentProps = ref ? { ...restProps, ref } : restProps
+          return React.createElement(TestableComponent, componentProps)
+        })
+
+        ForwardedComponent.displayName = displayName
+        ;(ForwardedComponent as any).selector = selector
+
+        return ForwardedComponent
       })
 
 export default testable


### PR DESCRIPTION
The testable decorator was passing ref as a regular prop instead of using
React's ref forwarding mechanism, causing React warnings when components
decorated with @testable() received a ref prop.
    
This fix updates the decorator to use React.forwardRef and filters out
the ref prop before passing props to the wrapped component, eliminating
the warning: "ref is not a prop. Trying to access it will result in
undefined being returned."