### PR TITLE
INSTUI-4672 Add the (almost complete) regression test suite, fix small a11y issues, SSR errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
+        "@types/node": "^22",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.5.1",
         "@vitest/eslint-plugin": "^1.2.1",
@@ -57,7 +58,7 @@
         "webpack": "^5.99.9"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "yarn": "YARN NO LONGER USED - use npm instead."
       }
     },
@@ -7496,9 +7497,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
-      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -26692,6 +26697,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.5.1",
     "@vitest/eslint-plugin": "^1.2.1",
+    "@types/node": "^22",
     "chai": "^4.4.1",
     "chalk": "^4.1.2",
     "commitizen": "^4.3.1",
@@ -101,7 +102,7 @@
     "@types/jest": "needed because https://github.com/testing-library/jest-dom/issues/544 recheck if fixed"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=22",
     "yarn": "YARN NO LONGER USED - use npm instead."
   },
   "config": {

--- a/packages/ui-calendar/src/Calendar/index.tsx
+++ b/packages/ui-calendar/src/Calendar/index.tsx
@@ -28,11 +28,11 @@ import { View } from '@instructure/ui-view'
 import {
   safeCloneElement,
   callRenderProp,
-  omitProps
+  omitProps,
+  withDeterministicId
 } from '@instructure/ui-react-utils'
 import { createChainedFunction } from '@instructure/ui-utils'
 import { logError as error } from '@instructure/console'
-import { uid } from '@instructure/uid'
 import { AccessibleContent } from '@instructure/ui-a11y-content'
 
 import { testable } from '@instructure/ui-testable'
@@ -64,6 +64,7 @@ import { SimpleSelect } from '@instructure/ui-simple-select'
 category: components
 ---
 **/
+@withDeterministicId()
 @withStyle(generateStyle, generateComponentTheme)
 @testable()
 class Calendar extends Component<CalendarProps, CalendarState> {
@@ -82,14 +83,15 @@ class Calendar extends Component<CalendarProps, CalendarState> {
   }
 
   ref: Element | null = null
-  private _weekdayHeaderIds = (
-    this.props.renderWeekdayLabels || this.defaultWeekdays
-  ).reduce((ids: Record<number, string>, _label, i) => {
-    return { ...ids, [i]: uid(`weekday-header-${i}`) }
-  }, {})
+  private _weekdayHeaderIds
+
   constructor(props: CalendarProps) {
     super(props)
-
+    this._weekdayHeaderIds = (
+      this.props.renderWeekdayLabels || this.defaultWeekdays
+    ).reduce((ids: Record<number, string>, _label, i) => {
+      return { ...ids, [i]: this.props.deterministicId!('weekday-header') }
+    }, {})
     this.state = this.calculateState(
       this.locale(),
       this.timezone(),

--- a/packages/ui-calendar/src/Calendar/props.ts
+++ b/packages/ui-calendar/src/Calendar/props.ts
@@ -38,6 +38,7 @@ import { ReactElement } from 'react'
 import type { CalendarDayProps } from './Day/props'
 import { Renderable } from '@instructure/shared-types'
 import type { Moment } from '@instructure/ui-i18n'
+import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
 type CalendarOwnProps = {
   /**
@@ -178,7 +179,8 @@ type AllowedPropKeys = Readonly<Array<PropKeys>>
 
 type CalendarProps = CalendarOwnProps &
   WithStyleProps<CalendarTheme, CalendarStyle> &
-  OtherHTMLAttributes<CalendarOwnProps>
+  OtherHTMLAttributes<CalendarOwnProps> &
+  WithDeterministicIdProps
 
 type CalendarStyle = ComponentStyle<
   'navigation' | 'navigationWithButtons' | 'weekdayHeader' | 'yearPicker'

--- a/packages/ui-codemods/lib/__node_tests__/runTest.ts
+++ b/packages/ui-codemods/lib/__node_tests__/runTest.ts
@@ -45,10 +45,10 @@ export function runTest(codemod: Transform) {
   entries.forEach((entry) => {
     if (entry.isFile() && entry.name.includes('input')) {
       const isWarningTest = entry.name.includes('.warning.input')
-      const inputPath = path.join(entry.path, entry.name)
+      const inputPath = path.join(entry.parentPath, entry.name)
       const input = fs.readFileSync(inputPath, 'utf8')
       const expectedName = entry.name.replace('input', 'output')
-      const expectedPath = path.join(entry.path, expectedName)
+      const expectedPath = path.join(entry.parentPath, expectedName)
       const expected = fs.readFileSync(expectedPath, 'utf8')
 
       // eslint-disable-next-line no-console
@@ -61,12 +61,17 @@ export function runTest(codemod: Transform) {
       )
 
       if (isWarningTest) {
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
         try {
           const j = jscodeshift.withParser('tsx')
           const fileInfo = { path: inputPath, source: input }
-          const api = { jscodeshift: j, j: j, stats: () => { }, report: () => { } }
+          const api = {
+            jscodeshift: j,
+            j: j,
+            stats: () => {},
+            report: () => {}
+          }
           const options = {}
 
           // Run codemod withouth comparison

--- a/packages/ui-drilldown/src/Drilldown/DrilldownOption/__tests__/DrilldownOption.test.tsx
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownOption/__tests__/DrilldownOption.test.tsx
@@ -211,7 +211,7 @@ describe('<Drilldown.Option />', () => {
       )
       const option = screen.getByLabelText('Option')
 
-      expect(option).toHaveAttribute('role', 'button')
+      expect(option).toHaveAttribute('role', 'menuitem')
       expect(option).toHaveAttribute('aria-haspopup', 'true')
     })
   })

--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -1126,7 +1126,7 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
     if (subPageId) {
       optionProps.renderAfterLabel = <IconArrowOpenEndSolid />
       optionProps['aria-haspopup'] = true
-      optionProps.role = customRole || 'button'
+      optionProps.role = customRole || 'menuitem'
       warn(
         !renderAfterLabel,
         `The prop "renderAfterLabel" is reserved on item with id: "${id}". When it has "subPageId" provided, a navigation arrow will render after the label.`

--- a/packages/ui-heading/src/Heading/README.md
+++ b/packages/ui-heading/src/Heading/README.md
@@ -49,9 +49,9 @@ Pre-configured and with unique styles, the `ai-headings` are used for standardiz
 type: example
 ---
 <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
- <Heading aiVariant="stacked">Nutrition Facts</Heading>
- <Heading aiVariant="horizontal">Nutrition Facts</Heading>
- <Heading aiVariant="iconOnly">Nutrition Facts</Heading>
+  <Heading aiVariant="stacked" level="h2">Nutrition Facts</Heading>
+  <Heading aiVariant="horizontal" level="h3">Nutrition Facts</Heading>
+  <Heading aiVariant="iconOnly" level="h4">Nutrition Facts</Heading>
 </div>
 ```
 

--- a/packages/ui-options/src/Options/Item/styles.ts
+++ b/packages/ui-options/src/Options/Item/styles.ts
@@ -63,12 +63,11 @@ const generateStyle = (
       background: componentTheme.selectedBackground,
       color: componentTheme.highlightedLabelColor
     },
-    disabled: { cursor: 'not-allowed', opacity: 0.5 },
+    disabled: { cursor: 'not-allowed', opacity: 0.68 },
     'highlighted-disabled': {
       background: componentTheme.highlightedBackground,
       color: componentTheme.highlightedLabelColor,
-      cursor: 'not-allowed',
-      opacity: 0.5
+      cursor: 'not-allowed'
     },
     'selected-highlighted': {
       background: componentTheme.selectedHighlightedBackground,

--- a/packages/ui-select/src/Select/index.tsx
+++ b/packages/ui-select/src/Select/index.tsx
@@ -780,8 +780,14 @@ class Select extends Component<SelectProps> {
       onBlur: utils.createChainedFunction(onBlur, onRequestHideOptions),
       ...overrideProps
     }
-
-    return <TextInput {...triggerProps} {...getInputProps(inputProps)} />
+    // suppressHydrationWarning is needed because `role` depends on the browser type
+    return (
+      <TextInput
+        {...triggerProps}
+        {...getInputProps(inputProps)}
+        suppressHydrationWarning
+      />
+    )
   }
 
   render() {

--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/__tests__/TopNavBarSmallViewportLayout.test.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarLayout/SmallViewportLayout/__tests__/TopNavBarSmallViewportLayout.test.tsx
@@ -425,7 +425,7 @@ describe('<TopNavBarSmallViewportLayout />', () => {
       const dropdownMenu = await screen.findByRole('menu')
       expect(dropdownMenu).toBeInTheDocument()
 
-      const option = await within(dropdownMenu).findByRole('button')
+      const option = await within(dropdownMenu).findByRole('menuitem')
       expect(option).toHaveAttribute('id', `TestItem1`)
 
       fireEvent.click(option)
@@ -467,7 +467,7 @@ describe('<TopNavBarSmallViewportLayout />', () => {
         const dropdownMenu = await screen.findByRole('menu')
         expect(dropdownMenu).toBeInTheDocument()
 
-        const option = await within(dropdownMenu).findByRole('button')
+        const option = await within(dropdownMenu).findByRole('menuitem')
         expect(option).toHaveAttribute('id', `TestItem1`)
 
         fireEvent.click(option)

--- a/regression-test/cypress.config.ts
+++ b/regression-test/cypress.config.ts
@@ -26,7 +26,7 @@ import { installPlugin } from '@chromatic-com/cypress'
 
 export default defineConfig({
   env: {
-    delay: 100
+    delay: 100 // Chromatic snapshot delay time
   },
   e2e: {
     setupNodeEvents(on, config) {

--- a/regression-test/cypress/e2e/spec.cy.ts
+++ b/regression-test/cypress/e2e/spec.cy.ts
@@ -37,7 +37,7 @@ afterEach(() => {
   // After each test, assert that console.error was not called
   // Add a small wait if your application might log errors asynchronously
   cy.wait(100).then(() => {
-    expect(windowErrorSpy).to.not.be.called
+    expect(windowErrorSpy).to.have.callCount(0)
   })
 })
 
@@ -70,28 +70,200 @@ const axeOptions: { runOnly: RunOnly } = {
 }
 
 describe('visual regression test', () => {
-  it('check button', () => {
-    cy.visit('http://localhost:3000/button')
+  it('Metric, Pill, Tag, TimeSelect', () => {
+    cy.visit('http://localhost:3000/small-components')
     cy.injectAxe()
     cy.checkA11y('.axe-test', axeOptions, terminalLog)
   })
 
-  it('check alert', () => {
+  it('Alert', () => {
     cy.visit('http://localhost:3000/alert')
     cy.injectAxe()
     cy.checkA11y('.axe-test', axeOptions, terminalLog)
   })
 
-  it('check avatar', () => {
+  it('Avatar', () => {
     cy.visit('http://localhost:3000/avatar')
     cy.wait(300) // images render a frame later, Chromatic needs a bit more delay
     cy.injectAxe()
     cy.checkA11y('.axe-test', axeOptions, terminalLog)
   })
 
-  it('check tooltip', () => {
+  it('Badge', () => {
+    cy.visit('http://localhost:3000/badge')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Billboard', () => {
+    cy.visit('http://localhost:3000/billboard')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Breadcrumb', () => {
+    cy.visit('http://localhost:3000/breadcrumb')
+    cy.wait(300) // wait for text to be truncated
+    //TODO There are a11y issues, fix INSTUI-4676 before uncommenting
+    //cy.injectAxe()
+    //cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Button and derivatives', () => {
+    cy.visit('http://localhost:3000/button')
+    cy.wait(100)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Byline', () => {
+    cy.visit('http://localhost:3000/byline')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Calendar', () => {
+    cy.visit('http://localhost:3000/calendar')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Checkbox', () => {
+    cy.visit('http://localhost:3000/checkbox')
+    cy.wait(100) // needed so checkbox dont trigger axe check fails
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Checkboxgroup', () => {
+    cy.visit('http://localhost:3000/checkboxgroup')
+    cy.wait(300)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Contextview', () => {
+    cy.visit('http://localhost:3000/contextview')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Dateinput, DateInput2', () => {
+    cy.visit('http://localhost:3000/dateinput')
+    cy.wait(400)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('DateTimeInput', () => {
+    cy.visit('http://localhost:3000/datetimeinput')
+    cy.wait(400)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Drilldown', () => {
+    cy.visit('http://localhost:3000/drilldown')
+    cy.wait(300) // Drilldown dropdown renders a frame later, Chromatic needs a bit more delay
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Filedrop', () => {
+    cy.visit('http://localhost:3000/filedrop')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Form errors', () => {
+    cy.visit('http://localhost:3000/form-errors')
+    cy.wait(300)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Heading', () => {
+    cy.visit('http://localhost:3000/heading')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Img', () => {
+    cy.visit('http://localhost:3000/img')
+    cy.wait(100) // images may render a frame later
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Link', () => {
+    cy.visit('http://localhost:3000/link')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Menu', () => {
+    cy.visit('http://localhost:3000/menu')
+    cy.wait(100)
+    // TODO Fix INSTUI-4677 before enabling this
+    //cy.injectAxe()
+    //cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Options', () => {
+    cy.visit('http://localhost:3000/options')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Pagination', () => {
+    cy.visit('http://localhost:3000/pagination')
+    cy.wait(400) // needed so tooltips dont trigger axe check fails
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Progressbar', () => {
+    cy.visit('http://localhost:3000/progressbar')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Select, SimpleSelect', () => {
+    cy.visit('http://localhost:3000/select')
+    cy.wait(300)
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Table', () => {
+    cy.visit('http://localhost:3000/table')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Tabs', () => {
+    cy.visit('http://localhost:3000/tabs')
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('Tooltip', () => {
     cy.visit('http://localhost:3000/tooltip')
     cy.wait(300) // tooltips render a frame later, Chromatic needs a bit more delay
+    cy.injectAxe()
+    cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('TreeBrowser', () => {
+    cy.visit('http://localhost:3000/treebrowser')
+    cy.wait(600) // large timeout is needed for CI (to finish animation?)
+    // TODO axe fails with color contrast issues, try to remove animations from TreeBrowser
+    //cy.injectAxe()
+    //cy.checkA11y('.axe-test', axeOptions, terminalLog)
+  })
+
+  it('View', () => {
+    cy.visit('http://localhost:3000/view')
     cy.injectAxe()
     cy.checkA11y('.axe-test', axeOptions, terminalLog)
   })

--- a/regression-test/src/app/NoSSR.tsx
+++ b/regression-test/src/app/NoSSR.tsx
@@ -22,53 +22,20 @@
  * SOFTWARE.
  */
 
-'use client'
-import { Link } from 'instructure-ui/ui-link/es/index'
+import dynamic from 'next/dynamic'
+import React from 'react'
 
-const components = [
-  'small-components',
-  'alert',
-  'avatar',
-  'badge',
-  'billboard',
-  'breadcrumb',
-  'button',
-  'tooltip',
-  'byline',
-  'calendar',
-  'checkbox',
-  'checkboxgroup',
-  'colorpicker',
-  'contextview',
-  'dateinput',
-  'datetimeinput',
-  'drilldown',
-  'filedrop',
-  'form-errors',
-  'heading',
-  'img',
-  'link',
-  'menu',
-  'options',
-  'pagination',
-  'progressbar',
-  'select',
-  'table',
-  'tabs',
-  'treebrowser',
-  'view'
-]
+const ComponentWithChildren = (props: any) => (
+  <React.Fragment>{props.children}</React.Fragment>
+)
+/**
+ * This component disables SSR for its children. Use it as:
+ * ```
+ * <NoSSR>here is no SSR</NoSSR>
+ * ```
+ */
+const NoSSR = dynamic(() => Promise.resolve(ComponentWithChildren), {
+  ssr: false
+})
 
-export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-6">
-      <ul>
-        {components.map((component) => (
-          <li key={component}>
-            <Link href={component}>{component}</Link>
-          </li>
-        ))}
-      </ul>
-    </main>
-  )
-}
+export { NoSSR }

--- a/regression-test/src/app/badge/page.tsx
+++ b/regression-test/src/app/badge/page.tsx
@@ -1,0 +1,251 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Badge as b } from 'instructure-ui/ui-badge/es/index'
+import {
+  Button as btn,
+  IconButton as icb
+} from 'instructure-ui/ui-buttons/es/index'
+import { IconUserSolid as ius } from 'instructure-ui/ui-icons/es/index'
+import { Flex as flx } from 'instructure-ui/ui-flex/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import {
+  AccessibleContent as ac,
+  ScreenReaderContent as src
+} from 'instructure-ui/ui-a11y-content/es/index'
+
+// alias to avoid TS/SSR friction like other pages
+const Badge = b as any
+const Button = btn as any
+const IconButton = icb as any
+const IconUserSolid = ius as any
+const Flex = flx as any
+const View = vw as any
+const AccessibleContent = ac as any
+const ScreenReaderContent = src as any
+
+export default function BadgePage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Making badges accessible */}
+      <div>
+        <Badge
+          count={99}
+          margin="0 medium 0 0"
+          formatOutput={function (formattedCount: any) {
+            return (
+              <AccessibleContent
+                alt={`You have ${formattedCount} new edits to review`}
+              >
+                {formattedCount}
+              </AccessibleContent>
+            )
+          }}
+        >
+          <IconButton
+            renderIcon={IconUserSolid}
+            screenReaderLabel="Edits"
+            withBorder={false}
+            withBackground={false}
+          />
+        </Badge>
+        <Badge
+          type="notification"
+          formatOutput={function () {
+            return (
+              <ScreenReaderContent>
+                You have new edits to review
+              </ScreenReaderContent>
+            )
+          }}
+        >
+          <IconButton
+            renderIcon={IconUserSolid}
+            screenReaderLabel="Edits"
+            withBorder={false}
+            withBackground={false}
+          />
+        </Badge>
+      </div>
+
+      {/* Limit the count */}
+      <div>
+        <Badge count={105} countUntil={100} margin="0 medium 0 0">
+          <Button>Inbox</Button>
+        </Badge>
+        <Badge
+          count={250}
+          countUntil={100}
+          formatOverflowText={(_count: number, countUntil: number) =>
+            `more than ${countUntil}`
+          }
+        >
+          <Button>Assignments</Button>
+        </Badge>
+      </div>
+
+      {/* Standalone, notification and color variants */}
+      <div>
+        <Flex padding="small" display="inline-flex" alignItems="center">
+          <Badge standalone count={6} margin="0 small 0 0" />
+          <Badge
+            type="notification"
+            standalone
+            formatOutput={function () {
+              return (
+                <ScreenReaderContent>
+                  This is a notification
+                </ScreenReaderContent>
+              )
+            }}
+          />
+        </Flex>
+      </div>
+      <div>
+        <Flex padding="small" display="inline-flex" alignItems="center">
+          <Badge standalone variant="success" count={12} margin="0 small 0 0" />
+          <Badge
+            variant="success"
+            type="notification"
+            standalone
+            formatOutput={function () {
+              return (
+                <ScreenReaderContent>
+                  This is a success notification
+                </ScreenReaderContent>
+              )
+            }}
+          />
+        </Flex>
+      </div>
+      <div>
+        <Flex padding="small" display="inline-flex" alignItems="center">
+          <Badge
+            standalone
+            variant="danger"
+            count={18}
+            countUntil={10}
+            margin="0 small 0 0"
+          />
+          <Badge
+            variant="danger"
+            type="notification"
+            standalone
+            formatOutput={function () {
+              return (
+                <ScreenReaderContent>
+                  This is a danger notification
+                </ScreenReaderContent>
+              )
+            }}
+          />
+        </Flex>
+      </div>
+      <div>
+        <View display="inline-flex" background="primary-inverse">
+          <Flex
+            padding="small"
+            display="inline-flex"
+            alignItems="center"
+            background="primary-inverse"
+          >
+            <Badge
+              standalone
+              variant="inverse"
+              count={8}
+              margin="0 small 0 0"
+            />
+            <Badge
+              variant="inverse"
+              type="notification"
+              standalone
+              formatOutput={function () {
+                return (
+                  <ScreenReaderContent>
+                    This is a danger notification
+                  </ScreenReaderContent>
+                )
+              }}
+            />
+          </Flex>
+        </View>
+      </div>
+
+      {/* Placement */}
+      <div>
+        <View as="div" margin="0 0 medium">
+          <Badge count={21} margin="0 large 0 0" placement="top start">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+          <Badge count={21} margin="0 large 0 0">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+          <Badge count={21} margin="0 large 0 0" placement="bottom start">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+          <Badge count={21} margin="0 large 0 0" placement="bottom end">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+          <Badge count={21} margin="0 large 0 0" placement="start center">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+          <Badge count={21} placement="end center">
+            <IconButton
+              renderIcon={IconUserSolid}
+              screenReaderLabel="Edit page"
+              withBorder={false}
+              withBackground={false}
+            />
+          </Badge>
+        </View>
+      </div>
+    </main>
+  )
+}

