### PR TITLE
fix(ui-react-utils): fix "ref is not a prop" warning spam

### DIFF
--- a/packages/ui-react-utils/src/safeCloneElement.ts
+++ b/packages/ui-react-utils/src/safeCloneElement.ts
@@ -29,7 +29,8 @@ import {
   ReactElement,
   ReactNode,
   DOMElement,
-  cloneElement
+  cloneElement,
+  version
 } from 'react'
 
 import { logWarn as warn } from '@instructure/console'
@@ -63,10 +64,15 @@ function safeCloneElement<
   // Support both React 18 (element.ref) and React 19+ (element.props.ref)
   // TypeScript's ReactElement type does not always include a 'ref' property,
   // so we use 'as any' to safely access it for React 18 compatibility.
-  const originalRef =
-    element.props && element.props.ref !== undefined
-      ? element.props.ref
-      : (element as any).ref
+  let isReact19OrNewer = true
+  const versArr = version.split('.', 1)
+  if (versArr.length > 0 && parseInt(versArr[0], 10) < 19) {
+    isReact19OrNewer = false
+  }
+  // this needs to happen in such tricky way because React 18 and earlier
+  // throw warning when one tries to access element.props.ref, see
+  // https://github.com/facebook/react/blob/18-3-1/packages/react/src/jsx/ReactJSXElement.js#L108
+  const originalRef = isReact19OrNewer ? element.props.ref : element.ref
   const originalRefIsAFunction = typeof originalRef === 'function'
   const cloneRefIsFunction = typeof cloneRef === 'function'
 


### PR DESCRIPTION
the issue was that in React 18 or earlier if one tries to access props.ref it will emit this warning. This PR changes it so its only accessed if the React version number is 19 or above

To test: Launch app locally so you see the error messages. Component pages like Tooltip should not have any `Warning: [object Object]: ref is not a prop. Trying to access it will result in undefined being returned.` error messages

Fixes INSTUI-4664