### PR TITLE
[v11] remove not needed dependency, remove not needed warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "@instructure/pkg-utils": "workspace:*",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22",
-        "@types/react-dom": "^19.1",
+        "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "^4.5.1",
         "@vitest/eslint-plugin": "^1.2.1",
         "chai": "^4.4.1",
@@ -51,7 +51,7 @@
         "jsdom": "^26.1.0",
         "lerna": "^8.2.4",
         "lint-staged": "^15.2.10",
-        "react": "^19.1",
+        "react": "18.3.1",
         "tar": "^7.4.3",
         "typescript": "5.8.3",
         "typescript-eslint": "^8.33.1",
@@ -5667,27 +5667,26 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "16.3.0",
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.7.tgz",
+      "integrity": "sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5"
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }
@@ -6031,6 +6030,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "license": "MIT"
@@ -6040,23 +6046,24 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.0.0"
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -17483,7 +17490,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -20954,24 +20960,28 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -21785,10 +21795,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -26022,8 +26035,8 @@
         "marked": "^15.0.12",
         "marked-react": "^3.0.0",
         "moment": "^2.30.1",
-        "react": "19.1",
-        "react-dom": "19.1",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "semver": "^7.7.2",
         "uuid": "^11.1.0",
         "webpack-merge": "^6.0.1"
