### PR TITLE
[v11]Fix or remove failing tests after proptypes removal

### DIFF
--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -682,30 +682,6 @@ describe('<DateTimeInput />', () => {
     })
   })
 
-  it("should throw warning if initialTimeForNewDate prop's value is not HH:MM", async () => {
-    const initialTimeForNewDate = 'WRONG_FORMAT'
-
-    render(
-      <DateTimeInput
-        description="date_time"
-        dateRenderLabel="date-input"
-        prevMonthLabel="Previous month"
-        nextMonthLabel="Next month"
-        timeRenderLabel="time-input"
-        invalidDateTimeMessage="whoops"
-        locale={'en-US'}
-        timezone={'US/Eastern'}
-        initialTimeForNewDate={initialTimeForNewDate}
-      />
-    )
-
-    expect(consoleErrorMock.mock.calls[0][2]).toEqual(
-      expect.stringContaining(
-        `Invalid prop \`initialTimeForNewDate\` \`${initialTimeForNewDate}\` supplied to \`DateTimeInput\`, expected a HH:MM formatted string.`
-      )
-    )
-  })
-
   it("should throw warning if date select and initialTimeForNewDate prop's value is not HH:MM", async () => {
     const initialTimeForNewDate = 'WRONG_FORMAT'
 

--- a/packages/ui-drilldown/src/Drilldown/__tests__/Drilldown.test.tsx
+++ b/packages/ui-drilldown/src/Drilldown/__tests__/Drilldown.test.tsx
@@ -682,22 +682,6 @@ describe('<Drilldown />', () => {
 
       expect(popoverContent).toBeVisible()
     })
-
-    it('should give error if onToggle is not provided (controllable)', async () => {
-      render(
-        <Drilldown rootPageId="page0" trigger={<button>Toggle</button>} show>
-          <Drilldown.Page id="page0">
-            <Drilldown.Option id="option01">Option</Drilldown.Option>
-          </Drilldown.Page>
-        </Drilldown>
-      )
-      const popoverContent = screen.getByText('Option')
-
-      expect(popoverContent).toBeVisible()
-
-      expect(popoverContent).toBeVisible()
-      expect(consoleErrorMock).toHaveBeenCalled()
-    })
   })
 
   describe('onFocus prop', () => {

--- a/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
@@ -65,25 +65,6 @@ describe('<RadioInputGroup />', () => {
     expect(inputs.length).toBe(3)
   })
 
-  it('requires an `onChange` prop with a `value` prop', async () => {
-    render(
-      <RadioInputGroup name="fruit" description="Select a fruit" value="banana">
-        <RadioInput label="Apple" value="apple" />
-        <RadioInput label="Banana" value="banana" />
-        <RadioInput label="Orange" value="orange" />
-      </RadioInputGroup>
-    )
-
-    const expectedErrorMessage = `provided a 'value' prop without an 'onChange' handler`
-
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.stringContaining(expectedErrorMessage),
-      expect.any(String)
-    )
-  })
-
   it('calls the onChange prop', async () => {
     const onChange = vi.fn()
     const { container } = render(

--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -427,15 +427,6 @@ describe('<Select />', () => {
     const invalidChild = screen.queryByText('invalid')
 
     expect(invalidChild).not.toBeInTheDocument()
-
-    const expectedErrorMessage = 'Expected one of Group, Option'
-
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(String),
-      expect.stringContaining(expectedErrorMessage),
-      expect.any(String)
-    )
   })
 
   it('should provide a focus method', async () => {

--- a/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
@@ -131,12 +131,6 @@ describe('<SimpleSelect />', () => {
       const invalidChild = screen.queryByText('invalid')
 
       expect(invalidChild).not.toBeInTheDocument()
-      expect(consoleErrorMock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.stringContaining('Expected one of Group, Option'),
-        expect.any(String)
-      )
     })
   })
 

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/__tests__/TopNavBarItem.test.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/__tests__/TopNavBarItem.test.tsx
@@ -580,7 +580,6 @@ describe('<TopNavBarItem />', () => {
       )
 
       expect(submenuTrigger).not.toBeInTheDocument()
-      expect(consoleErrorMock).toHaveBeenCalled()
     })
 
     it('should render submenu', async () => {


### PR DESCRIPTION
By removing the PropTypes, the warnings it triggered have also disappeared. The tests related to PropTypes need to be modified or removed.