### PR TITLE
build: generate llms.txt and markdown files of the documentation for optimal AI consumption

### DIFF
--- a/docs/contributor-docs/ai-features.md
+++ b/docs/contributor-docs/ai-features.md
@@ -1,0 +1,77 @@
+---
+title: AI features
+category: Contributor Guides
+order: 8
+---
+
+## Generating AI agent friendly markdown files for components and guides
+
+InstUI's JSON metadata is used to create a markdown version of the documentation for easier use by AI tools and coding assistants.
+
+These markdown files are created during the build process then are made available for users using specific links.
+
+This collection includes structured files for almost everything under the 'Getting Started', 'Guides', 'Patterns' and 'Components' (including Components/AI Components and Components/Utilities) sections of the documentation.
+
+How it works:
+The core logic resides in `packages/__docs__/buildScripts/ai-accessible-documentation/generate-ai-accessible-markdowns.mts`.
+
+1. **Input and output**  
+   Input: The script processes the JSON files found under `packages/__docs__/__build__/docs` if they belong to the corresponding sections mentioned above.  
+   Output: A directory of generated .md files under `packages/__docs__/__build__/markdowns`, which are also compressed into a documentation.zip archive as well which also can be found in this directory.
+
+2. **Data loading and classification**  
+   The script reads all JSON files from the specified docs folder.
+   Identifies the necessary components and guides based on having props (components) or having a `relevantForAI: true` YAML flag (guides).
+
+3. **Markdown generation**  
+   A markdown file is generated using the data found under the 'description' key. As for components, an addtional table of props and a 'Usage' section is generated for showing how to import the component.
+   As for the table of props, the props of a child component (e.g. Tabs.Panel) of a parent component (e.g. Tabs) is also included in the table.
+
+4. **Index file creation and packaging**  
+   After all individual markdown files are written, index.md file is generated, which acts as a master list of contents for the entire documentation set.
+   Finally, the script uses the system's zip command to package all .md files in the output directory into the final documentation.zip file, which can be downloaded here: https://instructure.design/markdowns/documentation.zip  
+   The AI-friendly markdown files are now avaliable either downloading the documentation.zip file or through a link that follows this pattern: https://instructure.design/markdowns/Alert.md
+
+## Generating llms.txt for LLMs
+
+In addition to the markdown files, a llms.txt file is also generated. This file is specifically formatted for optimal consumption by Large Language Models (LLMs) and AI coding agents.
+This file contains a catalog of links pointing to the online markdown files of InstUI components and guides generated above and short description of each component/guide
+
+How it works:
+The core logic resides in `packages/__docs__/buildScripts/ai-accessible-documentation/ggenerate-ai-accessible-llms-file.mts`.
+
+1. **Input and output**  
+   Input: The script processes the following JSON file: `packages/__docs__/__build__/markdown-and-sources-data.json`  
+   Output: An llms.txt file is placed into `packages/__docs__/__build__` which can be found here: https://instructure.design/llms.txt
+
+2. **Data loading and classification**  
+   The script indenftifies the necessary elements looking for "Getting Started", "Guides", "Patterns", and "Components" section names.
+
+3. **Markdown generation**  
+   It creates a documentation structure like this:
+
+   ```md
+   ---
+   type: code
+   ---
+
+   # Instructure UI (InstUI) - React Component Library
+
+   ## Documentation
+
+   ### User Guides
+
+   #### Getting Started
+
+   #### Guides
+
+   #### Patterns
+
+   ### Components
+
+   #### Utilities
+
+   #### AI components
+   ```
+
+   It generates links for the components/guides and appends a brief summary of each of them using the `packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json` file, searching for matching component/guide title.

--- a/docs/contributor-docs/contributing.md
+++ b/docs/contributor-docs/contributing.md
@@ -102,6 +102,7 @@ Please update the documentation and examples with any changes.
 11. Visit [http://localhost:9090](http://localhost:9090) in a browser. You should see your component listed in the docs.
 12. Start making changes to your component, and watch it update in the browser automatically.
 13. Resolve all `FIXME` comments in the generated code (except in the `MyComponentLocator.ts`).
+14. Add a short description of the new component to the `packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json` file. This will optimize the component's documentation for consumption by AI agents.
 
 ### Adding a new dependency
 

--- a/docs/getting-started/accessibility.md
+++ b/docs/getting-started/accessibility.md
@@ -2,6 +2,7 @@
 title: Accessibility
 category: Getting Started
 order: 6
+relevantForAI: true
 ---
 
 ## Accessibility

--- a/docs/getting-started/theming-components.md
+++ b/docs/getting-started/theming-components.md
@@ -2,6 +2,7 @@
 title: Themes
 category: Getting Started
 order: 8
+relevantForAI: true
 ---
 
 ## Themes

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -2,6 +2,7 @@
 title: Usage
 category: Getting Started
 order: 1
+relevantForAI: true
 ---
 
 ## Quick Start
@@ -73,6 +74,20 @@ Congrats, you have now a (very) basic app that uses Instructure UI :)
 ## Integrating With an Existing Project
 
 Just add the `@instructure/ui` dependency as shown above and wrap the part of your app that will use InstUI in `<InstUISettingsProvider>` and start using InstUI components.
+
+## Using InstUI with AI coding agents
+
+InstUI provides a compressed, downloadable collection of all component documentation and user guides in an AI-agent-friendly markdown format.
+
+You can download the archive from the following link:
+https://instructure.design/markdowns/documentation.zip
+
+The download includes an index.md file that references all available documentation within the compressed folder.
+
+These files are designed to be used as context for AI coding agents.
+
+Additionally, an llms.txt file is available. This file contains a catalog of links pointing to the online markdown files for InstUI components and guides, which are also accessible to AI agents. It can be found at:
+https://instructure.design/llms.txt
 
 ## Further reading
 

--- a/docs/guides/accessing-the-dom.md
+++ b/docs/guides/accessing-the-dom.md
@@ -2,6 +2,7 @@
 title: Accessing the DOM
 category: Guides
 order: 5
+relevantForAI: true
 ---
 
 ## Accessing the DOM

--- a/docs/guides/color-system.md
+++ b/docs/guides/color-system.md
@@ -2,6 +2,7 @@
 title: Color System
 category: Guides
 order: 6
+relevantForAI: true
 ---
 
 ## Colors

--- a/docs/guides/focus-management.md
+++ b/docs/guides/focus-management.md
@@ -2,6 +2,7 @@
 title: Focus Management
 category: Guides
 order: 4
+relevantForAI: true
 ---
 
 ## The Focus Management Problem

--- a/docs/guides/form-errors.md
+++ b/docs/guides/form-errors.md
@@ -2,6 +2,7 @@
 title: Form Errors
 category: Guides
 order: 7