--- a/regression-test/src/app/billboard/page.tsx
+++ b/regression-test/src/app/billboard/page.tsx
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Billboard as bb } from 'instructure-ui/ui-billboard/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import {
+  IconUserLine as iul,
+  IconGradebookLine as igl,
+  IconPlusLine as ipl
+} from 'instructure-ui/ui-icons/es/index'
+
+const Billboard = bb as any
+const View = vw as any
+const IconUserLine = iul as any
+const IconGradebookLine = igl as any
+const IconPlusLine = ipl as any
+
+export default function BillboardPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Static Billboard */}
+      <Billboard
+        size="medium"
+        heading="Well, this is awkward."
+        message="Think there should be something here?"
+        hero={(size: string) => <IconGradebookLine size={size} />}
+      />
+
+      {/* Structure examples */}
+      <View display="block" width="400px">
+        <Billboard
+          margin="large"
+          heading="404"
+          message="Billboard is now a button"
+          size="small"
+          onClick={() => {}}
+          hero={(size: string) => <IconUserLine size={size} />}
+        />
+      </View>
+
+      <View display="block" width="600px">
+        <Billboard
+          margin="large"
+          message="Click this link"
+          href="https://instructure.com"
+          hero={(size: string) => <IconGradebookLine size={size} />}
+        />
+      </View>
+
+      <Billboard
+        readOnly
+        message="Create a new Module"
+        size="large"
+        onClick={() => {}}
+        hero={(size: string) => <IconPlusLine size={size} />}
+      />
+
+      {/* Disabled */}
+      <Billboard
+        size="small"
+        heading="This is disabled"
+        onClick={() => {}}
+        hero={(size: string) => <IconUserLine size={size} />}
+        disabled
+      />
+    </main>
+  )
+}

--- a/regression-test/src/app/breadcrumb/page.tsx
+++ b/regression-test/src/app/breadcrumb/page.tsx
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Breadcrumb as bc } from 'instructure-ui/ui-breadcrumb/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import {
+  IconBankLine as ibl,
+  IconClockLine as icl,
+  IconPlusLine as ipl
+} from 'instructure-ui/ui-icons/es/index'
+
+const Breadcrumb = bc as any
+const View = vw as any
+const IconBankLine = ibl as any
+const IconClockLine = icl as any
+const IconPlusLine = ipl as any
+
+export default function BreadcrumbPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      <Breadcrumb label="You are here">
+        <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="/courses">Courses</Breadcrumb.Link>
+        <Breadcrumb.Link>English 204</Breadcrumb.Link>
+      </Breadcrumb>
+      <div>
+        <Breadcrumb size="small" label="breadcrumb" margin="none none medium">
+          <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+            English 204
+          </Breadcrumb.Link>
+          <Breadcrumb.Link>Exploring John Updike</Breadcrumb.Link>
+          <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+            The Rabbit Novels
+          </Breadcrumb.Link>
+          <Breadcrumb.Link>Rabbit Is Rich</Breadcrumb.Link>
+        </Breadcrumb>
+        <View as="div" width="40rem">
+          <Breadcrumb label="breadcrumb" margin="none none medium">
+            <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+              English 204
+            </Breadcrumb.Link>
+            <Breadcrumb.Link>Exploring John Updike</Breadcrumb.Link>
+            <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+              The Rabbit Novels
+            </Breadcrumb.Link>
+            <Breadcrumb.Link>Rabbit Is Rich</Breadcrumb.Link>
+          </Breadcrumb>
+        </View>
+        <Breadcrumb size="large" label="breadcrumb">
+          <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+            English 204
+          </Breadcrumb.Link>
+          <Breadcrumb.Link>Exploring John Updike</Breadcrumb.Link>
+          <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">
+            The Rabbit Novels
+          </Breadcrumb.Link>
+          <Breadcrumb.Link>Rabbit Is Rich</Breadcrumb.Link>
+        </Breadcrumb>
+      </div>
+      <Breadcrumb label="Breadcrumb with icons">
+        <Breadcrumb.Link
+          renderIcon={<IconBankLine size="small" />}
+          href="#Breadcrumb"
+        >
+          Item Bank
+        </Breadcrumb.Link>
+        <Breadcrumb.Link
+          renderIcon={<IconClockLine size="small" />}
+          onClick={() => {}}
+        >
+          History
+        </Breadcrumb.Link>
+        <Breadcrumb.Link renderIcon={IconPlusLine} iconPlacement="end">
+          New Question
+        </Breadcrumb.Link>
+      </Breadcrumb>
+    </main>
+  )
+}

--- a/regression-test/src/app/button/page.tsx
+++ b/regression-test/src/app/button/page.tsx
@@ -23,8 +23,21 @@
  */
 'use client'
 import React, { useEffect, useRef } from 'react'
-import { Button } from 'instructure-ui/ui-buttons/es/index'
-import { IconAddLine } from 'instructure-ui/ui-icons/es/index'
+import {
+  Button,
+  CondensedButton,
+  CloseButton,
+  IconButton
+} from 'instructure-ui/ui-buttons/es/index'
+import { View } from 'instructure-ui/ui-view/es/index'
+import { Flex } from 'instructure-ui/ui-flex/es/index'
+import {
+  IconAddLine,
+  IconUserLine,
+  IconAiSolid,
+  IconAiColoredSolid,
+  IconXSolid
+} from 'instructure-ui/ui-icons/es/index'
 
 export default function ButtonPage() {
   const myElementRef = useRef<HTMLButtonElement>(null)
@@ -41,20 +54,117 @@ export default function ButtonPage() {
   const sizes = ['small', 'medium', 'large']
   return (
     <main className="flex gap-8 p-8 flex-col items-start axe-test">
-      <Button>Button</Button>
-      {colors.map((color) => (
-        <Button key={'color' + color} color={color}>
-          {color} color
-        </Button>
-      ))}
-      {sizes.map((size) => (
-        <Button key={'size' + size} size={size}>
-          {size} size
-        </Button>
-      ))}
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <Button>Button</Button>
+        {colors.map((color) => (
+          <Button key={'color' + color} color={color}>
+            {color} color
+          </Button>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        {sizes.map((size) => (
+          <Button key={'size' + size} size={size}>
+            {size} size
+          </Button>
+        ))}
+      </div>
       <Button renderIcon={IconAddLine}>Icon Button</Button>
       <Button disabled>Disabled Button</Button>
       <Button ref={myElementRef}>focused button</Button>
+      <CondensedButton>CondensedButton</CondensedButton>
+      {/* Positioned CloseButton (placement=end, offset=small) */}
+      <View
+        display="block"
+        position="relative"
+        height="5rem"
+        width="10rem"
+        background="primary"
+        shadow="resting"
+      >
+        <CloseButton placement="end" offset="small" screenReaderLabel="Close" />
+      </View>
+
+      <View
+        display="block"
+        position="relative"
+        background="primary"
+        shadow="resting"
+      >
+        <Flex
+          height="6rem"
+          justifyItems="space-between"
+          alignItems="center"
+          padding="medium"
+        >
+          <Flex.Item shouldShrink shouldGrow>
+            <h2>A heading</h2>
+          </Flex.Item>
+          <Flex.Item padding="none none none medium">
+            <CloseButton size="medium" screenReaderLabel="Close" />
+          </Flex.Item>
+        </Flex>
+      </View>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <IconButton screenReaderLabel="Add User">
+          <IconAddLine />
+        </IconButton>
+        <IconButton color="primary" screenReaderLabel="Add blog post">
+          <IconAddLine />
+        </IconButton>
+        <IconButton screenReaderLabel="View user profile">
+          <IconUserLine />
+        </IconButton>
+        <IconButton
+          color="ai-primary"
+          screenReaderLabel="AI button"
+          margin="small"
+        >
+          <IconAiSolid />
+        </IconButton>
+        <IconButton
+          color="ai-secondary"
+          screenReaderLabel="AI button"
+          margin="small"
+        >
+          <IconAiColoredSolid />
+        </IconButton>
+        <IconButton
+          shape="rectangle"
+          screenReaderLabel="Delete tag"
+          margin="small"
+        >
+          <IconXSolid />
+        </IconButton>
+        <IconButton
+          shape="circle"
+          screenReaderLabel="Delete tag"
+          margin="small"
+        >
+          <IconXSolid />
+        </IconButton>
+        <View display="inline-block" background="primary">
+          <IconButton
+            withBackground={false}
+            withBorder={false}
+            screenReaderLabel="Delete tag"
+            margin="large"
+          >
+            <IconXSolid />
+          </IconButton>
+        </View>
+        <View display="inline-block" background="primary-inverse">
+          <IconButton
+            withBackground={false}
+            withBorder={false}
+            color="primary-inverse"
+            screenReaderLabel="Delete tag"
+            margin="large"
+          >
+            <IconXSolid />
+          </IconButton>
+        </View>
+      </div>
     </main>
   )
 }

--- a/regression-test/src/app/byline/page.tsx
+++ b/regression-test/src/app/byline/page.tsx
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Byline as bl } from 'instructure-ui/ui-byline/es/index'
+import { Avatar as av } from 'instructure-ui/ui-avatar/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { Heading as hd } from 'instructure-ui/ui-heading/es/index'
+import { Link as lk } from 'instructure-ui/ui-link/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+
+const Byline = bl as any
+const Avatar = av as any
+const View = vw as any
+const Heading = hd as any
+const Link = lk as any
+const Text = tx as any
+
+export default function BylinePage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Basic Byline */}
+      <Byline description="A short description here.">
+        <Avatar name="Julia Childer" />
+      </Byline>
+
+      {/* With title, size and alignment */}
+      <Byline
+        margin="x-large auto"
+        size="small"
+        alignContent="top"
+        title="Graham Taylor"
+        description="This is a longer paragraph describing the person, their role and other details."
+      >
+        <Avatar name="Graham Taylor" />
+      </Byline>
+
+      {/* Rich description with nested components */}
+      <Byline
+        description={
+          <View display="block" margin="0 0 0 x-small">
+            <Heading level="h2">
+              <Link href="#">Clickable Heading</Link>
+            </Heading>
+            <Text size="x-small" transform="uppercase" letterSpacing="expanded">
+              Something here
+            </Text>
+          </View>
+        }
+      >
+        <Avatar name="Alex Johnson" />
+      </Byline>
+    </main>
+  )
+}

