### PR TITLE
fix(ui-modal): adjust scrollbar detection tolerance in ModalBody

### DIFF
--- a/packages/ui-modal/src/Modal/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/ModalBody/index.tsx
@@ -130,12 +130,12 @@ class ModalBody extends Component<ModalBodyProps> {
         css={this.props.styles?.modalBody}
         padding={padding}
         // check if there is a scrollbar, if so, the element has to be tabbable to be able to scroll with keyboard only
-        // epsilon tolerance is used to avoid false positives, this is generally safer than Math rounding techniques
+        // epsilon tolerance is used to avoid scrollbar for rounding errors
         {...(finalRef &&
         Math.abs(
           (finalRef.scrollHeight ?? 0) -
             (finalRef.getBoundingClientRect()?.height ?? 0)
-        ) > 0.05
+        ) > 1
           ? { tabIndex: 0 }
           : {})}
       >


### PR DESCRIPTION
Increase epsilon tolerance from 0.05 to 1 pixel to avoid false positives when detecting scrollbars due to browser rounding errors. This prevents unnecessary tabIndex=0 from being applied when no scrollbar is present.

Fixes INSTUI-4863

To test:
Set checkbox sizes with this code:
```
<Modal open={true} label="Modal">
  <Modal.Header> 
    <Heading>Modal</Heading>
  </Modal.Header>
  <Modal.Body>
    <Checkbox label="Modal" size="small" /> 
  </Modal.Body>
</Modal>
```

There should be no scrollbar


🤖 Generated with [Claude Code](https://claude.com/claude-code)