### PR TITLE
fix(ui-breadcrumb): fix Breadcrumb accessibility issues

### DIFF
--- a/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
+++ b/packages/ui-breadcrumb/src/Breadcrumb/BreadcrumbLink/index.tsx
@@ -68,6 +68,7 @@ class BreadcrumbLink extends Component<
       this.setState({ isTruncated })
     }
   }
+
   render() {
     const {
       children,
@@ -82,8 +83,15 @@ class BreadcrumbLink extends Component<
     const { isTruncated } = this.state
     const props = omitProps(this.props, BreadcrumbLink.allowedProps)
 
+    const isInteractive = onClick || href
     return (
-      <Tooltip renderTip={children} preventTooltip={!isTruncated}>
+      <Tooltip
+        renderTip={children}
+        preventTooltip={!isTruncated}
+        // this wraps the achor/button tag in a span and puts the aria-describedby on that instead of the anchor/button tag
+        // to avoid SRs reading the text twice when there is already an aria-label
+        {...(isInteractive && { as: 'span' })}
+      >
         <Link
           {...props}
           href={href}
@@ -95,6 +103,10 @@ class BreadcrumbLink extends Component<
           elementRef={this.handleRef}
           forceButtonRole={false}
           {...(isCurrentPage && { 'aria-current': 'page' })}
+          {...(isTruncated && {
+            ...(typeof children === 'string' && { 'aria-label': children }),
+            ...(!isInteractive && { role: 'text' })
+          })}
         >
           <TruncateText
             onUpdate={(isTruncated) => this.handleTruncation(isTruncated)}


### PR DESCRIPTION
INSTUI-4676

ISSUE:
- screenreaders do not read the truncated breadcrumb text when it's just plain text (no link or button)
- breadcrumb links do not have discernible text, see: https://dequeuniversity.com/rules/axe/4.10/link-name?application=AxeChrome

TEST PLAN:

- decrease the width of the window to make the "Rabbit Is Rich" breadcrumb elements truncated in the second example
- screenreaders should announce the truncated "Rabbit Is Rich" text (it does not get announced in the current release)
- decrease the width of the window to make every element truncated in the second example, all of them should be read by the screenreader, without duplication
- run the [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) browser extension check on the page when all the element are truncated in the second example, there should be no warning 'Links/buttons must have discernible text' like in the current release
- go over the examples when the elements aren't truncated, they should be announced by the screenreaders
- the href type breadercumb should redirect when clicked on
- breadcrumbs should behave as usual (truncate with no error etc.) and there should be no visual difference compared to the current release
- test it across different screenreaders and browsers