### PR TITLE
fix(ui-view): clipping ContextView child content overflow

### DIFF
--- a/packages/ui-view/src/ContextView/v2/styles.ts
+++ b/packages/ui-view/src/ContextView/v2/styles.ts
@@ -307,7 +307,8 @@ const generateStyle = (
     },
     contextView__content: {
       label: 'contextView__content',
-      position: 'relative'
+      position: 'relative',
+      overflow: 'clip'
     },
     contextView__arrow: {
       label: 'contextView__arrow',


### PR DESCRIPTION
INSTUI-4961

## Summary:
When ContextView renders child content (for example, a Calendar inside a DateInput popover), the child element overflows the container and becomes visible outside the rounded corners. This results in visual glitches at the container’s border corners.

## Fix:
clipping ContextView child content overflow

## Test:
On the DateInput doc page check the calendar corners.
On the Popover page verify that the "Small Target" text in the Align Arrow Example does not overflow outside the popup container.