### PR TITLE
fix(ui-date-input): add scrollbar to dateinput v2

### DIFF
--- a/packages/ui-date-input/src/DateInput/v2/index.tsx
+++ b/packages/ui-date-input/src/DateInput/v2/index.tsx
@@ -300,6 +300,7 @@ const DateInput = forwardRef(
             shouldContainFocus
             shouldReturnFocus
             shouldCloseOnDocumentClick
+            shouldScrollContent
             screenReaderLabel={screenReaderLabels.datePickerDialog}
           >
             <Calendar

--- a/packages/ui-popover/src/Popover/v2/styles.ts
+++ b/packages/ui-popover/src/Popover/v2/styles.ts
@@ -43,7 +43,8 @@ const generateStyle = (
       label: 'popover__scrollContainer',
       maxHeight: 'var(--ui-position-available-height, 100vh)',
       overflowY: 'auto',
-      overflowX: 'hidden'
+      overflowX: 'hidden',
+      borderRadius: componentTheme.borderRadius
     }
   }
 }


### PR DESCRIPTION
INSTUI-4999

This PR adds a scrollbar to DateInput v2, it uses Balazs' nested rAF ColorPicker technique as an inspiration.

Test:
Open the docs page, open DateInput v2 (use the v11.7 switch), Zoom in at least 200% and observe if a scrollbar appears in DateInput.