### PR TITLE
feat(ui-color-picker): improve ColorPicker paste behavior

### DIFF
--- a/packages/ui-color-picker/src/ColorPicker/__tests__/ColorPicker.test.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/__tests__/ColorPicker.test.tsx
@@ -392,6 +392,133 @@ describe('<ColorPicker />', () => {
 
       expect(inputRef).toHaveBeenCalledWith(input)
     })
+
+    describe('paste behavior', () => {
+      it('should strip leading # from pasted value', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => '#FF0000' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('FF0000')
+        })
+      })
+
+      it('should block pasted value that exceeds 6 characters', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'FF00001' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('')
+        })
+      })
+
+      it('should block pasted value with invalid hex characters', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'ZZZZZZ' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('')
+        })
+      })
+
+      it('should replace entirely selected text when pasting', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: 'FF0000' } })
+        await waitFor(() => expect(input).toHaveValue('FF0000'))
+
+        input.setSelectionRange(0, 6)
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'AABBCC' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('AABBCC')
+        })
+      })
+
+      it('should replace partially selected text when pasting', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: 'FF0000' } })
+        await waitFor(() => expect(input).toHaveValue('FF0000'))
+
+        // select the two middle zeros (positions 2–4), paste FF → FFFF00
+        input.setSelectionRange(2, 4)
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'FF' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('FFFF00')
+        })
+      })
+
+      it('should insert pasted text at cursor start position', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: '0000' } })
+        await waitFor(() => expect(input).toHaveValue('0000'))
+
+        input.setSelectionRange(0, 0)
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'FF' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('FF0000')
+        })
+      })
+
+      it('should insert pasted text at cursor middle position', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: 'FF00' } })
+        await waitFor(() => expect(input).toHaveValue('FF00'))
+
+        input.setSelectionRange(2, 2)
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'AB' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('FFAB00')
+        })
+      })
+
+      it('should insert pasted text at cursor end position', async () => {
+        render(<SimpleExample />)
+        const input = screen.getByRole('textbox') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: '0000' } })
+        await waitFor(() => expect(input).toHaveValue('0000'))
+
+        input.setSelectionRange(4, 4)
+        fireEvent.paste(input, {
+          clipboardData: { getData: () => 'FF' }
+        })
+
+        await waitFor(() => {
+          expect(input).toHaveValue('0000FF')
+        })
+      })
+    })
   })
 
   describe('complex mode', () => {

--- a/packages/ui-color-picker/src/ColorPicker/v1/index.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/v1/index.tsx
@@ -431,7 +431,14 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
       return event.preventDefault()
     }
 
-    const newHex = `${this.state.hexCode}${toPaste}`
+    const input = event.target as HTMLInputElement
+    const currentHex = this.state.hexCode
+    const selectionStart = input.selectionStart ?? currentHex.length
+    const selectionEnd = input.selectionEnd ?? currentHex.length
+    const newHex =
+      currentHex.slice(0, selectionStart) +
+      toPaste +
+      currentHex.slice(selectionEnd)
     if (isValid(newHex)) {
       if (typeof this.props.onChange === 'function') {
         this.props.onChange(`#${newHex}`)

--- a/packages/ui-color-picker/src/ColorPicker/v2/index.tsx
+++ b/packages/ui-color-picker/src/ColorPicker/v2/index.tsx
@@ -431,7 +431,15 @@ class ColorPicker extends Component<ColorPickerProps, ColorPickerState> {
       return event.preventDefault()
     }
 
-    const newHex = `${this.state.hexCode}${toPaste}`
+    const input = event.target as HTMLInputElement
+    const currentHex = this.state.hexCode
+    const selectionStart = input.selectionStart ?? currentHex.length
+    const selectionEnd = input.selectionEnd ?? currentHex.length
+    const newHex =
+      currentHex.slice(0, selectionStart) +
+      toPaste +
+      currentHex.slice(selectionEnd)
+
     if (isValid(newHex)) {
       if (typeof this.props.onChange === 'function') {
         this.props.onChange(`#${newHex}`)


### PR DESCRIPTION
INSTUI-4834

**ISSUE:**
- pasted hex color values can't replace existing values without manual clearing, e.g. pasting FF0000, then select all FF0000 and paste AABBCC resulted in nothing

**TEST PLAN:**

-  selection replacement
    - paste FF0000, then select all FF0000 and paste AABBCC, the input should become AABBCC and result in valid color
    - in FF0000, select 00 in the middle, paste FF, it input should become FFFF00 and result in valid color
  
-  cursor position
    - paste 0000, put the cursor at at the start of 0000 and paste FF, the input should become FF0000 and result in valid color
    - paste FF00, put the cursor in the middle of FF00 and paste AB, the input should become FFAB00 and result in valid color
    - put the cursor at the end of 0000 and  Paste FF, the input should become 0000FF

- '#' stripping
    - paste #FF0000, it should still become FF0000
    - paste FF0000, it should still become FF0000

- length limits
    - Paste a 7-char string like FF00001, it should be still blocked

- invalid content
    - paste ZZZZZZ, it should be still blocked