+relevantForAI: true
 ---
 
 # Adding Error Messages to Form Components

--- a/docs/guides/layout-spacing.md
+++ b/docs/guides/layout-spacing.md
@@ -2,6 +2,7 @@
 title: Layout Spacing
 category: Guides
 order: 8
+relevantForAI: true
 ---
 
 # Layout Spacing

--- a/docs/guides/module-federation.md
+++ b/docs/guides/module-federation.md
@@ -2,6 +2,7 @@
 title: Module federation
 category: Guides
 order: 1
+relevantForAI: true
 ---
 
 # Module federation

--- a/docs/guides/server-side-rendering.md
+++ b/docs/guides/server-side-rendering.md
@@ -2,6 +2,7 @@
 title: Server side rendering (SSR)
 category: Guides
 order: 2
+relevantForAI: true
 ---
 
 # SSR with Next.js

--- a/docs/guides/typography-system.md
+++ b/docs/guides/typography-system.md
@@ -2,6 +2,7 @@
 title: Typography
 category: Guides
 order: 9
+relevantForAI: true
 ---
 
 # Typography

--- a/docs/guides/using-theme-overrides.md
+++ b/docs/guides/using-theme-overrides.md
@@ -2,6 +2,7 @@
 title: Using theme overrides
 category: Guides
 order: 3
+relevantForAI: true
 ---
 
 ## Using theme overrides

--- a/docs/patterns/ContentAlignment.md
+++ b/docs/patterns/ContentAlignment.md
@@ -2,6 +2,7 @@
 title: Content Alignment
 category: Patterns
 id: ContentAlignment
+relevantForAI: true
 ---
 
 ## Content Alignment

--- a/docs/patterns/DestroyAction.md
+++ b/docs/patterns/DestroyAction.md
@@ -2,6 +2,7 @@
 title: Destroy Action
 category: Patterns
 id: DestroyAction
+relevantForAI: true
 ---
 
 ## Destroy Action

--- a/docs/patterns/Search.md
+++ b/docs/patterns/Search.md
@@ -2,6 +2,7 @@
 title: Search
 category: Patterns
 id: Search
+relevantForAI: true
 ---
 
 ## Search

--- a/docs/patterns/UsingIcons.md
+++ b/docs/patterns/UsingIcons.md
@@ -2,6 +2,7 @@
 title: Using Icons
 category: Patterns
 id: UsingIcons
+relevantForAI: true
 ---
 
 ## Using Icons

--- a/packages/__docs__/buildScripts/ai-accessible-documentation/generate-ai-accessible-llms-file.mts
+++ b/packages/__docs__/buildScripts/ai-accessible-documentation/generate-ai-accessible-llms-file.mts
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Processes InstUI JSON metadata to generate a file
+ * formatted for Large Language Models (LLMs) and AI agent consumption
+ * - Contains a catalog of links pointing to ai-accessible markdown files about InstUI components and guides
+ * - Contains a summary of each component/guide next to the links
+*/
+
+import { writeFileSync, readFileSync } from 'fs'
+
+interface SectionData {
+  docs?: string[]
+  sections?: string[]
+  title?: string
+}
+
+interface GenerateLLMSOptions {
+  summariesFilePath?: string
+  baseUrl?: string
+  outputFilePath?: string
+}
+
+function generateAIAccessibleLlmsFile(
+  sourceFilePath: string,
+  options: GenerateLLMSOptions = {}
+): string {
+  const { summariesFilePath, baseUrl = '', outputFilePath } = options
+
+  const fileContent = readFileSync(sourceFilePath, 'utf-8')
+  const jsonData = JSON.parse(fileContent)
+  const { sections, library } = jsonData
+
+  const version = library?.version
+
+  const summaries: Record<string, string> = {}
+  // Generate summaries object from the summaries file for later lookup
+  if (summariesFilePath) {
+    try {
+      const summariesContent = readFileSync(summariesFilePath, 'utf-8')
+      const data = JSON.parse(summariesContent)
+
+      data.forEach((item: { title: string; summary?: string }) => {
+        summaries[item.title] = item.summary || ''
+      })
+    } catch (error) {
+      console.warn('Could not load summaries file:', error)
+    }
+  }
+
+  let LlmsMarkdownContent = `# Instructure UI (InstUI) - React Component Library\n\n- version ${version} \n\n`
+  LlmsMarkdownContent += `- Instructure UI (InstUI) is a comprehensive React component library.\n\n`
+
+  // Add main Documentation section
+  LlmsMarkdownContent += `## Documentation\n\n`
+
+  // Add User Guides section
+  LlmsMarkdownContent += `### User Guides\n`
+
+  Object.entries(sections as Record<string, SectionData>).forEach(
+    ([sectionKey, sectionData]) => {
+      const sectionTitle = sectionData.title || sectionKey
+
+      // Only process these specific sections
+      if (!['Getting Started', 'Guides', 'Patterns'].includes(sectionTitle)) {
+        return
+      }
+
+      LlmsMarkdownContent += `#### ${sectionTitle}\n\n`
+
+      if (sectionData.docs && sectionData.docs.length > 0) {
+        const uniqueDocs = [...new Set(sectionData.docs)]
+        uniqueDocs.forEach((doc) => {
+          // Skip unnecessary documents
+          if (
+            doc === 'CODE_OF_CONDUCT' ||
+            doc === 'LICENSE' ||
+            doc.includes('upgrade-guide')
+          ) {
+            return
+          }
+          const displayName = doc
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/-/g, ' ')
+            .trim()
+            .toLowerCase()
+            .replace(/^\w/, (char) => char.toUpperCase())
+
+          const summary = summaries[doc]
+          LlmsMarkdownContent += `- [${displayName}](${baseUrl}${doc}.md)${
+            summary ? `: ${summary}` : ''
+          }\n`
+        })
+      }
+      LlmsMarkdownContent += '\n'
+    }
+  )
+
+  // Add Components section under Documentation
+  LlmsMarkdownContent += `### Components\n\n`
+
+  const componentsSection = sections['components'] as SectionData | undefined
+  if (componentsSection) {
+    const allComponents = [...new Set(componentsSection.docs || [])]
+    allComponents.forEach((component) => {
+      const summary = summaries[component]
+      LlmsMarkdownContent += `- [${component}](${baseUrl}${component}.md)${
+        summary ? `: ${summary}` : ''
+      }\n`
+    })
+  }
+
+  // Process component subsections like Components/AI Components and Components/Utilities, skip deprecated
+  if (componentsSection?.sections && componentsSection.sections.length > 0) {
+    const subsections = componentsSection.sections
+    subsections.forEach((subsectionPath: string) => {
+      if (subsectionPath.toLowerCase().includes('deprecated')) return
+
+      const subsection = sections[subsectionPath] as SectionData | undefined
+      if (subsection && subsection.docs && subsection.docs.length > 0) {
+        const subsectionTitle = subsection.title
+        LlmsMarkdownContent += `\n#### ${subsectionTitle}\n\n`
+        // Avoid duplicates
+        const uniqueSubDocs = [...new Set(subsection.docs)]
+        uniqueSubDocs.forEach((doc) => {
+          const summary = summaries[doc]
+          LlmsMarkdownContent += `- [${doc}](${baseUrl}${doc}.md)${
+            summary ? `: ${summary}` : ''
+          }\n`
+        })
+      }
+    })
+  }
+
+  if (outputFilePath) {
+    writeFileSync(outputFilePath, LlmsMarkdownContent)
+  }
+
+  return LlmsMarkdownContent
+}
+
+export { generateAIAccessibleLlmsFile }