--- a/regression-test/src/app/calendar/page.tsx
+++ b/regression-test/src/app/calendar/page.tsx
@@ -21,54 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 'use client'
-import { Link } from 'instructure-ui/ui-link/es/index'
+import React from 'react'
+import { Calendar as cl } from 'instructure-ui/ui-calendar/es/index'
 
-const components = [
-  'small-components',
-  'alert',
-  'avatar',
-  'badge',
-  'billboard',
-  'breadcrumb',
-  'button',
-  'tooltip',
-  'byline',
-  'calendar',
-  'checkbox',
-  'checkboxgroup',
-  'colorpicker',
-  'contextview',
-  'dateinput',
-  'datetimeinput',
-  'drilldown',
-  'filedrop',
-  'form-errors',
-  'heading',
-  'img',
-  'link',
-  'menu',
-  'options',
-  'pagination',
-  'progressbar',
-  'select',
-  'table',
-  'tabs',
-  'treebrowser',
-  'view'
-]
+const Calendar = cl as any
 
-export default function Home() {
+export default function CalendarPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-6">
-      <ul>
-        {components.map((component) => (
-          <li key={component}>
-            <Link href={component}>{component}</Link>
-          </li>
-        ))}
-      </ul>
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Default config */}
+      <Calendar />
+
+      {/* Default config with additional props */}
+      <Calendar
+        visibleMonth="2025-05"
+        currentDate="2023-12-15"
+        disabledDates={['2023-12-22', '2025-05-22', '2025-05-11']}
+      />
+
+      {/* With year picker */}
+      <Calendar
+        visibleMonth="2024-02"
+        currentDate="2024-02-29"
+        disabledDates={['2024-02-10', '2024-02-12']}
+        withYearPicker={{
+          screenReaderLabel: 'Year picker',
+          startYear: 1999,
+          endYear: 2024,
+          maxHeight: '200px'
+        }}
+      />
     </main>
   )
 }

--- a/regression-test/src/app/checkbox/page.tsx
+++ b/regression-test/src/app/checkbox/page.tsx
@@ -1,0 +1,160 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Checkbox as cb } from 'instructure-ui/ui-checkbox/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { ScreenReaderContent as src } from 'instructure-ui/ui-a11y-content/es/index'
+import { FormFieldGroup as ffg } from 'instructure-ui/ui-form-field/es/index'
+
+const Checkbox = cb as any
+const View = vw as any
+const ScreenReaderContent = src as any
+const FormFieldGroup = ffg as any
+
+export default function CheckboxPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Default checked */}
+      <Checkbox label="Default checked" value="medium" defaultChecked />
+
+      {/* Disabled state examples */}
+      <FormFieldGroup
+        description={
+          <ScreenReaderContent>Checkbox disabled examples</ScreenReaderContent>
+        }
+      >
+        <Checkbox
+          label="Disabled (checked)"
+          value="medium"
+          disabled
+          defaultChecked
+        />
+        <Checkbox label="Disabled (unchecked)" value="small" disabled />
+      </FormFieldGroup>
+
+      {/* Indeterminate parent with children */}
+      <FormFieldGroup
+        description={
+          <ScreenReaderContent>
+            <span id="groupLabel">Courses to edit</span>
+          </ScreenReaderContent>
+        }
+        rowSpacing="small"
+      >
+        <Checkbox
+          aria-labelledby="groupLabel selectAllLabel"
+          label={<span id="selectAllLabel">Select all courses</span>}
+          value="all"
+          indeterminate
+        />
+        <View as="div" padding="0 0 0 medium">
+          <Checkbox
+            aria-labelledby="groupLabel eng203Label"
+            label={<span id="eng203Label">English 203</span>}
+            value="eng203"
+            name="courses"
+            checked
+            readOnly
+          />
+        </View>
+        <View as="div" padding="0 0 0 medium">
+          <Checkbox
+            aria-labelledby="groupLabel sci101Label"
+            label={<span id="sci101Label">Science 101</span>}
+            value="sci101"
+            name="courses"
+          />
+        </View>
+        <View as="div" padding="0 0 0 medium">
+          <Checkbox
+            aria-labelledby="groupLabel hist111Label"
+            label={<span id="hist111Label">History 111</span>}
+            value="his111"
+            name="courses"
+            checked
+            readOnly
+          />
+        </View>
+      </FormFieldGroup>
+
+      {/* Toggle variant sizes */}
+      <FormFieldGroup
+        description={
+          <ScreenReaderContent>
+            Checkbox toggle size examples
+          </ScreenReaderContent>
+        }
+      >
+        <Checkbox
+          label="Small size"
+          value="small"
+          variant="toggle"
+          size="small"
+          defaultChecked
+        />
+        <Checkbox label="Medium size" value="medium" variant="toggle" />
+        <Checkbox
+          label="Large size"
+          value="large"
+          variant="toggle"
+          size="large"
+          defaultChecked
+        />
+      </FormFieldGroup>
+
+      {/* Toggle label placement */}
+      <FormFieldGroup
+        description={
+          <ScreenReaderContent>Toggle label examples</ScreenReaderContent>
+        }
+      >
+        <Checkbox
+          label="Top"
+          variant="toggle"
+          labelPlacement="top"
+          defaultChecked
+        />
+        <Checkbox label="Start" variant="toggle" labelPlacement="start" />
+        <Checkbox
+          label="End"
+          variant="toggle"
+          labelPlacement="end"
+          defaultChecked
+        />
+      </FormFieldGroup>
+
+      <span>Screenreader-only label:</span>
+      <Checkbox
+        label={
+          <ScreenReaderContent>
+            Screenreader-accessible label
+          </ScreenReaderContent>
+        }
+        value="accessible"
+        variant="toggle"
+      />
+    </main>
+  )
+}

--- a/regression-test/src/app/checkboxgroup/page.tsx
+++ b/regression-test/src/app/checkboxgroup/page.tsx
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import {
+  Checkbox as cb,
+  CheckboxGroup as cg
+} from 'instructure-ui/ui-checkbox/es/index'
+import { FormFieldGroup as ffg } from 'instructure-ui/ui-form-field/es/index'
+import { ScreenReaderContent as src } from 'instructure-ui/ui-a11y-content/es/index'
+
+const Checkbox = cb as any
+const CheckboxGroup = cg as any
+const FormFieldGroup = ffg as any
+const ScreenReaderContent = src as any
+
+export default function CheckboxGroupPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* FormFieldGroup with two CheckboxGroup examples */}
+      <FormFieldGroup
+        description={
+          <ScreenReaderContent>CheckboxGroup examples</ScreenReaderContent>
+        }
+      >
+        <CheckboxGroup
+          name="sports"
+          onChange={() => {}}
+          defaultValue={['football', 'volleyball']}
+          description="Select your favorite sports"
+        >
+          <Checkbox label="Football" value="football" />
+          <Checkbox label="Basketball" value="basketball" />
+          <Checkbox label="Volleyball" value="volleyball" />
+          <Checkbox label="Other" value="other" />
+        </CheckboxGroup>
+
+        <CheckboxGroup
+          name="sports"
+          size="small"
+          layout="columns"
+          onChange={() => {}}
+          defaultValue={['football', 'volleyball']}
+          description="Select your favorite sports"
+        >
+          <Checkbox label="Football" value="football" />
+          <Checkbox label="Basketball" value="basketball" />
+          <Checkbox label="Volleyball" value="volleyball" />
+          <Checkbox label="Other" value="other" />
+        </CheckboxGroup>
+      </FormFieldGroup>
+
+      {/* Toggle variant with inline layout and error message */}
+      <CheckboxGroup
+        name="sports2"
+        layout="inline"
+        messages={[{ text: 'Invalid name', type: 'error' }]}
+        onChange={() => {}}
+        defaultValue={['soccer', 'volleyball']}
+        description="I wish to receive score alerts for"
+      >
+        <Checkbox label="Football" value="football" variant="toggle" />
+        <Checkbox label="Basketball" value="basketball" variant="toggle" />
+        <Checkbox label="Volleyball" value="volleyball" variant="toggle" />
+        <Checkbox label="Soccer" value="soccer" variant="toggle" />
+      </CheckboxGroup>
+
+      {/* Disabled CheckboxGroup */}
+      <CheckboxGroup
+        name="sports4"
+        onChange={() => {}}
+        defaultValue={['soccer', 'volleyball']}
+        description="I wish to receive score alerts for"
+        disabled
+      >
+        <Checkbox label="Football" value="football" variant="toggle" />
+        <Checkbox label="Basketball" value="basketball" variant="toggle" />
+        <Checkbox label="Volleyball" value="volleyball" variant="toggle" />
+        <Checkbox label="Soccer" value="soccer" variant="toggle" />
+      </CheckboxGroup>
+    </main>
+  )
+}

--- a/regression-test/src/app/colorpicker/page.tsx
+++ b/regression-test/src/app/colorpicker/page.tsx
@@ -1,0 +1,184 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useState } from 'react'
+import {
+  ColorContrast as cc,
+  ColorIndicator as ci,
+  ColorMixer as cm,
+  ColorPreset as cp
+} from 'instructure-ui/ui-color-picker/es/index'
+
+const ColorContrast = cc as any
+const ColorIndicator = ci as any
+const ColorMixer = cm as any
+const ColorPreset = cp as any
+
+export default function ColorPickerPage() {
+  const value = '#328DCFC2'
+  const [selected, setSelected] = useState('')
+  const [colors, setColors] = useState([
+    '#ffffff',
+    '#0CBF94',
+    '#0C89BF00',
+    '#BF0C6D',
+    '#BF8D0C',
+    '#ff0000',
+    '#576A66',
+    '#35423A',
+    '#35423F'
+  ])
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      <ColorContrast
+        firstColor="#FF0000"
+        secondColor="#FFFF00"
+        label="Color Contrast Ratio"
+        successLabel="PASS"
+        failureLabel="FAIL"
+        normalTextLabel="Normal text"
+        largeTextLabel="Large text"
+        graphicsTextLabel="Graphics text"
+        firstColorLabel="Background"
+        secondColorLabel="Foreground"
+      />
+      <ColorContrast
+        withoutColorPreview
+        firstColor="#35423A"
+        secondColor="#0CBF94"
+        label="Contrast Ratio"
+        successLabel="PASS"
+        failureLabel="FAIL"
+        normalTextLabel="Normal text"
+        largeTextLabel="Large text"
+        graphicsTextLabel="Graphics text"
+        validationLevel="AA"
+      />
+      <span>ColorIndicator:</span>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <ColorIndicator
+          color="#FF0000"
+          aria-label="Selected color: red"
+          shape="rectangle"
+        />
+        <ColorIndicator
+          color="rgba(12, 191, 148, 0.5)"
+          aria-label="Selected color: teal with 50 percent opacity"
+        />
+        <ColorIndicator
+          color="transparent"
+          aria-label="Selected color: transparent"
+        />
+      </div>
+      <div style={{ display: 'flex' }}>
+        <ColorMixer
+          withAlpha
+          value="#328DCFC2"
+          onChange={(val: string) => null}
+          rgbRedInputScreenReaderLabel="Input field for red"
+          rgbGreenInputScreenReaderLabel="Input field for green"
+          rgbBlueInputScreenReaderLabel="Input field for blue"
+          rgbAlphaInputScreenReaderLabel="Input field for alpha"
+          colorSliderNavigationExplanationScreenReaderLabel={`You are on a color slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`}
+          alphaSliderNavigationExplanationScreenReaderLabel={`You are on an alpha slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`}
+          colorPaletteNavigationExplanationScreenReaderLabel={`You are on a color palette. To navigate on the palette up, left, down or right, use the 'W', 'A', 'S' and 'D' buttons respectively`}
+        />
+        <div
+          style={{
+            width: '100px',
+            height: '160px',
+            borderRadius: '4px',
+            backgroundColor: value,
+            marginLeft: '25px',
+            boxSizing: 'border-box',
+            borderStyle: 'solid',
+            borderColor: 'rgba(56, 74, 88, 0.6)'
+          }}
+        >
+          {value}
+        </div>
+      </div>
+      <ColorMixer
+        disabled
+        withAlpha
+        value="#328DCFC2"
+        onChange={() => {}}
+        rgbRedInputScreenReaderLabel="Input field for red"
+        rgbGreenInputScreenReaderLabel="Input field for green"
+        rgbBlueInputScreenReaderLabel="Input field for blue"
+        rgbAlphaInputScreenReaderLabel="Input field for alpha"
+        colorSliderNavigationExplanationScreenReaderLabel={`You are on a color slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`}
+        alphaSliderNavigationExplanationScreenReaderLabel={`You are on an alpha slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`}
+        colorPaletteNavigationExplanationScreenReaderLabel={`You are on a color palette. To navigate on the palette up, left, down or right, use the 'W', 'A', 'S' and 'D' buttons respectively`}
+      />
+      <ColorPreset
+        label="Choose a color"
+        colors={colors}
+        selected={selected}
+        onSelect={setSelected}
+        colorScreenReaderLabel={(hexCode: string, isSelected: boolean) =>
+          `color with hex code ${hexCode}${isSelected ? ' selected' : ''}`
+        }
+      />
+
+      <ColorPreset
+        colors={colors}
+        selected={selected}
+        onSelect={setSelected}
+        colorMixerSettings={{
+          addNewPresetButtonScreenReaderLabel: 'Add new preset button label',
+          selectColorLabel: 'Select',
+          removeColorLabel: 'Remove',
+          onPresetChange: setColors,
+          popoverAddButtonLabel: 'Add',
+          popoverCloseButtonLabel: 'Cancel',
+          colorMixer: {
+            rgbRedInputScreenReaderLabel: 'Input field for red',
+            rgbGreenInputScreenReaderLabel: 'Input field for green',
+            rgbBlueInputScreenReaderLabel: 'Input field for blue',
+            rgbAlphaInputScreenReaderLabel: 'Input field for alpha',
+            colorSliderNavigationExplanationScreenReaderLabel: `You are on a color slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`,
+            alphaSliderNavigationExplanationScreenReaderLabel: `You are on an alpha slider. To navigate the slider left or right, use the 'A' and 'D' buttons respectively`,
+            colorPaletteNavigationExplanationScreenReaderLabel: `You are on a color palette. To navigate on the palette up, left, down or right, use the 'W', 'A', 'S' and 'D' buttons respectively`
+          },
+          colorContrast: {
+            firstColor: '#FF0000',
+            label: 'Color Contrast Ratio',
+            successLabel: 'PASS',
+            failureLabel: 'FAIL',
+            normalTextLabel: 'Normal text',
+            largeTextLabel: 'Large text',
+            graphicsTextLabel: 'Graphics text',
+            firstColorLabel: 'Background',
+            secondColorLabel: 'Foreground'
+          }
+        }}
+        colorScreenReaderLabel={(hexCode: string, isSelected: boolean) =>
+          `color with hex code ${hexCode}${isSelected ? ' selected' : ''}`
+        }
+      />
+    </main>
+  )
+}

