### PR TITLE
fix(ui-dialog,ui-a11y-utils): fix focus getting stuck in some cases if something is removed from the middle of the focus stack

### DIFF
--- a/cypress/component/Focusable.cy.tsx
+++ b/cypress/component/Focusable.cy.tsx
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React from 'react'
+
 import { Focusable } from '@instructure/ui'
 
 import '../support/component'

--- a/packages/ui-a11y-utils/src/FocusRegion.ts
+++ b/packages/ui-a11y-utils/src/FocusRegion.ts
@@ -67,13 +67,15 @@ class FocusRegion {
       shouldCloseOnEscape: true,
       isTooltip: false
     }
+    this._id = uid()
+    // eslint-disable-next-line no-param-reassign
+    options.regionId = this._id
     this._contextElement = element
     this._screenReaderFocusRegion = new ScreenReaderFocusRegion(
       element,
       options
     )
     this._keyboardFocusRegion = new KeyboardFocusRegion(element, options)
-    this._id = uid()
   }
 
   updateElement(element: Element | Node, options?: FocusRegionOptions) {
@@ -211,17 +213,15 @@ class FocusRegion {
   }
 
   deactivate({ keyboard = true }: { keyboard?: boolean } = {}) {
-    if (this._active) {
-      this._listeners.forEach((listener) => {
-        listener.remove()
-      })
-      this._listeners = []
-      if (keyboard) {
-        this._keyboardFocusRegion.deactivate()
-      }
-      this._screenReaderFocusRegion.deactivate()
-      this._active = false
+    this._listeners.forEach((listener) => {
+      listener.remove()
+    })
+    this._listeners = []
+    if (keyboard) {
+      this._keyboardFocusRegion.deactivate()
     }
+    this._screenReaderFocusRegion.deactivate()
+    this._active = false
   }
 
   focus() {

--- a/packages/ui-a11y-utils/src/FocusRegionOptions.ts
+++ b/packages/ui-a11y-utils/src/FocusRegionOptions.ts
@@ -86,4 +86,8 @@ export type FocusRegionOptions = {
    * Whether or not the element is a Tooltip
    */
   isTooltip?: boolean
+  /**
+   * The ID of the `FocusRegion` this belongs to. Used only for debugging.
+   */
+  regionId?: string
 }

--- a/packages/ui-dialog/src/Dialog/props.ts
+++ b/packages/ui-dialog/src/Dialog/props.ts
@@ -136,7 +136,11 @@ const propTypes: PropValidators<PropKeys> = {
   /**
    * Whether or not the element is a Tooltip
    */
-  isTooltip: PropTypes.bool
+  isTooltip: PropTypes.bool,
+  /**
+   * The ID of the `FocusRegion` this belongs to. Used only for debugging.
+   */
+  regionId: PropTypes.string
 }
 
 const allowedProps: AllowedPropKeys = [


### PR DESCRIPTION
The issue occurred in the following conditions:

1. A non-keyboard focusable element is added to the top of the stack,e.g. an Overlay with just text
2. The keyboard focusable element is removed from the stack just below it. In this case the focus region stayed the now removed element getting the focus stuck

To test:
- Run the code in the Cypress test locally
- Test out ALL the examples that use popovers/modals. Play with their popover settings like `shouldReturnFocus`, `shouldCloseOnDocumentClick`, `shouldContainFocus`

Fixes INSTUI-4685