### PR TITLE
fix(ui-utils,ui-drilldown): make NVDA read options in Drilldown.Group…

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/DrilldownGroup/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownGroup/index.tsx
@@ -29,6 +29,7 @@ import { optionsThemeGenerator } from '@instructure/ui-options'
 
 import { propTypes, allowedProps } from './props'
 import type { DrilldownGroupProps } from './props'
+import { isMac, isFirefox } from '@instructure/ui-utils'
 
 /**
 ---
@@ -48,7 +49,9 @@ class DrilldownGroup extends Component<DrilldownGroupProps> {
   static defaultProps = {
     disabled: false,
     withoutSeparators: false,
-    role: 'group'
+    // Firefox with NVDA does not read Drilldown.Group with role="group" correctly
+    // but setting role="menu" on all other platforms results in Drilldown.Group label not being read
+    role: !isMac() && isFirefox() ? 'menu' : 'group'
   }
 
   render() {

--- a/packages/ui-utils/src/getBrowser.ts
+++ b/packages/ui-utils/src/getBrowser.ts
@@ -74,6 +74,12 @@ const isAndroidOrIOS = (): boolean => {
     : false
 }
 
+const isMac = (): boolean => {
+  const parser = new UAParser()
+  const result = parser.getResult()
+  return result.os.name === 'Mac OS'
+}
+
 export {
   getBrowser,
   isSafari,
@@ -81,5 +87,6 @@ export {
   isIE,
   isFirefox,
   isChromium,
-  isAndroidOrIOS
+  isAndroidOrIOS,
+  isMac
 }

--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -44,5 +44,6 @@ export {
   isIE,
   isFirefox,
   isChromium,
-  isAndroidOrIOS
+  isAndroidOrIOS,
+  isMac
 } from './getBrowser'


### PR DESCRIPTION
… correctly in Firefox

INSTUI-4330

**ISSUE:**

NVDA was not properly announcing options within Drilldown.Group components in Firefox. The issues were:
  * all options were announced simultaneously on focus
  * the `checked` state of the selected option was not read
  * options were not navigable with keyboard

**TEST PLAN:**

- with Firefox (!) and NVDA, inspect the 'Single-select Group' example
- go through the option, they should be navigable with keyboard and the checked option should be announced as checked and the options should not be announced
- other examples with a Drilldown.Group should behave the same like above (e.g.: 'Video Settings' example, 'Option Groups' example)
- on Mac with Chrome, Firefox and Safari, examples with a Drilldown.Group should have a role='group' instead of 'menu'
- because I could not define a screenreader-specific condition, the role is also changed to 'menu' in Firefox+JAWS. This results in the group titles not always being read in Firefox+JAWS, but it is still a less severe issue than the one with Firefox+NVDA.