--- a/regression-test/src/app/contextview/page.tsx
+++ b/regression-test/src/app/contextview/page.tsx
@@ -1,0 +1,82 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { ContextView as cv } from 'instructure-ui/ui-view/es/index'
+import { Heading as hd } from 'instructure-ui/ui-heading/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+
+const ContextView = cv as any
+const Heading = hd as any
+const Text = tx as any
+
+export default function ContextViewPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* padding + margin + placement + shadow */}
+      <ContextView
+        padding="small"
+        margin="large"
+        placement="end top"
+        shadow="resting"
+      >
+        <Heading level="h3">Hello World</Heading>
+      </ContextView>
+
+      {/* placement top with heading + text */}
+      <ContextView margin="0 large 0 0" padding="small" placement="top">
+        <Heading level="h3">Hello World</Heading>
+        <Text size="small">Some informational text that is helpful</Text>
+      </ContextView>
+
+      {/* end-aligned text */}
+      <ContextView
+        margin="0 large 0 0"
+        padding="small"
+        textAlign="end"
+        placement="start"
+      >
+        <Heading level="h3">Hello World</Heading>
+        <Text size="small">This ContextView is end-text-aligned</Text>
+      </ContextView>
+
+      {/* inverse background, fixed width */}
+      <ContextView
+        placement="end bottom"
+        padding="medium"
+        background="inverse"
+        width="30rem"
+        margin="x-large 0 0"
+      >
+        <Text size="small">
+          This ContextView uses the inverse background and medium padding. Its
+          width prop is set to 30rem, which causes long strings like this to
+          wrap. It also has top margin to separate it from the ContextViews
+          above it.
+        </Text>
+      </ContextView>
+    </main>
+  )
+}

--- a/regression-test/src/app/dateinput/page.tsx
+++ b/regression-test/src/app/dateinput/page.tsx
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useState } from 'react'
+import {
+  DateInput as di,
+  DateInput2 as di2
+} from 'instructure-ui/ui-date-input/es/index'
+import { IconAddLine } from 'instructure-ui/ui-icons/es/index'
+
+const DateInput = di as any
+const DateInput2 = di2 as any
+
+export default function DateInputExamplesPage() {
+  // DateInput2 states
+  const [di2Value, setDi2Value] = useState('')
+  const [di2DateString, setDi2DateString] = useState('')
+  const [di2Value2, setDi2Value2] = useState('')
+  const [di2Value3, setDi2Value3] = useState('2/5/2025')
+
+  const [diValue, setDiValue] = useState('')
+  const [diMessages, setDiMessages] = useState<any[]>([])
+
+  return (
+    <main className="flex gap-10 p-12 flex-col items-start axe-test">
+      <div>DateInput2:</div>
+      <section>
+        <DateInput2
+          locale="en-us"
+          dateFormat="en-us"
+          renderCalendarIcon={<IconAddLine />}
+          renderLabel="Choose a date"
+          screenReaderLabels={{
+            calendarIcon: 'Calendar',
+            nextMonthButton: 'Next month',
+            prevMonthButton: 'Previous month'
+          }}
+          value={di2Value}
+          width="40rem"
+          onChange={(e: any, inputValue: string, dateString: string) => {
+            setDi2Value(inputValue)
+            setDi2DateString(dateString)
+          }}
+          invalidDateErrorMessage="Invalid date"
+        />
+        <p>
+          Input Value: <code>{di2Value}</code>
+          <br />
+          UTC Date String: <code>{di2DateString}</code>
+        </p>
+      </section>
+
+      {/* DateInput2 - with year picker */}
+      <section>
+        <DateInput2
+          locale="en-us"
+          dateFormat="de-de"
+          renderLabel="Choose a date (with year picker)"
+          screenReaderLabels={{
+            calendarIcon: 'Calendar',
+            nextMonthButton: 'Next month',
+            prevMonthButton: 'Previous month'
+          }}
+          value={di2Value2}
+          width="40rem"
+          onChange={(e: any, inputValue: string) => setDi2Value2(inputValue)}
+          invalidDateErrorMessage="Invalid date"
+          withYearPicker={{
+            screenReaderLabel: 'Year picker',
+            startYear: 1900,
+            endYear: 2025
+          }}
+        />
+      </section>
+
+      {/* DateInput2 - disabled dates */}
+      <section>
+        <DateInput2
+          locale="en-us"
+          dateFormat="en-us"
+          renderLabel="Choose a date (with disabled dates)"
+          disabledDates={['2025-02-11', '2025-02-12', '2025-02-13']}
+          screenReaderLabels={{
+            calendarIcon: 'Calendar',
+            nextMonthButton: 'Next month',
+            prevMonthButton: 'Previous month'
+          }}
+          value={di2Value3}
+          width="40rem"
+          onChange={(e: any, inputValue: string) => setDi2Value3(inputValue)}
+          invalidDateErrorMessage="Invalid date"
+        />
+      </section>
+
+      <section>
+        <div>DateInput:</div>
+        <DateInput
+          locale="en-us"
+          renderLabel="Choose a date (legacy DateInput)"
+          assistiveText="Type a date or use arrow keys to navigate date picker."
+          value={diValue}
+          onChange={(e: any, { value }: { value: string }) => {
+            setDiValue(value)
+            // rudimentary validation example: flag very short values
+            if (value && value.length < 4) {
+              setDiMessages([{ type: 'error', text: 'This date is invalid' }])
+            } else {
+              setDiMessages([])
+            }
+          }}
+          messages={diMessages}
+          width="40rem"
+          isInline
+        />
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/datetimeinput/page.tsx
+++ b/regression-test/src/app/datetimeinput/page.tsx
@@ -1,0 +1,117 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useRef, useState } from 'react'
+import { DateTimeInput as dti } from 'instructure-ui/ui-date-time-input/es/index'
+import { ScreenReaderContent as src } from 'instructure-ui/ui-a11y-content/es/index'
+
+const DateTimeInput = dti as any
+const ScreenReaderContent = src as any
+
+export default function DateTimeInputPage() {
+  // Example 2: required + hint if in past
+  const [reqValue, setReqValue] = useState<string | undefined>(undefined)
+  const [reqMessages, setReqMessages] = useState<any[]>([])
+
+  return (
+    <main className="flex gap-10 p-8 flex-col items-start axe-test">
+      1) Columns layout with default value
+      <DateTimeInput
+        description="Pick a date and time"
+        datePlaceholder="Choose a date"
+        dateRenderLabel="Date"
+        timeRenderLabel="Time"
+        invalidDateTimeMessage="Invalid date!"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        defaultValue="2018-01-18T13:30"
+        layout="columns"
+      />
+      2) Required + hint when value is in the past, stacked layout
+      <DateTimeInput
+        description={
+          <ScreenReaderContent>Pick a date and time</ScreenReaderContent>
+        }
+        datePlaceholder="Choose"
+        dateRenderLabel="Date"
+        timeRenderLabel="Time"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        onChange={(_e: any, isoDate?: string) => {
+          let messages: any[] = []
+          if (!isoDate) {
+            setReqValue(undefined)
+            setReqMessages(messages)
+            return
+          }
+          const now = new Date()
+          const newValue = new Date(isoDate)
+          if (newValue.valueOf() <= now.valueOf()) {
+            messages = [{ text: 'That date-time is in the past', type: 'hint' }]
+          }
+          setReqValue(isoDate)
+          setReqMessages(messages)
+        }}
+        layout="stacked"
+        value={reqValue}
+        invalidDateTimeMessage="Invalid date!"
+        messages={reqMessages}
+        allowNonStepInput
+        isRequired
+      />
+      3) Disabled DateTimeInput
+      <DateTimeInput
+        description="Pick a date and time"
+        datePlaceholder="Choose a date"
+        dateRenderLabel="Date"
+        timeRenderLabel="Time"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        invalidDateTimeMessage={(dvalue: string) => `'${dvalue} is not valid.`}
+        layout="columns"
+        defaultValue="2018-01-18T13:30"
+        interaction="disabled"
+      />
+      {/*
+      4) Disabled dates via string array
+      <DateTimeInput
+        description="Pick a date and time"
+        datePlaceholder="Choose a date"
+        dateRenderLabel="Date"
+        timeRenderLabel="Time"
+        invalidDateTimeMessage="Invalid date"
+        disabledDateTimeMessage="Disabled date"
+        prevMonthLabel="Previous month"
+        nextMonthLabel="Next month"
+        defaultValue="2022-04-08T13:30"
+        layout="columns"
+        disabledDates={['2022-04-01T13:30', '2022-04-03T13:30', '2022-04-04T13:30']}
+        locale="en-us"
+        timezone="America/Denver"
+      />
+      */}
+    </main>
+  )
+}

--- a/regression-test/src/app/drilldown/page.tsx
+++ b/regression-test/src/app/drilldown/page.tsx
@@ -1,0 +1,227 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Drilldown as dd } from 'instructure-ui/ui-drilldown/es/index'
+import { Button as btn } from 'instructure-ui/ui-buttons/es/index'
+import { Pill as pl } from 'instructure-ui/ui-pill/es/index'
+import {
+  IconCheckSolid as ics,
+  IconArrowOpenEndSolid as iaoes
+} from 'instructure-ui/ui-icons/es/index'
+
+const Drilldown = dd as any
+const Button = btn as any
+const Pill = pl as any
+const IconCheckSolid = ics as any
+const IconArrowOpenEndSolid = iaoes as any
+
+export default function DrilldownPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Basic multi-page example (from README "Pages") */}
+      <Drilldown rootPageId="root" width="20rem" maxHeight="30rem">
+        <Drilldown.Page id="root" renderTitle="Groceries">
+          <Drilldown.Option id="Produce" subPageId="Produce">
+            Produce
+          </Drilldown.Option>
+          <Drilldown.Option id="GrainsAndBread" subPageId="GrainsAndBread">
+            Grains and Bread
+          </Drilldown.Option>
+        </Drilldown.Page>
+
+        <Drilldown.Page id="Produce" renderTitle="Produce">
+          <Drilldown.Option id="Fruits" subPageId="Fruits">
+            Fruits
+          </Drilldown.Option>
+          <Drilldown.Option id="Vegetables" subPageId="Vegetables">
+            Vegetables
+          </Drilldown.Option>
+        </Drilldown.Page>
+
+        <Drilldown.Page id="GrainsAndBread" renderTitle="Grains and Bread">
+          {['Pasta', 'Rice', 'Bread', 'Flour', 'Cereal', 'Oats'].map((item) => (
+            <Drilldown.Option id={`G_${item}`} key={item}>
+              {item}
+            </Drilldown.Option>
+          ))}
+        </Drilldown.Page>
+
+        <Drilldown.Page id="Fruits" renderTitle="Fruits">
+          {[
+            'Apple',
+            'Orange',
+            'Cherry',
+            'Grapefruit',
+            'Mango',
+            'Banana',
+            'Strawberry'
+          ].map((item) => (
+            <Drilldown.Option id={`F_${item}`} key={item}>
+              {item}
+            </Drilldown.Option>
+          ))}
+        </Drilldown.Page>
+
+        <Drilldown.Page id="Vegetables" renderTitle="Vegetables">
+          {[
+            'Tomato',
+            'Cucumber',
+            'Eggplant',
+            'Lettuce',
+            'Garlic',
+            'Onion',
+            'Corn',
+            'Carrot',
+            'Bell pepper'
+          ].map((item) => (
+            <Drilldown.Option id={`V_${item}`} key={item}>
+              {item}
+            </Drilldown.Option>
+          ))}
+        </Drilldown.Page>
+      </Drilldown>
+
+      <div style={{ height: '20rem' }}>
+        <Drilldown
+          rootPageId="rootRadio"
+          width="20rem"
+          maxHeight="30rem"
+          show={true}
+          trigger={<Button>Open Drilldown</Button>}
+          shouldHideOnSelect={false}
+        >
+          <Drilldown.Page id="rootRadio" renderTitle="Select one option">
+            <Drilldown.Option id="plus0" value="234" defaultSelected>
+              Some option
+            </Drilldown.Option>
+            <Drilldown.Group
+              disabled={true}
+              id="agreement"
+              renderGroupTitle="Disabled group"
+              selectableType="single"
+            >
+              <Drilldown.Option id="plus2" value="+2" defaultSelected>
+                Strongly agree
+              </Drilldown.Option>
+              <Drilldown.Option id="plus1" value="+1">
+                Somewhat agree
+              </Drilldown.Option>
+              <Drilldown.Option id="zero" value="0">
+                Neither agree nor disagree
+              </Drilldown.Option>
+              <Drilldown.Option id="minus1" value="-1">
+                Somewhat disagree
+              </Drilldown.Option>
+              <Drilldown.Option id="minus2" value="-2">
+                Strongly disagree
+              </Drilldown.Option>
+            </Drilldown.Group>
+          </Drilldown.Page>
+        </Drilldown>
+      </div>
+      {/* Icons, Pills, descriptions and page navigation */}
+      <Drilldown rootPageId="rootRich" width="22rem" maxHeight="30rem">
+        <Drilldown.Page id="rootRich" renderTitle="Products">
+          <Drilldown.Option
+            id="optAnalytics"
+            subPageId="analytics"
+            renderBeforeLabel={IconCheckSolid}
+            description="Insights and reports"
+            afterLabelContentVAlign="center"
+            renderLabelInfo={() => <Pill margin="0 0 0 x-small">Beta</Pill>}
+          >
+            Analytics
+          </Drilldown.Option>
+
+          <Drilldown.Option
+            id="optBilling"
+            subPageId="billing"
+            renderBeforeLabel={<IconCheckSolid style={{ opacity: 0 }} />}
+            description="Manage subscription and invoices"
+            afterLabelContentVAlign="center"
+            renderLabelInfo={() => (
+              <Pill color="danger" margin="0 0 0 x-small">
+                New
+              </Pill>
+            )}
+          >
+            Billing
+          </Drilldown.Option>
+
+          <Drilldown.Option
+            id="optIntegrations"
+            subPageId="integrations"
+            renderBeforeLabel={IconCheckSolid}
+            description="Connect external services"
+          >
+            Integrations
+          </Drilldown.Option>
+        </Drilldown.Page>
+
+        <Drilldown.Page id="analytics" renderTitle="Analytics">
+          <Drilldown.Option id="anaOverview">
+            Overview dashboard
+          </Drilldown.Option>
+          <Drilldown.Option id="anaReports">Scheduled reports</Drilldown.Option>
+          <Drilldown.Option
+            id="anaBack"
+            onOptionClick={(_e: any, { goToPreviousPage }: any) => {
+              goToPreviousPage()
+            }}
+          >
+            Back to Products
+          </Drilldown.Option>
+        </Drilldown.Page>
+
+        <Drilldown.Page id="billing" renderTitle="Billing">
+          <Drilldown.Option id="bilPlans">Plans</Drilldown.Option>
+          <Drilldown.Option id="bilInvoices">Invoices</Drilldown.Option>
+          <Drilldown.Option
+            id="bilBack"
+            onOptionClick={(_e: any, { goToPreviousPage }: any) => {
+              goToPreviousPage()
+            }}
+          >
+            Back to Products
+          </Drilldown.Option>
+        </Drilldown.Page>
+
+        <Drilldown.Page id="integrations" renderTitle="Integrations">
+          <Drilldown.Option id="intSlack">Slack</Drilldown.Option>
+          <Drilldown.Option id="intZapier">Zapier</Drilldown.Option>
+          <Drilldown.Option
+            id="intBack"
+            onOptionClick={(_e: any, { goToPreviousPage }: any) => {
+              goToPreviousPage()
+            }}
+          >
+            Back to Products
+          </Drilldown.Option>
+        </Drilldown.Page>
+      </Drilldown>
+    </main>
+  )
+}

