### PR TITLE
fix(ui-buttons): disabled button with href should not receive focus

### DIFF
--- a/packages/ui-buttons/src/BaseButton/index.tsx
+++ b/packages/ui-buttons/src/BaseButton/index.tsx
@@ -285,6 +285,7 @@ class BaseButton extends Component<BaseButtonProps> {
     if ((onClick && as && needsZeroTabIndex) || (isSafari() && as)) {
       tabIndexValue = tabIndex || 0
     }
+
     return (
       <View
         {...passthroughProps(props)}
@@ -299,12 +300,21 @@ class BaseButton extends Component<BaseButtonProps> {
         borderWidth="none"
         margin={margin}
         cursor={isDisabled ? 'not-allowed' : cursor}
-        href={href}
+        // if Button is disabled, don't pass href attribute (disabled <a> tags are not supported by default)
+        // and set aria-disabled true to inform screen readers
+        href={isDisabled ? undefined : href}
+        aria-disabled={isDisabled ? 'true' : undefined}
         type={href ? undefined : type}
         elementRef={this.handleElementRef}
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
-        role={onClick && as !== 'button' ? 'button' : undefined}
+        role={
+          elementType === 'a'
+            ? 'link'
+            : onClick && as !== 'button'
+            ? 'button'
+            : undefined
+        }
         tabIndex={tabIndexValue}
         disabled={isDisabled || isReadOnly}
         css={styles?.baseButton}


### PR DESCRIPTION
INSTUI-4687

Test:
- add disabled and href properties to Button
- observe if it is focusable (**it should NOT be**), try it in different browsers
- try it with ScreenReaders (it should be read as a disabled/dimmed link)