### PR TITLE
fix(many): fix for component previews

### DIFF
--- a/packages/emotion/src/InstUISettingsProvider/README.md
+++ b/packages/emotion/src/InstUISettingsProvider/README.md
@@ -77,21 +77,21 @@ type: example
 ---
 
 <InstUISettingsProvider dir="ltr">
-  <div>LTR text</div>
+  <div><Text>LTR text</Text></div>
   <Badge count={105} countUntil={100} margin="small medium 0 0">
     <Button>LTR Badge</Button>
   </Badge>
 
   <InstUISettingsProvider dir="rtl">
     <View as="div">
-      <div>Nested RTL text</div>
+      <div><Text>Nested RTL text</Text></div>
       <Badge count={105} countUntil={100} margin="small medium 0 0">
         <Button>Nested RTL Badge</Button>
       </Badge>
     </View>
   </InstUISettingsProvider>
 
-  <div>LTR text</div>
-  <div>LTR text</div>
+  <div><Text>LTR text</Text></div>
+  <div><Text>LTR text</Text></div>
 </InstUISettingsProvider>
 ```

--- a/packages/ui-avatar/src/Avatar/v2/README.md
+++ b/packages/ui-avatar/src/Avatar/v2/README.md
@@ -46,13 +46,13 @@ type: example
 readonly: true
 ---
 <View display="block" padding="small medium" background="primary">
-  <Avatar size="xx-small" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="x-small" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="small" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="medium" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="large" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="x-large" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
-  <Avatar size="xx-large" color="ai" name="AI Assistant" renderIcon={IconAiSolid} />
+  <Avatar size="xx-small" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="x-small" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="small" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="medium" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="large" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="x-large" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
+  <Avatar size="xx-large" color="ai" name="AI Assistant" renderIcon={IgniteaiLogoInstUIIcon} />
 </View>
 ```
 

--- a/packages/ui-flex/src/Flex/v2/README.md
+++ b/packages/ui-flex/src/Flex/v2/README.md
@@ -20,28 +20,28 @@ type: example
 ---
 <div>
   <Flex withVisualDebug margin="none none large">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="column" margin="none none large">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="row-reverse" margin="none none large">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="column-reverse">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
 </div>
 ```
@@ -56,28 +56,28 @@ type: example
 ---
 <div>
   <Flex withVisualDebug margin="none none large" gap="small">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="column" margin="none none large" gap="medium">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="row-reverse" margin="none none large" gap="medium">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug direction="column-reverse" gap="small">
-    <Flex.Item>One</Flex.Item>
-    <Flex.Item>Two</Flex.Item>
-    <Flex.Item>Three</Flex.Item>
-    <Flex.Item>Four</Flex.Item>
+    <Flex.Item><Text>One</Text></Flex.Item>
+    <Flex.Item><Text>Two</Text></Flex.Item>
+    <Flex.Item><Text>Three</Text></Flex.Item>
+    <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
 </div>
 ```
@@ -90,28 +90,28 @@ type: example
 ---
 <div>
   <Flex withVisualDebug margin="none none large" gap="small" wrap="wrap">
-    <Flex.Item size='25rem'>One</Flex.Item>
-    <Flex.Item size='25rem'>Two</Flex.Item>
-    <Flex.Item size='25rem'>Three</Flex.Item>
-    <Flex.Item size='25rem'>Four</Flex.Item>
+    <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug margin="none none large" gap="small large" wrap="wrap">
-    <Flex.Item size='25rem'>One</Flex.Item>
-    <Flex.Item size='25rem'>Two</Flex.Item>
-    <Flex.Item size='25rem'>Three</Flex.Item>
-    <Flex.Item size='25rem'>Four</Flex.Item>
+    <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug margin="none none large" gap="small" wrap="wrap-reverse">
-    <Flex.Item size='25rem'>One</Flex.Item>
-    <Flex.Item size='25rem'>Two</Flex.Item>
-    <Flex.Item size='25rem'>Three</Flex.Item>
-    <Flex.Item size='25rem'>Four</Flex.Item>
+    <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
   <Flex withVisualDebug margin="none none large" gap="small large" wrap="wrap-reverse">
