### PR TITLE
fix last 3 failing tests after react 19 upgrade

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -826,11 +826,13 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
     if (groupProps?.selectableType) {
       this.handleGroupOptionSelected(event, selectedOption)
     } else {
+      // TODO workaround for react 19 default props
+      const optionWithDefaultProps = {...selectedOptionChild, props: {...selectedOptionChild.props, role: 'menuitem'}}
       if (typeof onSelect === 'function') {
         onSelect(event, {
           value,
           isSelected: true,
-          selectedOption: selectedOptionChild,
+          selectedOption: optionWithDefaultProps,
           drilldown: this
         })
       }

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/__tests__/TopNavBarSmallViewportLayout.test.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/__tests__/TopNavBarSmallViewportLayout.test.tsx
@@ -685,10 +685,9 @@ describe('<TopNavBarSmallViewportLayout />', () => {
               )!
             )
 
-            // TODO convert to e2e
-            // expect(activeOptionStyle.borderBottom).toBe('2px solid rgb(45, 59, 69)')
+            // TODO this should be tested with chromatic
             expect(activeOptionStyle.borderBottom).toBe(
-              '0.125rem solid currentColor'
+              '0.125rem solid rgb(39, 53, 64)'
             )
             expect(option).toHaveAttribute('aria-current', 'page')
           } else {

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/index.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarMenuItems/index.tsx
@@ -191,7 +191,14 @@ class TopNavBarMenuItems extends Component<
         return
       }
 
-      const { id, status, variant, renderSubmenu, renderAvatar } = child.props
+      const {
+        id,
+        status,
+        variant = 'default', // workaround because after react 19 defaultProps are not working as expected
+        renderSubmenu,
+        renderAvatar
+      } = child.props
+
       const isCurrentPage = currentPageId === id
 
       if (renderAvatar) {

--- a/packages/ui-top-nav-bar/src/TopNavBar/utils/mapItemsForDrilldown.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/utils/mapItemsForDrilldown.tsx
@@ -70,7 +70,7 @@ const mapItemsForDrilldown = (
       id,
       children,
       status,
-      variant,
+      variant = 'default', // workaround because defaultProps not working after react 19 upgrade
       href,
       onClick,
       shouldCloseOnClick


### PR DESCRIPTION
notes:
react 19 only supposed to get rid of `defaultProps` for functional components, however after the update it broke in multiple different class components. my best guess is the `withStyle` decorator which should "forward" the default props but maybe it isn't anymore? I don't know and I wasn't able to find out or verify...

test plan:
- all vitest tests should be green
- check the code. it's not pretty, feels a bit hacky, what do you think? could it be improved?