### PR TITLE
fix(ui-top-nav-bar): fix aria-expanded added twice when displaying menus/popups

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/index.tsx
+++ b/packages/ui-top-nav-bar/src/TopNavBar/TopNavBarItem/index.tsx
@@ -636,7 +636,9 @@ class TopNavBarItem extends Component<TopNavBarItemProps, TopNavBarItemState> {
       withArrow: false,
       minWidth: renderSubmenu.props?.minWidth || '18.5rem',
       maxHeight: renderSubmenu.props?.maxHeight || `calc(100vh - 10rem)`,
-
+      // this is needed because the trigger is not a button. `aria-expanded`
+      // is set on `get itemProps()`
+      shouldSetAriaExpanded: false,
       ...(status === 'disabled' && {
         disabled: true,
         show: false,
@@ -692,10 +694,9 @@ class TopNavBarItem extends Component<TopNavBarItemProps, TopNavBarItemState> {
         }
       ),
       isShowingContent: this.state.isPopoverOpen,
-      // @ts-expect-error This is a force override for Popover, because it puts
-      // aria-expanded on the trigger when shouldContainFocus="true",
-      // even when it should be on the item's <button>
-      'aria-expanded': undefined
+      // this is needed because the trigger is not a button. `aria-expanded`
+      // is set on `get itemProps()`
+      shouldSetAriaExpanded: false
     }
 
     return <Popover {...popoverProps}>{customPopoverConfig.children}</Popover>


### PR DESCRIPTION
The root cause is that the trigger supplied to Drilldown/Popover is a div, and the button is deeper down the DOM.
I tried to fix the DOM but its tricky, it causes the popover to misalign, and some crashes because it tried to add a ref to `InstUISettingsProvider`

To test:
- TopNav examples
- run the in browser Axe check on TopNav examples, there should be no "Elements must only use supported ARIA attributes" error

Fixes INSTUI-4855