### PR TITLE
fix(ui-calendar): DateInput2 days missing aria-selected

### DIFF
--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -470,6 +470,38 @@ type: embed
 
 ```
 
+#### DateTimeInput v1 → v2 API changes
+
+**Removed props:**
+
+| Removed prop          | Replacement                      |
+| --------------------- | -------------------------------- |
+| `renderWeekdayLabels` | Built in — no replacement needed |
+
+**New props in v2:**
+
+| New prop           | Description                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `calendarIcon`     | **Required.** Screen reader label for the calendar icon button that opens the date picker. |
+| `datePickerDialog` | Optional. Screen reader label for the date picker dialog.                                  |
+| `withYearPicker`   | Optional. Enables a year dropdown in the calendar.                                         |
+
+```jsx
+// v1
+<DateTimeInput
+  prevMonthLabel="Previous month"
+  nextMonthLabel="Next month"
+/>
+
+// v2
+<DateTimeInput
+  prevMonthLabel="Previous month"
+  nextMonthLabel="Next month"
+  calendarIcon="Open calendar"
+  datePickerDialog="Date picker"  // optional
+/>
+```
+
 ### ColorPicker
 
 ```js

--- a/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.tsx
+++ b/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.tsx
@@ -40,6 +40,7 @@ const generateDays = (count = Calendar.DAY_COUNT) => {
         key={date.toISOString()}
         date={date.toISOString()}
         label={date.toISOString()}
+        selectedLabel="Selected"
         isOutsideMonth={date.getMonth() !== 7}
       >
         {date.getDate()}
@@ -71,14 +72,14 @@ describe('<Calendar />', () => {
 
   describe('with minimal config', () => {
     it('should render 44 buttons without config', async () => {
-      render(<Calendar />)
+      render(<Calendar selectedLabel="Selected" />)
       const buttons = document.getElementsByTagName('button')
 
       expect(buttons.length).toEqual(44)
     })
 
     it('should render proper week names by default', async () => {
-      const { container } = render(<Calendar />)
+      const { container } = render(<Calendar selectedLabel="Selected" />)
       const thead = container.querySelector('thead')
 
       expect(thead).toHaveTextContent(
@@ -87,7 +88,9 @@ describe('<Calendar />', () => {
     })
 
     it('should render proper week names if locale is set', async () => {
-      const { container } = render(<Calendar locale="hu" />)
+      const { container } = render(
+        <Calendar locale="hu" selectedLabel="Selected" />
+      )
       const thead = container.querySelector('thead')
 
       expect(thead).toHaveTextContent(
@@ -100,6 +103,7 @@ describe('<Calendar />', () => {
         <Calendar
           currentDate="2023-12-15"
           disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
+          selectedLabel="Selected"
         />
       )
       const buttons = container.querySelectorAll('button[disabled]')
@@ -115,23 +119,29 @@ describe('<Calendar />', () => {
     })
 
     it('should indicate selected day', async () => {
-      render(<Calendar currentDate="2023-12-15" selectedDate="2023-12-22" />)
+      render(
+        <Calendar
+          currentDate="2023-12-15"
+          selectedDate="2023-12-22"
+          selectedLabel="Selected"
+        />
+      )
 
-      const selectedDay =
-        screen.queryByText('22 December 2023')?.parentElement?.parentElement
+      const selectedDay = screen.queryByText('22 December 2023, Selected')
+        ?.parentElement?.parentElement
 
       expect(selectedDay).toBeDefined()
-      if (selectedDay) {
-        expect(window.getComputedStyle(selectedDay)?.background).toBe(
-          'rgb(3, 137, 61)'
-        )
-      }
+      expect(window.getComputedStyle(selectedDay!).background).toBe(
+        'rgb(3, 137, 61)'
+      )
     })
   })
 
   it('should render children', async () => {
     const { container } = render(
-      <Calendar renderWeekdayLabels={weekdayLabels}>{generateDays()}</Calendar>
+      <Calendar renderWeekdayLabels={weekdayLabels} selectedLabel="Selected">
+        {generateDays()}
+      </Calendar>
     )
 
     const calendarDays = container.querySelectorAll(
@@ -145,7 +155,7 @@ describe('<Calendar />', () => {
     const count = Calendar.DAY_COUNT - 1
 
     render(
-      <Calendar renderWeekdayLabels={weekdayLabels}>
+      <Calendar renderWeekdayLabels={weekdayLabels} selectedLabel="Selected">
         {generateDays(count)}
       </Calendar>
     )
@@ -160,7 +170,9 @@ describe('<Calendar />', () => {
 
   it('should render weekday labels', async () => {
     const { container, rerender } = render(
-      <Calendar renderWeekdayLabels={weekdayLabels}>{generateDays()}</Calendar>
+      <Calendar renderWeekdayLabels={weekdayLabels} selectedLabel="Selected">
+        {generateDays()}
+      </Calendar>
     )
 
     const originalHeaders = container.querySelectorAll('th')
@@ -182,7 +194,10 @@ describe('<Calendar />', () => {
 
     // Set prop: renderWeekdayLabels
     rerender(
-      <Calendar renderWeekdayLabels={functionalWeekdayLabels}>
+      <Calendar
+        renderWeekdayLabels={functionalWeekdayLabels}
+        selectedLabel="Selected"
+      >
         {generateDays()}
       </Calendar>
     )
@@ -196,7 +211,11 @@ describe('<Calendar />', () => {
   })
 
   it('should warn if 7 weekday labels are not provided', async () => {
-    render(<Calendar renderWeekdayLabels={[]}>{generateDays()}</Calendar>)
+    render(
+      <Calendar renderWeekdayLabels={[]} selectedLabel="Selected">
+        {generateDays()}
+      </Calendar>
+    )
 
     const expectedErrorMessage =
       '`renderWeekdayLabels` should be an array with 7 labels (one for each weekday). 0 provided.'
@@ -209,7 +228,9 @@ describe('<Calendar />', () => {
 
   it('should format the weekday labels and days correctly', async () => {
     const { container } = render(
-      <Calendar renderWeekdayLabels={weekdayLabels}>{generateDays()}</Calendar>
+      <Calendar renderWeekdayLabels={weekdayLabels} selectedLabel="Selected">
+        {generateDays()}
+      </Calendar>
     )
 
     const headerRow = container.querySelectorAll('thead > tr')
@@ -239,6 +260,7 @@ describe('<Calendar />', () => {
       <Calendar
         renderWeekdayLabels={weekdayLabels}
         renderNavigationLabel={navLabel}
+        selectedLabel="Selected"
       >
         {generateDays()}
       </Calendar>
@@ -254,6 +276,7 @@ describe('<Calendar />', () => {
       <Calendar
         renderWeekdayLabels={weekdayLabels}
         renderNavigationLabel={() => navLabel}
+        selectedLabel="Selected"
       >
         {generateDays()}
       </Calendar>
@@ -267,7 +290,9 @@ describe('<Calendar />', () => {
 
   it('should render next and prev buttons', async () => {
     const { rerender } = render(
-      <Calendar renderWeekdayLabels={weekdayLabels}>{generateDays()}</Calendar>
+      <Calendar renderWeekdayLabels={weekdayLabels} selectedLabel="Selected">
+        {generateDays()}
+      </Calendar>
     )
     const defaultPrevButton = screen.getByText('Previous month')
     const defaultNextButton = screen.getByText('Next month')
@@ -280,6 +305,7 @@ describe('<Calendar />', () => {
         renderWeekdayLabels={weekdayLabels}
         renderPrevMonthButton={<button>test-prev</button>}
         renderNextMonthButton={<button>test-next</button>}
+        selectedLabel="Selected"
       >
         {generateDays()}
       </Calendar>
@@ -295,6 +321,7 @@ describe('<Calendar />', () => {
         renderWeekdayLabels={weekdayLabels}
         renderPrevMonthButton={() => <button>func-test-prev</button>}
         renderNextMonthButton={() => <button>func-test-next</button>}
+        selectedLabel="Selected"
       >
         {generateDays()}
       </Calendar>
@@ -317,6 +344,7 @@ describe('<Calendar />', () => {
         renderNextMonthButton={<button>next month</button>}
         onRequestRenderPrevMonth={onRequestRenderPrevMonth}
         onRequestRenderNextMonth={onRequestRenderNextMonth}
+        selectedLabel="Selected"
       >
         {generateDays()}
       </Calendar>
@@ -340,7 +368,11 @@ describe('<Calendar />', () => {
   describe('when role="listbox"', () => {
     it('should set role="listbox" on table root and role="presentation" on the correct elements', async () => {
       const { container } = render(
-        <Calendar renderWeekdayLabels={weekdayLabels} role="listbox">
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          role="listbox"
+          selectedLabel="Selected"
+        >
           {generateDays()}
         </Calendar>
       )
@@ -361,7 +393,11 @@ describe('<Calendar />', () => {
 
     it("should link each day with it's weekday header via `aria-describedby`", async () => {
       const { container } = render(
-        <Calendar renderWeekdayLabels={weekdayLabels} role="listbox">
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          role="listbox"
+          selectedLabel="Selected"
+        >
           {generateDays()}
         </Calendar>
       )
@@ -379,11 +415,119 @@ describe('<Calendar />', () => {
         )
       })
     })
+
+    it('should set role="option" and aria-selected on each day', async () => {
+      const { container } = render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          role="listbox"
+          currentDate="2019-08-01"
+          selectedDate="2019-08-02"
+          selectedLabel="Selected"
+        >
+          {generateDays()}
+        </Calendar>
+      )
+
+      const days = container.querySelectorAll('tbody [data-cid="Calendar.Day"]')
+      expect(days.length).toBe(Calendar.DAY_COUNT)
+      days.forEach((day) => {
+        expect(day).toHaveAttribute('role', 'option')
+        expect(day).toHaveAttribute('aria-selected')
+      })
+    })
+
+    it('should announce selected state via accessible label when selectedLabel is provided', async () => {
+      const { container } = render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          role="listbox"
+          currentDate="2019-08-01"
+          selectedDate="2019-08-02"
+          selectedLabel="selected"
+        />
+      )
+
+      const days = container.querySelectorAll('tbody [data-cid="Calendar.Day"]')
+
+      // Check that the selected day's accessible label includes "selected"
+      const selectedDay = Array.from(days).find((day) => {
+        const screenReaderContent = day.querySelector(
+          '[class*="-screenReaderContent"]'
+        )
+        return screenReaderContent?.textContent?.includes('selected')
+      })
+      expect(selectedDay).toBeDefined()
+
+      // Unselected days should not have "selected" in their label
+      const unselectedDays = Array.from(days).filter((day) => {
+        const screenReaderContent = day.querySelector(
+          '[class*="-screenReaderContent"]'
+        )
+        return !screenReaderContent?.textContent?.includes('selected')
+      })
+      expect(unselectedDays.length).toBe(Calendar.DAY_COUNT - 1)
+    })
+  })
+
+  describe('when role="table" (default)', () => {
+    it('should set role="button" on each day and not set aria-selected', async () => {
+      const { container } = render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          currentDate="2019-08-01"
+          selectedDate="2019-08-02"
+          selectedLabel="Selected"
+        />
+      )
+
+      const days = container.querySelectorAll('tbody [data-cid="Calendar.Day"]')
+      expect(days.length).toBe(Calendar.DAY_COUNT)
+      days.forEach((day) => {
+        expect(day).toHaveAttribute('role', 'button')
+        expect(day).not.toHaveAttribute('aria-selected')
+      })
+    })
+
+    it('should announce selected state via accessible label when selectedLabel is provided', async () => {
+      const { container } = render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          currentDate="2019-08-01"
+          selectedDate="2019-08-02"
+          selectedLabel="selected"
+        />
+      )
+
+      const days = container.querySelectorAll('tbody [data-cid="Calendar.Day"]')
+
+      // Check that the selected day's accessible label includes "selected"
+      const selectedDay = Array.from(days).find((day) => {
+        const screenReaderContent = day.querySelector(
+          '[class*="-screenReaderContent"]'
+        )
+        return screenReaderContent?.textContent?.includes('selected')
+      })
+      expect(selectedDay).toBeDefined()
+
+      // Unselected days should not have "selected" in their label
+      const unselectedDays = Array.from(days).filter((day) => {
+        const screenReaderContent = day.querySelector(
+          '[class*="-screenReaderContent"]'
+        )
+        return !screenReaderContent?.textContent?.includes('selected')
+      })
+      expect(unselectedDays.length).toBe(Calendar.DAY_COUNT - 1)
+    })
   })
 
   it('should render root as designated by the `as` prop', async () => {
     render(
-      <Calendar renderWeekdayLabels={weekdayLabels} as="ul">
+      <Calendar
+        renderWeekdayLabels={weekdayLabels}
+        as="ul"
+        selectedLabel="Selected"
+      >
         {generateDays()}
       </Calendar>
     )

--- a/packages/ui-calendar/src/Calendar/__tests__/Day.test.tsx
+++ b/packages/ui-calendar/src/Calendar/__tests__/Day.test.tsx
@@ -31,7 +31,11 @@ import { CalendarDay as Day } from '@instructure/ui-calendar/latest'
 describe('Day', () => {
   it('should render children', async () => {
     const { rerender } = render(
-      <Day date="2019-08-02" label="1 August 2019 Friday">
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+      >
         8
       </Day>
     )
@@ -40,7 +44,11 @@ describe('Day', () => {
     expect(child).toBeInTheDocument()
 
     rerender(
-      <Day date="2019-08-02" label="1 August 2019 Friday">
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+      >
         31
       </Day>
     )
@@ -52,7 +60,7 @@ describe('Day', () => {
   it('should have an accessible label', async () => {
     const label = '1 August 2019 Friday'
     const { container } = render(
-      <Day date="2019-08-02" label={label}>
+      <Day date="2019-08-02" label={label} selectedLabel="Selected">
         8
       </Day>
     )
@@ -66,7 +74,12 @@ describe('Day', () => {
 
   it('should set aria-current="date" when `isToday`', async () => {
     const { container, rerender } = render(
-      <Day date="2019-08-02" label="1 August 2019 Friday" isToday>
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+        isToday
+      >
         8
       </Day>
     )
@@ -75,7 +88,12 @@ describe('Day', () => {
     expect(today).toHaveAttribute('aria-current', 'date')
 
     rerender(
-      <Day date="2019-08-02" label="1 August 2019 Friday" isToday={false}>
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+        isToday={false}
+      >
         8
       </Day>
     )
@@ -86,7 +104,11 @@ describe('Day', () => {
 
   it('should not set aria-selected without a role', async () => {
     const { container, rerender } = render(
-      <Day date="2019-08-02" label="1 August 2019 Friday">
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+      >
         8
       </Day>
     )
@@ -95,7 +117,12 @@ describe('Day', () => {
     expect(day).not.toHaveAttribute('aria-selected')
 
     rerender(
-      <Day date="2019-08-02" label="1 August 2019 Friday" isSelected={true}>
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+        isSelected={true}
+      >
         8
       </Day>
     )
@@ -106,7 +133,12 @@ describe('Day', () => {
 
   it('should set aria-selected="true/false" when `isSelected` and `role` is `option` or `gridcell`', async () => {
     const { container, rerender } = render(
-      <Day date="2019-08-02" label="1 August 2019 Friday" role="option">
+      <Day
+        date="2019-08-02"
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+        role="option"
+      >
         8
       </Day>
     )
@@ -117,6 +149,7 @@ describe('Day', () => {
       <Day
         date="2019-08-02"
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         role="option"
         isSelected={true}
       >
@@ -130,6 +163,7 @@ describe('Day', () => {
       <Day
         date="2019-08-02"
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         role="gridcell"
         isSelected={false}
       >
@@ -143,6 +177,7 @@ describe('Day', () => {
       <Day
         date="2019-08-02"
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         role="gridcell"
         isSelected={true}
       >
@@ -158,7 +193,12 @@ describe('Day', () => {
     const date = '2019-08-02'
 
     const { container } = render(
-      <Day date={date} label="1 August 2019 Friday" onClick={onClick}>
+      <Day
+        date={date}
+        label="1 August 2019 Friday"
+        selectedLabel="Selected"
+        onClick={onClick}
+      >
         8
       </Day>
     )
@@ -182,6 +222,7 @@ describe('Day', () => {
       <Day
         date={date}
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         onKeyDown={onKeyDown}
         onClick={() => {}}
       >
@@ -208,6 +249,7 @@ describe('Day', () => {
       <Day
         date="2019-08-02"
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         onClick={onClick}
         interaction="disabled"
       >
@@ -233,6 +275,7 @@ describe('Day', () => {
       <Day
         date="2019-08-02"
         label="1 August 2019 Friday"
+        selectedLabel="Selected"
         elementRef={elementRef}
       >
         8
@@ -246,7 +289,11 @@ describe('Day', () => {
   describe('element type', () => {
     it('should render as a span by default', async () => {
       const { container } = render(
-        <Day date="2019-08-02" label="1 August 2019 Friday">
+        <Day
+          date="2019-08-02"
+          label="1 August 2019 Friday"
+          selectedLabel="Selected"
+        >
           8
         </Day>
       )
@@ -257,7 +304,12 @@ describe('Day', () => {
 
     it('should render as a button when onClick is provided', async () => {
       const { container } = render(
-        <Day date="2019-08-02" label="1 August 2019 Friday" onClick={() => {}}>
+        <Day
+          date="2019-08-02"
+          label="1 August 2019 Friday"
+          selectedLabel="Selected"
+          onClick={() => {}}
+        >
           8
         </Day>
       )
@@ -271,6 +323,7 @@ describe('Day', () => {
         <Day
           date="2019-08-02"
           label="1 August 2019 Friday"
+          selectedLabel="Selected"
           onClick={() => {}}
           as="li"
         >

--- a/packages/ui-calendar/src/Calendar/v1/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v1/Day/index.tsx
@@ -117,6 +117,7 @@ class Day extends Component<CalendarDayProps> {
       interaction,
       isOutsideMonth,
       isSelected,
+      selectedLabel,
       isToday,
       onClick,
       onKeyDown,
@@ -164,7 +165,11 @@ class Day extends Component<CalendarDayProps> {
         data-cid="Calendar.Day"
       >
         <span css={styles?.day}>
-          <AccessibleContent alt={label}>
+          <AccessibleContent
+            alt={
+              selectedLabel && isSelected ? `${label}, ${selectedLabel}` : label
+            }
+          >
             {callRenderProp(children)}
           </AccessibleContent>
         </span>

--- a/packages/ui-calendar/src/Calendar/v1/Day/props.ts
+++ b/packages/ui-calendar/src/Calendar/v1/Day/props.ts
@@ -58,6 +58,11 @@ type CalendarDayOwnProps = {
    */
   isSelected?: boolean
   /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel?: string
+  /**
    * Is the `<Calendar.Day />` today
    */
   isToday?: boolean
@@ -114,6 +119,7 @@ const allowedProps: AllowedPropKeys = [
   'label',
   'interaction',
   'isSelected',
+  'selectedLabel',
   'isToday',
   'isOutsideMonth',
   'onClick',

--- a/packages/ui-calendar/src/Calendar/v1/README.md
+++ b/packages/ui-calendar/src/Calendar/v1/README.md
@@ -33,6 +33,7 @@ type: example
         currentDate="2023-12-15"
         disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
         selectedDate={selectedDate}
+        selectedLabel="selected"
         onRequestRenderNextMonth={(_e, requestedMonth) =>
           setVisibleMonth(requestedMonth)
         }
@@ -64,6 +65,7 @@ type: example
         currentDate="2024-02-29"
         disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
         selectedDate={selectedDate}
+        selectedLabel="selected"
         onRequestRenderNextMonth={(_e, requestedMonth) =>
           setVisibleMonth(requestedMonth)
         }

--- a/packages/ui-calendar/src/Calendar/v1/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v1/index.tsx
@@ -436,9 +436,13 @@ class Calendar extends Component<CalendarProps, CalendarState> {
             <td key={day.props.date} role={role}>
               {role === 'presentation'
                 ? safeCloneElement(day, {
-                    'aria-describedby': this._weekdayHeaderIds[i]
+                    'aria-describedby': this._weekdayHeaderIds[i],
+                    role: 'option'
                   })
-                : day}
+                : safeCloneElement(day, {
+                    'aria-describedby': this._weekdayHeaderIds[i],
+                    role: 'button'
+                  })}
             </td>
           ))}
         </tr>
@@ -488,7 +492,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
   }
 
   renderDefaultdays() {
-    const { selectedDate } = this.props
+    const { selectedDate, selectedLabel } = this.props
     const { visibleMonth, today } = this.state
     // Sets it to the first local day of the week counting back from the start of the month.
     // Note that first day depends on the locale, e.g. it's Sunday in the US and
@@ -525,6 +529,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
           isToday={date.isSame(today, 'day')}
           isOutsideMonth={!date.isSame(visibleMonth, 'month')}
           label={date.format('D MMMM YYYY')} // used by screen readers
+          selectedLabel={selectedLabel}
           onClick={this.handleDayClick}
           interaction={this.isDisabledDate(date) ? 'disabled' : 'enabled'}
         >

--- a/packages/ui-calendar/src/Calendar/v1/props.ts
+++ b/packages/ui-calendar/src/Calendar/v1/props.ts
@@ -131,6 +131,11 @@ type CalendarOwnProps = {
    */
   selectedDate?: string
   /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel?: string
+  /**
    * A timezone identifier in the format: *Area/Location*
    *
    * See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for the list
@@ -194,6 +199,7 @@ const allowedProps: AllowedPropKeys = [
   'renderWeekdayLabels',
   'role',
   'selectedDate',
+  'selectedLabel',
   'timezone',
   'visibleMonth'
 ]

--- a/packages/ui-calendar/src/Calendar/v2/Day/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v2/Day/index.tsx
@@ -116,6 +116,7 @@ class Day extends Component<CalendarDayProps> {
       interaction,
       isOutsideMonth,
       isSelected,
+      selectedLabel,
       isToday,
       onClick,
       onKeyDown,
@@ -163,7 +164,11 @@ class Day extends Component<CalendarDayProps> {
         data-cid="Calendar.Day"
       >
         <span css={styles?.day}>
-          <AccessibleContent alt={label}>
+          <AccessibleContent
+            alt={
+              selectedLabel && isSelected ? `${label}, ${selectedLabel}` : label
+            }
+          >
             {callRenderProp(children)}
           </AccessibleContent>
         </span>

--- a/packages/ui-calendar/src/Calendar/v2/Day/props.ts
+++ b/packages/ui-calendar/src/Calendar/v2/Day/props.ts
@@ -58,6 +58,11 @@ type CalendarDayOwnProps = {
    */
   isSelected?: boolean
   /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel: string
+  /**
    * Is the `<Calendar.Day />` today
    */
   isToday?: boolean
@@ -117,6 +122,7 @@ const allowedProps: AllowedPropKeys = [
   'label',
   'interaction',
   'isSelected',
+  'selectedLabel',
   'isToday',
   'isOutsideMonth',
   'onClick',

--- a/packages/ui-calendar/src/Calendar/v2/README.md
+++ b/packages/ui-calendar/src/Calendar/v2/README.md
@@ -33,6 +33,7 @@ type: example
         currentDate="2023-12-15"
         disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
         selectedDate={selectedDate}
+        selectedLabel="selected"
         onRequestRenderNextMonth={(_e, requestedMonth) =>
           setVisibleMonth(requestedMonth)
         }
@@ -64,6 +65,7 @@ type: example
         currentDate="2024-02-29"
         disabledDates={['2023-12-22', '2023-12-12', '2023-12-11']}
         selectedDate={selectedDate}
+        selectedLabel="selected"
         onRequestRenderNextMonth={(_e, requestedMonth) =>
           setVisibleMonth(requestedMonth)
         }

--- a/packages/ui-calendar/src/Calendar/v2/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v2/index.tsx
@@ -422,26 +422,43 @@ class Calendar extends Component<CalendarProps, CalendarState> {
       `[Calendar] should have exactly ${Calendar.DAY_COUNT} children. ${length} provided.`
     )
 
-    return childrenArr
-      .reduce((days: ReactElement<any>[][], day, i) => {
-        const index = Math.floor(i / 7)
-        if (!days[index]) days.push([])
-        days[index].push(day)
-        return days // 7xN 2D array of `Day`s
-      }, [])
-      .map((row) => (
-        <tr key={`row${row[0].props.date}`} role={role}>
-          {row.map((day, i) => (
-            <td key={day.props.date} role={role}>
-              {role === 'presentation'
-                ? safeCloneElement(day, {
-                    'aria-describedby': this._weekdayHeaderIds[i]
-                  })
-                : day}
-            </td>
-          ))}
-        </tr>
-      ))
+    return (
+      childrenArr
+        .reduce((days: ReactElement<any>[][], day, i) => {
+          const index = Math.floor(i / 7)
+          if (!days[index]) days.push([])
+          days[index].push(day)
+          return days // 7xN 2D array of `Day`s
+        }, [])
+        // TODO: Implement proper WAI-ARIA grid pattern for table mode to enable aria-selected on days.
+        // Currently in table mode, days use role="button" which does not support aria-selected
+        // (axe violation), so selection is announced via selectedLabel text only.
+        //
+        // To implement properly (per https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/):
+        //   1. Add role="grid" to the <table> in table mode (renderBody)
+        //   2. Add role="row" to each <tr>
+        //   3. Set role="gridcell" + aria-selected on each <td> (not on the Day)
+        //   4. Keep Day as role="button" inside the gridcell
+        // This allows aria-selected to live on the <td role="gridcell"> which is spec-correct,
+        // while the Day button remains the interactive element.
+        .map((row) => (
+          <tr key={`row${row[0].props.date}`} role={role}>
+            {row.map((day, i) => (
+              <td key={day.props.date} role={role}>
+                {role === 'presentation'
+                  ? safeCloneElement(day, {
+                      'aria-describedby': this._weekdayHeaderIds[i],
+                      role: 'option'
+                    })
+                  : safeCloneElement(day, {
+                      'aria-describedby': this._weekdayHeaderIds[i],
+                      role: 'button'
+                    })}
+              </td>
+            ))}
+          </tr>
+        ))
+    )
   }
 
   locale(): string {
@@ -524,6 +541,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
           isToday={date.isSame(today, 'day')}
           isOutsideMonth={!date.isSame(visibleMonth, 'month')}
           label={date.format('D MMMM YYYY')} // used by screen readers
+          selectedLabel={this.props.selectedLabel}
           onClick={this.handleDayClick}
           interaction={this.isDisabledDate(date) ? 'disabled' : 'enabled'}
         >

--- a/packages/ui-calendar/src/Calendar/v2/props.ts
+++ b/packages/ui-calendar/src/Calendar/v2/props.ts
@@ -131,6 +131,11 @@ type CalendarOwnProps = {
    */
   selectedDate?: string
   /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel: string
+  /**
    * A timezone identifier in the format: *Area/Location*
    *
    * See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for the list
@@ -194,6 +199,7 @@ const allowedProps: AllowedPropKeys = [
   'renderWeekdayLabels',
   'role',
   'selectedDate',
+  'selectedLabel',
   'timezone',
   'visibleMonth'
 ]

--- a/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.tsx
+++ b/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.tsx
@@ -42,7 +42,9 @@ const DateInputExample = () => {
       screenReaderLabels={{
         calendarIcon: 'Calendar',
         nextMonthButton: 'Next month',
-        prevMonthButton: 'Previous month'
+        prevMonthButton: 'Previous month',
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'Selected'
       }}
       value={inputValue}
       onChange={(_e, inputValue, _dateString) => {
@@ -92,7 +94,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         placeholder={placeholder}
         value=""
@@ -111,7 +115,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: iconLabel,
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
       />
@@ -135,7 +141,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
       />
     )
@@ -153,7 +161,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: iconLabel,
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         renderCalendarIcon={<HeartInstUIIcon />}
@@ -197,7 +207,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: nextMonthLabel,
-          prevMonthButton: prevMonthLabel
+          prevMonthButton: prevMonthLabel,
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
       />
@@ -243,7 +255,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         locale="en-GB"
         timezone="UTC"
@@ -264,7 +278,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         interaction={interactionDisabled}
@@ -283,7 +299,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         interaction={interactionReadOnly}
@@ -311,7 +329,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         isRequired
@@ -330,7 +350,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         onBlur={onBlur}
@@ -356,7 +378,9 @@ describe('<DateInput />', () => {
           screenReaderLabels={{
             calendarIcon: 'Calendar',
             nextMonthButton: 'Next month',
-            prevMonthButton: 'Previous month'
+            prevMonthButton: 'Previous month',
+            datePickerDialog: 'Date picker',
+            selectedLabel: 'Selected'
           }}
           value={inputValue}
           onChange={(_e, inputValue, _dateString) => {
@@ -398,7 +422,9 @@ describe('<DateInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
-          prevMonthButton: 'Previous month'
+          prevMonthButton: 'Previous month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         value=""
         messages={messages}
@@ -425,7 +451,8 @@ describe('<DateInput />', () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: datePickerLabel
+          datePickerDialog: datePickerLabel,
+          selectedLabel: 'Selected'
         }}
         value=""
       />

--- a/packages/ui-date-input/src/DateInput/v1/README.md
+++ b/packages/ui-date-input/src/DateInput/v1/README.md
@@ -207,6 +207,7 @@ class Example extends React.Component {
           isToday={date.isSame(todayDate, 'day')}
           isOutsideMonth={!date.isSame(renderedDate, 'month')}
           label={`${date.format('D')} ${date.format('MMMM')} ${date.format('YYYY')}`}
+          selectedLabel="Selected"
           onClick={this.handleDayClick}
         >
           {date.format('D')}

--- a/packages/ui-date-input/src/DateInput/v1/index.tsx
+++ b/packages/ui-date-input/src/DateInput/v1/index.tsx
@@ -328,7 +328,8 @@ class DateInput extends Component<DateInputProps, DateInputState> {
       value,
       onChange,
       disabledDates,
-      currentDate
+      currentDate,
+      selectedLabel
     } = this.props
 
     const isValidDate = value
@@ -365,7 +366,8 @@ class DateInput extends Component<DateInputProps, DateInputState> {
           renderNavigationLabel,
           renderWeekdayLabels,
           renderNextMonthButton: this.renderMonthNavigationButton('next'),
-          renderPrevMonthButton: this.renderMonthNavigationButton('prev')
+          renderPrevMonthButton: this.renderMonthNavigationButton('prev'),
+          selectedLabel
         }) as CalendarProps)}
         {...noChildrenProps}
       >

--- a/packages/ui-date-input/src/DateInput/v1/props.ts
+++ b/packages/ui-date-input/src/DateInput/v1/props.ts
@@ -253,6 +253,11 @@ type DateInputOwnProps = {
     startYear: number
     endYear: number
   }
+  /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel?: string
 }
 
 type PropKeys = keyof DateInputOwnProps
@@ -302,7 +307,9 @@ const allowedProps: AllowedPropKeys = [
   'disabledDateErrorMessage',
   'invalidDateErrorMessage',
   'locale',
-  'timezone'
+  'timezone',
+  'withYearPicker',
+  'selectedLabel'
 ]
 
 type DateInputState = {

--- a/packages/ui-date-input/src/DateInput/v2/README.md
+++ b/packages/ui-date-input/src/DateInput/v2/README.md
@@ -29,7 +29,8 @@ type: example
             calendarIcon: 'Calendar',
             nextMonthButton: 'Next month',
             prevMonthButton: 'Previous month',
-            datePickerDialog: 'Date picker'
+            datePickerDialog: 'Date picker',
+            selectedLabel: 'Selected'
           }}
           value={inputValue}
           width="20rem"
@@ -79,7 +80,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value}
@@ -93,7 +95,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value2}
@@ -108,7 +111,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value3}
@@ -160,7 +164,8 @@ type: example
             calendarIcon: 'Calendar',
             nextMonthButton: 'Next month',
             prevMonthButton: 'Previous month',
-            datePickerDialog: 'Date picker'
+            datePickerDialog: 'Date picker',
+            selectedLabel: 'Selected'
           }}
           value={inputValue}
           width="20rem"
@@ -230,7 +235,8 @@ const Example = () => {
         calendarIcon: 'Calendar',
         nextMonthButton: 'Next month',
         prevMonthButton: 'Previous month',
-        datePickerDialog: 'Date picker'
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'Selected'
       }}
       width="20rem"
       value={value}
@@ -272,7 +278,8 @@ const Example = () => {
         calendarIcon: 'Calendar',
         nextMonthButton: 'Next month',
         prevMonthButton: 'Previous month',
-        datePickerDialog: 'Date picker'
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'Selected'
       }}
       value={inputValue}
       locale="en-us"

--- a/packages/ui-date-input/src/DateInput/v2/index.tsx
+++ b/packages/ui-date-input/src/DateInput/v2/index.tsx
@@ -306,6 +306,7 @@ const DateInput = forwardRef(
               withYearPicker={withYearPicker}
               onDateSelected={handleDateSelected}
               selectedDate={selectedDate}
+              selectedLabel={screenReaderLabels.selectedLabel}
               disabledDates={disabledDates}
               visibleMonth={selectedDate}
               locale={userLocale}

--- a/packages/ui-date-input/src/DateInput/v2/props.ts
+++ b/packages/ui-date-input/src/DateInput/v2/props.ts
@@ -33,14 +33,14 @@ type DateInputOwnProps = {
    */
   renderLabel: Renderable
   /**
-   * Accessible labels for the calendar button, month navigation buttons, and date picker dialog.
+   * Accessible labels for the calendar button, month navigation buttons, date picker dialog, and selected date state.
    */
   screenReaderLabels: {
     calendarIcon: string
     prevMonthButton: string
     nextMonthButton: string
-    // TODO: Make this field required in the next version. Currently optional to avoid breaking change.
-    datePickerDialog?: string
+    datePickerDialog: string
+    selectedLabel: string
   }
   /**
    * Specifies the input value.

--- a/packages/ui-date-input/src/DateInput2/v1/README.md
+++ b/packages/ui-date-input/src/DateInput2/v1/README.md
@@ -29,7 +29,8 @@ type: example
             calendarIcon: 'Calendar',
             nextMonthButton: 'Next month',
             prevMonthButton: 'Previous month',
-            datePickerDialog: 'Date picker'
+            datePickerDialog: 'Date picker',
+            selectedLabel: 'Selected'
           }}
           value={inputValue}
           width="20rem"
@@ -79,7 +80,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value}
@@ -93,7 +95,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value2}
@@ -108,7 +111,8 @@ const Example = () => {
           calendarIcon: 'Calendar',
           nextMonthButton: 'Next month',
           prevMonthButton: 'Previous month',
-          datePickerDialog: 'Date picker'
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'Selected'
         }}
         width="20rem"
         value={value3}
@@ -160,7 +164,8 @@ type: example
             calendarIcon: 'Calendar',
             nextMonthButton: 'Next month',
             prevMonthButton: 'Previous month',
-            datePickerDialog: 'Date picker'
+            datePickerDialog: 'Date picker',
+            selectedLabel: 'Selected'
           }}
           value={inputValue}
           width="20rem"
@@ -230,7 +235,8 @@ const Example = () => {
         calendarIcon: 'Calendar',
         nextMonthButton: 'Next month',
         prevMonthButton: 'Previous month',
-        datePickerDialog: 'Date picker'
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'Selected'
       }}
       width="20rem"
       value={value}
@@ -272,7 +278,8 @@ const Example = () => {
         calendarIcon: 'Calendar',
         nextMonthButton: 'Next month',
         prevMonthButton: 'Previous month',
-        datePickerDialog: 'Date picker'
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'Selected'
       }}
       value={inputValue}
       locale="en-us"

--- a/packages/ui-date-input/src/DateInput2/v1/index.tsx
+++ b/packages/ui-date-input/src/DateInput2/v1/index.tsx
@@ -305,6 +305,7 @@ const DateInput2 = forwardRef(
               withYearPicker={withYearPicker}
               onDateSelected={handleDateSelected}
               selectedDate={selectedDate}
+              selectedLabel={screenReaderLabels.selectedLabel}
               disabledDates={disabledDates}
               visibleMonth={selectedDate}
               locale={userLocale}

--- a/packages/ui-date-input/src/DateInput2/v1/props.ts
+++ b/packages/ui-date-input/src/DateInput2/v1/props.ts
@@ -33,7 +33,7 @@ type DateInput2OwnProps = {
    */
   renderLabel: Renderable
   /**
-   * Accessible labels for the calendar button, month navigation buttons, and date picker dialog.
+   * Accessible labels for the calendar button, month navigation buttons, date picker dialog, and selected date state.
    */
   screenReaderLabels: {
     calendarIcon: string
@@ -41,6 +41,7 @@ type DateInput2OwnProps = {
     nextMonthButton: string
     // TODO: Make this field required in the next version. Currently optional to avoid breaking change.
     datePickerDialog?: string
+    selectedLabel?: string
   }
   /**
    * Specifies the input value.

--- a/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/__tests__/DateTimeInput.test.tsx
@@ -59,7 +59,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -88,7 +90,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -119,7 +123,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -151,7 +157,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -177,7 +185,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         locale="en-US"
@@ -207,7 +217,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         locale="en-US"
@@ -241,7 +253,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -271,7 +285,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -301,7 +317,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -326,7 +344,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -349,7 +369,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -381,7 +403,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       dateRenderLabel: 'date',
       timeRenderLabel: 'time',
@@ -411,7 +435,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -439,7 +465,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -464,7 +492,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -487,7 +517,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -512,7 +544,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -542,7 +576,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -578,7 +614,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -635,7 +673,9 @@ describe('<DateTimeInput />', () => {
           screenReaderLabels={{
             calendarIcon: 'Open calendar',
             prevMonthButton: 'Previous month',
-            nextMonthButton: 'Next month'
+            nextMonthButton: 'Next month',
+            datePickerDialog: 'Date picker dialog',
+            selectedLabel: 'Selected date'
           }}
           timeRenderLabel="time-input"
           invalidDateTimeMessage="whoops"
@@ -657,7 +697,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -702,7 +744,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -733,7 +777,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -768,7 +814,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -801,7 +849,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -838,7 +888,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -868,7 +920,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         invalidDateTimeMessage="whoops"
         locale="en-US"
@@ -908,7 +962,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         invalidDateTimeMessage="whoops"
         locale={locale}
@@ -951,7 +1007,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         invalidDateTimeMessage="whoops"
         locale="en-US"
@@ -986,7 +1044,9 @@ describe('<DateTimeInput />', () => {
           screenReaderLabels={{
             calendarIcon: 'Open calendar',
             prevMonthButton: 'Previous month',
-            nextMonthButton: 'Next month'
+            nextMonthButton: 'Next month',
+            datePickerDialog: 'Date picker dialog',
+            selectedLabel: 'Selected date'
           }}
           invalidDateTimeMessage="whoops"
           locale="en-US"
@@ -1065,7 +1125,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         invalidDateTimeMessage="whoops"
         locale="en-US"
@@ -1099,7 +1161,9 @@ describe('<DateTimeInput />', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker dialog',
+          selectedLabel: 'Selected date'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -1127,7 +1191,9 @@ describe('<DateTimeInput />', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker dialog',
+        selectedLabel: 'Selected date'
       },
       dateRenderLabel: 'date-input',
       timeRenderLabel: 'time-input',

--- a/packages/ui-date-time-input/src/DateTimeInput/v1/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/v1/README.md
@@ -34,6 +34,7 @@ type: example
           invalidDateTimeMessage="Invalid date!"
           prevMonthLabel="Previous month"
           nextMonthLabel="Next month"
+          selectedLabel="Selected"
           defaultValue="2018-01-18T13:30"
           layout="columns"
         />
@@ -92,6 +93,7 @@ type: example
             timeRenderLabel="Time"
             prevMonthLabel="Previous month"
             nextMonthLabel="Next month"
+            selectedLabel="Selected"
             onChange={onChange}
             layout="stacked"
             value={value}
@@ -145,6 +147,7 @@ type: example
             timeRenderLabel="Time"
             prevMonthLabel="Previous month"
             nextMonthLabel="Next month"
+            selectedLabel="Selected"
             invalidDateTimeMessage={(dvalue) => {
               return `'${dvalue} is not valid.`
             }}
@@ -218,6 +221,7 @@ type: example
           }
           prevMonthLabel="Previous month"
           nextMonthLabel="Next month"
+          selectedLabel="Selected"
           defaultValue="2022-04-08T13:30"
           layout="columns"
           disabledDates={getDisabledDates}
@@ -253,6 +257,7 @@ type: example
           invalidDateTimeMessage="Invalid date!"
           prevMonthLabel="Previous month"
           nextMonthLabel="Next month"
+          selectedLabel="Selected"
           value={date}
           onChange={(e, newDate) => setDate(newDate)}
           reset={(reset) => (resetFn.current = reset)}

--- a/packages/ui-date-time-input/src/DateTimeInput/v1/index.tsx
+++ b/packages/ui-date-time-input/src/DateTimeInput/v1/index.tsx
@@ -427,6 +427,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
   }
 
   renderDays() {
+    const { selectedLabel } = this.props
     const renderedDate = this.state.renderedDate
     // Sets it to the first local day of the week counting back from the start of the month.
     // Note that first day depends on the locale, e.g. it's Sunday in the US and
@@ -467,6 +468,7 @@ class DateTimeInput extends Component<DateTimeInputProps, DateTimeInputState> {
           )}
           isOutsideMonth={!date.isSame(renderedDate, 'month')}
           label={date.format('D MMMM YYYY')} // used by screen readers
+          selectedLabel={selectedLabel}
           onClick={this.handleDayClick}
           interaction={this.isDisabledDate(date) ? 'disabled' : 'enabled'}
         >

--- a/packages/ui-date-time-input/src/DateTimeInput/v1/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/v1/props.ts
@@ -250,6 +250,11 @@ type DateTimeInputProps = {
    * NOTE: this won't call onChange, so you have to reset the value manually when calling reset
    */
   reset?: (reset: () => void) => void
+  /**
+   * Screen reader label appended to the date label when the day is selected.
+   * Used to announce the selected state to assistive technologies.
+   */
+  selectedLabel?: string
 }
 
 type DateTimeInputState = {
@@ -309,7 +314,8 @@ const allowedProps: AllowedPropKeys = [
   'disabledDates',
   'disabledDateTimeMessage',
   'allowNonStepInput',
-  'reset'
+  'reset',
+  'selectedLabel'
 ]
 
 export type { DateTimeInputProps, DateTimeInputState }

--- a/packages/ui-date-time-input/src/DateTimeInput/v2/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/v2/README.md
@@ -32,7 +32,13 @@ type: example
           dateRenderLabel="Date"
           timeRenderLabel="Time"
           invalidDateTimeMessage="Invalid date!"
-          screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+          screenReaderLabels={{
+            calendarIcon: 'Open calendar',
+            prevMonthButton: 'Previous month',
+            nextMonthButton: 'Next month',
+            datePickerDialog: 'Date picker dialog',
+            selectedLabel: 'Selected'
+          }}
           defaultValue="2018-01-18T13:30"
           layout="columns"
         />
@@ -91,7 +97,13 @@ type: example
             datePlaceholder="Choose"
             dateRenderLabel="Date"
             timeRenderLabel="Time"
-            screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+            screenReaderLabels={{
+              calendarIcon: 'Open calendar',
+              prevMonthButton: 'Previous month',
+              nextMonthButton: 'Next month',
+              datePickerDialog: 'Date picker dialog',
+              selectedLabel: 'Selected'
+            }}
             onChange={onChange}
             layout="stacked"
             value={value}
@@ -119,7 +131,13 @@ type: example
   datePlaceholder="Choose a date"
   dateRenderLabel="Date"
   timeRenderLabel="Time"
-  screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+  screenReaderLabels={{
+    calendarIcon: 'Open calendar',
+    prevMonthButton: 'Previous month',
+    nextMonthButton: 'Next month',
+    datePickerDialog: 'Date picker dialog',
+    selectedLabel: 'Selected'
+  }}
   invalidDateTimeMessage={(dvalue) => { return `'${dvalue} is not valid.` }}
   layout="columns"
   defaultValue="2018-01-18T13:30"
@@ -142,7 +160,13 @@ type: example
             datePlaceholder="Choose a date"
             dateRenderLabel="Date"
             timeRenderLabel="Time"
-            screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+            screenReaderLabels={{
+              calendarIcon: 'Open calendar',
+              prevMonthButton: 'Previous month',
+              nextMonthButton: 'Next month',
+              datePickerDialog: 'Date picker dialog',
+              selectedLabel: 'Selected'
+            }}
             invalidDateTimeMessage={(dvalue) => {
               return `'${dvalue} is not valid.`
             }}
@@ -170,7 +194,13 @@ type: example
   timeRenderLabel="Time"
   invalidDateTimeMessage="Invalid date"
   disabledDateTimeMessage="Disabled date"
-  screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+  screenReaderLabels={{
+    calendarIcon: 'Open calendar',
+    prevMonthButton: 'Previous month',
+    nextMonthButton: 'Next month',
+    datePickerDialog: 'Date picker dialog',
+    selectedLabel: 'Selected'
+  }}
   defaultValue="2022-04-08T13:30"
   layout="columns"
   disabledDates={['2022-04-01T13:30', '2022-04-03T13:30', '2022-04-04T13:30']}
@@ -213,7 +243,13 @@ type: example
           disabledDateTimeMessage={(rawDateValue) =>
             'Disabled date: ' + rawDateValue
           }
-          screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+          screenReaderLabels={{
+            calendarIcon: 'Open calendar',
+            prevMonthButton: 'Previous month',
+            nextMonthButton: 'Next month',
+            datePickerDialog: 'Date picker dialog',
+            selectedLabel: 'Selected'
+          }}
           defaultValue="2022-04-08T13:30"
           layout="columns"
           disabledDates={getDisabledDates}
@@ -247,7 +283,13 @@ type: example
           dateRenderLabel="Date"
           timeRenderLabel="Time"
           invalidDateTimeMessage="Invalid date!"
-          screenReaderLabels={{ calendarIcon: 'Open calendar', prevMonthButton: 'Previous month', nextMonthButton: 'Next month' }}
+          screenReaderLabels={{
+            calendarIcon: 'Open calendar',
+            prevMonthButton: 'Previous month',
+            nextMonthButton: 'Next month',
+            datePickerDialog: 'Date picker dialog',
+            selectedLabel: 'Selected'
+          }}
           value={date}
           onChange={(e, newDate) => setDate(newDate)}
           reset={(reset) => (resetFn.current = reset)}

--- a/packages/ui-date-time-input/src/DateTimeInput/v2/props.ts
+++ b/packages/ui-date-time-input/src/DateTimeInput/v2/props.ts
@@ -38,13 +38,14 @@ type DateTimeInputProps = {
    **/
   dateRenderLabel: Renderable
   /**
-   * Accessible labels for the calendar icon button, month navigation buttons, and date picker dialog.
+   * Accessible labels for the calendar icon button, month navigation buttons, selected date, and date picker dialog.
    */
   screenReaderLabels: {
     calendarIcon: string
     prevMonthButton: string
     nextMonthButton: string
-    datePickerDialog?: string
+    datePickerDialog: string
+    selectedLabel: string
   }
   /**
    * HTML placeholder text to display when the date input has no value.


### PR DESCRIPTION
INSTUI-4989

When a user selects a date, screen readers had no way to know which day was currently selected — aria-selected

## Solution summary

Every ARIA role that supports aria-selected requires a specific ancestor context — there's no standalone option
The only axe-clean alternatives for table mode without structural changes:

- aria-pressed on role="button" — valid, but "pressed" implies a toggle, not date selection. Wrong semantic.
- selectedLabel text ← what's implemented. Axe-clean, universally supported, correct semantic.


## Changes


- Fixes missing `aria-selected` on calendar days in `DateInput`, `DateInput2`, and `DateTimeInput` when using the default table layout
- In `listbox` mode (`role="listbox"`), days correctly use `role="option"` with `aria-selected="true/false"`; in table mode, days use `role="button"` where `aria-selected` is not ARIA-valid, so selection is now announced via a new `selectedLabel` prop that appends text to the accessible label (e.g. `"15 April 2026, Selected"`)
- Adds a `selectedLabel` prop to `Calendar`, `Calendar.Day`, `DateInput` (v1/v2), `DateInput2`, and `DateTimeInput` — passed through `screenReaderLabels.selectedLabel` in the DateInput variants;
- Adds a TODO comment documenting the future WAI-ARIA grid pattern implementation path


## Test plan
On the docs page, try this code sample and check what VoiceOver announces:
```
const Example = () => {
    const [selectedDate, setSelectedDate] = useState('')
    const [visibleMonth, setVisibleMonth] = useState('2025-05')
    const [useListbox, setUseListbox] = useState(false)

    return (
      <div>
        <Checkbox
          label={`role="${useListbox ? 'listbox' : 'table (default)'}" — click to toggle`}
          checked={useListbox}
          onChange={() => {
            setUseListbox((prev) => !prev)
            setSelectedDate('')
          }}
        />
        <View as="div" margin="small 0">
          <Text size="small" color="secondary">
            {useListbox
              ? 'Listbox mode: days have role="option" and aria-selected="true/false". Selection is announced via aria-selected.'
              : 'Table mode: days have role="button" with no aria-selected. Selection is announced via the accessible label (selectedLabel).'}
          </Text>
        </View>
        <Calendar
          role={useListbox ? 'listbox' : undefined}
          visibleMonth={visibleMonth}
          currentDate="2025-05-01"
          selectedDate={selectedDate}
          selectedLabel="selected"
          onRequestRenderNextMonth={(_e, requestedMonth) =>
            setVisibleMonth(requestedMonth)
          }
          onRequestRenderPrevMonth={(_e, requestedMonth) =>
            setVisibleMonth(requestedMonth)
          }
          onDateSelected={(date) => setSelectedDate(date)}
        />
      </div>
    )
  }

  render(<Example />)
```
  
  
  Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)