### PR TITLE
[v10] fix(ui-color-picker): complete color mixer button alignment fix

### DIFF
--- a/packages/ui-color-picker/src/ColorPicker/styles.ts
+++ b/packages/ui-color-picker/src/ColorPicker/styles.ts
@@ -122,7 +122,6 @@ const generateStyle = (
     },
     colorMixerButtonContainer: {
       label: 'colorPicker__colorMixerButtonContainer',
-      alignSelf: 'flex-start',
       marginInlineStart: componentTheme.colorMixerButtonContainerLeftMargin
     },
     popoverContentContainer: {


### PR DESCRIPTION
## Summary
Complete the color mixer button alignment fix by removing the static `alignSelf: 'flex-start'` CSS rule from `colorMixerButtonContainer` in styles.ts. This allows the dynamic inline style control to work properly, preventing the visual jump on load.

## Changes
- Removed static `alignSelf: 'flex-start'` from `colorMixerButtonContainer` style object

## Background
The v10_maintenance branch already contains the JavaScript logic for dynamic button alignment (from commit b7fbf0b807), but it still had a conflicting static CSS rule that prevented the fix from working fully. This PR aligns the v10 implementation with the master branch (commits 66f2b18af0 and 68c3e60acc).

## Test plan
- [ ] Verify the color mixer button no longer jumps visually when the ColorPicker loads
- [ ] Verify the button aligns correctly with or without a label
- [ ] Test in different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)