@@ -26319,23 +26332,10 @@
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@instructure/shared-types": "10.25.0",
-        "@instructure/theme-registry": "10.25.0",
         "@instructure/ui-themes": "10.25.0"
       },
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0"
-      }
-    },
-    "packages/canvas-high-contrast-theme/node_modules/@instructure/theme-registry": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/@instructure/theme-registry/-/theme-registry-10.25.0.tgz",
-      "integrity": "sha512-J45roEysrQyEIa3jTcztBOG5xPciWt9C4ugylBCEl9u7z2tFeeZ774TFmUsOjQbNdznoRR2XQeWN/EdZEKClDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "@instructure/console": "10.25.0",
-        "@instructure/shared-types": "10.25.0",
-        "@instructure/ui-utils": "10.25.0"
       }
     },
     "packages/canvas-theme": {
@@ -26345,23 +26345,10 @@
       "dependencies": {
         "@babel/runtime": "^7.27.6",
         "@instructure/shared-types": "10.25.0",
-        "@instructure/theme-registry": "10.25.0",
         "@instructure/ui-themes": "10.25.0"
       },
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0"
-      }
-    },
-    "packages/canvas-theme/node_modules/@instructure/theme-registry": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/@instructure/theme-registry/-/theme-registry-10.25.0.tgz",
-      "integrity": "sha512-J45roEysrQyEIa3jTcztBOG5xPciWt9C4ugylBCEl9u7z2tFeeZ774TFmUsOjQbNdznoRR2XQeWN/EdZEKClDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "@instructure/console": "10.25.0",
-        "@instructure/shared-types": "10.25.0",
-        "@instructure/ui-utils": "10.25.0"
       }
     },
     "packages/command-utils": {
@@ -26435,7 +26422,6 @@
         "@emotion/react": "^11",
         "@instructure/console": "10.25.0",
         "@instructure/shared-types": "10.25.0",
-        "@instructure/theme-registry": "10.25.0",
         "@instructure/ui-decorator": "10.25.0",
         "@instructure/ui-i18n": "10.25.0",
         "@instructure/ui-react-utils": "10.25.0",
@@ -26446,25 +26432,13 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
-        "react-dom": "^19.1",
+        "react-dom": "18.3.1",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
         "react": ">=18 <=19"
-      }
-    },
-    "packages/emotion/node_modules/@instructure/theme-registry": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/@instructure/theme-registry/-/theme-registry-10.25.0.tgz",
-      "integrity": "sha512-J45roEysrQyEIa3jTcztBOG5xPciWt9C4ugylBCEl9u7z2tFeeZ774TFmUsOjQbNdznoRR2XQeWN/EdZEKClDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "@instructure/console": "10.25.0",
-        "@instructure/shared-types": "10.25.0",
-        "@instructure/ui-utils": "10.25.0"
       }
     },
     "packages/pkg-utils": {
@@ -26700,7 +26674,7 @@
         "@instructure/ui-axe-check": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -26725,7 +26699,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-color-utils": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -26756,7 +26730,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-scripts": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -26783,7 +26757,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -26890,7 +26864,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -26917,7 +26891,7 @@
         "@instructure/ui-icons": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -26947,7 +26921,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -26980,7 +26954,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27005,7 +26979,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27036,7 +27010,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27069,7 +27043,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27163,7 +27137,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-scripts": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27209,7 +27183,7 @@
         "@instructure/ui-buttons": "10.25.0",
         "@instructure/ui-scripts": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27239,7 +27213,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27273,7 +27247,7 @@
         "@instructure/console": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27293,7 +27267,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27326,7 +27300,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27359,7 +27333,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27389,7 +27363,7 @@
         "@instructure/ui-axe-check": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27413,7 +27387,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-color-utils": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27442,7 +27416,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27466,7 +27440,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27489,7 +27463,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27519,7 +27493,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27544,7 +27518,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27569,7 +27543,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27593,9 +27567,9 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@types/hoist-non-react-statics": "^3.3.6",
-        "react-dom": "^19.1",
+        "react-dom": "18.3.1",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27634,7 +27608,7 @@
         "@instructure/ui-axe-check": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27663,7 +27637,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27691,7 +27665,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27717,7 +27691,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27749,7 +27723,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27774,7 +27748,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27806,7 +27780,7 @@
         "@instructure/ui-position": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27830,7 +27804,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -27867,7 +27841,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27895,7 +27869,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27922,7 +27896,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -27959,7 +27933,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "@types/no-scroll": "^2.1.2",
         "vitest": "^3.2.2"
@@ -27987,7 +27961,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28021,7 +27995,7 @@
         "@instructure/ui-axe-check": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28052,7 +28026,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28083,7 +28057,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-color-utils": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28106,7 +28080,7 @@
         "@instructure/ui-axe-check": "10.25.0",
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28135,7 +28109,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28161,7 +28135,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28186,7 +28160,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28217,7 +28191,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28245,7 +28219,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28269,7 +28243,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28294,7 +28268,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-color-utils": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28565,7 +28539,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28589,7 +28563,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28619,7 +28593,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28646,7 +28620,7 @@
         "@instructure/ui-icons": "10.25.0",
         "@instructure/ui-utils": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28689,7 +28663,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28718,7 +28692,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -28741,7 +28715,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28771,7 +28745,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28805,7 +28779,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28833,7 +28807,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28858,7 +28832,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1"
+        "@testing-library/react": "15.0.7"
       },
       "peerDependencies": {
         "react": ">=18 <=19"
@@ -28885,7 +28859,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28914,7 +28888,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -28939,26 +28913,13 @@
       "version": "10.25.0",
       "license": "MIT",
       "dependencies": {
-        "@instructure/shared-types": "10.25.0",
-        "@instructure/theme-registry": "10.25.0"
+        "@instructure/shared-types": "10.25.0"
       },
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
-      }
-    },
-    "packages/ui-themes/node_modules/@instructure/theme-registry": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/@instructure/theme-registry/-/theme-registry-10.25.0.tgz",
-      "integrity": "sha512-J45roEysrQyEIa3jTcztBOG5xPciWt9C4ugylBCEl9u7z2tFeeZ774TFmUsOjQbNdznoRR2XQeWN/EdZEKClDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "@instructure/console": "10.25.0",
-        "@instructure/shared-types": "10.25.0",
-        "@instructure/ui-utils": "10.25.0"
       }
     },
     "packages/ui-time-select": {
@@ -28978,7 +28939,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "moment-timezone": "^0.6.0",
         "vitest": "^3.2.2"
@@ -29011,7 +28972,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -29038,7 +28999,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -29080,7 +29041,7 @@
         "@instructure/ui-scripts": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -29110,7 +29071,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@testing-library/user-event": "^14.6.1",
         "vitest": "^3.2.2"
       },
