### PR TITLE
feat(ui-table): add column ordering to caption

### DIFF
--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -582,10 +582,7 @@ By default, the options in the `Select` for sorting in stacked layout are genera
                 </View>
               )}
 
-              <Table
-                caption={`${caption}: sorted by ${sortBy} in ${direction} order`}
-                {...props}
-              >
+              <Table {...props}>
                 <Table.Head renderSortLabel="Sort by">
                   {this.renderHeaderRow(direction)}
                 </Table.Head>
@@ -601,13 +598,6 @@ By default, the options in the `Select` for sorting in stacked layout are genera
                   ))}
                 </Table.Body>
               </Table>
-              <Alert
-                liveRegion={() => document.getElementById('flash-messages')}
-                liveRegionPoliteness="polite"
-                screenReaderOnly
-              >
-                {`Sorted by ${sortBy} in ${direction} order`}
-              </Alert>
             </div>
           )}
         </Responsive>
@@ -806,10 +796,7 @@ By default, the options in the `Select` for sorting in stacked layout are genera
               </View>
             )}
 
-            <Table
-              caption={`${caption}: sorted by ${sortBy} in ${direction} order`}
-              {...props}
-            >
+            <Table {...props}>
               <Table.Head renderSortLabel="Sort by">
                 {renderHeaderRow(direction)}
               </Table.Head>
@@ -825,13 +812,6 @@ By default, the options in the `Select` for sorting in stacked layout are genera
                 ))}
               </Table.Body>
             </Table>
-            <Alert
-              liveRegion={() => document.getElementById('flash-messages')}
-              liveRegionPoliteness="polite"
-              screenReaderOnly
-            >
-              {`Sorted by ${sortBy} in ${direction} order`}
-            </Alert>
           </div>
         )}
       </Responsive>
@@ -966,10 +946,7 @@ that selection does not re-paginate or re-sort the table, and pagination does no
               <View as="div" padding="small" background="primary-inverse">
                 {`${selected.size} of ${rowIds.length} selected`}
               </View>
-              <Table
-                caption={`${caption}: sorted by ${sortBy} in ${direction} order`}
-                {...props}
-              >
+              <Table {...props}>
                 <Table.Head
                   renderSortLabel={
                     <ScreenReaderContent>Sort by</ScreenReaderContent>
@@ -1175,15 +1152,6 @@ that selection does not re-paginate or re-sort the table, and pagination does no
             ascending={ascending}
             perPage={perPage}
           />
-          <Alert
-            liveRegion={() => document.getElementById('flash-messages')}
-            liveRegionPoliteness="polite"
-            screenReaderOnly
-          >
-            {`Sorted by ${sortBy} in ${
-              ascending ? 'ascending' : 'descending'
-            } order`}
-          </Alert>
         </div>
       )
     }
@@ -1305,10 +1273,7 @@ that selection does not re-paginate or re-sort the table, and pagination does no
             <View as="div" padding="small" background="primary-inverse">
               {`${selected.size} of ${rowIds.length} selected`}
             </View>
-            <Table
-              caption={`${caption}: sorted by ${sortBy} in ${direction} order`}
-              {...props}
-            >
+            <Table {...props}>
               <Table.Head
                 renderSortLabel={
                   <ScreenReaderContent>Sort by</ScreenReaderContent>
@@ -1485,15 +1450,6 @@ that selection does not re-paginate or re-sort the table, and pagination does no
           ascending={ascending}
           perPage={perPage}
         />
-        <Alert
-          liveRegion={() => document.getElementById('flash-messages')}
-          liveRegionPoliteness="polite"
-          screenReaderOnly
-        >
-          {`Sorted by ${sortBy} in ${
-            ascending ? 'ascending' : 'descending'
-          } order`}
-        </Alert>
       </div>
     )
   }

--- a/packages/ui-table/src/Table/props.ts
+++ b/packages/ui-table/src/Table/props.ts
@@ -80,7 +80,7 @@ type TableProps = TableOwnProps &
   WithStyleProps<TableTheme, TableStyle> &
   OtherHTMLAttributes<TableOwnProps>
 
-type TableStyle = ComponentStyle<'table'>
+type TableStyle = ComponentStyle<'table' | 'liveRegion'>
 
 const propTypes: PropValidators<PropKeys> = {
   caption: PropTypes.node.isRequired,

--- a/packages/ui-table/src/Table/styles.ts
+++ b/packages/ui-table/src/Table/styles.ts
@@ -55,6 +55,14 @@ const generateStyle = (
       borderSpacing: 0,
       ...(layout === 'fixed' && { tableLayout: 'fixed' }),
       caption: { textAlign: 'start' }
+    },
+    liveRegion: {
+      label: 'table__liveRegion',
+      position: 'absolute',
+      left: '-10000px',
+      width: '1px',
+      height: '1px',
+      overflow: 'hidden'
     }
   }
 }


### PR DESCRIPTION
INSTUI-4699

**Test plan**:

1. Move to the Table docs page
2. Turn on NVDA/VoiceOver/Jaws
3. Focus the Table example that can be ordered by columns
4. Observe whether the Screenreader announce ordering - it has to announce the right column, right order
5. Try changing the ordering and observe whether it announce the changed column and order