### PR TITLE
Separate focus logic from view

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,8 +16,8 @@ jobs:
         run: npm ci
       - name: Bootstrap project
         run: npm run bootstrap
-      - name: Lint commits
-        run: npm run lint:commits
+      - name: Run commitlint for the commits in the PR
+        uses: wagoid/commitlint-github-action@v6
       - name: Lint code
         run: npm run lint:changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26613,6 +26613,7 @@
         "@emotion/react": "^11",
         "@instructure/console": "11.0.1",
         "@instructure/shared-types": "11.0.1",
+        "@instructure/ui-color-utils": "11.0.1",
         "@instructure/ui-decorator": "11.0.1",
         "@instructure/ui-i18n": "11.0.1",
         "@instructure/ui-react-utils": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint": "lerna run lint --stream",
     "lint:changes": "npm run lint -- --since HEAD^",
     "lint:fix": "lerna run lint:fix --stream",
-    "lint:commits": "commitlint --from=HEAD^1",
     "bootstrap": "node scripts/bootstrap.js",
     "build": "lerna run build --stream",
     "build:watch": "lerna run build:watch --stream",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -32,6 +32,7 @@
     "@instructure/ui-react-utils": "11.0.1",
     "@instructure/ui-themes": "11.0.1",
     "@instructure/ui-utils": "11.0.1",
+    "@instructure/ui-color-utils": "11.0.1",
     "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -33,7 +33,8 @@ export {
   getShorthandPropValue,
   mirrorShorthandCorners,
   mirrorShorthandEdges,
-  mapSpacingToShorthand
+  calcMarginFromShorthand,
+  calcFocusOutlineStyles
 } from './styleUtils'
 
 export { useStyle } from './useStyle'

--- a/packages/emotion/src/styleUtils/calcFocusOutlineStyles.ts
+++ b/packages/emotion/src/styleUtils/calcFocusOutlineStyles.ts
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { alpha } from '@instructure/ui-color-utils'
+
+/**
+ * Generates consistent focus outline styles.
+ *
+ * This function creates CSS-in-JS styles for focus indicators.
+ *
+ * @param {Object} theme - The focus outline theme configuration object containing color and sizing tokens.
+ * @param {string} theme.offset - Outline offset value for 'offset' positioning (e.g., '2px').
+ * @param {string} theme.inset - Outline offset value for 'inset' positioning (e.g., '-2px').
+ * @param {string} theme.width - Outline width value (e.g., '2px').
+ * @param {string} theme.infoColor - Default info/primary focus color (typically blue).
+ * @param {string} theme.onColor - High contrast color for use on dark backgrounds.
+ * @param {string} theme.successColor - Success state focus color (typically green).
+ * @param {string} theme.dangerColor - Error/danger state focus color (typically red).
+ *
+ * @param {Object} [params] - Optional configuration parameters to customize the focus styles.
+ * @param {'info' | 'inverse' | 'success' | 'danger'} [params.focusColor='info'] - The color variant to use for the focus outline.
+ * @param {'offset' | 'inset'} [params.focusPosition='offset'] - Whether to position the outline outside ('offset') or inside ('inset') the element.
+ * @param {boolean} [params.shouldAnimateFocus=true] - Whether to include smooth transition animations for focus changes.
+ * @param {boolean} [params.focusWithin=false] - Whether to apply focus styles to :focus-within pseudo-class for container elements.
+ *
+ * @returns {Object} CSS-in-JS style object containing focus outline styles ready for use with emotion or similar libraries.
+ */
+const calcFocusOutlineStyles = (
+  theme: {
+    offset: string
+    inset: string
+    width: string
+    infoColor: string
+    onColor: string
+    successColor: string
+    dangerColor: string
+  },
+  params?: {
+    focusColor?: 'info' | 'inverse' | 'success' | 'danger'
+    focusPosition?: 'offset' | 'inset'
+    shouldAnimateFocus?: boolean
+    focusWithin?: boolean
+  }
+) => {
+  const focusColor = params?.focusColor ?? 'info'
+  const focusPosition = params?.focusPosition ?? 'offset'
+  const shouldAnimateFocus = params?.shouldAnimateFocus ?? true
+  const focusWithin = params?.focusWithin ?? false
+
+  const focusColorVariants = {
+    info: theme.infoColor,
+    inverse: theme.onColor,
+    success: theme.successColor,
+    danger: theme.dangerColor
+  }
+
+  const outlineStyle = {
+    outlineColor: focusColorVariants[focusColor!],
+    outlineStyle: 'solid',
+    outlineWidth: theme.width,
+    outlineOffset: theme[focusPosition]
+  }
+  return {
+    ...(shouldAnimateFocus && {
+      transition: 'outline-color 0.2s, outline-offset 0.25s'
+    }),
+    outlineOffset: '-0.8rem',
+    outlineColor: alpha(outlineStyle.outlineColor, 0),
+    '&:focus': {
+      ...outlineStyle,
+      '&:hover, &:active': {
+        // apply the same style so it's not overridden by some global style
+        ...outlineStyle
+      }
+    },
+    ...(focusWithin && {
+      '&:focus-within': outlineStyle
+    })
+  }
+}
+
+export default calcFocusOutlineStyles
+export { calcFocusOutlineStyles }

