### PR TITLE
fix: themes for subcomponents displaying wrong in the docs app

### DIFF
--- a/packages/__docs__/src/Document/props.ts
+++ b/packages/__docs__/src/Document/props.ts
@@ -46,9 +46,9 @@ type DocumentProps = DocumentOwnProps & WithStyleProps<null, DocumentStyle>
 type DocumentStyle = ComponentStyle<'githubCornerOctoArm' | 'githubCorner'>
 
 type DocumentState = {
-  selectedDetailsTabIndex: number
+  selectedDetailsTabId: string | undefined
   pageRef: HTMLDivElement | null
-  componentTheme: Partial<ThemeVariables[keyof ThemeVariables]>
+  componentTheme: Partial<ThemeVariables[keyof ThemeVariables]> | undefined
 }
 
 const allowedProps: AllowedPropKeys = [

--- a/packages/ui-tabs/src/Tabs/props.ts
+++ b/packages/ui-tabs/src/Tabs/props.ts
@@ -42,7 +42,9 @@ type TabsOwnProps = {
    */
   screenReaderLabel?: string
   /**
-   * Called when the selected tab should change
+   * Called when the selected tab should change.
+   * @param tabData.index - The zero-based index of the tab that was selected
+   * @param tabData.id - The HTML `id` of the tab that was selected
    */
   onRequestTabChange?: (
     event: React.MouseEvent<ViewOwnProps> | React.KeyboardEvent<ViewOwnProps>,


### PR DESCRIPTION
Also do not show properties if there arent any (like `Menu.Separator`)

To test: Check that theme variables are displayed correctly for subcomponents (e.g. Menu, Tabs, TopNavBar,..)

Fixes INSTUI-4833