--- a/regression-test/src/app/filedrop/page.tsx
+++ b/regression-test/src/app/filedrop/page.tsx
@@ -1,0 +1,190 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { FileDrop as fd } from 'instructure-ui/ui-file-drop/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { Heading as hd } from 'instructure-ui/ui-heading/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+import { Billboard as bb } from 'instructure-ui/ui-billboard/es/index'
+import { Flex as fl } from 'instructure-ui/ui-flex/es/index'
+import {
+  IconModuleLine as iml,
+  IconUploadSolid as ius,
+  IconVideoLine as ivl,
+  IconImageLine as iil,
+  IconAnnotateLine as ial,
+  IconPdfLine as ipfl
+} from 'instructure-ui/ui-icons/es/index'
+
+const FileDrop = fd as any
+const View = vw as any
+const Heading = hd as any
+const Text = tx as any
+const Billboard = bb as any
+const Flex = fl as any
+
+const IconModuleLine = iml as any
+const IconUploadSolid = ius as any
+const IconVideoLine = ivl as any
+const IconImageLine = iil as any
+const IconAnnotateLine = ial as any
+const IconPdfLine = ipfl as any
+
+export default function FileDropPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <FileDrop
+          accept="image/*"
+          renderLabel={
+            <View as="div" padding="xx-large large" background="primary">
+              <IconModuleLine size="large" />
+              <Heading>Drop files here to add them to module</Heading>
+              <Text color="brand">
+                Drag and drop, or click to browse your computer
+              </Text>
+            </View>
+          }
+        />
+
+        <FileDrop
+          renderLabel={
+            <Billboard
+              heading="Upload your image"
+              message="Drag and drop, or click to browse your computer"
+              hero={<IconImageLine />}
+            />
+          }
+          interaction="disabled"
+        />
+      </div>
+
+      {/* Accept examples (README Accept section) */}
+      <View display="block">
+        <FileDrop
+          accept=".csv"
+          renderLabel={
+            <View
+              background="secondary"
+              as="div"
+              textAlign="center"
+              padding="x-large large"
+            >
+              <IconUploadSolid />
+              <Text as="div" weight="bold">
+                Upload document
+              </Text>
+              <Text>Drag and drop or browse your files</Text>
+              <Text size="small" as="div" lineHeight="double">
+                A single CSV document
+              </Text>
+            </View>
+          }
+          display="inline-block"
+          width="22rem"
+          margin="x-small"
+        />
+        <FileDrop
+          accept="video/*"
+          renderLabel={
+            <Billboard
+              size="small"
+              message="All video file types"
+              hero={<IconVideoLine />}
+            />
+          }
+          display="inline-block"
+          width="11rem"
+          margin="x-small"
+        />
+        <FileDrop
+          accept=".jpg"
+          messages={[{ text: 'Invalid file type', type: 'error' }]}
+          renderLabel={
+            <Billboard
+              size="small"
+              message="Only .jpg files"
+              hero={<IconImageLine />}
+            />
+          }
+          maxWidth="15rem"
+          margin="0 auto"
+        />
+      </View>
+
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <FileDrop
+          shouldAllowMultiple
+          renderLabel={
+            <View
+              as="div"
+              textAlign="center"
+              padding="large"
+              margin="large 0 0 0"
+            >
+              <IconAnnotateLine color="brand" size="large" />
+              <Text as="div" color="brand">
+                Drag and Drop or Click to Browser your Computer
+              </Text>
+            </View>
+          }
+          width="18rem"
+          height="16rem"
+          margin="x-small"
+        />
+
+        {/* height="100%" container (README height Property) */}
+        <div style={{ height: '20rem' }}>
+          <FileDrop
+            height="100%"
+            renderLabel={
+              <Flex
+                direction="column"
+                height="100%"
+                alignItems="center"
+                justifyItems="center"
+              >
+                <Flex.Item padding="small">
+                  <IconPdfLine size="large" />
+                </Flex.Item>
+                <Flex.Item padding="small">
+                  <Text size="large">
+                    Drag and Drop or Click to Browser your Computer
+                  </Text>
+                </Flex.Item>
+                <Flex.Item padding="small">
+                  <Text color="secondary" size="small">
+                    Accepted File Type is PDF
+                  </Text>
+                </Flex.Item>
+              </Flex>
+            }
+          />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/regression-test/src/app/form-errors/page.tsx
+++ b/regression-test/src/app/form-errors/page.tsx
@@ -1,0 +1,131 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { TextInput as ti } from 'instructure-ui/ui-text-input/es/index'
+import { NumberInput as ni } from 'instructure-ui/ui-number-input/es/index'
+import { TextArea as ta } from 'instructure-ui/ui-text-area/es/index'
+import {
+  Checkbox as cb,
+  CheckboxGroup as cg
+} from 'instructure-ui/ui-checkbox/es/index'
+import {
+  RadioInput as ri,
+  RadioInputGroup as rig
+} from 'instructure-ui/ui-radio-input/es/index'
+import { FileDrop as fd } from 'instructure-ui/ui-file-drop/es/index'
+import { ColorPicker as cp } from 'instructure-ui/ui-color-picker/es/index'
+import { DateTimeInput as dti } from 'instructure-ui/ui-date-time-input/es/index'
+
+const TextInput = ti as any
+const NumberInput = ni as any
+const TextArea = ta as any
+const Checkbox = cb as any
+const CheckboxGroup = cg as any
+const RadioInput = ri as any
+const RadioInputGroup = rig as any
+const FileDrop = fd as any
+const ColorPicker = cp as any
+const DateTimeInput = dti as any
+
+export default function FormErrorsPage() {
+  const messages = [{ type: 'newError', text: 'Short error message' }]
+
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      <div style={{ display: 'flex', gap: '2rem', flexDirection: 'column' }}>
+        <TextInput renderLabel="TextInput" messages={messages} isRequired />
+        <NumberInput renderLabel="NumberInput" messages={messages} isRequired />
+        <TextArea label="TextArea" messages={messages} required />
+
+        <Checkbox label="Checkbox" isRequired messages={messages} />
+        <Checkbox
+          label='Checkbox (variant="toggle")'
+          variant="toggle"
+          isRequired
+          messages={messages}
+        />
+
+        <CheckboxGroup
+          name="CheckboxGroup"
+          messages={messages}
+          description="CheckboxGroup"
+        >
+          <Checkbox label="Checkbox 1" value="checkbox1" />
+          <Checkbox label="Checkbox 2" value="checkbox2" />
+          <Checkbox label="Checkbox 3" value="checkbox3" />
+        </CheckboxGroup>
+
+        <RadioInputGroup
+          name="radioInputGroup"
+          description="RadioInputGroup"
+          messages={messages}
+          isRequired
+        >
+          <RadioInput label="RadioInput 1" value="radioInput1" />
+          <RadioInput label="RadioInput 2" value="radioInput2" />
+          <RadioInput label="RadioInput 3" value="radioInput3" />
+        </RadioInputGroup>
+
+        <FileDrop messages={messages} renderLabel="FileDrop" />
+
+        <ColorPicker
+          label="ColorPicker"
+          placeholderText="Enter HEX"
+          isRequired
+          renderMessages={() => messages}
+        />
+
+        <DateTimeInput
+          description={`DateTimeInput (layout="columns")`}
+          datePlaceholder="Choose a date"
+          dateRenderLabel="Date"
+          timeRenderLabel="Time"
+          invalidDateTimeMessage="Invalid date!"
+          prevMonthLabel="Previous month"
+          nextMonthLabel="Next month"
+          defaultValue="2018-01-18T13:30"
+          layout="columns"
+          isRequired
+          messages={messages}
+        />
+
+        <DateTimeInput
+          description={`DateTimeInput (layout="stacked")`}
+          datePlaceholder="Choose a date"
+          dateRenderLabel="Date"
+          timeRenderLabel="Time"
+          invalidDateTimeMessage="Invalid date!"
+          prevMonthLabel="Previous month"
+          nextMonthLabel="Next month"
+          defaultValue="2018-01-18T13:30"
+          layout="stacked"
+          isRequired
+          messages={messages}
+        />
+      </div>
+    </main>
+  )
+}

--- a/regression-test/src/app/heading/page.tsx
+++ b/regression-test/src/app/heading/page.tsx
@@ -1,0 +1,118 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Heading as hd } from 'instructure-ui/ui-heading/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { IconAdminSolid as ias } from 'instructure-ui/ui-icons/es/index'
+
+const Heading = hd as any
+const View = vw as any
+const IconAdminSolid = ias as any
+
+export default function HeadingPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      {/* Variant showcase (explicit level as recommended) */}
+      <section>
+        <Heading variant="titlePageDesktop" level="h1">
+          titlePageDesktop
+        </Heading>
+        <Heading variant="titlePageMobile" level="h1">
+          titlePageMobile
+        </Heading>
+        <Heading variant="titleSection" level="h2">
+          titleSection
+        </Heading>
+        <Heading variant="titleCardSection" level="h2">
+          titleCardSection
+        </Heading>
+        <Heading variant="titleModule" level="h3">
+          titleModule
+        </Heading>
+        <Heading variant="titleCardLarge" level="h3">
+          titleCardLarge
+        </Heading>
+        <Heading variant="titleCardRegular" level="h3">
+          titleCardRegular
+        </Heading>
+        <Heading variant="titleCardMini" level="h4">
+          titleCardMini
+        </Heading>
+        <Heading variant="label" level="h5">
+          label
+        </Heading>
+        <Heading variant="labelInline" level="h6">
+          labelInline
+        </Heading>
+      </section>
+
+      {/* AI Heading variants */}
+      <section style={{ display: 'flex', flexDirection: 'row', gap: '14px' }}>
+        <Heading aiVariant="stacked" level="h2">
+          Nutrition Facts
+        </Heading>
+        <Heading aiVariant="horizontal" level="h3">
+          Nutrition Facts
+        </Heading>
+        <Heading aiVariant="iconOnly" level="h4">
+          Nutrition Facts
+        </Heading>
+      </section>
+
+      {/* Colors */}
+      <section>
+        <Heading>I inherit my color via the CSS cascade (default)</Heading>
+        <Heading color="primary">I am primary color</Heading>
+        <Heading color="secondary">I am secondary color</Heading>
+      </section>
+
+      {/* Inverse colors */}
+      <section>
+        <View background="primary-inverse" as="div" padding="small medium">
+          <Heading color="primary-inverse">I am primary-inverse color</Heading>
+          <Heading color="secondary-inverse">
+            I am secondary-inverse color
+          </Heading>
+        </View>
+      </section>
+
+      {/* With icon */}
+      <section>
+        <Heading renderIcon={<IconAdminSolid />}>
+          I am heading with icon
+        </Heading>
+      </section>
+
+      {/* Borders */}
+      <section>
+        <Heading margin="0 0 medium" border="bottom">
+          I have a bottom border
+        </Heading>
+        <Heading border="top">I have a top border</Heading>
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/img/page.tsx
+++ b/regression-test/src/app/img/page.tsx
@@ -23,52 +23,52 @@
  */
 
 'use client'
-import { Link } from 'instructure-ui/ui-link/es/index'
+import React from 'react'
+import { Img as ig } from 'instructure-ui/ui-img/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
 
-const components = [
-  'small-components',
-  'alert',
-  'avatar',
-  'badge',
-  'billboard',
-  'breadcrumb',
-  'button',
-  'tooltip',
-  'byline',
-  'calendar',
-  'checkbox',
-  'checkboxgroup',
-  'colorpicker',
-  'contextview',
-  'dateinput',
-  'datetimeinput',
-  'drilldown',
-  'filedrop',
-  'form-errors',
-  'heading',
-  'img',
-  'link',
-  'menu',
-  'options',
-  'pagination',
-  'progressbar',
-  'select',
-  'table',
-  'tabs',
-  'treebrowser',
-  'view'
-]
+const Img = ig as any
+const View = vw as any
 
-export default function Home() {
+export default function ImgPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-6">
-      <ul>
-        {components.map((component) => (
-          <li key={component}>
-            <Link href={component}>{component}</Link>
-          </li>
-        ))}
-      </ul>
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <section>
+        <Img src="/assets/avatarSquare.jpg" alt="Sample image" />
+      </section>
+
+      <section>
+        <Img
+          src="/assets/avatarSquare.jpg"
+          overlay={{ color: '#0374B5', opacity: 9, blend: 'overlay' }}
+          alt="Overlay example"
+          margin="x-small"
+        />
+      </section>
+
+      <section>
+        <div style={{ width: '5rem', height: '7rem' }}>
+          <Img src="/assets/avatarSquare.jpg" constrain="cover" alt="test" />
+        </div>
+      </section>
+
+      <section>
+        <View
+          as="div"
+          withGrayscale
+          background="primary-inverse"
+          width="500px"
+          height="200px"
+          textAlign="center"
+        >
+          <Img
+            withBlur
+            src="/assets/avatarSquare.jpg"
+            constrain="contain"
+            alt=""
+          />
+        </View>
+      </section>
     </main>
   )
 }