--- a/packages/emotion/src/styleUtils/calcMarginFromShorthand.ts
+++ b/packages/emotion/src/styleUtils/calcMarginFromShorthand.ts
@@ -23,9 +23,23 @@
  */
 import type { Spacing } from './ThemeablePropValues'
 
-export function mapSpacingToShorthand(
+/**
+ * Converts shorthand margin values into CSS margin strings using theme spacing tokens.
+ *
+ * This function parses space-separated margin values and resolves theme tokens to their
+ * actual CSS values. It supports CSS shorthand syntax (1-4 values) and nested theme
+ * token paths using dot notation.
+ *
+ * @param {Spacing | undefined} value - The shorthand margin value string containing space-separated tokens or CSS values.
+ *   Can be undefined, in which case '0' is returned.
+ * @param {Record<string, any>} spacingMap - The spacing theme object containing margin tokens and nested values.
+ *   Typically comes from `sharedTokens.margin` in the component theme.
+ *
+ * @returns {string} The resolved CSS margin string ready to be used in styles.
+ */
+export function calcMarginFromShorthand(
   value: Spacing | undefined,
-  spacingMap: { [key: string]: string }
+  spacingMap: { [key: string]: any }
 ) {
   // array from "space2 space2 space4 space2"
   const splitMargin = value?.split(' ')

--- a/packages/emotion/src/styleUtils/index.ts
+++ b/packages/emotion/src/styleUtils/index.ts
@@ -27,7 +27,8 @@ export { makeThemeVars } from './makeThemeVars'
 export { getShorthandPropValue } from './getShorthandPropValue'
 export { mirrorShorthandCorners } from './mirrorShorthandCorners'
 export { mirrorShorthandEdges } from './mirrorShorthandEdges'
-export { mapSpacingToShorthand } from './mapSpacingToShorthand'
+export { calcMarginFromShorthand } from './calcMarginFromShorthand'
+export { calcFocusOutlineStyles } from './calcFocusOutlineStyles'
 
 export type {
   SpacingValues,

--- a/packages/emotion/src/useStyle.ts
+++ b/packages/emotion/src/useStyle.ts
@@ -86,8 +86,12 @@ const useStyle = <
 
   const componentTheme = { ...baseComponentTheme, ...themeOverride }
 
-  //@ts-expect-error TODO fix these later
-  return generateStyle(componentTheme, params ? params : {}, theme.newTheme)
+  return generateStyle(
+    componentTheme,
+    params ? params : {},
+    //@ts-expect-error TODO fix these later
+    theme?.newTheme?.components?.SharedTokens
+  )
 }
 
 export default useStyle

--- a/packages/emotion/tsconfig.build.json
+++ b/packages/emotion/tsconfig.build.json
@@ -30,6 +30,9 @@
     },
     {
       "path": "../ui-react-utils/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-color-utils/tsconfig.build.json"
     }
   ]
 }

