### PR TITLE
fix(ui-text): text component letter spacing bug

### DIFF
--- a/packages/__docs__/src/ComponentTheme/index.tsx
+++ b/packages/__docs__/src/ComponentTheme/index.tsx
@@ -42,7 +42,7 @@ class ComponentTheme extends Component<ComponentThemeProps> {
     value: undefined | string | object | number,
     colorPrimitives: object
   ) {
-    if (!value) {
+    if (!value && value !== 0) {
       return <code>ERROR - possible bug</code>
     }
     if (typeof value === 'object') {


### PR DESCRIPTION
INSTUI-4748
Fixed an issue where letterSpacingNormal theme variable previously showed an error because its value was 0
Now it properly displays the 0 value instead of showing an error.

Test plan:
Go to the Text documentation page Default Theme Variables section
Verify that letterSpacingNormal is displayed with the value 0.