### PR TITLE
[v11] Fix Tooltip placement in Text component + React 19

### DIFF
--- a/packages/ui-text/src/Text/index.tsx
+++ b/packages/ui-text/src/Text/index.tsx
@@ -51,6 +51,16 @@ class Text extends Component<TextProps> {
     children: null
   } as const
 
+  ref: Element | null = null
+
+  handleRef = (el: Element | null) => {
+    this.ref = el
+    const { elementRef } = this.props
+    if (typeof elementRef === 'function') {
+      elementRef(el)
+    }
+  }
+
   checkProps() {
     const { variant, lineHeight, weight, fontStyle } = this.props
     if (variant) {
@@ -85,7 +95,7 @@ class Text extends Component<TextProps> {
       <ElementType
         {...passthroughProps(this.props)}
         css={this.props.styles?.text}
-        ref={this.props.elementRef}
+        ref={this.handleRef}
       >
         {children}
       </ElementType>


### PR DESCRIPTION
the `ref` field was missing for Text (in master too), this was causing it to use `findDomNode`, which is gone in React 19, so stuff that tries to access its DOM like Tooltips were not working properly. To test run this code, the tooltip should be above the component:

```jsx
<Tooltip renderTip={`Tooltip 12`}
  isShowingContent={true}
   defaultIsShowingContent={true}>
        <Text>descriptionPage</Text>
</Tooltip>
```