--- a/regression-test/src/app/link/page.tsx
+++ b/regression-test/src/app/link/page.tsx
@@ -1,0 +1,174 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Link as lk } from 'instructure-ui/ui-link/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { IconUserLine as iul } from 'instructure-ui/ui-icons/es/index'
+import { ScreenReaderContent as src } from 'instructure-ui/ui-a11y-content/es/index'
+import { TruncateText as tt } from 'instructure-ui/ui-truncate-text/es/index'
+
+const Link = lk as any
+const Text = tx as any
+const View = vw as any
+const IconUserLine = iul as any
+const ScreenReaderContent = src as any
+const TruncateText = tt as any
+
+export default function LinkPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      {/* Inline usage */}
+      <section>
+        <Text>
+          The quick brown fox{' '}
+          <Link href="https://instructure.github.io/instructure-ui/">
+            jumps
+          </Link>{' '}
+          over the lazy dog.
+        </Text>
+      </section>
+
+      {/* Inverse on dark background */}
+      <section>
+        <View background="primary-inverse" as="div" padding="small medium">
+          <Text color="primary-inverse">
+            The quick brown fox{' '}
+            <Link
+              color="link-inverse"
+              href="https://instructure.github.io/instructure-ui/"
+            >
+              jumps
+            </Link>{' '}
+            over the lazy dog.
+          </Text>
+        </View>
+      </section>
+
+      {/* Controlled navigation */}
+      <section>
+        <Link
+          variant="standalone"
+          onClick={(e: any) => {
+            e.preventDefault()
+          }}
+          forceButtonRole={false}
+          href="#"
+        >
+          Go to places
+        </Link>
+      </section>
+
+      {/* Variants */}
+      <section>
+        <div>
+          In a line of text you should use the{' '}
+          <Link
+            variant="inline"
+            renderIcon={<IconUserLine />}
+            href="https://instructure.github.io/instructure-ui/"
+          >
+            inline
+          </Link>{' '}
+          link variant.
+        </div>
+        <br />
+        <div>
+          <Text variant="contentSmall">
+            In a line of text, where the text is smaller, use the{' '}
+            <Link
+              variant="inline-small"
+              renderIcon={<IconUserLine />}
+              href="https://instructure.github.io/instructure-ui/"
+            >
+              inline-small
+            </Link>{' '}
+            link variant
+          </Text>
+        </div>
+        <br />
+        <div>
+          If the link is standalone (not in a text), use the{' '}
+          <code>standalone</code>{' '}
+          <Link
+            display="block"
+            variant="standalone"
+            href="https://instructure.github.io/instructure-ui/"
+          >
+            standalone
+          </Link>
+        </div>
+        <br />
+        <div>
+          If the link is standalone (not in a text), but smaller, use the{' '}
+          <code>standalone-small</code>{' '}
+          <Link
+            display="block"
+            variant="standalone-small"
+            href="https://instructure.github.io/instructure-ui/"
+          >
+            standalone-small
+          </Link>
+        </div>
+      </section>
+
+      {/* Margin */}
+      <section>
+        <Text>
+          The quick brown fox{' '}
+          <Link
+            href="https://instructure.github.io/instructure-ui/"
+            margin="0 small"
+          >
+            jumps
+          </Link>{' '}
+          over the lazy dog.
+        </Text>
+      </section>
+
+      {/* Underlines (outside text) */}
+      <section>
+        <Link href="http://instructure.design" isWithinText={false}>
+          I have no default underline
+        </Link>
+      </section>
+
+      {/* Truncate text with icon */}
+      <section style={{ maxWidth: '24rem' }}>
+        <Link
+          onClick={() => {}}
+          isWithinText={false}
+          renderIcon={<IconUserLine size="small" />}
+        >
+          <TruncateText>
+            This is a very long piece of link text intended to demonstrate
+            truncation inside a Link component with an icon before the text.
+          </TruncateText>
+        </Link>
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/menu/page.tsx
+++ b/regression-test/src/app/menu/page.tsx
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Menu as mn } from 'instructure-ui/ui-menu/es/index'
+import { Button as btn } from 'instructure-ui/ui-buttons/es/index'
+import { NoSSR } from '../NoSSR'
+
+const Menu = mn as any
+const Button = btn as any
+
+export default function MenuPage() {
+  // Disabling SSR is needed here because Menu does not work when it starts in
+  // the open state
+  return (
+    <NoSSR>
+      <div id="main" className="flex gap-8 p-8 flex-col items-start axe-test">
+        <Menu
+          defaultShow
+          placement="bottom"
+          trigger={<Button>Menu</Button>}
+          mountNode={() => document.getElementById('main')}
+        >
+          <Menu.Item value="mastery">Learning Mastery</Menu.Item>
+          <Menu.Item
+            href="https://instructure.github.io/instructure-ui/"
+            target="_blank"
+          >
+            Default (Grid view)
+          </Menu.Item>
+          <Menu.Item disabled>Individual (List view)</Menu.Item>
+
+          <Menu label="More Options">
+            <Menu.Group
+              allowMultiple
+              label="Select Many"
+              selected={['optionOne', 'optionThree']}
+            >
+              <Menu.Item value="optionOne">Option 1</Menu.Item>
+              <Menu.Item value="optionTwo">Option 2</Menu.Item>
+              <Menu.Item value="optionThree">Option 3</Menu.Item>
+            </Menu.Group>
+            <Menu.Separator />
+            <Menu.Item value="navigation">Navigation</Menu.Item>
+            <Menu.Item value="set">Set as default</Menu.Item>
+          </Menu>
+
+          <Menu.Separator />
+
+          <Menu.Group label="Select One" selected="itemOne">
+            <Menu.Item value="itemOne">Item 1</Menu.Item>
+            <Menu.Item value="itemTwo">Item 2</Menu.Item>
+          </Menu.Group>
+
+          <Menu.Separator />
+          <Menu.Item value="baz">Open grading history...</Menu.Item>
+        </Menu>
+      </div>
+    </NoSSR>
+  )
+}

--- a/regression-test/src/app/options/page.tsx
+++ b/regression-test/src/app/options/page.tsx
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Options as op } from 'instructure-ui/ui-options/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import {
+  IconArrowOpenEndSolid as iaoes,
+  IconCheckSolid as ics,
+  IconCheckLine as icl
+} from 'instructure-ui/ui-icons/es/index'
+
+const Options = op as any
+const View = vw as any
+const IconArrowOpenEndSolid = iaoes as any
+const IconCheckSolid = ics as any
+const IconCheckLine = icl as any
+
+export default function OptionsPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      {/* Basic variants */}
+      <View display="block" width="300px">
+        <Options>
+          <Options.Item>Default option</Options.Item>
+          <Options.Item variant="highlighted">Highlighted option</Options.Item>
+          <Options.Item variant="selected">Selected option</Options.Item>
+          <Options.Item variant="disabled">Disabled option</Options.Item>
+          <Options.Item variant="highlighted-disabled">
+            Highlighted disabled option
+          </Options.Item>
+        </Options>
+      </View>
+
+      {/* Nested menus with roles, separators and radio group */}
+      <View display="block" width="400px">
+        <Options role="menu" as="ul">
+          <Options.Item role="menuitem">Option one</Options.Item>
+          <Options.Item role="menuitem" variant="highlighted">
+            Option two
+          </Options.Item>
+          <Options.Item
+            role="menuitem"
+            renderAfterLabel={IconArrowOpenEndSolid}
+          >
+            Flyout menu option
+          </Options.Item>
+          <Options.Separator as="li" />
+          <Options role="menu" as="ul" renderLabel={'Sub menu'}>
+            <Options.Item role="menuitem">Sub option one</Options.Item>
+            <Options.Item role="menuitem">Sub option two</Options.Item>
+          </Options>
+          <Options.Separator />
+          <Options role="menu" as="ul" renderLabel={'Radio group'}>
+            <Options.Item
+              role="menuitemradio"
+              aria-checked="true"
+              renderBeforeLabel={IconCheckSolid}
+            >
+              Radio option one
+            </Options.Item>
+            <Options.Item
+              role="menuitemradio"
+              aria-checked="false"
+              renderBeforeLabel={<IconCheckLine style={{ opacity: 0 }} />}
+            >
+              Radio option two
+            </Options.Item>
+          </Options>
+          <Options.Separator />
+          <Options.Item role="menuitem">Option three</Options.Item>
+        </Options>
+      </View>
+
+      {/* Description + icon alignment */}
+      <View display="block" width="300px">
+        <Options>
+          <Options.Item
+            description="Curabitur fringilla, urna ut efficitur molestie, nibh lacus tincidunt elit, ut tempor ipsum nunc sit amet massa."
+            renderBeforeLabel={IconCheckSolid}
+            renderAfterLabel={IconArrowOpenEndSolid}
+            beforeLabelContentVAlign="start"
+            afterLabelContentVAlign="start"
+          >
+            Option one
+          </Options.Item>
+          <Options.Item
+            variant="highlighted"
+            description="Curabitur fringilla, urna ut efficitur molestie, nibh lacus tincidunt elit, ut tempor ipsum nunc sit amet massa."
+            renderBeforeLabel={IconCheckSolid}
+            renderAfterLabel={IconArrowOpenEndSolid}
+            beforeLabelContentVAlign="center"
+            afterLabelContentVAlign="center"
+          >
+            Option two
+          </Options.Item>
+          <Options.Item
+            description="Curabitur fringilla, urna ut efficitur molestie, nibh lacus tincidunt elit, ut tempor ipsum nunc sit amet massa."
+            renderBeforeLabel={IconCheckSolid}
+            renderAfterLabel={IconArrowOpenEndSolid}
+            beforeLabelContentVAlign="end"
+            afterLabelContentVAlign="end"
+          >
+            Option three
+          </Options.Item>
+        </Options>
+      </View>
+    </main>
+  )
+}