--- a/packages/__docs__/buildScripts/ai-accessible-documentation/generate-ai-accessible-markdowns.mts
+++ b/packages/__docs__/buildScripts/ai-accessible-documentation/generate-ai-accessible-markdowns.mts
@@ -1,0 +1,294 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Processes InstUI JSON metadata to generate AI-accessible materials:
+ * - Generates structured markdown files for InstUI components (with prop tables and usage section) and guides
+ * - Packages all documentation with an index file into a downloadable zip file
+ */
+
+import { execFileSync } from 'child_process'
+
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  mkdirSync,
+  existsSync
+} from 'fs'
+import path from 'path'
+import { generateAIAccessibleLlmsFile } from './generate-ai-accessible-llms-file.mjs'
+
+interface PropDefinition {
+  tsType?: {
+    raw?: string
+    name?: string
+  }
+  type?: {
+    name?: string
+  }
+  required?: boolean
+  defaultValue?: {
+    value?: string
+  }
+  description?: string
+}
+
+interface ComponentData {
+  displayName: string
+  description: string
+  props: Record<string, PropDefinition>
+  category?: string
+  parent?: string
+  id?: string
+  packageName?: string
+  esPath?: string
+  title?: string
+  relevantForAI?: boolean
+}
+
+interface GuideData {
+  title: string
+  description: string
+  category?: string
+  order?: number
+  id?: string
+  [key: string]: any
+  relevantForAI?: boolean
+}
+
+type DocumentationData = ComponentData | GuideData
+
+function isComponent(data: DocumentationData): data is ComponentData {
+  return (
+    (data as ComponentData).displayName !== undefined &&
+    (data as ComponentData).props !== undefined
+  )
+}
+
+function isGuide(data: DocumentationData): data is GuideData {
+  return (data as GuideData).title !== undefined && data.relevantForAI === true
+}
+
+function formatPropsMarkdownTable(text: string): string {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function formatPropsTypeDefinitionForMarkdownTable(type: string): string {
+  return `\`${type
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()}\``
+}
+
+function formatPropsDefaultValueForMarkdownTable(value: string): string {
+  return value ? `\`${value}\`` : '-'
+}
+
+function generatePropsTable(
+  component: ComponentData,
+  childComponents: ComponentData[] = []
+): string {
+  const { displayName, props } = component
+
+  const allProps: Array<{
+    name: string
+    data: PropDefinition
+    component: string
+  }> = []
+
+  // Collect props from parent component e.g. for Tabs
+  for (const [propName, propData] of Object.entries(props)) {
+    if (propName === 'dir') continue
+    allProps.push({
+      name: propName,
+      data: propData,
+      component: displayName
+    })
+  }
+
+  // Collect props from child components e.g. for Tabs.Panel
+  for (const child of childComponents) {
+    const childName = child.displayName.split('.').pop() || ''
+    for (const [propName, propData] of Object.entries(child.props)) {
+      if (propName === 'dir') continue
+      allProps.push({
+        name: propName,
+        data: propData,
+        component: `${displayName}.${childName}`
+      })
+    }
+  }
+
+  if (allProps.length === 0) {
+    return ''
+  }
+
+  let propsContent = `### Props\n\n`
+  propsContent += `| Component | Prop | Type | Required | Default | Description |\n`
+  propsContent += `|-----------|------|------|----------|---------|-------------|\n`
+
+  for (const prop of allProps) {
+    const type = formatPropsTypeDefinitionForMarkdownTable(
+      prop.data.tsType?.raw || prop.data.tsType?.name || ''
+    )
+    const required = prop.data.required ? 'Yes' : 'No'
+    const defaultValue = formatPropsDefaultValueForMarkdownTable(
+      prop.data.defaultValue?.value || ''
+    )
+    const description = formatPropsMarkdownTable(prop.data.description || '')
+
+    propsContent += `| ${prop.component} | ${prop.name} | ${type} | ${required} | ${defaultValue} | ${description} |\n`
+  }
+  propsContent += '\n'
+
+  return propsContent
+}
+
+function generateComponentUsage(doc: DocumentationData): string {
+  if (!isComponent(doc)) return ''
+
+  const { id, displayName, packageName } = doc
+  const importName = displayName || id
+
+  if (!packageName) return ''
+
+  let usageContent = `### Usage\n\n`
+
+  usageContent += `Install the package:\n\n\`\`\`shell\nnpm install ${packageName}\n\`\`\`\n\n`
+
+  usageContent += `Import the component:\n\n\`\`\`javascript
+/*** ES Modules (with tree shaking) ***/
+import { ${importName} } from '${packageName}'
+\`\`\`\n\n`
+
+  return usageContent
+}
+
+function generateComponentMarkdown(
+  jsonData: ComponentData,
+  childComponents: ComponentData[] = []
+): string {
+  const { displayName, description } = jsonData
+
+  let markdownContent = `# ${displayName}\n\n`
+  markdownContent += `${description}\n\n`
+  markdownContent += generatePropsTable(jsonData, childComponents)
+  markdownContent += generateComponentUsage(jsonData)
+
+  return markdownContent
+}
+
+function generateGuideMarkdown(jsonData: GuideData): string {
+  const { description } = jsonData
+
+  const markdownContent = `${description}\n\n`
+
+  return markdownContent
+}
+
+async function generateAIAccessibleMarkdowns(
+  docsFolder: string,
+  outputDir: string
+): Promise<void> {
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true })
+    // eslint-disable-next-line no-console
+    console.log(`Created markdown directory: ${outputDir}`)
+  }
+
+  const files = readdirSync(docsFolder)
+  const jsonFiles = files.filter((file) => file.endsWith('.json'))
+
+  const allDocs: DocumentationData[] = []
+  for (const file of jsonFiles) {
+    try {
+      const filePath = path.join(docsFolder, file)
+      const fileContent = readFileSync(filePath, 'utf-8')
+      const jsonData: DocumentationData = JSON.parse(fileContent)
+      allDocs.push(jsonData)
+    } catch (error) {
+      console.error(`Error processing file ${file}:`, error)
+    }
+  }
+
+  // Process guides
+  const guides = allDocs.filter(isGuide)
+  for (const guide of guides) {
+    const markdownContent = generateGuideMarkdown(guide)
+    const fileName = `${
+      guide.id || guide.title.toLowerCase().replace(/\s+/g, '-')
+    }.md`
+    const filePath = path.join(outputDir, fileName)
+    writeFileSync(filePath, markdownContent)
+  }
+
+  // Process components
+  const components = allDocs.filter(isComponent)
+
+  for (const component of components) {
+    const childComponents = components.filter(
+      (c) => c.parent === component.displayName
+    )
+    // Do not generate a markdown file for child components like Tabs.Panel
+    if (!component.parent) {
+      const markdownContent = generateComponentMarkdown(
+        component,
+        childComponents
+      )
+      const fileName = `${
+        component.id ||
+        component.displayName.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+      }.md`
+      const filePath = path.join(outputDir, fileName)
+      writeFileSync(filePath, markdownContent)
+    }
+  }
+
+  const buildDir = './__build__/'
+  // create an llms-like index file for docs in the zip
+  generateAIAccessibleLlmsFile(buildDir + 'markdown-and-sources-data.json', {
+    outputFilePath: path.join(outputDir, 'index.md'),
+    baseUrl: './',
+    summariesFilePath:
+      './buildScripts/ai-accessible-documentation/summaries-for-llms-file.json'
+  })
+  const mdFiles = readdirSync(outputDir).filter((file) => file.endsWith('.md'))
+
+  // Create zip using system command
+  try {
+    execFileSync('zip', ['documentation.zip', ...mdFiles], { cwd: outputDir })
+  } catch (error) {
+    console.error('Failed to create zip file:', error)
+  }
+}
+
+export { generateAIAccessibleMarkdowns }

