### PR TITLE
docs(many): add required field examples and * required field note to …

### DIFF
--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -1,11 +1,35 @@
 ---
-title: Form Errors
+title: Forms
 category: Guides
 order: 4
 relevantForAI: true
 ---
 
-# Adding Error Messages to Form Components
+## Required Fields
+
+InstUI form components display an asterisk (`*`) next to labels when the `isRequired` (or `required`) prop is set. Whenever a form contains required fields, you **must include a note** explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+> **Exception:** You can omit this note when the form's purpose is entirely self-evident — for example, a standard login screen where it is obvious that both the email and password fields are required.
+
+```ts
+---
+type: example
+---
+const RequiredFieldsExample = () => {
+  return (
+    <FormFieldGroup description="Contact Information" rowSpacing="small" layout="stacked">
+      <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+      <TextInput renderLabel="Full Name" isRequired />
+      <TextInput renderLabel="Email Address" isRequired />
+      <TextInput renderLabel="Phone Number" />
+    </FormFieldGroup>
+  )
+}
+
+render(<RequiredFieldsExample />)
+```
+
+## Error Messages
 
 InstUI offers a range of form elements and all of them have a similar API to handle error/hint/success messages. These components use the `messages` prop with the following type definition:
 
@@ -86,6 +110,8 @@ const Example = () => {
       </CheckboxGroup>
       <div style={{display: 'flex', gap: '2rem', marginTop: '3rem', flexDirection: 'column'}}>
 
+        {isRequired && <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>}
+
         <TextInput renderLabel="TextInput" messages={messages} isRequired={isRequired}/>
 
         <NumberInput renderLabel="NumberInput" messages={messages} isRequired={isRequired}/>
@@ -138,6 +164,11 @@ const Example = () => {
           invalidDateTimeMessage="Invalid date!"
           prevMonthLabel="Previous month"
           nextMonthLabel="Next month"
+          screenReaderLabels={{
+            calendarIcon: 'Open calendar',
+            prevMonthButton: 'Previous month',
+            nextMonthButton: 'Next month'
+          }}
           defaultValue="2018-01-18T13:30"
           layout="columns"
           isRequired={isRequired}
@@ -152,6 +183,11 @@ const Example = () => {
           invalidDateTimeMessage="Invalid date!"
           prevMonthLabel="Previous month"
           nextMonthLabel="Next month"
+          screenReaderLabels={{
+            calendarIcon: 'Open calendar',
+            prevMonthButton: 'Previous month',
+            nextMonthButton: 'Next month'
+          }}
           defaultValue="2018-01-18T13:30"
           layout="stacked"
           isRequired={isRequired}

--- a/packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json
+++ b/packages/__docs__/buildScripts/ai-accessible-documentation/summaries-for-llms-file.json
@@ -433,7 +433,7 @@
     "summary": "Comprehensive focus management system for dialogs, modals, and popovers. Uses Dialog component with FocusRegion and FocusRegionManager to trap focus, handle escape keys, and manage screen reader accessibility."
   },
   {
-    "title": "form-errors",
+    "title": "forms",
     "summary": "InstUI form components use a `messages` prop for error/hint/success messages. Required fields now show an asterisk automatically. Examples provided for various form components like TextInput, Checkbox, and DateTimeInput."
   },
   {

--- a/packages/ui-checkbox/src/Checkbox/v1/README.md
+++ b/packages/ui-checkbox/src/Checkbox/v1/README.md
@@ -162,6 +162,20 @@ type: example
 />
 ```
 
+### Required Fields
+
+Whenever a `Checkbox` is required, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup description="Terms" rowSpacing="small" layout="stacked">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <Checkbox label="I agree to the terms and conditions" value="terms" isRequired />
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-checkbox/src/Checkbox/v2/README.md
+++ b/packages/ui-checkbox/src/Checkbox/v2/README.md
@@ -166,6 +166,20 @@ type: example
 
 The underlying `<input>` has a `data-checked` attribute (`"true"`, `"false"`, or `"mixed"` when indeterminate) that can be queried from the DOM to read the current state.
 
+### Required Fields
+
+Whenever a `Checkbox` is required, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup description="Terms" rowSpacing="small" layout="stacked">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <Checkbox label="I agree to the terms and conditions" value="terms" isRequired />
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-color-picker/src/ColorPicker/v1/README.md
+++ b/packages/ui-color-picker/src/ColorPicker/v1/README.md
@@ -201,6 +201,7 @@ type: example
 
     return (
       <View as="div">
+        {isRequired && <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>}
         <ColorPicker
           onChange={(val) => setValue(val)}
           value={value}

--- a/packages/ui-color-picker/src/ColorPicker/v2/README.md
+++ b/packages/ui-color-picker/src/ColorPicker/v2/README.md
@@ -201,6 +201,7 @@ type: example
 
     return (
       <View as="div">
+        {isRequired && <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>}
         <ColorPicker
           onChange={(val) => setValue(val)}
           value={value}

--- a/packages/ui-date-time-input/src/DateTimeInput/v1/README.md
+++ b/packages/ui-date-time-input/src/DateTimeInput/v1/README.md
@@ -82,6 +82,7 @@ type: example
           <br />
           {text}
         </div>
+        <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
         <div style={{ height: '14rem' }}>
           <DateTimeInput
             description={

--- a/packages/ui-form-field/src/FormFieldGroup/v1/README.md
+++ b/packages/ui-form-field/src/FormFieldGroup/v1/README.md
@@ -100,6 +100,26 @@ type: example
   </FormFieldGroup>
 ```
 
+### Required Fields
+
+Whenever a `FormFieldGroup` contains required fields, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup
+  description="Contact Information"
+  rowSpacing="small"
+  layout="stacked"
+>
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <TextInput renderLabel="Full Name" isRequired />
+  <TextInput renderLabel="Email Address" isRequired />
+  <TextInput renderLabel="Phone Number" />
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-form-field/src/FormFieldGroup/v2/README.md
+++ b/packages/ui-form-field/src/FormFieldGroup/v2/README.md
@@ -100,6 +100,26 @@ type: example
   </FormFieldGroup>
 ```
 
+### Required Fields
+
+Whenever a `FormFieldGroup` contains required fields, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup
+  description="Contact Information"
+  rowSpacing="small"
+  layout="stacked"
+>
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <TextInput renderLabel="Full Name" isRequired />
+  <TextInput renderLabel="Email Address" isRequired />
+  <TextInput renderLabel="Phone Number" />
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-number-input/src/NumberInput/v1/README.md
+++ b/packages/ui-number-input/src/NumberInput/v1/README.md
@@ -125,6 +125,7 @@ const Example = () => {
         label="Inline display"
         onChange={toggleInline}
       />
+      <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
       <NumberInput
         renderLabel={`How old are you? (${MIN}-${MAX})`}
         display={inline ? 'inline-block' : null}

--- a/packages/ui-number-input/src/NumberInput/v2/README.md
+++ b/packages/ui-number-input/src/NumberInput/v2/README.md
@@ -123,6 +123,7 @@ const Example = () => {
         label="Inline display"
         onChange={toggleInline}
       />
+      <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
       <NumberInput
         renderLabel={`How old are you? (${MIN}-${MAX})`}
         display={inline ? 'inline-block' : null}

--- a/packages/ui-radio-input/src/RadioInputGroup/v1/README.md
+++ b/packages/ui-radio-input/src/RadioInputGroup/v1/README.md
@@ -220,6 +220,24 @@ type: example
 </RadioInputGroup>
 ```
 
+### Required Fields
+
+Whenever a `RadioInputGroup` contains required fields, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup description="Preferences" rowSpacing="small" layout="stacked">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <RadioInputGroup name="frequency" description="Notification Frequency" isRequired>
+    <RadioInput label="Daily" value="daily" />
+    <RadioInput label="Weekly" value="weekly" />
+    <RadioInput label="Monthly" value="monthly" />
+  </RadioInputGroup>
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
@@ -220,6 +220,24 @@ type: example
 </RadioInputGroup>
 ```
 
+### Required Fields
+
+Whenever a `RadioInputGroup` contains required fields, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
+
+```js
+---
+type: example
+---
+<FormFieldGroup description="Preferences" rowSpacing="small" layout="stacked">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <RadioInputGroup name="frequency" description="Notification Frequency" isRequired>
+    <RadioInput label="Daily" value="daily" />
+    <RadioInput label="Weekly" value="weekly" />
+    <RadioInput label="Monthly" value="monthly" />
+  </RadioInputGroup>
+</FormFieldGroup>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-text-area/src/TextArea/v1/README.md
+++ b/packages/ui-text-area/src/TextArea/v1/README.md
@@ -102,6 +102,18 @@ type: example
   render(<Example />)
 ```
 
+A required `TextArea`:
+
+```js
+---
+type: example
+---
+<View as="div">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <TextArea label="Description" required />
+</View>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-text-area/src/TextArea/v2/README.md
+++ b/packages/ui-text-area/src/TextArea/v2/README.md
@@ -102,6 +102,18 @@ type: example
   render(<Example />)
 ```
 
+A required `TextArea`:
+
+```js
+---
+type: example
+---
+<View as="div">
+  <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+  <TextArea label="Description" required />
+</View>
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-text-input/src/TextInput/v2/README.md
+++ b/packages/ui-text-input/src/TextInput/v2/README.md
@@ -317,6 +317,14 @@ type: example
       placeholder="placeholder"
       size='small'
     />
+    <View as="div">
+      <Text>Fields marked with an asterisk <span aria-hidden="true">(*)</span> are required.</Text>
+      <TextInput
+        renderLabel='required'
+        placeholder="placeholder"
+        isRequired
+      />
+    </View>
   </Flex>
 ```
 


### PR DESCRIPTION
…form component docs

INSTUI-4944

**ISSUE:**
- documentation is missing explanation about the necessity of including a required field note in form fields     

**TEST PLAN:**                                                        
- check the explanation about the necessity of including a required field note in form fields                                
- check if all the relevant form examples in the documentation have the required field note in TextInput, TextArea,        RadioInputGroup, Checkbox, ColorPicker, FormFieldGroup, DateTimeInput, NumberInput and the Forms guide 