### PR TITLE
docs app displays new theme variables, better theme type parsing

### DIFF
--- a/packages/__docs__/buildScripts/utils/getPathInfo.mts
+++ b/packages/__docs__/buildScripts/utils/getPathInfo.mts
@@ -45,8 +45,8 @@ export function getPathInfo(
   const themePath = resourcePath.replace('index.tsx', 'theme.ts')
 
   if (fs.existsSync(themePath)) {
-    pathInfo.themePath = pathInfo.srcPath.replace('index.tsx', 'theme.ts')
-    pathInfo.themeUrl = pathInfo.srcUrl.replace('index.tsx', 'theme.ts')
+    pathInfo.themePath = pathInfo.srcPath.replace('index.tsx', 'styles.ts')
+    pathInfo.themeUrl = pathInfo.srcUrl.replace('index.tsx', 'styles.ts')
   }
   return pathInfo
 }

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -563,8 +563,13 @@ class App extends Component<AppProps, AppState> {
     if (olderVersionsGitBranchMap && versionInPath) {
       legacyGitBranch = olderVersionsGitBranchMap[versionInPath]
     }
-
-    const themeVariables = themes[themeKey!].resource
+    let themeVariables
+    if (themes[themeKey!].resource.newTheme.components[docId]) {
+      // new theme
+      themeVariables = themes[themeKey!].resource.newTheme
+    } else {
+      themeVariables = themes[themeKey!].resource // old theme
+    }
     const heading = currentData.extension !== '.md' ? currentData.title : ''
     const documentContent = (
       <View as="div" padding="x-large none none">

--- a/packages/__docs__/src/ComponentTheme/index.tsx
+++ b/packages/__docs__/src/ComponentTheme/index.tsx
@@ -34,53 +34,69 @@ import generateStyle from './styles'
 import { allowedProps } from './props'
 import type { ComponentThemeProps } from './props'
 
+type ThemeEntry = { name: string; value: string | number }
+
 @withStyle(generateStyle, null)
 class ComponentTheme extends Component<ComponentThemeProps> {
   static allowedProps = allowedProps
 
-  renderValueCell(
-    value: undefined | string | object | number,
-    colorPrimitives: object
-  ) {
+  renderValueCell(value: undefined | string | number) {
     if (!value && value !== 0) {
       return <code>ERROR - possible bug</code>
-    }
-    if (typeof value === 'object') {
-      return <code>{JSON.stringify(value)}</code>
     }
     if (
       value.toString().charAt(0) === '#' ||
       value.toString().substring(0, 3) === 'rgb'
     ) {
-      // find color primitive name from hex value
-      const color = Object.entries(colorPrimitives).find(([, v]) => v === value)
       return (
         <span>
           <View margin="0 xx-small 0 0">
             <ColorSwatch color={value} />
           </View>
-          <code>{color?.[0] ?? value}</code>
+          <code>{value}</code>
         </span>
       )
     }
     return <code>{value}</code>
   }
 
-  renderRows() {
-    const { componentTheme, themeVariables } = this.props
-    const colorPrimitives = themeVariables.colors.primitives
+  /**
+   * Theme objects can be nested, so we need to walk the tree to get all the
+   * keys, e.g., box shadow values
+   */
+  themeToArray(
+    componentTheme: typeof this.props.componentTheme,
+    arr: ThemeEntry[],
+    prefix: string | undefined = undefined
+  ) {
+    for (const key in componentTheme) {
+      if (typeof componentTheme[key] === 'object') {
+        this.themeToArray(componentTheme[key], arr, key)
+      } else if (componentTheme[key] !== undefined) {
+        const name = prefix ? `${prefix}.${key}` : key
+        arr.push({ name: name, value: componentTheme[key] })
+      } else {
+        console.error(
+          `ComponentTheme: Key "${key}" is undefined`,
+          componentTheme
+        )
+      }
+    }
+    return arr
+  }
 
-    return Object.keys(componentTheme)
-      .sort((a, b) => a.localeCompare(b))
-      .map((name) => {
+  renderRows() {
+    const { componentTheme } = this.props
+    const ret = this.themeToArray(componentTheme, [])
+    return ret
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((entry) => {
         return (
-          <Table.Row key={name}>
+          <Table.Row key={entry.name}>
             <Table.Cell>
-              <code>{name}</code>
+              <code>{entry.name}</code>
             </Table.Cell>
-            <Table.Cell>
-              {this.renderValueCell(componentTheme[name], colorPrimitives)}
-            </Table.Cell>
+            <Table.Cell>{this.renderValueCell(entry.value)}</Table.Cell>
           </Table.Row>
         )
       })

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -76,8 +76,19 @@ class Document extends Component<DocumentProps, DocumentState> {
     const { doc, themeVariables } = this.props
     let generateTheme
     if (this.state.selectedDetailsTabId === doc.id) {
-      generateTheme = doc?.componentInstance?.generateComponentTheme
+      // @ts-ignore todo type
+      if (this.props.themeVariables.components?.[doc.id]) {
+        // new theme
+        // @ts-ignore todo type
+        generateTheme = this.props.themeVariables.components[doc.id]
+        this.setState({ componentTheme: generateTheme })
+        return
+      } else {
+        // old theme
+        generateTheme = doc?.componentInstance?.generateComponentTheme
+      }
     } else {
+      // TODO make it work for new themes
       generateTheme = doc?.children?.find(
         (value) => value.id === this.state.selectedDetailsTabId
       )?.componentInstance?.generateComponentTheme
@@ -138,6 +149,15 @@ class Document extends Component<DocumentProps, DocumentState> {
           <View as="div" margin="0 0 x-small 0">
             See which global theme variables are mapped to the component here:{' '}
             {this.renderThemeLink(doc)}
+            <br />
+            <br />
+            Note: Theme variables with a dot in their name are nested objects,
+            to override them you need to override the whole object, for example:
+            &nbsp;
+            <code>
+              themeOverride=
+              {`{{ boxShadow: {x: "0.3rem", y: "0.5rem", color: "red"}}}`}
+            </code>
           </View>
         ) : null}
         <ComponentTheme

--- a/packages/ui-scripts/lib/build/buildThemes/setupThemes.js
+++ b/packages/ui-scripts/lib/build/buildThemes/setupThemes.js
@@ -30,6 +30,7 @@ import generateSemantics, {
   mergeSemanticSets
 } from './generateSemantics.js'
 import generateComponent, {
+  boxShadowType,
   generateComponentType
 } from './generateComponents.js'
 import { exec } from 'child_process'
@@ -68,8 +69,18 @@ const setupThemes = async (targetPath, input) => {
   //make new root folder
   await promises.mkdir(targetPath, { recursive: true })
 
+  await createFile(
+    `${targetPath}/commonTypes.ts`,
+    `export type BoxShadow ={
+    x: string | 0
+    y: string | 0
+    blur: string | 0
+    spread: string | 0
+    color: string // CSS color string like "red" or "#f00"
+    type: "dropShadow" | "innerShadow"
+  }`
+  )
   const themeData = transformThemes(input['$themes'])
-
   //TODO-rework the Primitive theme is a hackaround for design and only for the duration of the v12 work. This should be removed before the release (.filter(t=>t!=="Primitive"))
   const themes = Object.keys(themeData).filter((t) => t !== 'Primitive')
   for (let themeIndex = 0; themeIndex < themes.length; themeIndex++) {
@@ -136,8 +147,17 @@ const setupThemes = async (targetPath, input) => {
         componentFileContent
       )
       if (themeIndex === 0) {
+        let importSemantics = ''
+        if (componentTypes.includes(`Semantics[`)) {
+          importSemantics = `import type { Semantics } from "../${theme}/semantics"`
+        }
+        let importBoxShadow = ''
+        if (componentTypes.includes(boxShadowType)) {
+          importBoxShadow = `import type { BoxShadow } from '../commonTypes'\n`
+        }
         const typeFileContent = `
-          import type { Semantics } from "../${theme}/semantics"
+          ${importSemantics}
+          ${importBoxShadow}
 
           export type ${capitalize(componentName)} = ${componentTypes}
 

--- a/packages/ui-themes/src/utils/boxShadowObjectToString.ts
+++ b/packages/ui-themes/src/utils/boxShadowObjectToString.ts
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// TODO get this type from token types, now its coming from generateComponents.js
+type BoxShadowObject = {
+  x: string | 0 | number
+  y: string | 0 | number
+  blur: string | 0 | number
+  spread: string | 0 | number
+  color: string // CSS color string like "red" or "#f00"
+  type: 'dropShadow' | 'innerShadow'
+}
+
+/**
+ * Converts a BoxShadowObject from Token Studio to a CSS box-shadow string
+ */
+function boxShadowObjectToString(boxShadowObject: BoxShadowObject) {
+  if (boxShadowObject.type === 'innerShadow') {
+    return `inset ${boxShadowObject.x}
+    ${boxShadowObject.y}
+    ${boxShadowObject.blur ? boxShadowObject.blur : ''}
+    ${boxShadowObject.spread ? boxShadowObject.spread : ''}
+    ${boxShadowObject.color}`
+  }
+  return `${boxShadowObject.x}
+    ${boxShadowObject.y}
+    ${boxShadowObject.blur ? boxShadowObject.blur : ''}
+    ${boxShadowObject.spread ? boxShadowObject.spread : ''}
+    ${boxShadowObject.color}`
+}
+
+export default boxShadowObjectToString
+export { boxShadowObjectToString }


### PR DESCRIPTION
- if a component uses an old theme it works too
- Its not working yet for subcomponents.
- Add a utility function to convert box shadow objects to strings
- Update theme type generator script to make it possible to customize types
- Nested variables, like box shadows are deconstructed recursively and displayed in separate rows.

To test:
- Check that the theme variables have the correct value in new components, e.g. `Avatar`
- Old components like `Menu` should show everything correctly too
- check the generated codein `ui-themes/src/themes/newThemes` 

Completes INSTUI-4707