### PR TITLE
[v12] fix(ui-checkbox): checkbox unfocuses on click - old

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/index.tsx
@@ -341,7 +341,18 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             onBlur={createChainedFunction(onBlur, this.handleBlur)}
             checked={this.checked}
           />
-          <label htmlFor={this.id} css={styles?.control}>
+          {/* Prevent the browser from firing a blur on the hidden input during
+              mousedown on the label, which would cause Focusable to lose focus
+              before the click event is processed. Manually restore focus instead. */}
+          <label
+            htmlFor={this.id}
+            css={styles?.control}
+            /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */
+            onMouseDown={(e) => {
+              e.preventDefault()
+              this._input?.focus()
+            }}
+          >
             {this.renderFacade()}
             {this.renderMessages()}
           </label>


### PR DESCRIPTION
INSTUI-4768
##  Bug: 

When a Checkbox is wrapped in a Focusable component, clicking the checkbox causes the Focusable to lose focus unexpectedly. The root cause is that the user clicks the label element (not the hidden input directly), and the browser interprets the mousedown on the label as a focus transfer — firing a blur event on the already-focused checkbox input.
Focusable's native DOM blur listener catches this immediately and sets focused: false

## Fix: 

Added an onMouseDown handler to the Checkbox label that calls e.preventDefault() to suppress the browser's default focus handling, then manually restores focus to the input.

## Test plan:
Try this in the doc app:
```
function App() {
  const [isChecked, setIsChecked] = useState(false);
  const [textVal, setTextVal] = useState("");

  return (
    <>
      <Focusable>
        {({ focused }) =>
          focused ? (
            <Checkbox
              label="label"
              checked={isChecked}
              onChange={() => setIsChecked(!isChecked)}
            />
          ) : (
            <View tabIndex={0}>
              Focus for checkbox (checked: {isChecked.toString()})
            </View>
          )
        }
      </Focusable>
      <br />
      <Focusable>
        {({ focused }) =>
          focused ? (
            <TextInput
              label="label"
              value={textVal}
              onChange={(e) => {
                setTextVal(e.target.value);
              }}
            />
          ) : (
            <View tabIndex={0}>Focus for textInput (val: {textVal})</View>
          )
        }
      </Focusable>
    </>
  );
}

  render(<App />)
```