### PR TITLE
fix(ui-color-picker): prevent selection outside of ColorMixer when dr…

### DIFF
--- a/packages/ui-color-picker/src/ColorMixer/ColorPalette/index.tsx
+++ b/packages/ui-color-picker/src/ColorMixer/ColorPalette/index.tsx
@@ -120,6 +120,14 @@ class ColorPalette extends Component<ColorPaletteProps, ColorPaletteState> {
   }
 
   handlePaletteMouseDown(e: React.MouseEvent<ViewOwnProps, MouseEvent>) {
+    // Prevent selection outside palette during dragging the indicator
+    e.preventDefault()
+
+    // Restore focus since preventDefault() blocks automatic focus on mouse event
+    if (e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.focus()
+    }
+
     this.handleChange(e)
 
     this._mouseMoveListener = addEventListener(

--- a/packages/ui-color-picker/src/ColorMixer/Slider/index.tsx
+++ b/packages/ui-color-picker/src/ColorMixer/Slider/index.tsx
@@ -104,6 +104,14 @@ class Slider extends Component<SliderProps> {
   }
 
   handleMouseDown(e: React.MouseEvent<ViewOwnProps, MouseEvent>) {
+    // Prevent selection outside palette during dragging the indicator
+    e.preventDefault()
+
+    // Restore focus since preventDefault() blocks automatic focus on mouse event
+    if (e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.focus()
+    }
+
     this.handleChange(e)
 
     this._mouseMoveListener = addEventListener(


### PR DESCRIPTION
…agging the indicator

INSTUI-4698

**ISSUE:**
- other page contents get selected when mouse leaves the ColorMixer when dragging the indicator
- for a video of the bug, see this video: https://instructure.slack.com/files/U079VLHH97S/F09DQL04M0R/screen_recording_2025-09-03_at_14.27.16.mov

**TEST PLAN:**
- open the first example in ColorMixer
- try and drag all three white indicator buttons to the edge of the palette then make the mouse leave the palette while holding the mouse down
- nearby content or text should not get selected
- ColorMixer should get focused when clicked on
- ColorMixer should remain keyboard accessible (should be tabable, the indicator should be navigable with keyboard)
- check the first two examples in ColorPicker, other page content should not get selected when indicators are getting dragged in the ColorMixer
- the two examples should be keyboard accessible 