### PR TITLE
INSTUI-4682 fix(ui-buttons): fix for AI secondary button visual glitch

### DIFF
--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -361,6 +361,9 @@ const generateStyle = (
           touchAction: 'manipulation',
           // This sets the focus ring's border radius displayed by the `View`
           borderRadius: componentTheme.borderRadius,
+          // Prevents vertical stretching in flex parents with fixed height
+          // Avoids background/focus ring distortion
+          height: 'fit-content',
 
           '&::-moz-focus-inner': {
             border: '0' /* removes default dotted focus outline in Firefox */


### PR DESCRIPTION
When rendering the AI button inside a flex container with a fixed height, the button was being stretched vertically due to the parent’s default align-items: stretch.


Test:
You can verify the fix by trying the example below on the button docs page.
The visual glitch should no longer appear when the AI secondary button is inside a flex parent with a fixed height.

```
<>
  <View display="block">
    <Button color="ai-primary" renderIcon={IconAiSolid} margin="small">AI Primary</Button>
    <Button color="ai-secondary" renderIcon={IconAiColoredSolid} margin="small">AI Secondary</Button>
    <IconButton color="ai-primary" screenReaderLabel="AI button" margin="small"><IconAiSolid/></IconButton>
    <IconButton color="ai-secondary" screenReaderLabel="AI button"  margin="small"><IconAiColoredSolid/></IconButton>
  </View>
  
  <div style={{height:"100px", display: "flex", marginLeft:"15px", gap: "24px"}}>
    <Button color="ai-primary" renderIcon={IconAiSolid} >AI Primary</Button>
    <Button color="ai-secondary" renderIcon={IconAiColoredSolid} >AI Secondary</Button>
    <IconButton color="ai-primary" screenReaderLabel="AI button" ><IconAiSolid/></IconButton>
    <IconButton color="ai-secondary" screenReaderLabel="AI button" ><IconAiColoredSolid/></IconButton>
    <IconButton color="secondary" screenReaderLabel="AI button" ><IconAiColoredSolid/></IconButton>
  </div>
</>
```