### PR TITLE
feat(ui-drilldown): add new controlled selectedOptions prop for DrilldownGroup

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/DrilldownGroup/props.ts
+++ b/packages/ui-drilldown/src/Drilldown/DrilldownGroup/props.ts
@@ -89,6 +89,12 @@ type DrilldownGroupOwnProps = {
   defaultSelected?: DrilldownOptionValue[]
 
   /**
+   * An array of the values for the selected items. If defined, the component will act controlled and will not manage its own state. Works only with "selectableType" set.
+   * If "selectableType" is "single", the array has to have 1 item.
+   */
+  selectedOptions?: DrilldownOptionValue[]
+
+  /**
    * Callback fired when an option within the `<Drilldown.Group />` is selected
    */
   onSelect?: (
@@ -120,6 +126,7 @@ const allowedProps: AllowedPropKeys = [
   'elementRef',
   'selectableType',
   'defaultSelected',
+  'selectedOptions',
   'onSelect'
 ]
 


### PR DESCRIPTION
INSTUI-4689

Add new controlled selectedOptions prop for DrilldownGroup.
Add tests to cover the new feature.

Test plan:
Go to Drilldown doc page and add the new prop for DrilldownGroup.
Add an array of values or an empty array. Add more groups next to each other with different setups and make user interactions. Modify the selectedOptions value and verify the controlled behavior.