--- a/packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json
+++ b/packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json
@@ -1,0 +1,475 @@
+[
+  {
+    "title": "AccessibleContent",
+    "summary": "Hides children from screen readers, providing alternative text via the 'alt' prop. Functions similarly to HTML img alt attributes, ensuring screen reader users get descriptive text equivalents of visual content."
+  },
+  {
+    "title": "AiInformation",
+    "summary": "Displays AI-related data in Instructure products. Composed from NutritionFacts and DataPermissionLevels components with prefixed APIs. Supports fullscreen modals for mobile viewports with comprehensive data structure for AI feature information."
+  },
+  {
+    "title": "Alert",
+    "summary": "Notifies users with contextual variants (success, info, error, warning). Supports dismissible dialogs, automatic timeout dismissal, live regions for screen readers, and inline usage without shadows. Includes accessibility guidelines for proper implementation."
+  },
+  {
+    "title": "AppNav",
+    "summary": "Navigation component for LTI apps that adapts to screen widths by truncating items. Provides update callbacks for visible item count and customizable truncation labels. Supports before/after items and responsive hamburger menu patterns."
+  },
+  {
+    "title": "ApplyLocale",
+    "summary": "Sets locale and timezone context for child components like TimeSelect. Enables internationalization by providing consistent localization settings throughout the component tree."
+  },
+  {
+    "title": "Avatar",
+    "summary": "Displays user avatars with fallback to initials or icons. Supports circle/rectangle shapes, multiple sizes, colors, and inverse styling. Includes special AI avatar variant and accessibility considerations with aria-hidden attribute."
+  },
+  {
+    "title": "Badge",
+    "summary": "Displays numeric counts or notifications with accessibility features. Supports count limits, various placements, standalone usage, and color variants. Requires formatOutput prop for screen reader context beyond simple numbers."
+  },
+  {
+    "title": "BaseButton",
+    "summary": "Low-level utility component for composing Instructure UI buttons. Not intended for direct use; developers should use Button, CloseButton, IconButton, or CondensedButton instead."
+  },
+  {
+    "title": "Billboard",
+    "summary": "Used for empty states, 404 pages, and redirects. Supports various sizes, hero icons, and interactive behaviors (button or link). Can be disabled and includes structured messaging with headings and calls to action."
+  },
+  {
+    "title": "Breadcrumb",
+    "summary": "Shows navigation path location with automatic text truncation. Best for tablet+ screens; use Link for mobile. Supports multiple sizes, icons, and accessibility with aria-current attribute for current page indication."
+  },
+  {
+    "title": "Button",
+    "summary": "Triggers actions or changes with multiple color schemes, sizes, and display options. Supports icons, text wrapping control, and backgroundless variants. Includes specific AI button styles with gradients and icons."
+  },
+  {
+    "title": "Byline",
+    "summary": "Combines visual elements (avatars, icons) with descriptive captions. Supports titles, various sizes, content alignment options, and margin control. Useful for author attribution or content metadata displays."
+  },
+
+  {
+    "title": "Code of Conduct",
+    "summary": "Instructure's commitment to fostering an open, welcoming community free from harassment. Includes standards for positive behavior, responsibilities of maintainers, enforcement procedures, and scope of application for all contributors and community members."
+  },
+  {
+    "title": "Calendar",
+    "summary": "Visual date selection component with configurable month navigation, disabled dates, selection handling, and optional year picker. Supports custom date libraries and accessibility features with proper weekday labels and screen reader support."
+  },
+  {
+    "title": "Checkbox",
+    "summary": "Custom styled checkbox component supporting standard, toggle, and indeterminate states. Includes size variants, accessibility features with aria-labelledby, and proper grouping for parent-child relationships. Guidelines recommend vertical stacking for multiple options."
+  },
+  {
+    "title": "CheckboxGroup",
+    "summary": "Groups multiple Checkbox components with shared name and value management. Supports vertical or horizontal layouts, toggle variants, and group-level disabled/readonly states. Handles validation messages and maintains consistent state across all checkboxes."
+  },
+  {
+    "title": "CloseButton",
+    "summary": "Specialized button for closing modals, dialogs, or containers. Supports absolute positioning with placement options (start/end/static) and offset control. Built with accessibility in mind using IconButton with X icon and screen reader labels."
+  },
+  {
+    "title": "ColorContrast",
+    "summary": "WCAG 2.1 compliance tool that calculates and displays contrast ratios between two colors. Validates against normal text (4.5:1), large text (3:1), and graphics (3:1) standards. Provides pass/fail indicators and supports AA/AAA validation levels."
+  },
+  {
+    "title": "ColorIndicator",
+    "summary": "Displays color swatches with checkerboard background for transparency visualization. Supports circle and rectangle shapes, various color formats (hex, RGB, HSL, HWB), and can be used within buttons for color selection interfaces."
+  },
+  {
+    "title": "ColorMixer",
+    "summary": "Interactive color selection component with RGBA input fields, color sliders, and visual palette. Supports alpha transparency, keyboard navigation for accessibility, and can be disabled. Provides real-time color feedback and value changes."
+  },
+  {
+    "title": "ColorPicker",
+    "summary": "Versatile color selection component with hex input validation and optional popover color mixer. Supports controlled/uncontrolled operation, contrast checking, alpha transparency, and custom popover content. Includes comprehensive error messaging and accessibility features."
+  },
+  {
+    "title": "ColorPreset",
+    "summary": "Color selection from predefined palettes with support for adding/removing colors. Includes visual color indicators, screen reader labels, and optional color mixer integration for custom color creation. Handles color management and selection callbacks."
+  },
+  {
+    "title": "CondensedButton",
+    "summary": "Button variant without padding for tight spaces or alignment with other content. Ideal for table cells or areas where standard button padding would disrupt layout. Maintains button functionality while minimizing visual footprint."
+  },
+  {
+    "title": "ContentAlignment",
+    "summary": "Guidelines for main content area alignment with maximum width (948px) for readability, minimum width (320px) for accessibility, and responsive padding (24px/12px). Ensures proper centering, avoids two-dimensional scrolling, and allows exceptions for complex data displays."
+  },
+  {
+    "title": "ContextView",
+    "summary": "A container that renders inline with an arrow pointing to another element. It displays contextual information without being a popover. Supports padding, text alignment, and margin customization. Often used with components like RangeInput and internally by Popover."
+  },
+  {
+    "title": "DataPermissionLevels",
+    "summary": "Displays AI-related data permissions in Instructure products. Shows hierarchical permission levels with titles and descriptions. Includes a modal interface with close functionality and supports highlighting specific levels for emphasis."
+  },
+  {
+    "title": "DateInput",
+    "summary": "A date input component with a calendar picker (uses Moment.js). Supports disabled dates, validation, and formatted display. Note: Being deprecated in favor of DateInput2 for better UX and accessibility."
+  },
+  {
+    "title": "DateInput2",
+    "summary": "An improved date input with easier configuration, better accessibility, and a year picker. Supports custom date parsing, timezone handling, validation, and disabled dates. Recommended over the original DateInput."
+  },
+  {
+    "title": "DateTimeInput",
+    "summary": "Combines DateInput and TimeSelect for entering date-time values. Supports localization, validation, disabled dates, and layout options (stacked or columns). Includes reset functionality and context-aware formatting."
+  },
+  {
+    "title": "DestroyAction",
+    "summary": "A modal used for irreversible actions like deletion. Includes guidelines for usage: use clear language, avoid vague confirmations, and use a danger button for the destructive action."
+  },
+  {
+    "title": "DeterministicIdContextProvider",
+    "summary": "Deprecated utility component for providing deterministic ID context. Do not use the instanceCounterMap prop. Part of InstUISettingsProvider infrastructure."
+  },
+  {
+    "title": "Dialog",
+    "summary": "A utility component for accessibility in modals, popovers, and trays. Manages focus trapping, screen reader visibility, and keyboard navigation. Essential for WCAG-compliant modal interactions."
+  },
+  {
+    "title": "DrawerLayout",
+    "summary": "A responsive layout component with a collapsible tray and content area. Tray can be placed at start or end and switches to overlay on small screens. Supports nested layouts and accessibility features."
+  },
+  {
+    "title": "Drilldown",
+    "summary": "A hierarchical navigation component for tree structures. Supports pages, groups, selectable options, and in-place editing. Replaces flyout menus and TreeBrowser for better responsiveness and accessibility."
+  },
+  {
+    "title": "Editable",
+    "summary": "Enables in-place editing of content. Manages state and transitions between view and edit modes. Provides render props for custom UI implementation. Used by InPlaceEdit."
+  },
+  {
+    "title": "Expandable",
+    "summary": "Handles expand/collapse functionality for components like ToggleDetails and ToggleGroup. Provides props for accessibility and event handling. Manages state for expanded content visibility."
+  },
+  {
+    "title": "FileDrop",
+    "summary": "A drag-and-drop file upload component with browse functionality. Supports file type validation via MIME types/extensions, multiple file uploads, and visual feedback for accepted/rejected files. Includes accessibility features and customizable rendering for labels and error messages."
+  },
+  {
+    "title": "Flex",
+    "summary": "A flexbox-based layout component for creating responsive multi-column designs. Supports directional layouts, gap control, item sizing (grow/shrink), alignment, and overflow handling. Includes visual debugging tools and common layout patterns like header-button combinations."
+  },
+  {
+    "title": "Focusable",
+    "summary": "A utility component that detects when elements receive focus. Provides render props for creating accessible focus-based interactions, such as skip-to-content links or focus-triggered tooltips. Ensures WCAG compliance for focus management."
+  },
+  {
+    "title": "FormField",
+    "summary": "A foundational component for building form inputs with consistent styling and layout. Supports stacked and inline layouts, validation messages, and accessibility features. Typically used internally by other form components rather than directly."
+  },
+  {
+    "title": "FormFieldGroup",
+    "summary": "Organizes multiple form fields into cohesive groups with consistent spacing and alignment. Supports various layouts (inline, columns, stacked) and provides validation messaging at the group level. Includes accessibility guidance against placeholder text."
+  },
+  {
+    "title": "Grid",
+    "summary": "A 12-column grid system for creating responsive layouts. Features breakpoint-based stacking, customizable column widths, spacing control, and alignment options. Supports visual debugging and common patterns like responsive header layouts."
+  },
+  {
+    "title": "Heading",
+    "summary": "A typographic component for creating accessible headings with consistent styling. Supports semantic heading levels, color variants, borders, icons, and AI-specific styles. Includes important accessibility guidelines for proper heading hierarchy."
+  },
+  {
+    "title": "IconButton",
+    "summary": "A button component designed specifically for icon-only actions. Requires screen reader labels for accessibility, supports various shapes (rectangle/circle), and can remove background/border for minimalist designs. Works well with Tooltip for additional context."
+  },
+  {
+    "title": "Img",
+    "summary": "An accessible image component with advanced features like color overlays, constraining options (cover/contain), and visual filters (grayscale/blur). Supports proper alt text implementation and follows accessibility guidelines for contextual vs. decorative images."
+  },
+  {
+    "title": "InPlaceEdit",
+    "summary": "Enables inline editing of content with smooth transitions between view and edit modes. Provides controlled component pattern for mode management, custom renderers for viewer/editor components, and support for various layouts and read-only states."
+  },
+  {
+    "title": "InlineList",
+    "summary": "Displays list items horizontally with customizable delimiters, spacing, and sizing options. Supports various separator styles (pipe, slash, arrow) and controlled item spacing without affecting list boundaries."
+  },
+  {
+    "title": "InlineSVG",
+    "summary": "Renders accessible SVG content inline with support for fixed dimensions or container filling. Differentiates from SVGIcon by being suitable for non-icon SVG graphics while maintaining accessibility standards."
+  },
+  {
+    "title": "InstUISettingsProvider",
+    "summary": "A global configuration component for applying themes and text direction settings across an application. It wraps Emotion's ThemeProvider and supports nested providers for theme inheritance and overrides. Also manages text direction (LTR/RTL) via context for descendant components."
+  },
+  {
+    "title": "The MIT License (MIT)",
+    "summary": "The MIT License grants permission to use, copy, modify, merge, publish, distribute, sublicense, and sell the software, provided the copyright notice and permission notice are included. The software is provided 'as is' without warranty."
+  },
+  {
+    "title": "Link",
+    "summary": "An inline link component for navigation within text content. Supports variants (inline, inline-small, standalone, standalone-small), icons, margin, and underline control. Includes accessibility guidelines for proper usage and contrast."
+  },
+  {
+    "title": "List",
+    "summary": "A component for rendering ordered, unordered, or unstyled lists. Supports delimiters, spacing, sizing, and custom margins. Only accepts List.Item children and includes options for item spacing and visual customization."
+  },
+  {
+    "title": "Mask",
+    "summary": "A component that covers its nearest positioned parent element. Can be used fullscreen within a Portal and supports click-to-close functionality. Useful for overlays and blocking UI interactions."
+  },
+  {
+    "title": "Menu",
+    "summary": "A Popover-based component for action lists, often triggered by a button. Supports single/multiple selection, groups, separators, and nested menus. Not for navigation or complex content—only Menu.Items are allowed."
+  },
+  {
+    "title": "Metric",
+    "summary": "Displays a value and label with configurable text alignment (start, center, end). Used for showing key metrics like grades, counts, or percentages in a clean, aligned format."
+  },
+  {
+    "title": "MetricGroup",
+    "summary": "A container for displaying multiple Metric components in rows. Groups related metrics together for consolidated data presentation, such as grade-related statistics."
+  },
+  {
+    "title": "Modal",
+    "summary": "A centered dialog that overlays app content with a mask. Supports headers, bodies, footers, form integration, media display, and constrained positioning. Includes variants (default, inverse) and accessibility features."
+  },
+  {
+    "title": "NumberInput",
+    "summary": "A controlled input for numeric values with increment/decrement arrows. Supports validation, error messages, sizing, and accessibility. Must be used with event handlers; does not support uncontrolled usage."
+  },
+  {
+    "title": "NutritionFacts",
+    "summary": "A specialized modal component for displaying AI-related data in structured blocks. Includes model info, privacy/compliance details, and output metrics. Features a trigger button and modal presentation."
+  },
+  {
+    "title": "Options",
+    "summary": "A view-only component for building option lists or menus. Supports variants (default, highlighted, selected, disabled), icons, nesting, and custom roles. Does not manage state—requires external event handling."
+  },
+  {
+    "title": "Overlay",
+    "summary": "A closable/dismissible component that transitions content in and out via a Portal. Supports focus management, accessibility features, and can be used with Mask components. Includes guidelines for ensuring content behind the overlay is hidden from screen readers and dismissible with ESC key."
+  },
+  {
+    "title": "Pages",
+    "summary": "A component for rendering paginated content across multiple pages. Supports navigation between pages, back buttons, and focus management. Each page should contain at least one focusable element. Useful for multi-step workflows or detailed views like user profiles."
+  },
+  {
+    "title": "Pagination",
+    "summary": "Component for navigating through multi-page content. Offers compact, full, and input variants with configurable page indicators. Supports large page numbers, custom labels, and accessibility features. Includes both new simplified API and legacy support for complex pagination needs."
+  },
+  {
+    "title": "Pill",
+    "summary": "Displays short, contextual information with color-coded status indicators. Supports icons, status labels, and various color schemes. Text truncates with ellipsis if overflow occurs. Not intended for dismissible content or counts - use Tag or Badge components instead."
+  },
+  {
+    "title": "Popover",
+    "summary": "Shows/hides content connected to a trigger element via click, hover, or focus. Supports arrows, various placements, colors, and shadows. Can function as a dialog with focus trapping. Includes controlled and uncontrolled variants with extensive customization options."
+  },
+  {
+    "title": "Portal",
+    "summary": "Renders a React subtree into a different DOM element. Useful for modal-like components that need to break out of parent containers. Typically used with Overlay, Modal, or other components that need to render outside their parent hierarchy."
+  },
+  {
+    "title": "Position",
+    "summary": "Positions content relative to a target element with various placement options. Supports RTL internationalization, offset adjustments, and mounting in specific DOM nodes. Replaces older Target/Content pattern with renderTarget prop."
+  },
+  {
+    "title": "PresentationContent",
+    "summary": "Attempts to hide content from screen readers while keeping it visible. Use with caution - not fully reliable across all screen readers. Primarily for visual elements that have alternative accessible representations."
+  },
+  {
+    "title": "ProgressBar",
+    "summary": "Styled HTML progress element with accessibility support. Offers multiple sizes, colors, and meter colors. Supports value formatting, animation, and screen reader customization. Meter color can be function-based for dynamic color changes."
+  },
+  {
+    "title": "ProgressCircle",
+    "summary": "Circular progress indicator with accessibility features. Supports sizes, colors, animations on mount, and custom value rendering. Meter color can be function-based. Useful for showing completion percentages in a compact visual format."
+  },
+  {
+    "title": "RadioInput",
+    "summary": "Custom styled radio button component. Typically used within RadioInputGroup for proper grouping and behavior. Supports different sizes and should always be used in groups rather than individually."
+  },
+  {
+    "title": "RadioInputGroup",
+    "summary": "Manages groups of radio buttons with shared name attribute. Supports various layouts (default, inline, columns), toggle variant, disabled states, and accessibility. Handles selection state and change events for the entire group."
+  },
+  {
+    "title": "RangeInput",
+    "summary": "An HTML5 range input/slider component with customizable size and thumb variants. Supports React class and functional component implementations with interactive examples for real-time updates."
+  },
+  {
+    "title": "Rating",
+    "summary": "Displays 3- or 5-star ratings based on valueNow and valueMax props. Supports rounding decimals, customizable sizes, animations, and accessibility-compliant text formatting for screen readers."
+  },
+  {
+    "title": "Responsive",
+    "summary": "Renders components differently based on element or viewport size. Supports breakpoint-based props and conditional rendering. Use sparingly to avoid performance issues."
+  },
+  {
+    "title": "SVGIcon",
+    "summary": "Renders accessible inline SVG icons. Supports custom sizing, color theming, rotation, and display properties. Accepts SVG content via children or external source strings."
+  },
+  {
+    "title": "ScreenReaderContent",
+    "summary": "Renders content accessible only to screen readers, not visible on screen. Essential for providing hidden context or instructions to assistive technologies."
+  },
+  {
+    "title": "Search",
+    "summary": "Provides search input patterns including auto-activated, activated, and autocomplete search. Includes guidelines, accessibility support, and clear state management examples."
+  },
+  {
+    "title": "Select",
+    "summary": "Accessible combobox component for single or multiple selections. Supports autocomplete, grouping, async loading, icons, and screen reader announcements. Fully controllable with extensive state management examples."
+  },
+  {
+    "title": "Selectable",
+    "summary": "Low-level utility for building custom combobox widgets. Provides ARIA-compliant prop getters and state management hooks. Use existing Select component when possible."
+  },
+  {
+    "title": "SideNavBar",
+    "summary": "Experimental top-level navigation component with toggleable minimized/expanded states. Supports icons, Avatars, badges, and theming. API may change significantly."
+  },
+  {
+    "title": "SimpleSelect",
+    "summary": "Simplified Select component mimicking native `<select>` behavior. Supports uncontrolled/controlled usage, option groups, and icons. Less configurable than Select but easier to implement."
+  },
+  {
+    "title": "SourceCodeEditor",
+    "summary": "Wrapper around CodeMirror with syntax highlighting, line numbers, folding, indentation, search, and RTL support. Recommended upgrade from deprecated CodeEditor component."
+  },
+  {
+    "title": "Spinner",
+    "summary": "Loading indicator with four sizes, inverse variant for dark backgrounds, configurable delay, and screen reader support via renderTitle prop."
+  },
+  {
+    "title": "Tab",
+    "summary": "A tab component for organizing content into separate views within a single context. Typically used in tabbed interfaces where users can switch between different sections or categories of information."
+  },
+  {
+    "title": "Table",
+    "summary": "A versatile table component supporting multiple layouts (auto, fixed, stacked), column customization, sorting, selection, pagination, and responsive behavior. Includes accessibility features and supports custom components for advanced use cases."
+  },
+  {
+    "title": "Tabs",
+    "summary": "Accessible tabbed navigation component with support for secondary variants, overflow handling, size control, dynamic content, and tab persistence. Supports disabled tabs and controlled/uncontrolled usage patterns."
+  },
+  {
+    "title": "Tag",
+    "summary": "Compact component for representing categories or groups, featuring dismissible functionality, multiple sizes, inline variants, and accessibility support. Ideal for form elements and filtering interfaces."
+  },
+  {
+    "title": "Text",
+    "summary": "Comprehensive text styling component with semantic variants, color options, font properties, line heights, text transformation, and wrapping controls. Replaces deprecated legacy values with semantic alternatives."
+  },
+  {
+    "title": "TextArea",
+    "summary": "Resizable textarea input with height constraints, validation messages, disabled states, and inline display options. Supports controlled/uncontrolled usage and includes accessibility guidelines."
+  },
+  {
+    "title": "TextInput",
+    "summary": "Custom styled input supporting various types, prepend/append content, inline display, and controlled/uncontrolled behavior. Features validation, disabled/readonly states, and flexible content wrapping options."
+  },
+  {
+    "title": "TimeSelect",
+    "summary": "Specialized time selection component built on Select, supporting controlled/uncontrolled usage, freeform input, locale/timezone awareness, and step-based time increments. Ideal for time-based form inputs."
+  },
+  {
+    "title": "ToggleButton",
+    "summary": "Controlled button for toggling between two states (on/off), featuring icon support, tooltips, inverse variants for dark backgrounds, and accessibility labels. Perfect for status toggles like lock/unlock."
+  },
+  {
+    "title": "ToggleDetails",
+    "summary": "Collapsible content component with configurable expansion, icon positioning, sizing variants, and fluid width options. Supports controlled behavior and custom summary formatting with text components."
+  },
+  {
+    "title": "ToggleGroup",
+    "summary": "Enhanced toggle component with separated summary/toggle button, built-in padding/borders, and nesting support. Features custom icons, transition control, and expanded state management."
+  },
+  {
+    "title": "Tooltip",
+    "summary": "Contextual text overlays triggered by hover/focus, featuring placement options, color variants, and controlled/uncontrolled behavior. Designed for non-focusable content with comprehensive accessibility support."
+  },
+  {
+    "title": "TopNavBar",
+    "summary": "A responsive navigation bar component for site branding, navigation, user actions, and login. Adapts to small screens by truncating items and supports desktop and mobile layouts. Includes sections for brand, breadcrumbs, menu items, action items, and user controls."
+  },
+  {
+    "title": "Transition",
+    "summary": "A wrapper component for transitioning elements in and out of the UI. Supports fade, scale, and slide transitions with customizable directions. Handles mount/unmount transitions and supports RTL mirroring for slide animations."
+  },
+  {
+    "title": "Tray",
+    "summary": "A slide-out container triggered by click, appearing from top/bottom/start/end of viewport. Used for actionable content that doesn't require a modal overlay. Supports various sizes and placements with accessibility focus management."
+  },
+  {
+    "title": "TreeBrowser",
+    "summary": "A keyboard-accessible tree structure component for browsing hierarchical content. Supports custom icons, sorting, state management, and customizable node content. Not intended for site navigation."
+  },
+  {
+    "title": "TruncateList",
+    "summary": "A utility component that truncates items when space is limited, commonly used in navigation bars. Controls visible item count and provides dropdown for hidden items with customizable spacing and menu triggers."
+  },
+  {
+    "title": "TruncateText",
+    "summary": "Component for truncating text content with single or multiple line support. Supports custom ellipsis, truncation position (end or middle), and tooltips for full text accessibility. Not for buttons or navigation items."
+  },
+  {
+    "title": "UsingIcons",
+    "summary": "Guidelines for using icons with proper accessibility roles, size variants, and color options. Line icons for light backgrounds, solid for dark backgrounds. Icons scale with parent font-size by default."
+  },
+  {
+    "title": "View",
+    "summary": "The foundational visual component providing styling for backgrounds, borders, shadows, positioning, and focus states. Supports visual debugging and semantic HTML elements via the 'as' prop."
+  },
+  {
+    "title": "accessibility",
+    "summary": "Instructure UI targets WCAG 2.1 AA/AAA standards with proper color contrast, keyboard navigation, screen reader support, and ARIA compliance. Components are perceivable, operable, understandable, and robust."
+  },
+  {
+    "title": "accessing-the-dom",
+    "summary": "Guidance for properly accessing DOM elements in React components using refs instead of findDOMNode to avoid warnings. Examples show good and bad patterns for component ref handling."
+  },
+  {
+    "title": "color-system",
+    "summary": "Color system divided into primitive (hex values) and semantic (contextual) colors. Includes data visualization palette with primary and secondary hues for charts and graphs on white backgrounds."
+  },
+  {
+    "title": "focus-management",
+    "summary": "Comprehensive focus management system for dialogs, modals, and popovers. Uses Dialog component with FocusRegion and FocusRegionManager to trap focus, handle escape keys, and manage screen reader accessibility."
+  },
+  {
+    "title": "form-errors",
+    "summary": "InstUI form components use a `messages` prop for error/hint/success messages. Supports both `error` (legacy) and `newError` (accessible) types. Required fields now show an asterisk automatically. Examples provided for various form components like TextInput, Checkbox, and DateTimeInput."
+  },
+  {
+    "title": "layout-spacing",
+    "summary": "InstUI provides semantic spacing tokens (e.g., buttons, tags) for consistent layouts. Apply spacing via `margin` prop, container `gap`, or importing from theme. Legacy tokens are available for compatibility but not recommended for new layouts."
+  },
+  {
+    "title": "module-federation",
+    "summary": "InstUI supports module federation with specific version requirements. For v10.14+, use local themes (`canvasThemeLocal`). For older hosts, guest apps must use v10.14+ and local themes. Global theme overrides don't apply to local themes."
+  },
+  {
+    "title": "server-side-rendering",
+    "summary": "SSR with Next.js requires wrapping the app with `InstUISettingsProvider` for deterministic ID generation. Avoid `@instructure/ui` meta-package; install only needed packages. CodeEditor isn't SSR-compatible and must be dynamically imported."
+  },
+  {
+    "title": "theming-components",
+    "summary": "InstUI has two themes: `canvas` (default) and `canvas-high-contrast`. Colors are layered: primitives (base), contrasts (theme-specific), and UI (curated tokens). Use `InstUISettingsProvider` to set themes. Overrides allow customization but must maintain accessibility."
+  },
+  {
+    "title": "typography-system",
+    "summary": "Use `<Text>` and `<Heading>` components with semantic variants for consistent typography. Variants define font style, weight, size, and line height. Legacy tokens (e.g., fontSizeXSmall) are deprecated and should not be used in new designs."
+  },
+  {
+    "title": "Upgrade Guide for Version 10.0",
+    "summary": "v10 introduces a new color system. Upgrade step-by-step through major versions. Remove Instructure theme; use `canvas` or `canvas-high-contrast`. Migrate color overrides using new contrast values (e.g., `blue4570`). Theme-level overrides require per-component updates."
+  },
+  {
+    "title": "usage",
+    "summary": "Quick start: Create a React app, add `@instructure/ui`, wrap with `InstUISettingsProvider`, and use components. Integrate with existing projects by adding the dependency and provider. Read about theme overrides and accessibility for best practices."
+  },
+  {
+    "title": "using-theme-overrides",
+    "summary": "Customize components via theme overrides while ensuring WCAG compliance. Use nested `InstUISettingsProvider` for subtree themes, override global or component themes, and leverage branding variables for user customization. Deprecated global theming causes issues with multiple InstUI versions."
+  },
+  {
+    "title": "Upgrade Guide for Version 11",
+    "summary": "v11 removes deprecated APIs: `InstUISettingsProvider` `as` prop, Table props (use context), and global theming (`canvas.use()`). Codemods automate most changes. Check for API changes like `getComputedStyle` returning `undefined` and TimeSelect behavior on clear."
+  }
+]

