### PR TITLE
fix(ui-text-area,ui-radio-input,ui-number-input): fix Tooltip placements

### DIFF
--- a/packages/ui-number-input/src/NumberInput/v2/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/v2/index.tsx
@@ -28,7 +28,8 @@ import {
   useCallback,
   useImperativeHandle,
   forwardRef,
-  useEffect
+  useEffect,
+  type RefObject
 } from 'react'
 import keycode from 'keycode'
 
@@ -267,7 +268,8 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
         },
         get value() {
           return inputRef.current?.value
-        }
+        },
+        ref: containerRef
       }),
       [id, invalid, interaction]
     )
@@ -376,6 +378,7 @@ export interface NumberInputHandle {
   readonly invalid: boolean
   readonly interaction: ReturnType<typeof getInteraction>
   readonly value: string | undefined
+  readonly ref: RefObject<Element | null>
 }
 
 export default NumberInput

--- a/packages/ui-radio-input/src/RadioInput/v2/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/v2/index.tsx
@@ -28,7 +28,8 @@ import {
   useImperativeHandle,
   forwardRef,
   useCallback,
-  useEffect
+  useEffect,
+  type RefObject
 } from 'react'
 
 import {
@@ -164,7 +165,8 @@ const RadioInput = forwardRef<RadioInputHandle, RadioInputProps>(
         },
         get id() {
           return id
-        }
+        },
+        ref: containerRef
       }),
       [checked, id]
     )
@@ -217,6 +219,7 @@ export interface RadioInputHandle {
   readonly focused: boolean
   readonly checked: boolean
   readonly id: string | undefined
+  readonly ref: RefObject<HTMLDivElement | null>
 }
 
 export default RadioInput

--- a/packages/ui-text-area/src/TextArea/v2/index.tsx
+++ b/packages/ui-text-area/src/TextArea/v2/index.tsx
@@ -29,7 +29,8 @@ import {
   useContext,
   useImperativeHandle,
   useCallback,
-  useMemo
+  useMemo,
+  type RefObject
 } from 'react'
 import { FormField } from '@instructure/ui-form-field/latest'
 import {
@@ -60,6 +61,7 @@ export type TextAreaElement = {
   readonly minHeight: string
   readonly focused: boolean
   readonly invalid: boolean
+  readonly ref: RefObject<Element | null>
   readonly id: string
 }
 
@@ -361,7 +363,8 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
       },
       get id() {
         return id
-      }
+      },
+      ref: formFieldRef
     }),
     [id, messages]
   )

--- a/regression-test/package-lock.json
+++ b/regression-test/package-lock.json
@@ -35,7 +35,7 @@
     },
     "../packages/ui": {
       "name": "@instructure/ui",
-      "version": "11.6.0",
+      "version": "11.7.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
@@ -123,7 +123,7 @@
     },
     "../packages/ui-icons": {
       "name": "@instructure/ui-icons",
-      "version": "11.6.0",
+      "version": "11.7.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
@@ -136,7 +136,6 @@
         "lucide-react": "^0.559.0"
       },
       "devDependencies": {
-        "@instructure/command-utils": "workspace:^",
         "@instructure/ui-babel-preset": "workspace:*",
         "@types/node": "^22.5.4"
       },


### PR DESCRIPTION
INSTUI-4991

**ISSUES:**
- in the regression tests, NumberInput, TextArea and RadioInput has misplaced Tooltips

**TEST PLAN:**

- open the PR in local
- run the regression tests
```
1. Run `pnpm install` and `pnpm run bootstrap` from the project root.
2. Then open the regression test folder: `cd regression-test`
3. Install dependencies: `npm install`
4. Run the dev server with `npm run dev`
5. The dev server will be accessible at `localhost:3000`
```
- go to http://localhost:3000/tooltip and check if Tooltips are not misaligned and are not missing from any component unlike these in the corner
<img width="1028" height="1062" alt="image" src="https://github.com/user-attachments/assets/0b02dfc2-b100-4fad-b0d7-acdb9b5aa5e1" />


