### PR TITLE
fix(ui-list): align ordered list start position with unordered lists

### DIFF
--- a/packages/ui-list/src/List/styles.ts
+++ b/packages/ui-list/src/List/styles.ts
@@ -51,7 +51,9 @@ const generateStyle = (
 
       ...(ordered && {
         listStyleType: 'none',
-        paddingInlineStart: `calc(${componentTheme.listPadding} / 2)`,
+        // 1.3 rem is removed to have the ordered list start at the same point
+        // as the unordered vertically
+        paddingInlineStart: `calc(${componentTheme.listPadding} - 1.3rem)`,
         paddingInlineEnd: 0,
         counterReset: 'ol-counter',
 


### PR DESCRIPTION
The previous implementation divided `listPadding` by 2, but this did not correctly align ordered and unordered lists. Changed to subtract a fixed `1.3rem` offset from the `listPadding` to ensure both list types start at the same vertical position.

To test: Compare ordered and unordered lists side-by-side as shown in the steps to reproduce example. Both list types should now start at the same horizontal position. Test with different override values

Fixes https://github.com/instructure/instructure-ui/issues/2249

🤖 Generated with [Claude Code](https://claude.com/claude-code)