### PR TITLE
refactor(ui-table): Remove deprecated prop passing down

### DIFF
--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -22,7 +22,13 @@
  * SOFTWARE.
  */
 
-import { Component, Children, ContextType, isValidElement, type ReactElement } from 'react'
+import {
+  Component,
+  Children,
+  ContextType,
+  isValidElement,
+  type ReactElement
+} from 'react'
 
 import { safeCloneElement, omitProps } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -46,7 +52,7 @@ class Body extends Component<TableBodyProps> {
   static contextType = TableContext
   declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
-static defaultProps = {
+  static defaultProps = {
     children: null
   }
 
@@ -60,7 +66,7 @@ static defaultProps = {
 
   render() {
     const { children, styles } = this.props
-    const { isStacked, hover, headers } = this.context
+    const { isStacked } = this.context
 
     return (
       <View
@@ -72,16 +78,7 @@ static defaultProps = {
         {Children.map(children, (child) => {
           if (isValidElement(child)) {
             return safeCloneElement(child, {
-              key: (child as ReactElement<any>).props.name,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              hover,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              isStacked,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              headers
+              key: (child as ReactElement<any>).props.name
             })
           }
           return child

--- a/packages/ui-table/src/Table/ColHeader/props.ts
+++ b/packages/ui-table/src/Table/ColHeader/props.ts
@@ -31,10 +31,6 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableColHeaderOwnProps = {
   /**
-   * DEPRECATED. Use `TableContext` to read this value
-   */
-  isStacked?: boolean
-  /**
    * A unique id for this column. The `id` is also used as option in combobox,
    * when sortable table is in stacked layout,
    * and no `stackedSortByLabel` is provided.
@@ -91,7 +87,6 @@ type TableColHeaderStyle = ComponentStyle<
 >
 const allowedProps: AllowedPropKeys = [
   'id',
-  'isStacked',
   'stackedSortByLabel',
   'children',
   'width',

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -54,7 +54,7 @@ class Head extends Component<TableHeadProps> {
   static contextType = TableContext
   declare context: ContextType<typeof TableContext>
   static allowedProps = allowedProps
-static defaultProps = {
+  static defaultProps = {
     children: null
   }
 
@@ -65,12 +65,15 @@ static defaultProps = {
     const [firstRow] = Children.toArray(this.props.children) as RowChild[]
     let sortable = false
     if (firstRow && firstRow.props && firstRow.props.children) {
-      Children.forEach(firstRow.props.children, (grandchild: ReactElement<any>) => {
-        if (grandchild?.props?.onRequestSort) {
-          sortable = true
-          return
+      Children.forEach(
+        firstRow.props.children,
+        (grandchild: ReactElement<any>) => {
+          if (grandchild?.props?.onRequestSort) {
+            sortable = true
+            return
+          }
         }
-      })
+      )
     }
     return sortable
   }
@@ -114,20 +117,23 @@ static defaultProps = {
     > = {}
     let selectedOption: TableColHeaderProps['id'] | undefined
     let count = 0
-    Children.forEach(firstRow.props.children, (grandchild: ReactElement<any>) => {
-      count += 1
-      if (!grandchild?.props) return // grandchild can be false
-      const { id, stackedSortByLabel, sortDirection, onRequestSort } =
-        grandchild.props
-      if (id && onRequestSort) {
-        const label = stackedSortByLabel || id
-        options.push({ id, label })
-        clickHandlers[id] = onRequestSort
-        if (sortDirection !== 'none') {
-          selectedOption = id
+    Children.forEach(
+      firstRow.props.children,
+      (grandchild: ReactElement<any>) => {
+        count += 1
+        if (!grandchild?.props) return // grandchild can be false
+        const { id, stackedSortByLabel, sortDirection, onRequestSort } =
+          grandchild.props
+        if (id && onRequestSort) {
+          const label = stackedSortByLabel || id
+          options.push({ id, label })
+          clickHandlers[id] = onRequestSort
+          if (sortDirection !== 'none') {
+            selectedOption = id
+          }
         }
       }
-    })
+    )
     if (!options.length) {
       return null
     }
@@ -178,11 +184,7 @@ static defaultProps = {
     return this.context.isStacked ? (
       this.renderSelect()
     ) : (
-      // TODO remove 'hover' exclude in v11, its passed down for compatibility with custom components
-      <thead
-        {...omitProps(this.props, Head.allowedProps, ['hover'])}
-        css={styles?.head}
-      >
+      <thead {...omitProps(this.props, Head.allowedProps)} css={styles?.head}>
         {children}
       </thead>
     )

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -22,7 +22,13 @@
  * SOFTWARE.
  */
 
-import { Component, Children, ContextType, isValidElement, type ReactElement } from 'react'
+import {
+  Component,
+  Children,
+  ContextType,
+  isValidElement,
+  type ReactElement
+} from 'react'
 
 import { omitProps, safeCloneElement } from '@instructure/ui-react-utils'
 import { View } from '@instructure/ui-view'
@@ -85,9 +91,6 @@ class Row extends Component<TableRowProps> {
             if (isValidElement(child)) {
               return safeCloneElement(child, {
                 key: (child as ReactElement<any>).props.name,
-                // Sent down for compatibility with custom components
-                // TODO DEPRECATED, remove in v11
-                isStacked,
                 // used by `Cell` to render its column title in `stacked` layout
                 header: headers && headers[index]
               })


### PR DESCRIPTION
Remove deprecated prop passing down and use TableContext instead.

Test:
Check the Table Compnent if its working as before