### PR TITLE
test(many): reduce console spam during test runs

### DIFF
--- a/packages/ui-codemods/lib/__node_tests__/codemodHelpers.test.tsx
+++ b/packages/ui-codemods/lib/__node_tests__/codemodHelpers.test.tsx
@@ -35,9 +35,28 @@ import {
   removeAllChildren,
   findElement
 } from '../utils/codemodHelpers'
-import { expect } from 'vitest'
+import { expect, type MockInstance, vi } from 'vitest'
 
 describe('test codemod helpers', () => {
+  let consoleLogMock: ReturnType<typeof vi.spyOn>
+  let consoleWarningMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // Mocking console to prevent test output pollution
+    // comment these out to see the test output
+    consoleLogMock = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {}) as MockInstance
+    consoleWarningMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {}) as MockInstance
+  })
+
+  afterEach(() => {
+    consoleLogMock.mockRestore()
+    consoleWarningMock.mockRestore()
+  })
+
   it('test findElement', () => {
     // Test finding simple elements by tag name
     const source = `
@@ -536,7 +555,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     let root = j(source)
-    let result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    let result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -562,7 +587,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -586,7 +617,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j.withParser('tsx')(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -609,7 +646,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -632,7 +675,13 @@ import { Modal } from "@instructure/ui-modal";`)
     `
     root = j(source)
     const originalSource = root.toSource()
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(false)
     expect(root.toSource()).toBe(originalSource)
@@ -649,7 +698,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -673,7 +728,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -696,7 +757,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'oldName', 'newName', '@import-path')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'oldName',
+      'newName',
+      '@import-path'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -723,7 +790,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'Button', 'PrimaryButton', '@instructure/ui-buttons')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'Button',
+      'PrimaryButton',
+      '@instructure/ui-buttons'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -748,7 +821,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'Button', 'PrimaryButton', '@instructure/ui-buttons')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'Button',
+      'PrimaryButton',
+      '@instructure/ui-buttons'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -769,7 +848,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'Button', 'PrimaryButton', '@instructure/ui-buttons')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'Button',
+      'PrimaryButton',
+      '@instructure/ui-buttons'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -795,7 +880,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'Button', 'PrimaryButton', '@instructure/ui-buttons')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'Button',
+      'PrimaryButton',
+      '@instructure/ui-buttons'
+    )
 
     expect(result).toBe(true)
     expect(root.toSource()).toBe(`
@@ -826,7 +917,13 @@ import { Modal } from "@instructure/ui-modal";`)
       }
     `
     root = j(source)
-    result = renameImportAndUsages(j, root, 'Button', 'PrimaryButton', '@instructure/ui-buttons')
+    result = renameImportAndUsages(
+      j,
+      root,
+      'Button',
+      'PrimaryButton',
+      '@instructure/ui-buttons'
+    )
 
     expect(result).toBe(false)
     expect(root.toSource()).toBe(source)

--- a/packages/ui-codemods/lib/__node_tests__/codemods.test.ts
+++ b/packages/ui-codemods/lib/__node_tests__/codemods.test.ts
@@ -29,8 +29,28 @@ import renameCanvasThemesCodemod from '../renameCanvasThemesCodemod'
 import renameGetComputedStyleToGetCSSStyleDeclaration from '../renameGetComputedStyleToGetCSSStyleDeclaration'
 import warnTableCaptionMissing from '../warnTableCaptionMissing'
 import warnCodeEditorRemoved from '../warnCodeEditorRemoved'
+import { type MockInstance, vi } from 'vitest'
 
 describe('test codemods', () => {
+  let consoleLogMock: ReturnType<typeof vi.spyOn>
+  let consoleWarningMock: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // Mocking console to prevent test output pollution
+    // comment these out to see the test output
+    consoleLogMock = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {}) as MockInstance
+    consoleWarningMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {}) as MockInstance
+  })
+
+  afterEach(() => {
+    consoleLogMock.mockRestore()
+    consoleWarningMock.mockRestore()
+  })
+
   it('test InstUI v10 color codemods', () => {
     runTest(updateV10Breaking)
   })

