### PR TITLE
fix(ui-buttons): fix focus ring distortion on circle shape buttons

### DIFF
--- a/packages/ui-buttons/src/BaseButton/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/styles.ts
@@ -361,6 +361,7 @@ const generateStyle = (
           touchAction: 'manipulation',
           // This sets the focus ring's border radius displayed by the `View`
           borderRadius: componentTheme.borderRadius,
+          ...shapeVariants[shape!],
           // Prevents vertical stretching in flex parents with fixed height
           // Avoids background/focus ring distortion
           height: 'fit-content',


### PR DESCRIPTION
INSTUI-4751

Test:
Check buttons doc page and the focus ring on buttons with prop shape="circle"