--- a/packages/ui-avatar/src/Avatar/styles.ts
+++ b/packages/ui-avatar/src/Avatar/styles.ts
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { mapSpacingToShorthand } from '@instructure/emotion'
+import { calcMarginFromShorthand } from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 import { AvatarProps, AvatarStyle } from './props'
 
@@ -49,8 +49,7 @@ type StyleParams = {
 const generateStyle = (
   componentTheme: NewComponentTypes['Avatar'],
   params: StyleParams,
-  //TODO type themes properly
-  theme: any // TODO BaseTheme is is not good, it accesses theme.semantics.spacing
+  sharedTokens: NewComponentTypes['SharedTokens']
 ): AvatarStyle => {
   const {
     loaded,
@@ -180,7 +179,7 @@ const generateStyle = (
       borderColor: componentTheme.borderColor,
       fontWeight: componentTheme.fontWeight,
       overflow: 'hidden',
-      margin: mapSpacingToShorthand(margin, theme.semantics.spacing)
+      margin: calcMarginFromShorthand(margin, sharedTokens.margin)
     },
     image: {
       label: 'avatar__image',

--- a/packages/ui-color-picker/src/ColorPicker/styles.ts
+++ b/packages/ui-color-picker/src/ColorPicker/styles.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { mapSpacingToShorthand } from '@instructure/emotion'
+import { calcMarginFromShorthand } from '@instructure/emotion'
 import type { ColorPickerTheme } from '@instructure/shared-types'
 
 import type {
@@ -56,7 +56,7 @@ const generateStyle = (
   const { checkContrast, popoverMaxHeight, margin } = props
   const { isSimple } = state
 
-  const cssMargin = mapSpacingToShorthand(margin, spacing)
+  const cssMargin = calcMarginFromShorthand(margin, spacing)
   return {
     colorPicker: {
       label: 'colorPicker',

--- a/packages/ui-form-field/src/FormFieldLayout/styles.ts
+++ b/packages/ui-form-field/src/FormFieldLayout/styles.ts
@@ -28,7 +28,7 @@ import type {
   FormFieldStyleProps
 } from './props'
 import type { FormFieldLayoutTheme } from '@instructure/shared-types'
-import { mapSpacingToShorthand } from '@instructure/emotion'
+import { calcMarginFromShorthand } from '@instructure/emotion'
 
 const generateGridLayout = (
   isInlineLayout: boolean,
@@ -77,7 +77,7 @@ const generateStyle = (
 ): FormFieldLayoutStyle => {
   const { inline, layout, vAlign, labelAlign, margin, messages } = props
   const { hasMessages, hasVisibleLabel, hasNewErrorMsgAndIsGroup } = styleProps
-  const cssMargin = mapSpacingToShorthand(margin, componentTheme.spacing)
+  const cssMargin = calcMarginFromShorthand(margin, componentTheme.spacing)
   const isInlineLayout = layout === 'inline'
 
   const hasNonEmptyMessages = messages?.reduce(


### PR DESCRIPTION
This pr adds a new util to emotion's `styleUtils`, `calcFocusOutlineStyles` and injects the `sharedTokens` to the `generateStyles` function. Through that one can access `margin`, `boxShadow` and `focusOutline`.

TEST_PLAN:

- Check the margin prop of avatar
- set tabIndex to 0 in avatar's outermost div and follow the instructions of the `/global-style-utils`docs
- read through said docs and check if it's correct (written mostly by ai and checked by @HerrTopi )

NOTE: `calcFocusOutlineStyles` is much simpler than the original `View` calculations. This is by design. If most cases can be covered by this simplified version, it's better to keep this way. If new requirements arise, adjustments are possible