### PR TITLE
feat(ui-drilldown): make Drilldown.Page handle optional Options

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/DrilldownPage/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownPage/props.ts
@@ -39,7 +39,7 @@ import DrilldownSeparator from '../DrilldownSeparator'
 import type { OptionChild, SeparatorChild, GroupChild } from '../props'
 import { Renderable } from '@instructure/shared-types'
 
-type PageChildren = GroupChild | OptionChild | SeparatorChild
+type PageChildren = GroupChild | OptionChild | SeparatorChild | null | false
 
 type DrilldownPageOwnProps = {
   id: string

--- a/packages/ui-drilldown/src/Drilldown/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/index.tsx
@@ -528,15 +528,17 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
     const childMap = new Map<string, boolean>()
 
     for (const child of children) {
-      if (!childMap.has(child.props.id)) {
-        childMap.set(child.props.id, true)
-      } else {
-        warn(
-          false,
-          `Duplicate id: "${child.props.id}"! Make sure all options have unique ids, otherwise they won't be rendered.`
-        )
+      if (child && typeof child === 'object' && child.props?.id) {
+        if (!childMap.has(child.props.id)) {
+          childMap.set(child.props.id, true)
+        } else {
+          warn(
+            false,
+            `Duplicate id: "${child.props.id}"! Make sure all options have unique ids, otherwise they won't be rendered.`
+          )
 
-        return (containsDuplicate = true)
+          return (containsDuplicate = true)
+        }
       }
     }
 


### PR DESCRIPTION
INSTUI-4688

**ISSUE:**

- including an optional Option (e.g.: {someBool && renderAnOption()}) as child of DrillDown.Page now result in type error

**TEST PLAN:**
- open the brach locally
- create the file with the code below in your InstUI codebase
- {someBool && renderAnOption()}) or {someBool ? renderAnOption() : null} should not get a TypeScipt type error in your IDE

```
import React from 'react'
import Drilldown from '.'
import { createRoot } from 'react-dom/client'

const Example = () => {
  const [someBool] = React.useState(true)

  const renderAnOption = () => (
    <Drilldown.Option id="conditionalOption">
      Conditional Option
    </Drilldown.Option>
  )

  return (
    <Drilldown rootPageId="root" width="20rem" maxHeight="30rem">
      <Drilldown.Page id="root">
        <Drilldown.Option id="option1">Option</Drilldown.Option>
        <Drilldown.Option id="option2">
        </Drilldown.Option >
        {someBool && renderAnOption()}


        <Drilldown.Option id="option3">Option</Drilldown.Option>
        <Drilldown.Option id="option4" disabled>
          Option
        </Drilldown.Option>
      </Drilldown.Page>
    </Drilldown>
  )
}

const container = document.getElementById('app');
if (container) {
  const root = createRoot(container);
  root.render(<Example />);
}
```