-    <Flex.Item size='25rem'>One</Flex.Item>
-    <Flex.Item size='25rem'>Two</Flex.Item>
-    <Flex.Item size='25rem'>Three</Flex.Item>
-    <Flex.Item size='25rem'>Four</Flex.Item>
+    <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
+    <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
 </div>
 ```
@@ -127,16 +127,16 @@ type: example
 ---
 <Flex withVisualDebug>
   <Flex.Item padding="x-small">
-    Villum dolore eu fugiat nulla pariatur.
+    <Text>Villum dolore eu fugiat nulla pariatur.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    <Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small">
-    Duis aute irure.
+    <Text>Duis aute irure.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    <Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Text>
   </Flex.Item>
 </Flex>
 ```
@@ -150,16 +150,16 @@ type: example
 ---
 <Flex withVisualDebug>
   <Flex.Item padding="x-small" shouldShrink>
-    Villum dolore eu fugiat nulla pariatur.
+    <Text>Villum dolore eu fugiat nulla pariatur.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small" shouldShrink>
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    <Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small" shouldShrink>
-    Duis aute irure.
+    <Text>Duis aute irure.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small" shouldShrink>
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    <Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Text>
   </Flex.Item>
 </Flex>
 ```
@@ -172,10 +172,10 @@ type: example
 ---
 <Flex withVisualDebug>
   <Flex.Item padding="x-small" shouldShrink shouldGrow>
-    I am growing and shrinking!
+    <Text>I am growing and shrinking!</Text>
   </Flex.Item>
   <Flex.Item>
-    I am not shrinking or growing.
+    <Text>I am not shrinking or growing.</Text>
   </Flex.Item>
 </Flex>
 ```
@@ -191,13 +191,13 @@ type: example
 ---
 <Flex withVisualDebug>
   <Flex.Item padding="x-small" size="200px">
-    I am always 200px.
+    <Text>I am always 200px.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small" shouldShrink shouldGrow size="200px">
-    I can grow, and shrink down to 200px.
+    <Text>I can grow, and shrink down to 200px.</Text>
   </Flex.Item>
   <Flex.Item padding="x-small" size="25%">
-    I am always 25%.
+    <Text>I am always 25%.</Text>
   </Flex.Item>
 </Flex>
 ```
@@ -218,13 +218,13 @@ type: example
     <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
   </Flex.Item>
   <Flex.Item shouldGrow shouldShrink>
-    I should be aligned to the bottom of the Avatar.
+    <Text>I should be aligned to the bottom of the Avatar.</Text>
   </Flex.Item>
   <Flex.Item>
-    Me, too.
+    <Text>Me, too.</Text>
   </Flex.Item>
   <Flex.Item align="start">
-    I am aligning myself to the top.
+    <Text>I am aligning myself to the top.</Text>
   </Flex.Item>
 </Flex>
 ```
@@ -243,10 +243,10 @@ type: example
       <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
     </Flex.Item>
     <Flex.Item>
-      We are all centered!
+      <Text>We are all centered!</Text>
     </Flex.Item>
     <Flex.Item>
-      Yeah!
+      <Text>Yeah!</Text>
     </Flex.Item>
   </Flex>
 
@@ -255,10 +255,10 @@ type: example
       <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
     </Flex.Item>
     <Flex.Item>
-      Ah, a little more space.
+      <Text>Ah, a little more space.</Text>
     </Flex.Item>
     <Flex.Item>
-      Totally.
+      <Text>Totally.</Text>
     </Flex.Item>
   </Flex>
 
@@ -267,10 +267,10 @@ type: example
       <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
     </Flex.Item>
     <Flex.Item>
-      Smooshed again.
+      <Text>Smooshed again.</Text>
     </Flex.Item>
     <Flex.Item>
