### PR TITLE
INSTUI-4842 [v12] better typing for themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5817,6 +5817,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tokens-studio/types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@tokens-studio/types/-/types-0.5.2.tgz",
+      "integrity": "sha512-rzMcZP0bj2E5jaa7Fj0LGgYHysoCrbrxILVbT0ohsCUH5uCHY/u6J7Qw/TE0n6gR9Js/c9ZO9T8mOoz0HdLMbA==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "dev": true,
@@ -29098,7 +29104,8 @@
       "version": "11.0.1",
       "license": "MIT",
       "dependencies": {
-        "@instructure/shared-types": "11.0.1"
+        "@instructure/shared-types": "11.0.1",
+        "@tokens-studio/types": "^0.5.2"
       },
       "devDependencies": {
         "@instructure/ui-babel-preset": "11.0.1",

--- a/packages/emotion/src/useStyle.ts
+++ b/packages/emotion/src/useStyle.ts
@@ -71,14 +71,10 @@ const useStyle = <
       : {}
 
   if (
-    //@ts-expect-error TODO fix these later
-    theme.newTheme &&
-    //@ts-expect-error TODO fix these later
-    theme.newTheme.components[componentId]
+    (theme as BaseTheme).newTheme &&
+    (theme as BaseTheme).newTheme.components[componentId!]
   ) {
-    baseComponentTheme =
-      //@ts-expect-error TODO fix these later
-      theme.newTheme.components[componentId]
+    baseComponentTheme = (theme as BaseTheme).newTheme.components[componentId!]
   }
   const themeOverride = getComponentThemeOverride(
     theme,

--- a/packages/ui-avatar/src/Avatar/styles.ts
+++ b/packages/ui-avatar/src/Avatar/styles.ts
@@ -50,7 +50,7 @@ const generateStyle = (
   componentTheme: NewComponentTypes['Avatar'],
   params: StyleParams,
   //TODO type themes properly
-  theme: any
+  theme: any // TODO BaseTheme is is not good, it accesses theme.semantics.spacing
 ): AvatarStyle => {
   const {
     loaded,

--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -28,7 +28,8 @@
     "vitest": "^3.2.2"
   },
   "dependencies": {
-    "@instructure/shared-types": "11.0.1"
+    "@instructure/shared-types": "11.0.1",
+    "@tokens-studio/types": "^0.5.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-themes/src/index.ts
+++ b/packages/ui-themes/src/index.ts
@@ -21,7 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import type NewComponentTypes from './themes/newThemes/componentTypes'
+import type { ComponentTypes as NewComponentTypes } from './themes/newThemes/componentTypes'
+import type { BaseTheme as NewBaseTheme } from './themes/newThemes/commonTypes'
 import type { CanvasHighContrastTheme } from './themes/canvasHighContrast'
 import type { CanvasTheme, CanvasBrandVariables } from './themes/canvas'
 import type {
@@ -97,5 +98,6 @@ export type {
   NewCanvasHighContrast,
   NewRebrandDark,
   NewRebrandLight,
-  NewComponentTypes
+  NewComponentTypes,
+  NewBaseTheme
 }

--- a/packages/ui-themes/src/utils/boxShadowObjectToString.ts
+++ b/packages/ui-themes/src/utils/boxShadowObjectToString.ts
@@ -22,20 +22,12 @@
  * SOFTWARE.
  */
 
-// TODO get this type from token types, now its coming from generateComponents.js
-type BoxShadowObject = {
-  x: string | 0 | number
-  y: string | 0 | number
-  blur: string | 0 | number
-  spread: string | 0 | number
-  color: string // CSS color string like "red" or "#f00"
-  type: 'dropShadow' | 'innerShadow'
-}
+import { TokenBoxshadowValueInst } from '../themes/newThemes/commonTypes'
 
 /**
  * Converts a BoxShadowObject from Token Studio to a CSS box-shadow string
  */
-function boxShadowObjectToString(boxShadowObject: BoxShadowObject) {
+function boxShadowObjectToString(boxShadowObject: TokenBoxshadowValueInst) {
   if (boxShadowObject.type === 'innerShadow') {
     return `inset ${boxShadowObject.x}
     ${boxShadowObject.y}


### PR DESCRIPTION
- Use [types from Token studio](https://github.com/tokens-studio/types) from typing their converted JSONs instead of types from semantics/primitives
- Add some simple typing for the whole theme object

To test: 
run `build:themes` and check out the generated code (especially the types) in `ui-themes/src/themes/newThemes`