--- a/regression-test/src/app/pagination/page.tsx
+++ b/regression-test/src/app/pagination/page.tsx
@@ -1,0 +1,159 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useMemo, useState } from 'react'
+import { Pagination as pg } from 'instructure-ui/ui-pagination/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+
+const Pagination = pg as any
+const View = vw as any
+
+export default function PaginationPage() {
+  // New API states
+  const [currentNewSmall, setCurrentNewSmall] = useState(1)
+  const [currentNewLarge, setCurrentNewLarge] = useState(1)
+  const [currentFull, setCurrentFull] = useState(1)
+  const [currentInput, setCurrentInput] = useState(1)
+
+  // Legacy API states
+  const [legacyCompactPage, setLegacyCompactPage] = useState(0)
+  const [legacyInputPage, setLegacyInputPage] = useState(0)
+
+  const pageMap = useMemo(() => ['A-G', 'H-J', 'K-M', 'N-Q', 'R-Z'], [])
+
+  const renderLegacyPages = (
+    count: number,
+    current: number,
+    setter: (p: number) => void
+  ) =>
+    Array.from(Array(count)).map((_, i) => (
+      <Pagination.Page
+        key={i}
+        onClick={() => setter(i)}
+        current={i === current}
+      >
+        {i + 1}
+      </Pagination.Page>
+    ))
+
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      {/* New API: compact variant with 9 pages */}
+      <section>
+        <Pagination
+          as="nav"
+          margin="small"
+          variant="compact"
+          labelNext="Next Page"
+          labelPrev="Previous Page"
+          currentPage={currentNewSmall}
+          totalPageNumber={9}
+          onPageChange={(nextPage: number) => setCurrentNewSmall(nextPage)}
+        />
+      </section>
+
+      {/* New API: compact variant with very large totalPageNumber, sibling/boundary and SR labels */}
+      <section>
+        <Pagination
+          as="nav"
+          margin="small"
+          variant="compact"
+          labelNext="Next Page"
+          labelPrev="Previous Page"
+          currentPage={currentNewLarge}
+          totalPageNumber={100000}
+          onPageChange={(nextPage: number) => setCurrentNewLarge(nextPage)}
+          siblingCount={3}
+          boundaryCount={2}
+          screenReaderLabelPageButton={(
+            currentPage: number,
+            totalPageNumber: number
+          ) => `Page ${currentPage} of ${totalPageNumber}`}
+        />
+      </section>
+
+      {/* New API: full variant with custom page indicator */}
+      <section>
+        <Pagination
+          as="nav"
+          margin="small"
+          variant="full"
+          labelNext="Next Page"
+          labelPrev="Previous Page"
+          currentPage={currentFull}
+          totalPageNumber={5}
+          onPageChange={(nextPage: number) => setCurrentFull(nextPage)}
+          siblingCount={5}
+          boundaryCount={0}
+          renderPageIndicator={(page: number) => pageMap[page - 1]}
+        />
+      </section>
+
+      {/* New API: input variant */}
+      <section>
+        <Pagination
+          as="nav"
+          margin="small"
+          variant="input"
+          labelNext="Next Page"
+          labelPrev="Previous Page"
+          currentPage={currentInput}
+          totalPageNumber={9}
+          onPageChange={(nextPage: number) => setCurrentInput(nextPage)}
+        />
+      </section>
+      <div>Legacy API</div>
+      {/* Legacy API: compact variant with children */}
+      <section>
+        <View as="div" display="block" margin="small 0">
+          <Pagination
+            as="nav"
+            margin="small"
+            variant="compact"
+            labelNext="Next Page"
+            labelPrev="Previous Page"
+          >
+            {renderLegacyPages(9, legacyCompactPage, setLegacyCompactPage)}
+          </Pagination>
+        </View>
+      </section>
+
+      {/* Legacy API: input variant with children + first/last labels */}
+      <section>
+        <Pagination
+          as="nav"
+          margin="small"
+          variant="input"
+          labelFirst="First Page"
+          labelPrev="Previous Page"
+          labelNext="Next Page"
+          labelLast="Last Page"
+        >
+          {renderLegacyPages(9, legacyInputPage, setLegacyInputPage)}
+        </Pagination>
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/progressbar/page.tsx
+++ b/regression-test/src/app/progressbar/page.tsx
@@ -1,0 +1,261 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import {
+  ProgressBar as pb,
+  ProgressCircle as pc
+} from 'instructure-ui/ui-progress/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+
+const ProgressCircle = pc as any
+const ProgressBar = pb as any
+const View = vw as any
+const Text = tx as any
+
+export default function ProgressBarPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <section style={{ width: '500px' }}>
+        <div>Sizes:</div>
+        <ProgressBar
+          size="x-small"
+          screenReaderLabel="Loading completion"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          size="small"
+          screenReaderLabel="Loading completion"
+          valueNow={20}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          size="large"
+          screenReaderLabel="Loading completion"
+          valueNow={40}
+          valueMax={60}
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+      </section>
+
+      <section style={{ width: '500px' }}>
+        <div>Inverse:</div>
+        <View background="primary-inverse" as="div" padding="small">
+          <ProgressBar
+            screenReaderLabel="Loading completion"
+            color="primary-inverse"
+            valueNow={30}
+            valueMax={60}
+            renderValue={({ valueNow, valueMax }: any) => (
+              <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+            )}
+            formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+              Math.round((valueNow / valueMax) * 100) + ' percent'
+            }
+          />
+        </View>
+      </section>
+
+      <section style={{ width: '500px' }}>
+        <div>Colors:</div>
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          meterColor="info"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          meterColor="success"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          meterColor="alert"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          meterColor="warning"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+        <ProgressBar
+          screenReaderLabel="Loading completion"
+          meterColor="danger"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+          renderValue={({ valueNow, valueMax }: any) => (
+            <Text>{Math.round((valueNow / valueMax) * 100)}%</Text>
+          )}
+          formatScreenReaderValue={({ valueNow, valueMax }: any) =>
+            Math.round((valueNow / valueMax) * 100) + ' percent'
+          }
+        />
+      </section>
+
+      <div>ProgressCircle:</div>
+      <section style={{ width: '600px' }}>
+        <ProgressCircle
+          size="x-small"
+          screenReaderLabel="Loading completion"
+          valueNow={40}
+          valueMax={60}
+          margin="0 small 0 0"
+        />
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          valueNow={40}
+          valueMax={60}
+          margin="0 small 0 0"
+          formatScreenReaderValue={function ({ valueNow, valueMax }: any) {
+            return valueNow + ' out of ' + valueMax
+          }}
+          renderValue={function ({ valueNow, valueMax }: any) {
+            return (
+              <span>
+                <Text size="large" weight="bold">
+                  {valueNow}
+                </Text>
+                <br />
+                <Text size="small">/&nbsp;</Text>
+                <Text size="small">{valueMax}</Text>
+              </span>
+            )
+          }}
+        />
+        <View background="primary-inverse" as="div">
+          <ProgressCircle
+            screenReaderLabel="Loading completion"
+            color="primary-inverse"
+            valueNow={50}
+            valueMax={60}
+          />
+        </View>
+      </section>
+      <section style={{ width: '600px' }}>
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          meterColor="info"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+        />
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          meterColor="success"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+        />
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          meterColor="alert"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+        />
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          meterColor="warning"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+        />
+        <ProgressCircle
+          screenReaderLabel="Loading completion"
+          meterColor="danger"
+          valueNow={40}
+          valueMax={60}
+          margin="0 0 small"
+        />
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/select/page.tsx
+++ b/regression-test/src/app/select/page.tsx
@@ -1,0 +1,346 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useRef, useState } from 'react'
+import { Select as sl } from 'instructure-ui/ui-select/es/index'
+import { SimpleSelect as ss } from 'instructure-ui/ui-simple-select/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import {
+  IconUserSolid as ius,
+  IconUserLine as iul,
+  IconSearchLine as isl
+} from 'instructure-ui/ui-icons/es/index'
+
+const Select = sl as any
+const SimpleSelect = ss as any
+const View = vw as any
+const IconUserSolid = ius as any
+const IconUserLine = iul as any
+const IconSearchLine = isl as any
+
+type OptionT = { id: string; label: string; disabled?: boolean }
+
+function SingleSelectExample({ options }: { options: OptionT[] }) {
+  const [inputValue, setInputValue] = useState(options[0].label)
+  const [isShowingOptions, setIsShowingOptions] = useState(false)
+  const [highlightedOptionId, setHighlightedOptionId] = useState<string | null>(
+    null
+  )
+  const [selectedOptionId, setSelectedOptionId] = useState<string>(
+    options[0].id
+  )
+  const inputRef = useRef<any>()
+
+  const getOptionById = (id?: string | null) => options.find((o) => o.id === id)
+
+  const handleShowOptions = (event: any) => {
+    setIsShowingOptions(true)
+    if (!inputValue && !selectedOptionId && options.length > 0) {
+      if (event.key === 'ArrowDown') setHighlightedOptionId(options[0].id)
+      if (event.key === 'ArrowUp')
+        setHighlightedOptionId(options[options.length - 1].id)
+    }
+  }
+  const handleHideOptions = () => {
+    setIsShowingOptions(false)
+    setHighlightedOptionId(null)
+    const option = getOptionById(selectedOptionId)
+    setInputValue(option ? option.label : '')
+  }
+  const handleHighlightOption = (_e: any, { id }: { id: string }) => {
+    setHighlightedOptionId(id)
+  }
+  const handleSelectOption = (_e: any, { id }: { id: string }) => {
+    const option = getOptionById(id)
+    if (!option) return
+    // focus juggling improves SR experience
+    if (inputRef.current) {
+      inputRef.current.blur()
+      inputRef.current.focus()
+    }
+    setSelectedOptionId(id)
+    setInputValue(option.label)
+    setIsShowingOptions(false)
+  }
+
+  return (
+    <View display="block" width="22rem">
+      <Select
+        renderLabel="Single Select"
+        assistiveText="Use arrow keys to navigate options."
+        inputValue={inputValue}
+        isShowingOptions={isShowingOptions}
+        onBlur={() => setHighlightedOptionId(null)}
+        onRequestShowOptions={handleShowOptions}
+        onRequestHideOptions={handleHideOptions}
+        onRequestHighlightOption={handleHighlightOption}
+        onRequestSelectOption={handleSelectOption}
+        inputRef={(el: any) => (inputRef.current = el)}
+      >
+        {options.map((opt) => (
+          <Select.Option
+            key={opt.id}
+            id={opt.id}
+            isHighlighted={opt.id === highlightedOptionId}
+            isSelected={opt.id === selectedOptionId}
+            isDisabled={opt.disabled}
+          >
+            {opt.label}
+          </Select.Option>
+        ))}
+      </Select>
+    </View>
+  )
+}
+
+function AutocompleteExample({ options }: { options: OptionT[] }) {
+  const [inputValue, setInputValue] = useState('')
+  const [isShowingOptions, setIsShowingOptions] = useState(false)
+  const [highlightedOptionId, setHighlightedOptionId] = useState<string | null>(
+    null
+  )
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
+  const [filteredOptions, setFilteredOptions] = useState<OptionT[]>(options)
+  const inputRef = useRef<any>()
+
+  const getOptionById = (id?: string | null) => options.find((o) => o.id === id)
+  const filterOptions = (val: string) =>
+    options.filter((o) => o.label.toLowerCase().startsWith(val.toLowerCase()))
+
+  const handleShowOptions = () => setIsShowingOptions(true)
+  const handleHideOptions = () => {
+    setIsShowingOptions(false)
+    // basic matching behavior
+    if (
+      filteredOptions.length === 1 &&
+      filteredOptions[0].label.toLowerCase() === inputValue.toLowerCase()
+    ) {
+      const only = filteredOptions[0]
+      setSelectedOptionId(only.id)
+      setInputValue(only.label)
+      setFilteredOptions(options)
+      return
+    }
+    if (inputValue.length === 0) {
+      setSelectedOptionId(null)
+      setFilteredOptions(options)
+      return
+    }
+    if (selectedOptionId) {
+      const selected = getOptionById(selectedOptionId)
+      if (selected) setInputValue(selected.label)
+    }
+  }
+  const handleInputChange = (e: any) => {
+    const val = e.target.value
+    const newOptions = filterOptions(val)
+    setInputValue(val)
+    setFilteredOptions(newOptions)
+    setHighlightedOptionId(newOptions.length > 0 ? newOptions[0].id : null)
+    setIsShowingOptions(true)
+  }
+  const handleHighlightOption = (_e: any, { id }: { id: string }) => {
+    setHighlightedOptionId(id)
+  }
+  const handleSelectOption = (_e: any, { id }: { id: string }) => {
+    const option = getOptionById(id)
+    if (!option) return
+    if (inputRef.current) {
+      inputRef.current.blur()
+      inputRef.current.focus()
+    }
+    setSelectedOptionId(id)
+    setInputValue(option.label)
+    setIsShowingOptions(false)
+    setFilteredOptions(options)
+  }
+
+  return (
+    <View display="block" width="26rem">
+      <Select
+        renderLabel="Autocomplete"
+        assistiveText="Type or use arrow keys to navigate options."
+        placeholder="Start typing to search..."
+        inputValue={inputValue}
+        isShowingOptions={isShowingOptions}
+        onBlur={() => setHighlightedOptionId(null)}
+        onInputChange={handleInputChange}
+        onRequestShowOptions={handleShowOptions}
+        onRequestHideOptions={handleHideOptions}
+        onRequestHighlightOption={handleHighlightOption}
+        onRequestSelectOption={handleSelectOption}
+        renderBeforeInput={<IconUserSolid inline={false} />}
+        renderAfterInput={<IconSearchLine inline={false} />}
+        inputRef={(el: any) => (inputRef.current = el)}
+      >
+        {filteredOptions.length > 0 ? (
+          filteredOptions.map((opt) => (
+            <Select.Option
+              key={opt.id}
+              id={opt.id}
+              isHighlighted={opt.id === highlightedOptionId}
+              isSelected={opt.id === selectedOptionId}
+              isDisabled={opt.disabled}
+              renderBeforeLabel={!opt.disabled ? IconUserSolid : IconUserLine}
+            >
+              {!opt.disabled ? opt.label : `${opt.label} (unavailable)`}
+            </Select.Option>
+          ))
+        ) : (
+          <Select.Option id="empty-option" key="empty-option">
+            ---
+          </Select.Option>
+        )}
+      </Select>
+    </View>
+  )
+}
+
+function GroupSelectExample({
+  options
+}: {
+  options: Record<string, OptionT[]>
+}) {
+  const groupKeys = Object.keys(options)
+  const first = options[groupKeys[0]][0]
+  const [inputValue, setInputValue] = useState(first.label)
+  const [isShowingOptions, setIsShowingOptions] = useState(false)
+  const [highlightedOptionId, setHighlightedOptionId] = useState<string | null>(
+    null
+  )
+  const [selectedOptionId, setSelectedOptionId] = useState<string>(first.id)
+  const inputRef = useRef<any>()
+
+  const getOptionById = (id?: string | null) =>
+    groupKeys.flatMap((k) => options[k]).find((o) => o.id === id)
+
+  return (
+    <View display="block" width="24rem">
+      <Select
+        renderAfterInput={<IconUserLine />}
+        renderLabel="Group Select"
+        assistiveText="Use arrow keys to navigate options."
+        inputValue={inputValue}
+        isShowingOptions={isShowingOptions}
+        onBlur={() => setHighlightedOptionId(null)}
+        onRequestShowOptions={() => setIsShowingOptions(true)}
+        onRequestHideOptions={() => {
+          setIsShowingOptions(false)
+          const selected = getOptionById(selectedOptionId)
+          setInputValue(selected ? selected.label : '')
+        }}
+        onRequestHighlightOption={(_e: any, { id }: { id: string }) =>
+          setHighlightedOptionId(id)
+        }
+        onRequestSelectOption={(_e: any, { id }: { id: string }) => {
+          const opt = getOptionById(id)
+          if (!opt) return
+          if (inputRef.current) {
+            inputRef.current.blur()
+            inputRef.current.focus()
+          }
+          setSelectedOptionId(id)
+          setInputValue(opt.label)
+          setIsShowingOptions(false)
+        }}
+        inputRef={(el: any) => (inputRef.current = el)}
+      >
+        {groupKeys.map((groupKey) => (
+          <Select.Group key={groupKey} renderLabel={groupKey}>
+            {options[groupKey].map((opt) => (
+              <Select.Option
+                key={opt.id}
+                id={opt.id}
+                isHighlighted={opt.id === highlightedOptionId}
+                isSelected={opt.id === selectedOptionId}
+              >
+                {opt.label}
+              </Select.Option>
+            ))}
+          </Select.Group>
+        ))}
+      </Select>
+      <div>SimpleSelect:</div>
+      <div>
+        <SimpleSelect renderLabel="Uncontrolled Select">
+          <SimpleSelect.Option
+            id="foo"
+            value="foo"
+            renderBeforeLabel={(props: any) => {
+              return <IconUserSolid />
+            }}
+          >
+            Foo
+          </SimpleSelect.Option>
+          <SimpleSelect.Option id="bar" value="bar">
+            Bar
+          </SimpleSelect.Option>
+          <SimpleSelect.Option id="baz" value="baz">
+            Baz
+          </SimpleSelect.Option>
+        </SimpleSelect>
+      </div>
+    </View>
+  )
+}
+
+export default function SelectPage() {
+  const basicOptions: OptionT[] = [
+    { id: 'opt1', label: 'Alaska' },
+    { id: 'opt2', label: 'American Samoa' },
+    { id: 'opt3', label: 'Arizona' },
+    { id: 'opt4', label: 'Arkansas' }
+  ]
+  const autoOptions: OptionT[] = [
+    { id: 'opt0', label: 'Aaron Aaronson' },
+    { id: 'opt1', label: 'Amber Murphy' },
+    { id: 'opt2', label: 'Andrew Miller' },
+    { id: 'opt3', label: 'Barbara Ward' },
+    { id: 'opt4', label: 'Byron Cranston', disabled: true },
+    { id: 'opt5', label: 'Dennis Reynolds' },
+    { id: 'opt6', label: 'Dee Reynolds' },
+    { id: 'opt7', label: 'Ezra Betterthan' }
+  ]
+  const grouped = {
+    Western: [
+      { id: 'g_opt1', label: 'Alaska' },
+      { id: 'g_opt2', label: 'California' },
+      { id: 'g_opt3', label: 'Colorado' }
+    ],
+    Eastern: [
+      { id: 'g_opt4', label: 'Alabama' },
+      { id: 'g_opt5', label: 'Connecticut' },
+      { id: 'g_opt6', label: 'Delaware' }
+    ]
+  }
+
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <SingleSelectExample options={basicOptions} />
+      <AutocompleteExample options={autoOptions} />
+      <GroupSelectExample options={grouped} />
+    </main>
+  )
+}

--- a/regression-test/src/app/small-components/page.tsx
+++ b/regression-test/src/app/small-components/page.tsx
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+/* eslint-disable no-restricted-imports */
+import React from 'react'
+import {
+  Metric as mc,
+  MetricGroup as mcg
+} from 'instructure-ui/ui-metric/es/index'
+import { Pill as pl } from 'instructure-ui/ui-pill/es/index'
+import { Tag as tg } from 'instructure-ui/ui-tag/es/index'
+import { TimeSelect as ts } from 'instructure-ui/ui-time-select/es/index'
+import {
+  IconMessageLine,
+  IconClockLine,
+  IconEndLine,
+  IconCheckLine
+} from 'instructure-ui/ui-icons/es/index'
+import { AccessibleContent } from '@instructure/ui-a11y-content/es/index'
+
+const Metric = mc as any
+const MetricGroup = mcg as any
+const Pill = pl as any
+const Tag = tg as any
+const TimeSelect = ts as any
+
+export default function MetricPage() {
+  return (
+    <main id="main" className="flex gap-8 p-8 flex-col items-start axe-test">
+      <div>Metric:</div>
+      <Metric textAlign="start" renderLabel="Grade" renderValue="80%" />
+      <Metric renderLabel="Grade" renderValue="80%" />
+      <Metric textAlign="end" renderLabel="Grade" renderValue="80%" />
+      <div>MetricGroup:</div>
+      <MetricGroup>
+        <Metric renderLabel="Grade" renderValue="80%" />
+        <Metric renderLabel="Late" renderValue="4" />
+        <Metric renderLabel="Missing" renderValue="2" />
+      </MetricGroup>
+      <div>Pill:</div>
+      <div>
+        <Pill margin="x-small">Excused</Pill>
+        <Pill statusLabel="Status" color="info" margin="x-small">
+          Draft
+        </Pill>
+        <Pill
+          statusLabel="Status"
+          renderIcon={<IconCheckLine />}
+          color="success"
+          margin="x-small"
+        >
+          Checked In
+        </Pill>
+        <Pill renderIcon={<IconEndLine />} color="danger" margin="x-small">
+          Missing
+        </Pill>
+        <Pill renderIcon={<IconClockLine />} color="warning" margin="x-small">
+          Late
+        </Pill>
+        <Pill renderIcon={<IconMessageLine />} color="alert" margin="x-small">
+          Notification
+        </Pill>
+      </div>
+      <div>Tag:</div>
+      <div>
+        <Tag text="Static" margin="0 xx-small 0 0" />
+        <Tag
+          text={
+            <AccessibleContent alt="Remove dismissible tag">
+              Dismissible tag
+            </AccessibleContent>
+          }
+          dismissible
+          margin="0 xx-small 0 0"
+          onClick={function () {}}
+        />
+        <Tag text="Small" size="small" margin="0 xx-small 0 0" />
+        <Tag text="Medium" margin="0 xx-small 0 0" />
+        <Tag
+          disabled
+          dismissible
+          text="Large"
+          size="large"
+          margin="0 xx-small 0 0"
+          onClick={function () {}}
+        />
+      </div>
+      <p>
+        This is an
+        <Tag
+          dismissible
+          onClick={() => alert('Tag dismissed')}
+          size="large"
+          text={
+            <AccessibleContent alt="Remove 'inline'">inline</AccessibleContent>
+          }
+          variant="inline"
+        />
+        tag.
+      </p>
+      <div>TimeSelect:</div>
+      <TimeSelect
+        renderLabel="Choose a time"
+        onChange={(e: any, { value }: any) => 3}
+        onHideOptions={(e: any) => 5}
+        defaultValue="2025-08-18T09:30:00+00:00"
+      />
+    </main>
+  )
+}