-      Ugh.
+      <Text>Ugh.</Text>
     </Flex.Item>
   </Flex>
 </div>
@@ -319,7 +319,7 @@ type: example
     <Button margin="none x-small none none">
       Cancel
     </Button>
-    <Button color="success" renderIcon={IconUserSolid}>
+    <Button color="success" renderIcon={UserInstUIIcon}>
       Add user
     </Button>
   </Flex.Item>
@@ -339,15 +339,15 @@ type: example
 
     <Flex withVisualDebug wrap="wrap" justifyItems="space-around" margin="0 0 medium">
       <Flex.Item padding="small">
-        <SVGIcon src={iconExample} size="medium" title="Icon Example" />
+        <HeartInstUIIcon size="medium" title="Icon Example" color="primary" />
         <Text weight="bold" size="large" as="div">We love you!</Text>
       </Flex.Item>
       <Flex.Item padding="small">
-        <SVGIcon src={iconExample} size="medium" title="Icon Example" />
+        <HeartInstUIIcon size="medium" title="Icon Example" color="primary" />
         <Text weight="bold" size="large" as="div">We love you!</Text>
       </Flex.Item>
       <Flex.Item padding="small">
-        <SVGIcon src={iconExample} size="medium" title="Icon Example" />
+        <HeartInstUIIcon size="medium" title="Icon Example" color="primary" />
         <Text weight="bold" size="large" as="div">We love you!</Text>
       </Flex.Item>
     </Flex>
@@ -374,7 +374,7 @@ type: example
   </Flex.Item>
 
   <Flex.Item shouldGrow shouldShrink padding="small" as="main">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    <Text>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</Text>
   </Flex.Item>
 
   <Flex.Item padding="small" as="footer">
@@ -382,7 +382,7 @@ type: example
     <Flex withVisualDebug justifyItems="space-between">
       <Flex.Item>
         <IconButton
-          renderIcon={IconEmailLine}
+          renderIcon={MailInstUIIcon}
           withBackground={false}
           withBorder={false}
           screenReaderLabel="Some app function"
@@ -390,7 +390,7 @@ type: example
       </Flex.Item>
       <Flex.Item>
         <IconButton
-          renderIcon={IconPrinterLine}
+          renderIcon={PrinterInstUIIcon}
           withBackground={false}
           withBorder={false}
           screenReaderLabel="Some app function"
@@ -398,7 +398,7 @@ type: example
       </Flex.Item>
       <Flex.Item>
         <IconButton
-          renderIcon={IconCalendarDayLine}
+          renderIcon={Calendar1InstUIIcon}
           withBackground={false}
           withBorder={false}
           screenReaderLabel="Some app function"
@@ -406,7 +406,7 @@ type: example
       </Flex.Item>
       <Flex.Item>
         <IconButton
-          renderIcon={IconSettingsLine}
+          renderIcon={SettingsInstUIIcon}
           withBackground={false}
           withBorder={false}
           screenReaderLabel="Some app function"