@@ -29138,7 +29099,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -29165,7 +29126,7 @@
         "@instructure/ui-color-utils": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {
@@ -29194,7 +29155,7 @@
         "@instructure/ui-text": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "@types/escape-html": "^1.0.4",
         "vitest": "^3.2.2"
       },
@@ -29219,7 +29180,7 @@
       "devDependencies": {
         "@instructure/ui-babel-preset": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "15.0.7",
         "@types/json-stable-stringify": "^1.2.0",
         "vitest": "^3.2.2"
       },
@@ -29272,7 +29233,7 @@
         "@instructure/ui-babel-preset": "10.25.0",
         "@instructure/ui-themes": "10.25.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.0.1",
+        "@testing-library/react": "15.0.7",
         "vitest": "^3.2.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
   },
   "license": "MIT",
   "resolutions": {
-    "react": "^19.1",
-    "react-dom": "^19.1",
-    "@types/react": "^19.1"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.2",
@@ -58,11 +57,11 @@
     "@instructure/pkg-utils": "workspace:*",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22",
-    "@types/react-dom": "^19.1",
+    "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "^4.5.1",
     "@vitest/eslint-plugin": "^1.2.1",
     "chai": "^4.4.1",
@@ -86,7 +85,7 @@
     "jsdom": "^26.1.0",
     "lerna": "^8.2.4",
     "lint-staged": "^15.2.10",
-    "react": "^19.1",
+    "react": "18.3.1",
     "tar": "^7.4.3",
     "typescript": "5.8.3",
     "typescript-eslint": "^8.33.1",

--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -118,8 +118,8 @@
     "marked": "^15.0.12",
     "marked-react": "^3.0.0",
     "moment": "^2.30.1",
-    "react": "19.1",
-    "react-dom": "19.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "semver": "^7.7.2",
     "uuid": "^11.1.0",
     "webpack-merge": "^6.0.1"

--- a/packages/__docs__/resolve.mjs
+++ b/packages/__docs__/resolve.mjs
@@ -219,11 +219,7 @@ const alias = {
     '../ui-file-drop/src/'
   ),
   '@instructure/ui-heading$': path.resolve(import.meta.dirname, '../ui-heading/src/'),
-  '@instructure/emotion$': path.resolve(import.meta.dirname, '../emotion/src/'),
-  '@instructure/theme-registry$': path.resolve(
-    import.meta.dirname,
-    '../theme-registry/src/'
-  )
+  '@instructure/emotion$': path.resolve(import.meta.dirname, '../emotion/src/')
 }
 
 export default { alias }

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -105,8 +105,8 @@ class App extends Component<AppProps, AppState> {
   _mediaQueryListener?: ReturnType<typeof addMediaQueryMatchListener>
   _defaultDocumentTitle?: string
   _controller?: AbortController
-  _heroRef: React.RefObject<Hero | null>
-  _navRef: React.RefObject<Nav | null>
+  _heroRef: React.RefObject<any>
+  _navRef: React.RefObject<any>
   _skipToMainButtonRef?: HTMLElement
   _mainContentRef?: HTMLElement
 

--- a/packages/canvas-high-contrast-theme/package.json
+++ b/packages/canvas-high-contrast-theme/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/runtime": "^7.27.6",
     "@instructure/shared-types": "10.25.0",
-    "@instructure/theme-registry": "10.25.0",
     "@instructure/ui-themes": "10.25.0"
   },
   "publishConfig": {

--- a/packages/canvas-theme/package.json
+++ b/packages/canvas-theme/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/runtime": "^7.27.6",
     "@instructure/shared-types": "10.25.0",
-    "@instructure/theme-registry": "10.25.0",
     "@instructure/ui-themes": "10.25.0"
   },
   "publishConfig": {

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -27,7 +27,6 @@
     "@emotion/react": "^11",
     "@instructure/console": "10.25.0",
     "@instructure/shared-types": "10.25.0",
-    "@instructure/theme-registry": "10.25.0",
     "@instructure/ui-decorator": "10.25.0",
     "@instructure/ui-i18n": "10.25.0",
     "@instructure/ui-react-utils": "10.25.0",
@@ -38,9 +37,9 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
-    "react-dom": "^19.1",
+    "react-dom": "18.3.1",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-a11y-content/package.json
+++ b/packages/ui-a11y-content/package.json
@@ -32,7 +32,7 @@
     "@instructure/ui-axe-check": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-a11y-utils/package.json
+++ b/packages/ui-a11y-utils/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-color-utils": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-alerts/package.json
+++ b/packages/ui-alerts/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-scripts": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-badge/package.json
+++ b/packages/ui-badge/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-billboard/package.json
+++ b/packages/ui-billboard/package.json
@@ -29,7 +29,7 @@
     "@instructure/ui-icons": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-breadcrumb/package.json
+++ b/packages/ui-breadcrumb/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-byline/package.json
+++ b/packages/ui-byline/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-calendar/package.json
+++ b/packages/ui-calendar/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -43,7 +43,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-color-picker/package.json
+++ b/packages/ui-color-picker/package.json
@@ -49,7 +49,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-scripts": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-date-input/package.json
+++ b/packages/ui-date-input/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-buttons": "10.25.0",
     "@instructure/ui-scripts": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-date-time-input/package.json
+++ b/packages/ui-date-time-input/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -33,7 +33,7 @@
     "@instructure/console": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-dom-utils/package.json
+++ b/packages/ui-dom-utils/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-dom-utils/src/findDOMNode.ts
+++ b/packages/ui-dom-utils/src/findDOMNode.ts
@@ -30,10 +30,14 @@ import ReactDOM from 'react-dom'
  * React 18 (element.ref) and React 19+ (element.props.ref)
  */
 function getElementRef(elem: { ref?: any; props?: { ref: any } }) {
-  if (elem?.props?.ref !== undefined) {
-    return elem.props.ref
+  // Note that this is added by InstUI components like Position
+  if (elem.ref) {
+    return elem.ref
   }
-  return elem.ref
+  // note that trying to access this will display a warning in React 18.
+  // this is OK because without it React itself would show an error because
+  // its using findDOMNode
+  return elem?.props?.ref
 }
 
 /**
@@ -82,7 +86,7 @@ function findDOMNode(el?: UIElement): Element | Node | Window | undefined {
       ? (node as any).constructor.componentId
       : (node as any).constructor.name
     console.error(
-      `Error: ${elName} doesn't have "ref" property.\n
+      `findDOMNode error: ${elName} doesn't have "ref" property.\n
       your code will likely not work with React 19+, because ReactDOM.findDOMNode() was removed.\n
       See more here: https://instructure.design/#accessing-the-dom`
     )

--- a/packages/ui-drawer-layout/package.json
+++ b/packages/ui-drawer-layout/package.json
@@ -43,7 +43,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-drilldown/package.json
+++ b/packages/ui-drilldown/package.json
@@ -44,7 +44,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-editable/package.json
+++ b/packages/ui-editable/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-axe-check": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-expandable/package.json
+++ b/packages/ui-expandable/package.json
@@ -33,7 +33,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-color-utils": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-flex/package.json
+++ b/packages/ui-flex/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-focusable/package.json
+++ b/packages/ui-focusable/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-form-field/package.json
+++ b/packages/ui-form-field/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-grid/package.json
+++ b/packages/ui-grid/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-heading/package.json
+++ b/packages/ui-heading/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-i18n/package.json
+++ b/packages/ui-i18n/package.json
@@ -25,9 +25,9 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@types/hoist-non-react-statics": "^3.3.6",
-    "react-dom": "^19.1",
+    "react-dom": "18.3.1",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-img/package.json
+++ b/packages/ui-img/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-axe-check": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-instructure/package.json
+++ b/packages/ui-instructure/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-link/package.json
+++ b/packages/ui-link/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-list/package.json
+++ b/packages/ui-list/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-metric/package.json
+++ b/packages/ui-metric/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -46,7 +46,7 @@
     "@instructure/ui-position": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-navigation/package.json
+++ b/packages/ui-navigation/package.json
@@ -29,7 +29,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-number-input/package.json
+++ b/packages/ui-number-input/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-overlays/package.json
+++ b/packages/ui-overlays/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "@types/no-scroll": "^2.1.2",
     "vitest": "^3.2.2"

--- a/packages/ui-pages/package.json
+++ b/packages/ui-pages/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-pagination/package.json
+++ b/packages/ui-pagination/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-axe-check": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-popover/package.json
+++ b/packages/ui-popover/package.json
@@ -42,7 +42,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-color-utils": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-axe-check": "10.25.0",
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-position/package.json
+++ b/packages/ui-position/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-progress/package.json
+++ b/packages/ui-progress/package.json
@@ -37,7 +37,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-radio-input/package.json
+++ b/packages/ui-radio-input/package.json
@@ -36,7 +36,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-range-input/package.json
+++ b/packages/ui-range-input/package.json
@@ -41,7 +41,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-rating/package.json
+++ b/packages/ui-rating/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-react-utils/package.json
+++ b/packages/ui-react-utils/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-responsive/package.json
+++ b/packages/ui-responsive/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-color-utils": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-selectable/package.json
+++ b/packages/ui-selectable/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-side-nav-bar/package.json
+++ b/packages/ui-side-nav-bar/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-simple-select/package.json
+++ b/packages/ui-simple-select/package.json
@@ -37,7 +37,7 @@
     "@instructure/ui-icons": "10.25.0",
     "@instructure/ui-utils": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-source-code-editor/package.json
+++ b/packages/ui-source-code-editor/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-svg-images/package.json
+++ b/packages/ui-svg-images/package.json
@@ -26,7 +26,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-tabs/package.json
+++ b/packages/ui-tabs/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-tag/package.json
+++ b/packages/ui-tag/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-text-area/package.json
+++ b/packages/ui-text-area/package.json
@@ -39,7 +39,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-text-input/package.json
+++ b/packages/ui-text-input/package.json
@@ -29,7 +29,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-text/package.json
+++ b/packages/ui-text/package.json
@@ -35,7 +35,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1"
+    "@testing-library/react": "15.0.7"
   },
   "peerDependencies": {
     "react": ">=18 <=19"

--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -24,12 +24,11 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {
-    "@instructure/shared-types": "10.25.0",
-    "@instructure/theme-registry": "10.25.0"
+    "@instructure/shared-types": "10.25.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-time-select/package.json
+++ b/packages/ui-time-select/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "moment-timezone": "^0.6.0",
     "vitest": "^3.2.2"

--- a/packages/ui-toggle-details/package.json
+++ b/packages/ui-toggle-details/package.json
@@ -27,7 +27,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-tooltip/package.json
+++ b/packages/ui-tooltip/package.json
@@ -37,7 +37,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-top-nav-bar/package.json
+++ b/packages/ui-top-nav-bar/package.json
@@ -52,7 +52,7 @@
     "@instructure/ui-scripts": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-tray/package.json
+++ b/packages/ui-tray/package.json
@@ -40,7 +40,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "^14.6.1",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -28,7 +28,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "dependencies": {

--- a/packages/ui-truncate-list/package.json
+++ b/packages/ui-truncate-list/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-color-utils": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {

--- a/packages/ui-truncate-text/package.json
+++ b/packages/ui-truncate-text/package.json
@@ -40,7 +40,7 @@
     "@instructure/ui-text": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "@types/escape-html": "^1.0.4",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@instructure/ui-babel-preset": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "15.0.7",
     "@types/json-stable-stringify": "^1.2.0",
     "vitest": "^3.2.2"
   },

--- a/packages/ui-view/package.json
+++ b/packages/ui-view/package.json
@@ -38,7 +38,7 @@
     "@instructure/ui-babel-preset": "10.25.0",
     "@instructure/ui-themes": "10.25.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.0.1",
+    "@testing-library/react": "15.0.7",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
- some `instructure/theme-registry` dependencies were still there, this package was removed
-  findDOMNode tries to access `elem?.props?.ref` after it has tried `elem.ref` because accessing`elem?.props?.ref` triggers a warning
- downgrade docs app React 18 because this is what most use. This also required the downgrade of `@testing-library/react`

to test: check things that display a popup that they work well and there are no console errors/warnings.