### PR TITLE
INSTUI-4592 feat(ui-table): remove deprecated prop from Table

### DIFF
--- a/packages/ui-table/src/Table/Body/index.tsx
+++ b/packages/ui-table/src/Table/Body/index.tsx
@@ -66,7 +66,7 @@ class Body extends Component<TableBodyProps> {
 
   render() {
     const { children, styles } = this.props
-    const { isStacked, hover, headers } = this.context
+    const { isStacked } = this.context
 
     return (
       <View
@@ -78,16 +78,7 @@ class Body extends Component<TableBodyProps> {
         {Children.map(children, (child) => {
           if (isValidElement(child)) {
             return safeCloneElement(child, {
-              key: (child as ReactElement<any>).props.name,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              hover,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              isStacked,
-              // Sent down for compatibility with custom components
-              // TODO DEPRECATED, remove in v11
-              headers
+              key: (child as ReactElement<any>).props.name
             })
           }
           return child

--- a/packages/ui-table/src/Table/ColHeader/props.ts
+++ b/packages/ui-table/src/Table/ColHeader/props.ts
@@ -31,10 +31,6 @@ import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 
 type TableColHeaderOwnProps = {
   /**
-   * DEPRECATED. Use `TableContext` to read this value
-   */
-  isStacked?: boolean
-  /**
    * A unique id for this column. The `id` is also used as option in combobox,
    * when sortable table is in stacked layout,
    * and no `stackedSortByLabel` is provided.
@@ -91,7 +87,6 @@ type TableColHeaderStyle = ComponentStyle<
 >
 const allowedProps: AllowedPropKeys = [
   'id',
-  'isStacked',
   'stackedSortByLabel',
   'children',
   'width',

--- a/packages/ui-table/src/Table/Head/index.tsx
+++ b/packages/ui-table/src/Table/Head/index.tsx
@@ -184,11 +184,7 @@ class Head extends Component<TableHeadProps> {
     return this.context.isStacked ? (
       this.renderSelect()
     ) : (
-      // TODO remove 'hover' exclude in v11, its passed down for compatibility with custom components
-      <thead
-        {...omitProps(this.props, Head.allowedProps, ['hover'])}
-        css={styles?.head}
-      >
+      <thead {...omitProps(this.props, Head.allowedProps)} css={styles?.head}>
         {children}
       </thead>
     )

--- a/packages/ui-table/src/Table/Row/index.tsx
+++ b/packages/ui-table/src/Table/Row/index.tsx
@@ -91,9 +91,6 @@ class Row extends Component<TableRowProps> {
             if (isValidElement(child)) {
               return safeCloneElement(child, {
                 key: (child as ReactElement<any>).props.name,
-                // Sent down for compatibility with custom components
-                // TODO DEPRECATED, remove in v11
-                isStacked,
                 // used by `Cell` to render its column title in `stacked` layout
                 header: headers && headers[index]
               })


### PR DESCRIPTION
Remove deprecated prop passing down and use TableContext instead.

Test:
Check the Table Compnent if its working as before