--- a/packages/__docs__/buildScripts/build-docs.mts
+++ b/packages/__docs__/buildScripts/build-docs.mts
@@ -31,11 +31,14 @@ import { theme as canvasTheme } from '@instructure/canvas-theme'
 import { theme as canvasHighContrastTheme } from '@instructure/canvas-high-contrast-theme'
 import type {
   LibraryOptions,
-  MainDocsData, ProcessedFile
+  MainDocsData,
+  ProcessedFile
 } from './DataTypes.mjs'
 import { getFrontMatter } from './utils/getFrontMatter.mjs'
-import { createRequire } from "module"
+import { createRequire } from 'module'
 import { fileURLToPath, pathToFileURL } from 'url'
+import { generateAIAccessibleMarkdowns } from './ai-accessible-documentation/generate-ai-accessible-markdowns.mjs'
+import { generateAIAccessibleLlmsFile } from './ai-accessible-documentation/generate-ai-accessible-llms-file.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -101,7 +104,7 @@ const pathsToIgnore = [
   // deprecated packages and modules:
   '**/InputModeListener.ts',
   // regression testing app:
-  '**/regression-test/**',
+  '**/regression-test/**'
 ]
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -146,9 +149,28 @@ function buildDocs() {
         markdownsAndSources
       )
 
