### PR TITLE
chore: add pnpm override for dargs to fix bump command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "overrides": {
       "react": "18.3.1",
       "react-dom": "18.3.1",
-      "@types/react": "18.3.26"
+      "@types/react": "18.3.26",
+      "git-raw-commits>dargs": "7.0.0"
     }
   },
   "devDependencies": {
@@ -106,7 +107,8 @@
     "tar": "Lerna 8 needs tar for this fixed(?) bug: https://github.com/lerna/lerna/issues/4005",
     "eslint-import-resolver-typescript": "^3.6.1 not supported by ESLint 9",
     "eslint-plugin-import-x": "^3.1.0 not supported by ESLint 9",
-    "@types/jest": "needed because https://github.com/testing-library/jest-dom/issues/544 recheck if fixed"
+    "@types/jest": "needed because https://github.com/testing-library/jest-dom/issues/544 recheck if fixed",
+    "git-raw-commits>dargs": "Force dargs@7.0.0 (CommonJS) for git-raw-commits@3.0.0 used by lerna. pnpm hoisting was causing ESM dargs@8.1.0 to be resolved instead, breaking 'pnpm run bump' with 'TypeError: dargs is not a function'"
   },
   "engines": {
     "node": ">=22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   react: 18.3.1
   react-dom: 18.3.1
   '@types/react': 18.3.26
+  git-raw-commits>dargs: 7.0.0
 
 importers:
 
@@ -8235,10 +8236,6 @@ packages:
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
-
-  dargs@8.1.0:
-    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
-    engines: {node: '>=12'}
 
   dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
@@ -16961,8 +16958,6 @@ snapshots:
 
   dargs@7.0.0: {}
 
-  dargs@8.1.0: {}
-
   dashdash@1.14.1:
     dependencies:
       assert-plus: 1.0.0
@@ -18147,7 +18142,7 @@ snapshots:
 
   git-raw-commits@4.0.0:
     dependencies:
-      dargs: 8.1.0
+      dargs: 7.0.0
       meow: 12.1.1
       split2: 4.2.0
 


### PR DESCRIPTION
## Summary

- Fixes `pnpm run bump` failing with "TypeError: dargs is not a function"
- Adds pnpm override to force CommonJS-compatible `dargs@7.0.0` for `git-raw-commits`
- Resolves module incompatibility caused by pnpm hoisting ESM version instead of CommonJS version

## Background

The bump command started failing after a `pnpm install` reorganized hoisted dependencies. The issue occurs because:
- `git-raw-commits@3.0.0` (used by lerna) is a CommonJS module requiring `dargs@7.0.0`
- pnpm was hoisting `dargs@8.1.0` (pure ESM) to the root node_modules
- CommonJS `require()` cannot load pure ESM modules, causing the TypeError

## Test Plan

- [ ] Checkout this branch
- [ ] Run `pnpm install`
- [ ] Run `pnpm run bump` - it should succeed without the "dargs is not a function" error
- [ ] Verify the bump command generates version changes and changelogs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)