### PR TITLE
refactor(ui-radio-input,ui-avatar,emotion): split useStyle into old and new theming engine part

### DIFF
--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade Guide for Version 11
+title: Upgrade Guide for Version 12
 category: Guides
 order: 1
 ---
@@ -35,6 +35,11 @@ The new icons automatically sync with theme changes, support all InstUI color to
 ## Removal of deprecated props/components/APIs
 
 ## API Changes
+
+### RadioInput
+
+- Setting `readonly` does not set the low level `<input>` to disabled, but to `readonly`. This also means that the input is still focusable when `readonly`
+- its DOM structure has been significantly simplified
 
 ## Codemods
 

--- a/packages/emotion/src/__tests__/getComponentThemeOverride.test.tsx
+++ b/packages/emotion/src/__tests__/getComponentThemeOverride.test.tsx
@@ -81,9 +81,7 @@ describe('@getComponentThemeOverride', () => {
         canvas,
         componentName,
         componentId,
-        {
-          themeOverride: componentOverride
-        }
+        componentOverride
       )
 
       expect(override).toEqual(componentOverride)
@@ -100,12 +98,10 @@ describe('@getComponentThemeOverride', () => {
         canvas,
         componentName,
         componentId,
-        {
-          themeOverride: (componentTheme, currentTheme) => ({
-            backgroundBlue: componentTheme.backgroundGreen,
-            backgroundDark: currentTheme.colors.contrasts.white1010
-          })
-        },
+        (componentTheme: any, currentTheme: any) => ({
+          backgroundBlue: componentTheme.backgroundGreen,
+          backgroundDark: currentTheme.colors.contrasts.white1010
+        }),
         theme
       )
 
@@ -128,9 +124,7 @@ describe('@getComponentThemeOverride', () => {
         componentName,
         componentId,
         {
-          themeOverride: {
-            componentColor: 'rgb(0, 150, 0)'
-          }
+          componentColor: 'rgb(0, 150, 0)'
         }
       )
 

--- a/packages/emotion/src/__tests__/useStyleRework.test.tsx
+++ b/packages/emotion/src/__tests__/useStyleRework.test.tsx
@@ -28,7 +28,11 @@ import type { MockInstance } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
-import { InstUISettingsProvider, WithStyleProps, useStyle } from '../index'
+import {
+  InstUISettingsProvider,
+  WithStyleProps,
+  useStyleRework
+} from '../index'
 
 type Props = {
   inverse?: boolean
@@ -102,7 +106,7 @@ describe('useStyle', () => {
   const ThemedComponent = ({ inverse = false, themeOverride }: Props) => {
     const [clearBackground, setClearBackground] = useState(false)
 
-    const styles = useStyle({
+    const styles = useStyleRework({
       generateStyle,
       generateComponentTheme,
       componentId: 'ThemedComponent',

--- a/packages/emotion/src/getComponentThemeOverride.ts
+++ b/packages/emotion/src/getComponentThemeOverride.ts
@@ -27,8 +27,9 @@ import type {
   Overrides,
   ComponentOverride
 } from './EmotionTypes'
-import type { BaseTheme, ComponentTheme } from '@instructure/shared-types'
-import type { WithStyleProps } from './withStyleRework'
+import type { ComponentTheme } from '@instructure/shared-types'
+import { ThemeOverrideProp } from './withStyle'
+import { ThemeOverrideValue } from './useStyle'
 
 type ComponentName = keyof ComponentOverride | undefined
 
@@ -42,7 +43,7 @@ type ComponentName = keyof ComponentOverride | undefined
  * @param theme - Theme object
  * @param displayName - Name of the component
  * @param componentId - componentId of the component
- * @param props - The component's props object
+ * @param themeOverride - The theme override object
  * @param componentTheme - The component's default theme
  * @returns The calculated theme override object
  */
@@ -50,13 +51,12 @@ const getComponentThemeOverride = (
   theme: ThemeOrOverride,
   displayName: string,
   componentId?: string,
-  props?: { [k: string]: unknown } & WithStyleProps,
+  // ThemeOverrideProp is the old type, ThemeOverrideValue is the new one
+  themeOverride?: ThemeOverrideProp['themeOverride'] | ThemeOverrideValue,
   componentTheme?: ComponentTheme
 ): Partial<ComponentTheme> => {
   const name = displayName as ComponentName
   const id = componentId as ComponentName
-
-  const themeOverride = props ? props.themeOverride : undefined
 
   const { componentOverrides } = theme as Overrides
 
@@ -71,10 +71,11 @@ const getComponentThemeOverride = (
   if (themeOverride) {
     if (typeof themeOverride === 'function') {
       overrideFromComponent = themeOverride(
-        componentTheme || {},
+        //TODO type properly when the old theme is gone
+        componentTheme || ({} as any),
         // the `theme` technically could be a partial theme / override object too,
         // but we want to display all possible options
-        theme as BaseTheme
+        theme as any
       )
     } else {
       overrideFromComponent = themeOverride

--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -39,11 +39,13 @@ export {
   calcFocusOutlineStyles
 } from './styleUtils'
 
+export { useStyleRework } from './useStyleRework'
 export { useStyle } from './useStyle'
 export { useTheme } from './useTheme'
 
 export type { ComponentStyle, StyleObject, Overrides } from './EmotionTypes'
 export type { WithStyleProps } from './withStyleRework'
+export type { ThemeOverrideValue } from './useStyle'
 export type {
   SpacingValues,
   Spacing,

--- a/packages/emotion/src/useStyleRework.ts
+++ b/packages/emotion/src/useStyleRework.ts
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { useTheme } from './useTheme'
+import { getComponentThemeOverride } from './getComponentThemeOverride'
+import type { ComponentTheme } from '@instructure/shared-types'
+import type { Theme } from '@instructure/ui-themes'
+
+// returns the second parameter of a function
+type SecondParameter<T extends (...args: any) => any> =
+  Parameters<T>[1] extends undefined ? never : Parameters<T>[1]
+
+type GenerateComponentTheme = (theme: Theme) => ComponentTheme
+
+type UseStyleParamsWithTheme<
+  P extends (componentTheme: any, params: any, theme: any) => any
+> = {
+  generateStyle: P
+  params?: SecondParameter<P>
+  generateComponentTheme: GenerateComponentTheme
+  componentId: string
+  displayName?: string
+}
+
+// TODO this is only used by the old themes, remove when everything uses the new
+// theming system
+type UseStyleParamsWithoutTheme<
+  P extends (componentTheme: any, params: any, theme: any) => any
+> = {
+  generateStyle: P
+  params?: SecondParameter<P>
+  generateComponentTheme?: undefined
+  componentId?: undefined
+  displayName?: undefined
+}
+
+/*
+ * This is only used by the **old themes**, remove when everything uses the new
+ * theming system (InstUI v12)
+ */
+const useStyleRework = <
+  P extends (componentTheme: any, params: any, theme: any) => any
+>(
+  useStyleParams: UseStyleParamsWithTheme<P> | UseStyleParamsWithoutTheme<P>
+): ReturnType<P> => {
+  const { generateStyle, params, componentId, displayName } = useStyleParams
+  const generateComponentTheme: GenerateComponentTheme = (
+    useStyleParams as UseStyleParamsWithTheme<P>
+  )?.generateComponentTheme
+  const theme = useTheme()
+
+  const baseComponentTheme =
+    typeof generateComponentTheme === 'function'
+      ? generateComponentTheme(theme as Theme)
+      : {}
+
+  const themeOverride = getComponentThemeOverride(
+    theme,
+    displayName ?? componentId ?? '',
+    componentId,
+    params?.themeOverride,
+    baseComponentTheme
+  )
+
+  const componentTheme = { ...baseComponentTheme, ...themeOverride }
+
+  return generateStyle(componentTheme, params ? params : {}, theme)
+}
+
+export default useStyleRework
+export { useStyleRework }

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -193,7 +193,7 @@ const withStyle = decorator(
         theme,
         displayName,
         ComposedComponent.componentId,
-        componentProps,
+        (componentProps as any).themeOverride,
         baseComponentTheme
       )
 
@@ -264,4 +264,4 @@ const withStyle = decorator(
 
 export default withStyle
 export { withStyle }
-export type { WithStyleProps }
+export type { WithStyleProps, ThemeOverrideProp }

--- a/packages/ui-avatar/src/Avatar/index.tsx
+++ b/packages/ui-avatar/src/Avatar/index.tsx
@@ -58,6 +58,7 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
 
     const styles = useStyle({
       generateStyle,
+      themeOverride,
       params: {
         loaded,
         size,
@@ -66,7 +67,6 @@ const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
         shape,
         src,
         showBorder,
-        themeOverride,
         display,
         margin,
         iconTokens

--- a/packages/ui-avatar/src/Avatar/props.ts
+++ b/packages/ui-avatar/src/Avatar/props.ts
@@ -26,12 +26,11 @@ import { SyntheticEvent } from 'react'
 
 import type {
   Spacing,
-  WithStyleProps,
-  ComponentStyle
+  ComponentStyle,
+  ThemeOverrideValue
 } from '@instructure/emotion'
 import type {
   AsElementType,
-  AvatarTheme,
   OtherHTMLAttributes
 } from '@instructure/shared-types'
 import { Renderable } from '@instructure/shared-types'
@@ -109,9 +108,9 @@ type PropKeys = keyof AvatarOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type AvatarProps = AvatarOwnProps &
-  WithStyleProps<AvatarTheme, AvatarStyle> &
-  OtherHTMLAttributes<AvatarOwnProps>
+type AvatarProps = AvatarOwnProps & {
+  themeOverride?: ThemeOverrideValue
+} & OtherHTMLAttributes<AvatarOwnProps>
 
 type AvatarStyle = ComponentStyle<'avatar' | 'image'>
 

--- a/packages/ui-avatar/src/Avatar/styles.ts
+++ b/packages/ui-avatar/src/Avatar/styles.ts
@@ -34,7 +34,6 @@ type StyleParams = {
   shape: AvatarProps['shape']
   src: AvatarProps['src']
   showBorder: AvatarProps['showBorder']
-  themeOverride: AvatarProps['themeOverride']
   display: AvatarProps['display']
   margin: AvatarProps['margin']
   iconTokens: NewComponentTypes['Icon']

--- a/packages/ui-icons-lucide/src/wrapLucideIcon/index.tsx
+++ b/packages/ui-icons-lucide/src/wrapLucideIcon/index.tsx
@@ -123,13 +123,13 @@ export function wrapLucideIcon(Icon: LucideIcon): LucideIcon {
     const styles = useStyle({
       componentId: 'Icon' as const,
       generateStyle,
+      themeOverride,
       params: {
         size: semanticSize as InstUIIconOwnProps['size'],
         color: colorValue,
         rotate,
         bidirectional,
-        inline,
-        themeOverride
+        inline
       },
       displayName: `LucideIcon(${Icon.displayName || Icon.name})`
     })

--- a/packages/ui-icons-lucide/src/wrapLucideIcon/props.ts
+++ b/packages/ui-icons-lucide/src/wrapLucideIcon/props.ts
@@ -23,7 +23,7 @@
  */
 
 import type { LucideProps } from 'lucide-react'
-import type { ComponentStyle, WithStyleProps } from '@instructure/emotion'
+import type { ComponentStyle, ThemeOverrideValue } from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 import type { OtherHTMLAttributes } from '@instructure/shared-types'
 
@@ -101,9 +101,9 @@ type LucideIconWrapperProps = Omit<
   LucideProps,
   'size' | 'color' | 'strokeWidth' | 'rotate'
 > &
-  InstUIIconOwnProps &
-  WithStyleProps<NewComponentTypes['Icon'], LucideIconStyle> &
-  OtherHTMLAttributes<InstUIIconOwnProps>
+  InstUIIconOwnProps & {
+    themeOverride?: ThemeOverrideValue
+  } & OtherHTMLAttributes<InstUIIconOwnProps>
 
 type LucideIconStyle = ComponentStyle<'lucideIcon'>
 

--- a/packages/ui-instructure/src/AiInformation/index.tsx
+++ b/packages/ui-instructure/src/AiInformation/index.tsx
@@ -26,7 +26,7 @@ import { Popover } from '@instructure/ui-popover'
 import { CloseButton } from '@instructure/ui-buttons'
 import { Heading } from '@instructure/ui-heading'
 import { Text } from '@instructure/ui-text'
-import { useStyle } from '@instructure/emotion'
+import { useStyleRework } from '@instructure/emotion'
 import { NutritionFacts, DataPermissionLevels } from '../'
 
 import { AiInformationProps } from './props'
@@ -61,7 +61,7 @@ const AiInformation = ({
 }: AiInformationProps) => {
   const [open, setOpen] = useState(false)
 
-  const styles = useStyle({
+  const styles = useStyleRework({
     generateStyle,
     generateComponentTheme,
     componentId: 'AiInformation',

--- a/packages/ui-instructure/src/DataPermissionLevels/index.tsx
+++ b/packages/ui-instructure/src/DataPermissionLevels/index.tsx
@@ -27,7 +27,7 @@ import { Button, CloseButton } from '@instructure/ui-buttons'
 import { Heading } from '@instructure/ui-heading'
 import { Text } from '@instructure/ui-text'
 import { Link } from '@instructure/ui-link'
-import { useStyle } from '@instructure/emotion'
+import { useStyleRework } from '@instructure/emotion'
 
 import { DataPermissionLevelsProps } from './props'
 import generateStyle from './styles'
@@ -51,7 +51,7 @@ const DataPermissionLevels = ({
 }: DataPermissionLevelsProps) => {
   const [open, setOpen] = useState(false)
 
-  const styles = useStyle({
+  const styles = useStyleRework({
     generateStyle,
     generateComponentTheme,
     componentId: 'DataPermissionLevels',

--- a/packages/ui-instructure/src/NutritionFacts/index.tsx
+++ b/packages/ui-instructure/src/NutritionFacts/index.tsx
@@ -27,7 +27,7 @@ import { Button, CloseButton } from '@instructure/ui-buttons'
 import { Heading } from '@instructure/ui-heading'
 import { Text } from '@instructure/ui-text'
 import { Link } from '@instructure/ui-link'
-import { useStyle } from '@instructure/emotion'
+import { useStyleRework } from '@instructure/emotion'
 
 import { NutritionFactsProps } from './props'
 import generateStyle from './styles'
@@ -50,7 +50,7 @@ const NutritionFacts = ({
 }: NutritionFactsProps) => {
   const [open, setOpen] = useState(false)
 
-  const styles = useStyle({
+  const styles = useStyleRework({
     generateStyle,
     generateComponentTheme,
     componentId: 'NutritionFacts',

--- a/packages/ui-radio-input/src/RadioInput/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/index.tsx
@@ -65,6 +65,7 @@ const RadioInput = forwardRef<RadioInputHandle, RadioInputProps>(
       onClick,
       onChange,
       inputRef,
+      themeOverride,
       ...rest
     } = props
     const [hovered, setHovered] = useState(false)
@@ -90,6 +91,7 @@ const RadioInput = forwardRef<RadioInputHandle, RadioInputProps>(
     // Styles - pass props with defaults applied for generateStyle
     const styles = useStyle({
       generateStyle,
+      themeOverride,
       params: {
         disabled,
         context,

--- a/packages/ui-radio-input/src/RadioInput/props.ts
+++ b/packages/ui-radio-input/src/RadioInput/props.ts
@@ -24,11 +24,8 @@
 
 import React from 'react'
 import type { InputHTMLAttributes } from 'react'
-import type {
-  OtherHTMLAttributes,
-  RadioInputTheme
-} from '@instructure/shared-types'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import type { OtherHTMLAttributes } from '@instructure/shared-types'
+import type { ComponentStyle, ThemeOverrideValue } from '@instructure/emotion'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
 type RadioInputOwnProps = {
@@ -95,9 +92,9 @@ type PropKeys = keyof RadioInputOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type RadioInputProps = RadioInputOwnProps &
-  WithStyleProps<RadioInputTheme, RadioInputStyle> &
-  OtherHTMLAttributes<
+type RadioInputProps = RadioInputOwnProps & {
+  themeOverride?: ThemeOverrideValue
+} & OtherHTMLAttributes<
     RadioInputOwnProps,
     InputHTMLAttributes<RadioInputOwnProps & Element>
   > &


### PR DESCRIPTION
also make `themeOverride` prop always avaiable in the props