### PR TITLE
fix(ui-table): prevent screen readers from announcing the label of the Select All checkbox when navigating through the rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1711,7 +1710,6 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
       "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-compilation-targets": "^7.27.2",
@@ -6309,7 +6307,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -6816,7 +6813,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7309,7 +7305,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7364,7 +7359,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7537,7 +7531,6 @@
       "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.1",
         "@typescript-eslint/types": "8.33.1",
@@ -8391,7 +8384,6 @@
     "node_modules/ajv": {
       "version": "8.12.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9291,7 +9283,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -11142,7 +11133,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -11246,7 +11236,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11459,6 +11448,7 @@
       "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "rrweb-cssom": "^0.6.0"
       },
@@ -11471,7 +11461,8 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -12124,6 +12115,7 @@
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0"
@@ -12271,7 +12263,8 @@
       "version": "10.4.3",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -12762,7 +12755,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -13142,7 +13134,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16723,7 +16714,8 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -17265,6 +17257,7 @@
       "integrity": "sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -17306,6 +17299,7 @@
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -17319,6 +17313,7 @@
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
       },
@@ -17332,6 +17327,7 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -17346,6 +17342,7 @@
       "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -17360,6 +17357,7 @@
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -17373,6 +17371,7 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -20652,7 +20651,8 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
       "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/nx": {
       "version": "20.2.1",
@@ -20660,7 +20660,6 @@
       "integrity": "sha512-zUw1DT9BW2ajbDZgcUFKfysGqrbJwsMRjPxT6GthuqcLtDc2iJi3+/UBTLsITSeiw4Za4qPVxjaK4+yma9Ju5w==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -22037,6 +22036,7 @@
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -22050,6 +22050,7 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -22389,7 +22390,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -22488,7 +22488,6 @@
     "node_modules/prettier": {
       "version": "2.8.8",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -22668,7 +22667,8 @@
       "version": "1.9.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pump": {
       "version": "1.0.3",
@@ -22722,7 +22722,8 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/queue": {
       "version": "6.0.1",
@@ -22830,7 +22831,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -22842,7 +22842,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -23510,7 +23509,8 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/run-applescript": {
       "version": "7.0.0",
@@ -23645,6 +23645,7 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -23679,7 +23680,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -24975,7 +24975,8 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -25642,7 +25643,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -25746,6 +25746,7 @@
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -25761,6 +25762,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -25771,6 +25773,7 @@
       "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -25858,8 +25861,7 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/ttf2eot": {
       "version": "3.1.0",
@@ -26439,7 +26441,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26885,6 +26886,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -26996,7 +26998,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.13.tgz",
       "integrity": "sha512-SSq1noJfY9pR3I1TUENL3rQYDQCFqgD+lM6fTRAM8Nv6Lsg5hDLaXkjETVeBt+7vZBCMoibD+6IWnT2mJ+Zb/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",
@@ -27689,6 +27690,7 @@
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -27734,6 +27736,7 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -27743,7 +27746,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -27862,7 +27864,6 @@
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -28206,6 +28207,7 @@
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28216,6 +28218,7 @@
       "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
@@ -28554,6 +28557,7 @@
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28562,7 +28566,8 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/packages/ui-table/src/Table/README.md
+++ b/packages/ui-table/src/Table/README.md
@@ -908,7 +908,7 @@ By default, the options in the `Select` for sorting in stacked layout are genera
 ### A sortable table with selection and pagination
 
 The composition order is important. `SelectableTable` -> `PaginatedTable` -> `SortableTable`, so
-that selection does not re-paginate or re-sort the table, and pagination does not re-sort the table.
+that selection does not re-paginate or re-sort the table, and pagination does not re-sort the table. To prevent screen readers from announcing the label of the `Select All` checkbox when navigating through the rows, an aria-label should be added to the corresponding `Table.ColHeader`, as shown in our example.
 
 - ```javascript
   class SelectableTable extends React.Component {
@@ -976,10 +976,12 @@ that selection does not re-paginate or re-sort the table, and pagination does no
                   }
                 >
                   <Table.Row>
-                    <Table.ColHeader id="select">
+                    <Table.ColHeader id="select" aria-label="Select">
                       <Checkbox
                         label={
-                          <ScreenReaderContent>Select all</ScreenReaderContent>
+                          <ScreenReaderContent>
+                            Select all rows
+                          </ScreenReaderContent>
                         }
                         onChange={() => this.handleSelectAll(allSelected)}
                         checked={allSelected}
@@ -1315,10 +1317,12 @@ that selection does not re-paginate or re-sort the table, and pagination does no
                 }
               >
                 <Table.Row>
-                  <Table.ColHeader id="select">
+                  <Table.ColHeader id="select" aria-label="Select">
                     <Checkbox
                       label={
-                        <ScreenReaderContent>Select all</ScreenReaderContent>
+                        <ScreenReaderContent>
+                          Select all rows
+                        </ScreenReaderContent>
                       }
                       onChange={() => handleSelectAll(allSelected)}
                       checked={allSelected}
@@ -2260,6 +2264,18 @@ Custom table with `stacked` layout support:
   ```
 
 ### Guidelines
+
+```js
+---
+type: embed
+---
+<Guidelines>
+  <Figure recommendation="a11y" title="Accessibility">
+    <Figure.Item>In the case of a Table with selection, to prevent screenreaders from announcing the label of the select all checkbox when navigating in the rows, an aria-label should be added to the corresponding Table.Colheader like in our example above.
+    </Figure.Item>
+  </Figure>
+</Guidelines>
+```
 
 ```js
 ---


### PR DESCRIPTION
INSTUI-4745 backport

When navigating a selectable table with a screen reader running, the “Select all” label was read out even when the user moved from a checkbox cell to a neighboring column and then back to another checkbox.
The issue was caused by the “Select all” checkbox placed in the column header, as the screen reader always announced it as the column header.
This was resolved by adding a separate aria-label to the column header.

Test plan:
Go to the docs page "A sortable table with selection..." section, and move from a checkbox cell to a neighboring column, then back again. Voice over should not announce "Select all"