+      generateAIAccessibleMarkdowns(
+        buildDir + 'docs/',
+        buildDir + 'markdowns/'
+      )
+
+      const parentOfDocs = path.dirname(buildDir + 'docs/')
+
+      generateAIAccessibleLlmsFile(
+        buildDir + 'markdown-and-sources-data.json',
+        {
+          outputFilePath: path.join(parentOfDocs, 'llms.txt'),
+          baseUrl: 'https://instructure.design/markdowns/',
+          summariesFilePath: path.join(__dirname, '../buildScripts/ai-accessible-documentation/summaries-for-llms-file.json')
+        }
+      )
+
       // eslint-disable-next-line no-console
       console.log('Copying icons data...')
-      fs.copyFileSync(projectRoot + '/packages/ui-icons/__build__/icons-data.json', buildDir + 'icons-data.json')
+      fs.copyFileSync(
+        projectRoot + '/packages/ui-icons/__build__/icons-data.json',
+        buildDir + 'icons-data.json'
+      )
 
       // eslint-disable-next-line no-console
       console.log('Finished building documentation data')


### PR DESCRIPTION
INSTUI-4701

ISSUE:
- InstUI lacks an ai-friendly documentation

TEST PLAN:

- check https://instructure.design/pr-preview/pr-2109/llms.txt it should open contain all necessary sections, components and guides and each link should be followed by a short summary of that guide/component
- the links in the llms.txt should redirect to existing markdown files, these should include every information and in the case of components, examples, prop tables and usage, in the case of sub-components like Tabs.Panel in Tabs, the prop table should include the props of the sub-component
- check the structure and section hierarchy of the llms.txt file and the markdown files, they should be error-free
- check https://instructure.design/pr-preview/pr-2109/markdowns/documentation.zip , it should download a compressed folder, the folder should contain all files about the necessary sections, components and guides, and the files should include every information and in the case of components, examples, prop tables and usage
- the compressed folder should contain and INDEX.md file, which should point to the files in the compressed folder, the INDEX.dm should contain all necessary sections, components and guides and each link should be followed by a short summary of that guide/component
- check the updated sections in 'Getting started' and 'Contributor guides'