### PR TITLE
fix(many): fix checkbox icons and fix border bugs in menu and in dateInput

### DIFF
--- a/packages/ui-calendar/src/Calendar/v2/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v2/index.tsx
@@ -546,6 +546,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
         display="inline-block"
         padding="small"
         background="primary"
+        borderRadius="inherit"
         elementRef={this.handleRef}
         data-cid="Calendar"
       >

--- a/packages/ui-checkbox/src/Checkbox/v2/ToggleFacade/styles.ts
+++ b/packages/ui-checkbox/src/Checkbox/v2/ToggleFacade/styles.ts
@@ -277,7 +277,7 @@ const generateStyle = (
         border: `${componentTheme.borderWidth} solid ${getIconBorderColor()}`
       },
 
-      '& [class*="lucideIcon"] svg': {
+      '& [class*="icon"] svg': {
         position: 'relative',
         zIndex: 1
       }

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -168,7 +168,8 @@ class Dialog extends Component<DialogProps> {
         {...omitProps(this.props, Dialog.allowedProps)}
         role={role}
         aria-label={this.props.label}
-        className={this.props.className}
+        className={this.props.className} // TODO in V2 remove className, there is no usage of it.
+        style={{ borderRadius: 'inherit' }} // ensure the dialog inherits border radius from View
         ref={this.getRef}
       >
         {this.props.children}

--- a/packages/ui-menu/src/Menu/v2/styles.ts
+++ b/packages/ui-menu/src/Menu/v2/styles.ts
@@ -55,7 +55,7 @@ const generateStyle = (
       padding: '0.25rem 0',
       // TODO-rework
       //background: componentTheme.background,
-      //borderRadius: componentTheme.borderRadius,
+      borderRadius: 'inherit',
       display: 'block',
       position: 'relative',
       overflow: 'hidden',

--- a/packages/ui-view/src/ContextView/v2/styles.ts
+++ b/packages/ui-view/src/ContextView/v2/styles.ts
@@ -307,8 +307,7 @@ const generateStyle = (
     },
     contextView__content: {
       label: 'contextView__content',
-      position: 'relative',
-      overflow: 'clip',
+      position: 'relative'
     },
     contextView__arrow: {
       label: 'contextView__arrow',


### PR DESCRIPTION
Use border-radius: inherit on Dialog, Menu, and Calendar so rounded
corners from ContextView flow through the component tree without
requiring overflow: clip (which was clipping CSS focus outlines).
Also broaden ToggleFacade icon selector from lucideIcon to icon.

Test:
check DateInput popup borders
check Menu borders
check Checkbox toggle variant icons

INSTUI-4961