--- a/regression-test/src/app/table/page.tsx
+++ b/regression-test/src/app/table/page.tsx
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Table as tb } from 'instructure-ui/ui-table/es/index'
+
+const Table = tb as any
+
+export default function TablePage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <section>
+        <Table caption="Top rated movies" layout="auto">
+          <Table.Head>
+            <Table.Row>
+              <Table.ColHeader id="Rank">Rank</Table.ColHeader>
+              <Table.ColHeader id="Title">Title</Table.ColHeader>
+              <Table.ColHeader id="Year">Year</Table.ColHeader>
+              <Table.ColHeader id="Rating">Rating</Table.ColHeader>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.RowHeader>1</Table.RowHeader>
+              <Table.Cell>The Shawshank Redemption</Table.Cell>
+              <Table.Cell>1994</Table.Cell>
+              <Table.Cell>9.3</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.RowHeader>2</Table.RowHeader>
+              <Table.Cell>The Godfather</Table.Cell>
+              <Table.Cell>1972</Table.Cell>
+              <Table.Cell>9.2</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.RowHeader>3</Table.RowHeader>
+              <Table.Cell>The Godfather: Part II</Table.Cell>
+              <Table.Cell>1974</Table.Cell>
+              <Table.Cell>9.0</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </section>
+
+      <section>
+        <Table caption="Top rated movies (fixed layout)" layout="fixed" hover>
+          <Table.Head>
+            <Table.Row>
+              <Table.ColHeader id="Title" width="40%" textAlign="start">
+                Title
+              </Table.ColHeader>
+              <Table.ColHeader id="Year" width="20%" textAlign="start">
+                Year
+              </Table.ColHeader>
+              <Table.ColHeader id="Rating" width="20%" textAlign="end">
+                Rating
+              </Table.ColHeader>
+              <Table.ColHeader id="BoxOffice" width="20%" textAlign="end">
+                Box Office
+              </Table.ColHeader>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>The Shawshank Redemption</Table.Cell>
+              <Table.Cell>1994</Table.Cell>
+              <Table.Cell>9.3</Table.Cell>
+              <Table.Cell>$28,341,469</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>The Godfather</Table.Cell>
+              <Table.Cell>1972</Table.Cell>
+              <Table.Cell>9.2</Table.Cell>
+              <Table.Cell>$133,698,921</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>The Godfather: Part II</Table.Cell>
+              <Table.Cell>1974</Table.Cell>
+              <Table.Cell>9.0</Table.Cell>
+              <Table.Cell>$47,542,841</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/tabs/page.tsx
+++ b/regression-test/src/app/tabs/page.tsx
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { Tabs as tbs } from 'instructure-ui/ui-tabs/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { Text as tx } from 'instructure-ui/ui-text/es/index'
+
+const Tabs = tbs as any
+const View = vw as any
+const Text = tx as any
+
+export default function TabsPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      {/* Basic tabs with 3 panels */}
+      <section>
+        <Tabs margin="small 0">
+          <Tabs.Panel id="tab-1" renderTitle="First tab">
+            <Text>First panel content</Text>
+          </Tabs.Panel>
+          <Tabs.Panel id="tab-2" renderTitle="Second tab" isDisabled>
+            <Text>Second panel (disabled)</Text>
+          </Tabs.Panel>
+          <Tabs.Panel id="tab-3" renderTitle="Third tab">
+            <Text>Third panel content</Text>
+          </Tabs.Panel>
+        </Tabs>
+      </section>
+
+      {/* Secondary variant */}
+      <section>
+        <Tabs margin="small 0" variant="secondary">
+          <Tabs.Panel id="sec-1" renderTitle="Overview">
+            <View as="div" padding="small 0">
+              <Text>Overview content</Text>
+            </View>
+          </Tabs.Panel>
+          <Tabs.Panel id="sec-2" renderTitle="Details">
+            <View as="div" padding="small 0">
+              <Text>Details content</Text>
+            </View>
+          </Tabs.Panel>
+          <Tabs.Panel id="sec-3" renderTitle="Activity">
+            <View as="div" padding="small 0">
+              <Text>Activity content</Text>
+            </View>
+          </Tabs.Panel>
+        </Tabs>
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/tooltip/page.tsx
+++ b/regression-test/src/app/tooltip/page.tsx
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 'use client'
 
 import React from 'react'
@@ -207,7 +208,7 @@ export default function TooltipPage() {
     <main className="items-start axe-test">
       <ApplyLocale locale="en-US">
         <br />
-        <div style={{ display: 'flex', flexWrap: 'wrap', margin: '3rem' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', width: '40rem' }}>
           {components.map(function (component, key) {
             return wrapComponent(component, key.toString())
           })}
@@ -220,15 +221,7 @@ export default function TooltipPage() {
 function wrapComponent(component: string | React.JSX.Element, key: string) {
   const Tooltip = to as any
   return (
-    <div
-      key={key}
-      style={{
-        flex: '0 0 calc(100% / 2 - 1rem)',
-        boxSizing: 'border-box',
-        display: 'flex',
-        marginBottom: '5rem'
-      }}
-    >
+    <div key={key} style={{ margin: '4rem' }}>
       <Tooltip
         renderTip={`Tooltip ${key}`}
         isShowingContent={true}

--- a/regression-test/src/app/treebrowser/page.tsx
+++ b/regression-test/src/app/treebrowser/page.tsx
@@ -1,0 +1,151 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React, { useState } from 'react'
+import { TreeBrowser as tb } from 'instructure-ui/ui-tree-browser/es/index'
+import {
+  RadioInput as ri,
+  RadioInputGroup as rig
+} from 'instructure-ui/ui-radio-input/es/index'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+import { ScreenReaderContent as src } from 'instructure-ui/ui-a11y-content/es/index'
+import {
+  IconGradebookLine as igl,
+  IconXSolid as ixs,
+  IconUserSolid as ius,
+  IconModuleLine as iml,
+  IconVideoLine as ivl
+} from 'instructure-ui/ui-icons/es/index'
+
+const TreeBrowser = tb as any
+const RadioInput = ri as any
+const RadioInputGroup = rig as any
+const View = vw as any
+const ScreenReaderContent = src as any
+const IconGradebookLine = igl as any
+const IconXSolid = ixs as any
+const IconUserSolid = ius as any
+const IconModuleLine = iml as any
+const IconVideoLine = ivl as any
+
+export default function TreeBrowserPage() {
+  const [size, setSize] = useState('medium')
+  const sizes = ['small', 'medium', 'large']
+
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <section>
+        <TreeBrowser
+          size="large"
+          collections={{
+            1: {
+              id: 1,
+              name: 'Assignments',
+              collections: [2, 3],
+              items: [3],
+              descriptor: 'Class Assignments'
+            },
+            2: {
+              id: 2,
+              name: 'English Assignments',
+              collections: [4],
+              items: []
+            },
+            3: {
+              id: 3,
+              name: 'Math Assignments',
+              collections: [5],
+              items: [1, 2]
+            },
+            4: {
+              id: 4,
+              name: 'Reading Assignments',
+              collections: [],
+              items: [4]
+            },
+            5: { id: 5, name: 'Advanced Math Assignments', items: [5] }
+          }}
+          items={{
+            1: { id: 1, name: 'Addition Worksheet' },
+            2: { id: 2, name: 'Subtraction Worksheet' },
+            3: { id: 3, name: 'General Questions' },
+            4: { id: 4, name: 'Vogon Poetry' },
+            5: {
+              id: 5,
+              name: 'Bistromath',
+              descriptor: 'Explain the Bistromathic Drive'
+            }
+          }}
+          defaultExpanded={[1, 3]}
+          rootId={1}
+        />
+      </section>
+
+      {/* Customizing icons example */}
+      <section>
+        <TreeBrowser
+          collections={{
+            1: { id: 1, name: 'Grades', collections: [], items: [1, 2, 3] }
+          }}
+          items={{
+            1: { id: 1, name: 'Sarah' },
+            2: { id: 2, name: 'Jenny' },
+            3: { id: 3, name: 'Juan' }
+          }}
+          defaultExpanded={[1]}
+          collectionIcon={IconGradebookLine}
+          collectionIconExpanded={IconXSolid}
+          itemIcon={IconUserSolid}
+          rootId={1}
+          size="medium"
+        />
+      </section>
+
+      {/* Different icons per item via getItemProps */}
+      <section>
+        <TreeBrowser
+          collections={{
+            1: { id: 1, name: 'Saved', collections: [], items: [1, 2, 3] }
+          }}
+          items={{
+            1: { id: 1, name: 'Modules' },
+            2: { id: 2, name: 'Videos' },
+            3: { id: 3, name: 'Students' }
+          }}
+          defaultExpanded={[1]}
+          itemIcon={IconUserSolid}
+          rootId={1}
+          size="large"
+          getItemProps={({ name, ...props }: any) => {
+            let itemIcon = IconUserSolid
+            if (name === 'Modules') itemIcon = IconModuleLine
+            if (name === 'Videos') itemIcon = IconVideoLine
+            return { ...props, itemIcon, name }
+          }}
+        />
+      </section>
+    </main>
+  )
+}

--- a/regression-test/src/app/view/page.tsx
+++ b/regression-test/src/app/view/page.tsx
@@ -1,0 +1,276 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use client'
+import React from 'react'
+import { View as vw } from 'instructure-ui/ui-view/es/index'
+
+const View = vw as any
+
+export default function ViewPage() {
+  return (
+    <main className="flex gap-12 p-8 flex-col items-start axe-test">
+      <section>
+        <View
+          as="div"
+          margin="small"
+          padding="large"
+          textAlign="center"
+          background="secondary"
+        >
+          Basic View content
+        </View>
+      </section>
+
+      {/* Backgrounds */}
+      <section>
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          {[
+            'transparent',
+            'primary',
+            'secondary',
+            'primary-inverse',
+            'brand',
+            'alert',
+            'success',
+            'danger',
+            'warning'
+          ].map((bg) => (
+            <View
+              key={bg}
+              as="div"
+              display="inline-block"
+              maxWidth="10rem"
+              margin="small"
+              padding="small"
+              background={bg}
+            >
+              {bg}
+            </View>
+          ))}
+        </div>
+      </section>
+
+      {/* Shadows */}
+      <section>
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          {['resting', 'above', 'topmost'].map((sh) => (
+            <View
+              key={sh}
+              as="span"
+              display="inline-block"
+              maxWidth="10rem"
+              margin="small"
+              padding="large"
+              background="primary"
+              shadow={sh}
+            >
+              {sh}
+            </View>
+          ))}
+        </div>
+      </section>
+
+      {/* Border width and color */}
+      <section>
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          <View
+            as="span"
+            display="inline-block"
+            margin="small"
+            padding="small"
+            background="primary"
+            borderWidth="small"
+          >
+            small
+          </View>
+          <View
+            as="span"
+            display="inline-block"
+            margin="small"
+            padding="small"
+            background="primary"
+            borderWidth="medium"
+          >
+            medium
+          </View>
+          <View
+            as="span"
+            display="inline-block"
+            margin="small"
+            padding="small"
+            background="primary"
+            borderWidth="large none"
+          >
+            large none
+          </View>
+          <View
+            as="div"
+            margin="small"
+            padding="small"
+            background="primary"
+            borderWidth="none none small none"
+          >
+            bottom only
+          </View>
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          {[
+            'primary',
+            'info',
+            'warning',
+            'danger',
+            'alert',
+            'success',
+            'brand'
+          ].map((bc) => (
+            <View
+              key={bc}
+              as="span"
+              display="inline-block"
+              margin="small"
+              padding="small"
+              background="primary"
+              borderWidth="large"
+              borderColor={bc}
+            >
+              {bc}
+            </View>
+          ))}
+        </div>
+      </section>
+
+      {/* Border radius */}
+      <section>
+        <div
+          style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}
+        >
+          <View
+            as="span"
+            display="inline-block"
+            maxWidth="10rem"
+            margin="small"
+            padding="medium"
+            background="primary-inverse"
+            borderRadius="medium"
+            textAlign="center"
+          >
+            medium
+          </View>
+          <View
+            as="span"
+            display="inline-block"
+            maxWidth="10rem"
+            margin="small"
+            padding="medium"
+            background="primary-inverse"
+            borderRadius="large large none none"
+            textAlign="center"
+          >
+            large large none none
+          </View>
+          <View
+            as="span"
+            display="inline-block"
+            maxWidth="10rem"
+            margin="small"
+            padding="medium"
+            background="primary-inverse"
+            borderRadius="none none large large"
+            textAlign="center"
+          >
+            none none large large
+          </View>
+          <View
+            display="inline-block"
+            width="6rem"
+            height="6rem"
+            margin="small"
+            padding="medium"
+            background="primary-inverse"
+            borderRadius="circle"
+            textAlign="center"
+          >
+            circle
+          </View>
+          <View
+            display="inline-block"
+            width="10rem"
+            margin="small"
+            padding="medium"
+            background="primary-inverse"
+            borderRadius="pill"
+            textAlign="center"
+          >
+            pill
+          </View>
+        </div>
+      </section>
+
+      <section>
+        <View
+          as="div"
+          height="7rem"
+          width="20rem"
+          margin="medium none x-large"
+          overflowY="auto"
+          overflowX="auto"
+          withVisualDebug
+          tabIndex="0"
+        >
+          <div style={{ width: '30rem', height: '10rem', background: '#ccc' }}>
+            Scrollable content
+          </div>
+        </View>
+        <View as="div" textAlign="center" padding="x-small" withVisualDebug>
+          <View
+            as="div"
+            display="inline-block"
+            withVisualDebug
+            textAlign="end"
+            margin="large auto"
+            padding="0 small 0 0"
+          >
+            Inline block A
+          </View>
+          <View
+            as="div"
+            display="inline-block"
+            withVisualDebug
+            margin="large auto"
+            padding="0 0 0 small"
+          >
+            Inline block B
+          </View>
+        </View>
+        <section style={{ margin: '15px' }}>
+          <View as="header" margin="0 0 medium" withVisualDebug>
+            Some header content
+          </View>
+          <div>Paragraph-like content</div>
+        </section>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
These tests are mostly AI generated based on our README examples.

- Also fix an SSR error in `Calendar`: inThe weekday header IDs were getting out of sync because they were not deterministically generated
- Also fix an a11y issue in `Drilldown` (see comments)
- Also fix an a11y issue in `Options` (see comments)

Note: The large rendering delays are needed because there is a large layout shift in some components that use `FormFieldLayout` when the hydration happens because we calculate the grid placement in `styles.ts`, so the barebones DOM is a half-complete grid.

To test: 
- Launch the regression test app, check the examples. For now we're not looking for 100% coverage on all visual features, just the happy paths.
- Check the changes in Chromatic