### PR TITLE
fix(emotion): fix useTheme export. The native emotion util was exported instead of our own

### DIFF
--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from './styleUtils'
 
 export { useStyle } from './useStyle'
+export { useTheme } from './useTheme'
 
 export type { ComponentStyle, StyleObject, Overrides } from './EmotionTypes'
 export type { WithStyleProps } from './withStyle'


### PR DESCRIPTION
TEST_PLAN: check out the repo and try to import useTheme from @instructure/emotion. Check if it imports our own util and not the native emotion/react method

INSTUI-4827