### PR TITLE
fix(ui-scripts): fix pnpm publish workflow failures after migration

### DIFF
--- a/packages/ui-scripts/lib/commands/publish.js
+++ b/packages/ui-scripts/lib/commands/publish.js
@@ -85,7 +85,7 @@ async function publish({ packageName, version, isMaintenance, prRelease }) {
         ? `v${version.split('.')[0]}_maintenance`
         : 'latest'
       info(`📦  Version: ${version}, Tag: ${tag}`)
-      return publishRegularVersion({
+      await publishRegularVersion({
         version,
         tag,
         packages
@@ -93,7 +93,7 @@ async function publish({ packageName, version, isMaintenance, prRelease }) {
     } else {
       const tag = prRelease ? 'pr-snapshot' : 'snapshot'
       info(`📦  Version: ${version}, Tag: ${tag}`)
-      return publishSnapshotVersion({
+      await publishSnapshotVersion({
         version,
         packageName,
         packages,
@@ -215,7 +215,7 @@ async function publishPackage(pkg, tag) {
       setTimeout(resolve, delay)
     })
 
-  const publishArgs = ['publish', pkg.location, '--tag', tag]
+  const publishArgs = ['publish', pkg.location, '--tag', tag, '--no-git-checks']
   await runCommandAsync('pnpm', publishArgs)
 
   return wait(500)


### PR DESCRIPTION
## Summary

This PR fixes two critical issues in the GitHub Actions release workflow that were introduced by the pnpm migration (commit f7bb16e114):

- Fixed `ENEEDAUTH` error occurring during regular release publishes
- Fixed `ERR_PNPM_GIT_UNCLEAN` error occurring during snapshot publishes

## Problem Analysis

### Issue 1: ENEEDAUTH Error (Release Commits)

**What happened:** The workflow failed when trying to publish packages on release commits (e.g., `chore(release): 11.1.0`) with error:
```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

**Root cause:** The pnpm migration added a `try/finally` block to clean up the `.npmrc` file containing the `NPM_TOKEN`. However, the publish functions used `return publishRegularVersion(...)` which returns a Promise immediately without waiting for it to complete. The `finally` block executed right away, deleting the auth credentials before the actual publishing started.

**Failed workflow:** https://github.com/instructure/instructure-ui/actions/runs/19106292706

### Issue 2: ERR_PNPM_GIT_UNCLEAN Error (Snapshot Commits)

**What happened:** The workflow failed when trying to publish packages on non-release commits with error:
```
ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
```

**Root cause:** Unlike npm, pnpm has built-in git checks that fail if the working directory is dirty. For snapshot releases, the workflow intentionally modifies package.json files (version bumps) without committing them - these are temporary CI-only builds. npm allowed this, but pnpm blocks it by default.

**Failed workflow:** https://github.com/instructure/instructure-ui/actions/runs/19087911742

## Solution

### Fix 1: Await async operations before cleanup
Changed `return publishRegularVersion(...)` and `return publishSnapshotVersion(...)` to use `await`, ensuring the finally block runs only after all publishing completes.

### Fix 2: Add --no-git-checks flag
Added `--no-git-checks` flag to `pnpm publish` command to allow publishing with dirty working tree, matching previous npm behavior. This is safe because snapshot version changes are intentionally temporary and should not be committed.

## Test Plan

This fix cannot be fully tested locally without actually publishing to npm. However, reviewers can verify:

- [ ] Code review: Confirm `await` is used instead of `return` for both publish functions
- [ ] Code review: Confirm `--no-git-checks` flag is added to pnpm publish command  
- [ ] Verify the workflow logic makes sense for both release and snapshot scenarios
- [ ] Once merged to master, monitor the next push to master to verify snapshot publish succeeds
- [ ] For release testing, verify the next release commit (created by lerna) successfully publishes

## Files Changed

- `packages/ui-scripts/lib/commands/publish.js` - Fixed async/await timing and added --no-git-checks flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)