--- a/packages/ui-file-drop/src/FileDrop/__tests__/FileDrop.test.tsx
+++ b/packages/ui-file-drop/src/FileDrop/__tests__/FileDrop.test.tsx
@@ -29,10 +29,11 @@ import '@testing-library/jest-dom'
 
 import { FileDrop } from '../index'
 import { FileDropProps } from '../props'
+import { act } from 'react'
 
 describe('<FileDrop/>', () => {
   it('should focus the input when focus is called', async () => {
-    let inputEl: any
+    let inputEl: HTMLInputElement | null | undefined
     const { container } = render(
       <FileDrop
         renderLabel="filedrop"
@@ -42,9 +43,9 @@ describe('<FileDrop/>', () => {
       />
     )
     const input = container.querySelector('input[class$="-fileDrop__input"]')
-
-    inputEl.focus()
-
+    act(() => {
+      inputEl!.focus()
+    })
     expect(input).toHaveFocus()
   })
 

--- a/packages/ui-options/src/Options/__tests__/Options.test.tsx
+++ b/packages/ui-options/src/Options/__tests__/Options.test.tsx
@@ -125,10 +125,10 @@ describe('<Options />', () => {
 
   it('should render nested options properly', async () => {
     const { container } = render(
-      <Options data-testId="outer-list">
+      <Options data-testid="outer-list">
         <Options.Item>Option one </Options.Item>
         <Options.Item>Option two </Options.Item>
-        <Options renderLabel={'Nested list'} data-testId="nested-list">
+        <Options renderLabel={'Nested list'} data-testid="nested-list">
           <Options.Item>Nested option one </Options.Item>
           <Options.Item>Nested option two </Options.Item>
         </Options>
@@ -168,7 +168,10 @@ describe('<Options />', () => {
         </Options>
       )
 
-      // axe-check is more strict now, and expects "list" role to have "listitem" children, but we use "role='none'" children. After discussing it with the A11y team, we agreed to ignore this error because the screen readers can read the component perfectly.
+      // axe-check is more strict now, and expects "list" role to have "listitem"
+      // children, but we use "role='none'" children. After discussing it with
+      // the A11y team, we agreed to ignore this error because the screen readers
+      // can read the component perfectly.
       // TODO: try to remove this ignore if axe-check is updated and isn't this strict anymore
       // https://dequeuniversity.com/rules/axe/4.6/aria-required-children?application=axeAPI
       const axeCheck = await runAxeCheck(container, {

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
@@ -32,7 +32,13 @@ import { RangeInput } from '../index'
 describe('<RangeInput />', () => {
   it('renders an input with type "range"', async () => {
     const { container } = render(
-      <RangeInput label="Opacity" name="opacity" max={100} min={0} />
+      <RangeInput
+        label="Opacity"
+        name="opacity"
+        max={100}
+        min={0}
+        displayValue={false}
+      />
     )
 
     const label = container.querySelector('[class$="-formFieldLayout__label"]')
@@ -111,14 +117,30 @@ describe('<RangeInput />', () => {
   })
 
   it('sets min value', async () => {
-    render(<RangeInput label="Opacity" name="opacity" max={100} min={25} />)
+    render(
+      <RangeInput
+        label="Opacity"
+        name="opacity"
+        max={100}
+        min={25}
+        displayValue={false}
+      />
+    )
     const input = screen.getByLabelText('Opacity')
 
     expect(input).toHaveAttribute('min', '25')
   })
 
   it('sets max value', async () => {
-    render(<RangeInput label="Opacity" name="opacity" max={75} min={0} />)
+    render(
+      <RangeInput
+        label="Opacity"
+        name="opacity"
+        max={75}
+        min={0}
+        displayValue={false}
+      />
+    )
 
     const input = screen.getByLabelText('Opacity')
 
@@ -127,7 +149,14 @@ describe('<RangeInput />', () => {
 
   it('sets step value', async () => {
     render(
-      <RangeInput label="Opacity" name="opacity" max={100} min={0} step={5} />
+      <RangeInput
+        label="Opacity"
+        name="opacity"
+        max={100}
+        min={0}
+        step={5}
+        displayValue={false}
+      />
     )
     const input = screen.getByLabelText('Opacity')
 


### PR DESCRIPTION
fix some warning and stub out console for codemods unit tests so there are less console messages when running tests.

How to test:
Run `test:vitest` and notice that all tests pass and there are less unnecessary console warnings/spam