--- a/packages/ui-form-field/src/FormField/v1/README.md
+++ b/packages/ui-form-field/src/FormField/v1/README.md
@@ -14,30 +14,25 @@ type: example
              messages={[{type:'success', text: 'This is a success message'}, {type:'newError', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo121"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo122" label="Stacked layout (inline=true)" width="400px" layout="stacked" inline
              messages={[{type:'success', text: 'This is a success message'}, {type:'newError', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo122"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo123" label="Inline layout" width="400px" layout="inline"
              messages={[{type:'success', text: 'success!'}, {type:'newError', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo123"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo124" label="Inline layout (inline=true)" width="400px" layout="inline" inline
              messages={[{type:'success', text: 'success!'}, {type:'newError', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo124"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo121" label={<ScreenReaderContent>hidden text</ScreenReaderContent>} width="400px" layout="stacked">
     <TextInput id="_foo121" />
   </FormField>
-  test
   <hr/>
 </div>
 ```

--- a/packages/ui-form-field/src/FormField/v2/README.md
+++ b/packages/ui-form-field/src/FormField/v2/README.md
@@ -14,30 +14,25 @@ type: example
              messages={[{type:'success', text: 'This is a success message'}, {type:'error', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo121"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo122" label="Stacked layout (inline=true)" width="400px" layout="stacked" inline
              messages={[{type:'success', text: 'This is a success message'}, {type:'error', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo122"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo123" label="Inline layout" width="400px" layout="inline"
              messages={[{type:'success', text: 'success!'}, {type:'error', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo123"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo124" label="Inline layout (inline=true)" width="400px" layout="inline" inline
              messages={[{type:'success', text: 'success!'}, {type:'error', text: 'An error message. It will wrap if the text is longer than the width of the container.'}]}>
     <TextInput id="_foo124"/>
   </FormField>
-  test
   <hr/>
   <FormField id="_foo121" label={<ScreenReaderContent>hidden text</ScreenReaderContent>} width="400px" layout="stacked">
     <TextInput id="_foo121" />
   </FormField>
-  test
   <hr/>
 </div>
 ```

--- a/packages/ui-heading/src/Heading/v2/styles.ts
+++ b/packages/ui-heading/src/Heading/v2/styles.ts
@@ -223,6 +223,7 @@ const generateStyle = (
       label: 'heading',
       lineHeight: componentTheme.lineHeight,
       margin: 0,
+      '& code': { background: '#99999945' },
       // NOTE: the input styles exist to accommodate the InPlaceEdit component
       // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)
       '&:is(input)[type]': inputStyles,

--- a/packages/ui-link/src/Link/v2/README.md
+++ b/packages/ui-link/src/Link/v2/README.md
@@ -86,14 +86,14 @@ Use the `variant` prop in combination with the `size` prop to control both the a
 type: example
 ---
 <div>
-  <div>
+  <Text>
     In a line of text you should use the <Link variant="inline" size="medium" renderIcon={<DiamondInstUIIcon />} href="https://instructure.github.io/instructure-ui/">inline</Link> link variant.
-  </div>
+  </Text>
   <br />
-  <div>
+  <Text>
     If the link is standalone (not in a text), use the <code>standalone</code> variant:
     <Link variant="standalone" size="medium" renderIcon={<DiamondInstUIIcon />} href="https://instructure.github.io/instructure-ui/">standalone</Link>
-  </div>
+  </Text>
 </div>
 ```
 
@@ -161,22 +161,29 @@ type: example
 ---
 <div>
   <View as="div" margin="0 0 small">
-    <Link href="https://instructure.design" renderIcon={<DiamondInstUIIcon />}>Icon before text</Link> with the quick brown fox
+    <Text>
+      <Link href="https://instructure.design" renderIcon={<DiamondInstUIIcon />}>Icon before text</Link> with the quick brown fox
+    </Text>
   </View>
   <View as="div" margin="0 0 small">
-    This Link has an icon and displays inline with text. <Link
-      href="https://instructure.design"
-      renderIcon={<DiamondInstUIIcon />}
-      iconPlacement="end"
-    >
-      Icon appears after Link text
-    </Link>. This is more text after the link.
+    <Text>
+      This Link has an icon and displays inline with text.
+      <Link
+        href="https://instructure.design"
+        renderIcon={<DiamondInstUIIcon />}
+        iconPlacement="end"
+      >
+        Icon appears after Link text
+      </Link>. This is more text after the link.
+    </Text>
   </View>
   <View as="div">
-    This Link consists of only an icon&nbsp;
-    <Link onClick={() => console.log('clicked!')} renderIcon={<DiamondInstUIIcon />}>
-      <ScreenReaderContent>Descriptive text</ScreenReaderContent>
-    </Link>.
+    <Text>
+      This Link consists of only an icon&nbsp;
+      <Link onClick={() => console.log('clicked!')} renderIcon={<DiamondInstUIIcon />}>
+        <ScreenReaderContent>Descriptive text</ScreenReaderContent>
+      </Link>.
+    </Text>
   </View>
 </div>
 ```

--- a/packages/ui-text/src/Text/v2/styles.ts
+++ b/packages/ui-text/src/Text/v2/styles.ts
@@ -239,7 +239,9 @@ const generateStyle = (
       },
       'pre, code': {
         all: 'initial',
-        fontFamily: componentTheme.fontFamilyMonospace
+        fontFamily: componentTheme.fontFamilyMonospace,
+        background: '#99999945',
+        color: 'inherit'
       },
       'i, em': {
         fontStyle: 'italic'

--- a/packages/ui-truncate-text/src/TruncateText/v2/README.md
+++ b/packages/ui-truncate-text/src/TruncateText/v2/README.md
@@ -48,9 +48,9 @@ type: example
           console.log(truncated, text)
         }}
       >
-        <span>
+        <Text>
           Regular sized text with <Link href="#">A Text Link </Link>and <Text weight="bold">some bold text.</Text>
-        </span>
+        </Text>
       </TruncateText>
     </div>
 

--- a/packages/ui-view/src/View/v2/README.md
+++ b/packages/ui-view/src/View/v2/README.md
@@ -431,11 +431,15 @@ type: example
 ---
 <Flex gap="medium" direction="column">
   <View tabIndex="0" role="button" cursor="pointer">
-    Tab here to see the focus outline
+    <Text>
+      Tab here to see the focus outline
+    </Text>
   </View>
   <View focusWithin>
-    if the <code>focusWithin</code> prop is <code>true</code>, the View will display the focus ring if any of its descendants receives focus
-    <div tabIndex="0" role="button" style={{outline: 'none'}}>Tab here to see the focus outline</div>
+    <Text>
+      if the <code>focusWithin</code> prop is <code>true</code>, the View will display the focus ring if any of its descendants receives focus
+    </Text>
+    <div tabIndex="0" role="button" style={{outline: 'none'}}><Text>Tab here to see the focus outline</Text></div>
   </View>
 </Flex>
 ```
@@ -723,7 +727,7 @@ type: example
     padding="large"
     withVisualDebug
   >
-    {lorem.sentence()}
+    <Text>{lorem.sentence()}</Text>
   </View>
   <View
     as="div"
@@ -736,7 +740,7 @@ type: example
       padding="small"
       withVisualDebug
     >
-      {lorem.sentence()}
+      <Text>{lorem.sentence()}</Text>
     </View>
     <View
       as="div"
@@ -744,7 +748,7 @@ type: example
       padding="small"
       withVisualDebug
     >
-      {lorem.sentence()}
+      <Text>{lorem.sentence()}</Text>
     </View>
   </View>
 </div>
@@ -771,7 +775,9 @@ type: example
     margin="0 0 medium"
     withVisualDebug
   >
-  Some header content
+    <Text>
+      Some header content
+    </Text>
   </View>
   <Text as="p">{lorem.paragraph()}</Text>
 </View>
@@ -796,7 +802,9 @@ type: example
     margin="large auto"
     padding="0 small 0 0"
   >
+    <Text>
     {lorem.sentence()}
+    </Text>
   </View>
   <Button color="success">Some Action</Button>
 </View>


### PR DESCRIPTION
INSTUI-4962

## Changes
- Wrap bare text in <Text> components across multiple v2 READMEs (Flex, View, Link, TruncateText, InstUISettingsProvider) so text content renders correctly in dark theme
- Replace deprecated icons with their new InstUIIcon equivalents
- Fix inline  < code >  block styling in Text and Heading
- Remove stray test text from FormField (leftover debug content)

## Test
Check the doc pages **in dark themes**:
 Avatar (ai icons),
 Flex (texts and icons),
 View (texts),
 Link (texts and code block),
 Text (code block),
 TruncateText (texts),
 InstUISettingsProvider (texts),
 Heading (code block)