### PR TITLE
feat: self hosted visual regression

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
       - v9_maintenance
       - v10_maintenance
   workflow_dispatch:
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
 jobs:
   deploy-release:
     if: startsWith(github.event.head_commit.message, 'chore(release)')
@@ -55,6 +58,7 @@ jobs:
             v9
             v10
             latest
+            visual-regression
           force: false
   deploy-latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-baselines.yml
+++ b/.github/workflows/visual-baselines.yml
@@ -1,0 +1,69 @@
+name: Update visual baselines
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  baselines:
+    name: Capture and publish baselines
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('regression-test/package-lock.json') }}
+
+      - name: Build InstUI
+        run: pnpm install --frozen-lockfile && pnpm run bootstrap
+
+      - name: Install regression-test dependencies
+        run: npm ci
+        working-directory: regression-test
+
+      - name: Install Cypress binary
+        run: npx cypress install
+        working-directory: regression-test
+
+      - name: Run Cypress
+        uses: cypress-io/github-action@v6
+        env:
+          ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
+        with:
+          install: false
+          build: npm run build
+          start: npm start
+          working-directory: regression-test
+
+      - name: Flatten screenshots
+        run: |
+          mkdir -p baseline-publish/screenshots
+          find regression-test/cypress/screenshots -name '*.png' -exec cp {} baseline-publish/screenshots/ \;
+
+      - name: Push baselines to visual-baselines branch
+        run: |
+          cd baseline-publish
+          git init -b visual-baselines
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add screenshots/
+          git commit -m "update baselines from ${GITHUB_SHA}"
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force origin visual-baselines

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,38 +1,64 @@
-name: "Chromatic"
+name: Visual regression
 
 on: [pull_request]
 
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
-  cypress:
-    name: Run Cypress for visual regression testing
+  visual-regression:
+    name: Capture, diff, and publish report
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:latest
       options: --user 1001
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
+
       - name: Cache Cypress binary
         uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('regression-test/package-lock.json') }}
+
       - name: Build InstUI
         run: pnpm install --frozen-lockfile && pnpm run bootstrap
+
       - name: Install regression-test dependencies
         run: npm ci
         working-directory: regression-test
+
       - name: Install Cypress binary
         run: npx cypress install
         working-directory: regression-test
-      - name: Run Cypress tests
+
+      - name: Fetch baselines
+        run: |
+          mkdir -p regression-test/.baselines
+          if git fetch origin visual-baselines 2>/dev/null; then
+            git worktree add /tmp/baselines-wt origin/visual-baselines
+            cp -r /tmp/baselines-wt/screenshots/. regression-test/.baselines/ 2>/dev/null || echo "::warning::baselines branch has no screenshots/ dir"
+            git worktree remove --force /tmp/baselines-wt
+          else
+            echo "::warning::visual-baselines branch does not exist — first run, everything will be 'added'"
+          fi
+
+      - name: Run Cypress
+        id: cypress
         uses: cypress-io/github-action@v6
+        continue-on-error: true
         env:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         with:
@@ -40,42 +66,95 @@ jobs:
           build: npm run build
           start: npm start
           working-directory: regression-test
-      - name: Upload cypress artifact for chromatic
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: regression-test/cypress/downloads
-          retention-days: 30
 
-  chromatic:
-    name: Run Chromatic
-    needs: cypress
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Build InstUI
-        run: pnpm install --frozen-lockfile && pnpm run bootstrap
-      - name: Install regression-test dependencies
-        run: npm ci
+      - name: Flatten screenshots
+        run: |
+          mkdir -p regression-test/.actual
+          find regression-test/cypress/screenshots -name '*.png' -exec cp {} regression-test/.actual/ \;
+
+      - name: Diff and generate report
+        id: diff
         working-directory: regression-test
-      - name: Download Cypress test results
-        uses: actions/download-artifact@v4
+        run: >
+          npx ui-scripts visual-diff
+          --actual-dir .actual
+          --baseline-dir .baselines
+          --output-dir .report
+          --no-fail-on-missing-baseline
+          --pr-number ${{ github.event.pull_request.number }}
+          --pr-url ${{ github.event.pull_request.html_url }}
+          --meta cypress/meta.json
+          --source-base-url https://github.com/${{ github.repository }}/blob/${{ github.head_ref }}/regression-test/src/app
+        continue-on-error: true
+
+      - name: Publish report to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          name: test-results
-          path: regression-test/cypress/downloads
-      - name: Run Chromatic
-        uses: chromaui/action@latest
-        with:
-          cypress: true
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
-          workingDir: regression-test
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: regression-test/.report
+          publish_branch: gh-pages
+          destination_dir: visual-regression/pr-${{ github.event.pull_request.number }}
+          keep_files: true
+          commit_message: "visual-regression: PR #${{ github.event.pull_request.number }} (${{ github.sha }})"
+
+      - name: Read summary
+        id: summary
         env:
-          CHROMATIC_ARCHIVE_LOCATION: ./cypress/downloads
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const { summary: s, results } = JSON.parse(fs.readFileSync('regression-test/.report/summary.json', 'utf8'));
+            const base = 'https://instructure.design/visual-regression/pr-' + process.env.PR_NUMBER;
+            const interesting = results.filter(r => r.status === 'changed' || r.status === 'removed');
+            let md = '';
+            if (interesting.length) {
+              md = '<details>\n<summary>Diff images (' + interesting.length + ')</summary>\n\n';
+              for (const r of interesting) {
+                if (r.status === 'changed') {
+                  md += '#### ' + r.name + ' — ' + r.numDiff + ' pixels differ\n\n';
+                  md += '![](' + base + '/diff/' + r.name + ')\n\n';
+                } else {
+                  md += '#### ' + r.name + ' — baseline no longer produced\n\n';
+                }
+              }
+              md += '</details>';
+            }
+            const lines = [
+              'total=' + s.total,
+              'unchanged=' + s.unchanged,
+              'changed=' + s.changed,
+              'added=' + s.added,
+              'removed=' + s.removed,
+              'status=' + (s.changed > 0 || s.removed > 0 ? '⚠️ **Changes detected.**' : '✅ **No changes.**')
+            ];
+            let out = lines.join('\n') + '\n';
+            out += 'diff_images<<DIFFIMAGES_EOF\n' + md + '\nDIFFIMAGES_EOF\n';
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, out);
+          "
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: visual-regression
+          message: |
+            ## Visual regression report
+
+            ${{ steps.summary.outputs.status }}
+
+            | Status | Count |
+            |---|---|
+            | Unchanged | ${{ steps.summary.outputs.unchanged }} |
+            | Changed | ${{ steps.summary.outputs.changed }} |
+            | New | ${{ steps.summary.outputs.added }} |
+            | Removed | ${{ steps.summary.outputs.removed }} |
+
+            📊 **[View full report](https://instructure.design/visual-regression/pr-${{ github.event.pull_request.number }}/index.html)**
+
+            ${{ steps.summary.outputs.diff_images }}
+
+            <sub>Baselines come from the `visual-baselines` branch. They refresh on every merge to `master`.</sub>
+
+      - name: Fail if regressions or Cypress failed
+        if: steps.diff.outcome == 'failure' || steps.cypress.outcome == 'failure'
+        run: exit 1

--- a/docs/testing/testing-overview.md
+++ b/docs/testing/testing-overview.md
@@ -22,10 +22,10 @@ For more information about our unit tests you can check out our [detailed guides
 
 For more information check out our [detailed guides and examples.](cypress-component-testing)
 
-#### Visual Regression Testing with Cypress and Chromatic:
+#### Visual Regression Testing with Cypress:
 
-We use [Cypress](https://docs.cypress.io/app/tooling/visual-testing) end-to-end (e2e) tests to generate structured layouts and capture screenshots of components. [Chromatic](https://www.chromatic.com/docs/diff-inspector/) handles the visual diffing and review process. It's especially effective for catching layout shifts, styling regressions, or broken UI elements that don’t trigger functional test failures. Tests are run after changes are pushed to remote, comparing the new screenshots to a baseline stored from a previously verified state. When differences are detected, the test fails and provides side-by-side diffs for easy review.
+We use [Cypress](https://docs.cypress.io/app/tooling/visual-testing) end-to-end (e2e) tests to capture screenshots of every component showcase page in the `regression-test` Next.js app. A custom [pixelmatch](https://github.com/mapbox/pixelmatch)-based `ui-scripts visual-diff` command compares each capture against a baseline stored on the `visual-baselines` branch and publishes an interactive HTML report to GitHub Pages for every PR. Tests are run after changes are pushed to remote; when differences are detected, the job fails and the sticky PR comment links to the report with inline diff images.
 
-These e2e tests also run [Axe](https://github.com/dequelabs/axe-core) accessibility checks and monitors `console.error`s.
+These e2e tests also run [Axe](https://github.com/dequelabs/axe-core) accessibility checks and monitor `console.error`s.
 
-You can read about these in the [README](https://github.com/instructure/instructure-ui/blob/master/regression-test/README.md) of the regression testing suite.
+For the full workflow, local dev loop, and how to add a new page, see the [visual regression testing guide](visual-regression).

--- a/docs/testing/visual-regression.md
+++ b/docs/testing/visual-regression.md
@@ -1,0 +1,145 @@
+---
+title: Visual Regression Testing
+category: Contributor Guides/Testing
+order: 4
+---
+
+# Visual regression testing
+
+InstUI runs visual regression tests on every pull request. They guard against unintended pixel-level changes to rendered components — a padding bump, an accidental color shift, a layout regression that a unit test wouldn't catch.
+
+## How it works
+
+On every PR:
+
+1. **Build & capture.** GitHub Actions builds InstUI, builds the `regression-test` Next.js app as a static site, and serves it. Cypress visits every page under `regression-test/src/app/*`, waits for it to render, and calls `cy.screenshot()` in an `afterEach` hook, producing one PNG per test case.
+2. **Diff.** The `ui-scripts visual-diff` command compares each screenshot against the matching baseline fetched from the `visual-baselines` branch of the repo. It uses [pixelmatch](https://github.com/mapbox/pixelmatch) with antialiasing detection enabled, so typical font-rendering noise doesn't register as a diff.
+3. **Publish.** The diff script writes an HTML report (with baseline / actual / diff for every row, plus a lightbox viewer) and the action publishes it to the `gh-pages` branch under `visual-regression/pr-<N>/`. The report is reachable at `https://instructure.design/visual-regression/pr-<N>/index.html`.
+4. **Comment.** A sticky PR comment summarizes the result, links to the report, and inlines each changed row's diff image inside a collapsed `<details>` block.
+5. **Fail.** If any screenshot is marked `Changed` or `Removed`, the `Capture, diff, and publish report` job fails. `New` screenshots (no matching baseline) are tolerated so a contributor who adds a new component page doesn't need to pre-seed a baseline.
+6. **Cleanup.** When the PR is closed or merged, a separate workflow removes `visual-regression/pr-<N>/` from `gh-pages`.
+
+Baselines are refreshed automatically: every push to `master` triggers the `Update visual baselines` workflow, which re-runs Cypress and force-pushes the fresh screenshots to the `visual-baselines` branch. There is no manual review or approval step — merging is the approval.
+
+## Local development
+
+### Running the full loop against local changes
+
+From the repo root:
+
+```sh
+---
+type: code
+---
+pnpm install && pnpm run bootstrap
+cd regression-test
+npm install
+npm run build       # produces out/
+npm start &         # serves the static export on http://localhost:3000
+npm run cypress     # captures screenshots
+```
+
+The resulting PNGs land in `regression-test/cypress/screenshots/spec.cy.ts/`.
+
+To compare them against a local baseline set:
+
+```sh
+---
+type: code
+---
+# Seed baselines by copying a known-good capture run
+mkdir -p .baselines
+cp cypress/screenshots/spec.cy.ts/*.png .baselines/
+
+# Later, after a visual change, capture again and diff
+cp cypress/screenshots/spec.cy.ts/*.png .actual/
+npm run visual-diff
+open .report/index.html
+```
+
+`npm run visual-diff` invokes the same `ui-scripts visual-diff` command CI uses. Pass extra flags to override the defaults:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--actual-dir <dir>` | `cypress/screenshots` | Newly captured screenshots. |
+| `--baseline-dir <dir>` | `.baselines` | Baselines to compare against. |
+| `--output-dir <dir>` | `visual-report` | Where the HTML report + diff PNGs are written. |
+| `--threshold <0..1>` | `0.1` | Per-pixel YIQ color threshold. Lower is stricter. |
+| `--fail-on-missing-baseline` / `--no-fail-on-missing-baseline` | on | Whether to exit 1 when actual screenshots have no baseline. |
+| `--pr-number <n>` | — | Rendered in the report header as a link to the PR. |
+| `--pr-url <url>` | — | Target of the PR link. |
+| `--meta <file>` | — | JSON mapping screenshot slug → visited URL path. Enables per-row source-file links in the report. Produced automatically by `spec.cy.ts` via `cy.task('recordMeta', ...)`. |
+| `--source-base-url <url>` | — | GitHub blob URL of `regression-test/src/app` on the branch being reviewed. Combined with `--meta` to build links like `treebrowser/page.tsx`. |
+
+### Interpreting the report
+
+The HTML report is a single self-contained page showing one section per screenshot. Each row has a status badge (`ok`, `changed`, `new`, `removed`), a three-up grid of baseline / actual / diff images, and — when metadata is available — a link to the source `page.tsx`.
+
+Top-bar controls:
+
+- **Filter buttons** (`All`, `Changed`, `New`, `Removed`, `Unchanged`) — the active one is highlighted.
+- **Search input** — live, debounced substring filter on the screenshot name.
+- **Lightbox** — click any thumbnail to open a fullscreen viewer. Inside:
+  - `Baseline`, `Actual`, `Diff` buttons switch between the three images.
+  - `Slider` mode overlays baseline and actual with a drag handle so you can scrub the boundary back and forth.
+  - `1:1` / `Fit` toggles between native pixel size (scrollable) and fit-to-window.
+  - `‹` / `›` step through visible rows (respects the current filter).
+
+## Adding a new component page
+
+1. Create `regression-test/src/app/<component-name>/page.tsx`. The page component must start with `'use client'` and render meaningful variations of the component you're covering.
+
+    ```tsx
+    ---
+    type: code
+    ---
+    'use client'
+    import { Button } from '@instructure/ui/latest'
+
+    export default function Page() {
+      return (
+        <main className="axe-test p-8 flex flex-col gap-4 items-start">
+          <Button>Default</Button>
+          <Button color="primary">Primary</Button>
+          <Button disabled>Disabled</Button>
+        </main>
+      )
+    }
+    ```
+
+    The outer `axe-test` class is required — the axe-core accessibility check runs against elements inside it.
+
+2. Add a test block in `regression-test/cypress/e2e/spec.cy.ts`:
+
+    ```ts
+    ---
+    type: code
+    ---
+    it('MyComponent', () => {
+      cy.visit('http://localhost:3000/my-component')
+      cy.injectAxe()
+      cy.checkA11y('.axe-test', axeOptions, terminalLog)
+    })
+    ```
+
+    If the component renders with an animation or asynchronous layout pass, add a `cy.wait(<ms>)` before `injectAxe()`. Keep waits as short as works — excessive waits compound across the suite.
+
+3. Commit the test page and the spec. On the first PR run the new screenshot will show up as `New`; it becomes a baseline automatically once the PR is merged.
+
+## Tuning stability
+
+Screenshots are captured with `capture: 'fullPage'` and `disableTimersAndAnimations: true`, at a fixed 1280×800 viewport, inside a `cypress/browsers` Docker container pinned in the workflow. That combination eliminates almost all environmental noise. When a real component still flakes:
+
+- **Bump `cy.wait()` modestly** for components with late-rendered content (tooltips, tree animations, image loading). TreeBrowser uses 1000ms.
+- **Don't lower the pixel threshold** below 0.1 unless you're chasing a specific subpixel regression — you'll start catching harmless antialiasing drift.
+- **Don't raise it above 0.2** — you'll mask real color regressions.
+
+## Troubleshooting
+
+**"View full report" link shows the docs site 404 page.** GitHub Pages' CDN lags ~30–120s behind a push. Hard-refresh (Cmd-Shift-R / Ctrl-F5) or wait a minute.
+
+**Every screenshot shows as `Changed` after a branch rebase.** Baselines may have been captured under a different layout. Merging to `master` refreshes them. If a PR's branch diverged from a baseline-producing commit, expect a one-time cascade of "fixes" that'll reset on merge.
+
+**`visual-baselines` branch missing.** The branch is created lazily on the first push to `master` after this feature landed. If it was force-deleted, the next merge to `master` will recreate it.
+
+**Diffs appear only on certain rows but the component hasn't changed.** Most often this is a font-rendering shift from a Chromium or Fastly CDN upgrade. Merging to `master` lets the baselines pick up the new rendering; no code change needed.

--- a/packages/ui-scripts/lib/commands/index.js
+++ b/packages/ui-scripts/lib/commands/index.js
@@ -27,6 +27,7 @@ import server from './server.js'
 import tag from './tag.js'
 import deprecate from './deprecate.js'
 import publish from './publish.js'
+import visualDiff from './visual-diff.ts'
 import lint from '../test/lint.js'
 import bundle from '../build/webpack.js'
 import clean from '../build/clean.js'
@@ -42,6 +43,7 @@ export const yargCommands = [
   tag,
   deprecate,
   publish,
+  visualDiff,
   lint,
   bundle,
   clean,

--- a/packages/ui-scripts/lib/commands/visual-diff.ts
+++ b/packages/ui-scripts/lib/commands/visual-diff.ts
@@ -1,0 +1,539 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  copyFileSync,
+  existsSync,
+  statSync
+} from 'node:fs'
+import { join, basename } from 'node:path'
+import { PNG } from 'pngjs'
+import pixelmatch from 'pixelmatch'
+
+type Status = 'unchanged' | 'changed' | 'added' | 'removed'
+
+type Result = {
+  name: string
+  status: Status
+  numDiff?: number
+  sizeMismatch?: boolean
+}
+
+type Args = {
+  actualDir: string
+  baselineDir: string
+  outputDir: string
+  threshold: number
+  failOnMissingBaseline: boolean
+  prNumber?: string
+  prUrl?: string
+  meta?: string
+  sourceBaseUrl?: string
+}
+
+type Meta = Record<string, string>
+
+function sourceLinkFor(
+  name: string,
+  meta: Meta | null,
+  sourceBaseUrl?: string
+): string {
+  if (!meta || !sourceBaseUrl) return ''
+  const slug = name.replace(/\.png$/, '')
+  const pagePath = meta[slug]
+  if (!pagePath) return ''
+  const url = sourceBaseUrl.replace(/\/$/, '') + pagePath + '/page.tsx'
+  const display = pagePath.replace(/^\//, '') + '/page.tsx'
+  return `<a class="source-link" href="${url}" target="_blank" rel="noopener">${display}</a>`
+}
+
+function walk(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) out.push(...walk(full))
+    else if (entry.endsWith('.png')) out.push(full)
+  }
+  return out
+}
+
+function indexByName(files: string[]): Map<string, { path: string }> {
+  const map = new Map<string, { path: string }>()
+  for (const f of files) map.set(basename(f), { path: f })
+  return map
+}
+
+function loadPng(path: string): PNG {
+  return PNG.sync.read(readFileSync(path))
+}
+
+function diffPair(baseline: PNG, actual: PNG, threshold: number) {
+  const { width: bw, height: bh } = baseline
+  const { width: aw, height: ah } = actual
+  const width = Math.max(bw, aw)
+  const height = Math.max(bh, ah)
+
+  const pad = (src: PNG, w: number, h: number): PNG => {
+    if (src.width === w && src.height === h) return src
+    const padded = new PNG({ width: w, height: h })
+    PNG.bitblt(src, padded, 0, 0, src.width, src.height, 0, 0)
+    return padded
+  }
+
+  const b = pad(baseline, width, height)
+  const a = pad(actual, width, height)
+  const diff = new PNG({ width, height })
+  const numDiff = pixelmatch(b.data, a.data, diff.data, width, height, {
+    threshold,
+    includeAA: false
+  })
+  return { diff, numDiff, sizeMismatch: bw !== aw || bh !== ah }
+}
+
+function copyInto(src: string, destDir: string, name: string) {
+  mkdirSync(destDir, { recursive: true })
+  copyFileSync(src, join(destDir, name))
+}
+
+function badgeFor(s: Status): string {
+  return {
+    unchanged: '<span class="pill pass">ok</span>',
+    changed: '<span class="pill fail">changed</span>',
+    added: '<span class="pill new">new</span>',
+    removed: '<span class="pill gone">removed</span>'
+  }[s]
+}
+
+function thumb(mode: string, name: string): string {
+  return `<img loading="lazy" src="${mode}/${name}" data-name="${name}" data-mode="${mode}" class="thumb" />`
+}
+
+function row(r: Result, meta: Meta | null, sourceBaseUrl?: string): string {
+  const b = r.status === 'added' ? '' : thumb('baseline', r.name)
+  const a = r.status === 'removed' ? '' : thumb('actual', r.name)
+  const d = r.status === 'changed' ? thumb('diff', r.name) : ''
+  const pixelMeta =
+    r.status === 'changed'
+      ? `<div class="meta">${r.numDiff} pixels differ${r.sizeMismatch ? ' · size mismatch' : ''}</div>`
+      : ''
+  const source = sourceLinkFor(r.name, meta, sourceBaseUrl)
+  const hasBoth = r.status === 'changed' || r.status === 'unchanged'
+  return `
+    <section class="row" data-status="${r.status}" data-name="${r.name}" data-has-both="${hasBoth}">
+      <header><h2>${r.name}</h2>${badgeFor(r.status)}${pixelMeta}${source}</header>
+      <div class="grid"><figure><figcaption>Baseline</figcaption>${b}</figure><figure><figcaption>Actual</figcaption>${a}</figure><figure><figcaption>Diff</figcaption>${d}</figure></div>
+    </section>`
+}
+
+function renderHtml(
+  results: Result[],
+  summary: Record<string, number>,
+  prNumber?: string,
+  prUrl?: string,
+  meta?: Meta | null,
+  sourceBaseUrl?: string
+): string {
+  const prBadge =
+    prNumber && prUrl
+      ? `<a href="${prUrl}" style="font-weight:600;color:#0969da;text-decoration:none;">PR #${prNumber}</a>`
+      : prNumber
+        ? `<span style="font-weight:600;">PR #${prNumber}</span>`
+        : ''
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>Visual regression report</title>
+<style>
+  body { font: 14px system-ui, sans-serif; margin: 0; background: #fafafa; color: #222; }
+  header.top { position: sticky; top: 0; background: #fff; border-bottom: 1px solid #e5e5e5; padding: 16px 24px; z-index: 2; }
+  .counts { display: flex; gap: 16px; margin-top: 8px; }
+  .counts span { font-weight: 600; }
+  main { padding: 24px; }
+  .row { background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .row header { padding: 12px 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid #f0f0f0; }
+  .row h2 { margin: 0; font-size: 14px; font-weight: 600; flex: 1; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: #f0f0f0; }
+  figure { margin: 0; background: #fff; padding: 12px; }
+  figcaption { font-size: 12px; color: #666; margin-bottom: 8px; }
+  img { max-width: 100%; display: block; border: 1px solid #eee; }
+  .pill { padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
+  .pass { background: #e7f6ec; color: #1a7f37; }
+  .fail { background: #ffebe9; color: #cf222e; }
+  .new { background: #ddf4ff; color: #0969da; }
+  .gone { background: #fff1e5; color: #9a6700; }
+  .meta { font-size: 12px; color: #666; }
+  .filter { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 8px; }
+  .filter button { font-size: 12px; padding: 4px 10px; border: 1px solid #ddd; background: #fff; border-radius: 4px; cursor: pointer; }
+  .filter button.active { background: #0969da; color: #fff; border-color: #0969da; }
+  .filter input[type=search] { flex: 1; min-width: 180px; max-width: 320px; margin-left: auto; padding: 4px 10px; border: 1px solid #ddd; border-radius: 4px; font: inherit; }
+  .source-link { font-size: 12px; color: #0969da; text-decoration: none; margin-left: auto; }
+  .source-link:hover { text-decoration: underline; }
+  [data-hidden] { display: none; }
+  .thumb { cursor: zoom-in; }
+
+  .lightbox { position: fixed; inset: 0; background: rgba(10,10,10,0.92); z-index: 100; display: none; flex-direction: column; }
+  .lightbox.open { display: flex; }
+  .lightbox .bar { display: flex; align-items: center; gap: 12px; padding: 12px 16px; color: #eee; background: rgba(0,0,0,0.5); border-bottom: 1px solid #333; }
+  .lightbox .bar h3 { margin: 0; font-size: 14px; font-weight: 600; flex: 1; }
+  .lightbox .bar button { background: transparent; color: #eee; border: 1px solid #555; padding: 4px 10px; border-radius: 4px; cursor: pointer; font: inherit; }
+  .lightbox .bar button.active { background: #fff; color: #111; border-color: #fff; }
+  .lightbox .viewer { flex: 1; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 16px; }
+  .lightbox .viewer.actual-size { align-items: flex-start; }
+  .lightbox .viewer > img { display: block; background: #fff; max-width: 100%; max-height: 100%; object-fit: contain; }
+  .lightbox .viewer.actual-size > img { max-width: none; max-height: none; image-rendering: pixelated; }
+  .lightbox .slider { position: relative; user-select: none; background: #fff; flex-shrink: 0; }
+  .lightbox .slider img { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+  .lightbox .slider .top { clip-path: inset(0 0 0 var(--split, 50%)); }
+  .lightbox .slider .handle { position: absolute; top: 0; bottom: 0; left: var(--split, 50%); width: 2px; background: #ff0080; cursor: ew-resize; transform: translateX(-1px); }
+  .lightbox .slider .handle::after { content: ''; position: absolute; top: 50%; left: 50%; width: 28px; height: 28px; margin: -14px 0 0 -14px; background: #ff0080; border-radius: 50%; box-shadow: 0 0 0 3px rgba(255,255,255,0.4); }
+</style></head>
+<body>
+  <header class="top">
+    <div style="display:flex;align-items:baseline;gap:12px;">
+      <h1 style="margin:0;font-size:18px;">Visual regression report</h1>
+      ${prBadge}
+    </div>
+    <div class="counts">
+      <span>Total: ${summary.total}</span>
+      <span style="color:#1a7f37;">OK: ${summary.unchanged}</span>
+      <span style="color:#cf222e;">Changed: ${summary.changed}</span>
+      <span style="color:#0969da;">New: ${summary.added}</span>
+      <span style="color:#9a6700;">Removed: ${summary.removed}</span>
+    </div>
+    <div class="filter">
+      <button data-filter="all" class="active">All</button>
+      <button data-filter="changed">Changed</button>
+      <button data-filter="added">New</button>
+      <button data-filter="removed">Removed</button>
+      <button data-filter="unchanged">Unchanged</button>
+      <input id="search" type="search" placeholder="Filter by name…" autocomplete="off" />
+    </div>
+  </header>
+  <main>${results.map(r => row(r, meta ?? null, sourceBaseUrl)).join('')}</main>
+
+  <div class="lightbox" id="lb" aria-hidden="true">
+    <div class="bar">
+      <h3 id="lb-title"></h3>
+      <div id="lb-modes">
+        <button data-mode="baseline">Baseline</button>
+        <button data-mode="actual">Actual</button>
+        <button data-mode="diff">Diff</button>
+        <button data-mode="slider" id="lb-slider-btn">Slider</button>
+      </div>
+      <button id="lb-zoom">1:1</button>
+      <button id="lb-prev" aria-label="Previous">‹</button>
+      <button id="lb-next" aria-label="Next">›</button>
+      <button id="lb-close" aria-label="Close">✕</button>
+    </div>
+    <div class="viewer" id="lb-viewer"></div>
+  </div>
+
+  <script>
+    (function () {
+      const listState = { filter: 'all', query: '' }
+
+      function applyFilters() {
+        const q = listState.query.toLowerCase()
+        document.querySelectorAll('.row').forEach(r => {
+          const matchesFilter = listState.filter === 'all' || r.dataset.status === listState.filter
+          const matchesQuery = !q || r.dataset.name.toLowerCase().includes(q)
+          if (matchesFilter && matchesQuery) r.removeAttribute('data-hidden')
+          else r.setAttribute('data-hidden', '')
+        })
+      }
+
+      document.querySelectorAll('.filter button').forEach(btn => {
+        btn.addEventListener('click', () => {
+          listState.filter = btn.dataset.filter
+          document.querySelectorAll('.filter button').forEach(b => b.classList.toggle('active', b === btn))
+          applyFilters()
+        })
+      })
+
+      let searchTimer
+      document.getElementById('search').addEventListener('input', (e) => {
+        clearTimeout(searchTimer)
+        searchTimer = setTimeout(() => {
+          listState.query = e.target.value.trim()
+          applyFilters()
+        }, 150)
+      })
+
+      const lb = document.getElementById('lb')
+      const lbTitle = document.getElementById('lb-title')
+      const lbViewer = document.getElementById('lb-viewer')
+      const lbSliderBtn = document.getElementById('lb-slider-btn')
+      const lbZoomBtn = document.getElementById('lb-zoom')
+      const state = { rows: [], idx: 0, mode: 'diff', zoom: false }
+
+      function applyZoom() {
+        lbViewer.classList.toggle('actual-size', state.zoom)
+        lbZoomBtn.classList.toggle('active', state.zoom)
+        lbZoomBtn.textContent = state.zoom ? 'Fit' : '1:1'
+      }
+
+      function refreshRows() {
+        state.rows = Array.from(document.querySelectorAll('.row')).filter(r => !r.hasAttribute('data-hidden'))
+      }
+
+      function render() {
+        const row = state.rows[state.idx]
+        if (!row) return
+        const name = row.dataset.name
+        const status = row.dataset.status
+        const hasBoth = row.dataset.hasBoth === 'true'
+        lbTitle.textContent = name + '  (' + (state.idx + 1) + '/' + state.rows.length + ') · ' + status
+        lbSliderBtn.style.display = hasBoth ? '' : 'none'
+
+        document.querySelectorAll('#lb-modes button').forEach(b => {
+          b.classList.toggle('active', b.dataset.mode === state.mode)
+        })
+
+        const availableModes = {
+          baseline: status !== 'added',
+          actual: status !== 'removed',
+          diff: status === 'changed',
+          slider: hasBoth
+        }
+        if (!availableModes[state.mode]) state.mode = availableModes.diff ? 'diff' : (availableModes.actual ? 'actual' : 'baseline')
+
+        if (state.mode === 'slider') {
+          lbViewer.innerHTML = ''
+          const wrap = document.createElement('div')
+          wrap.className = 'slider'
+          const bot = document.createElement('img')
+          bot.src = 'baseline/' + name
+          const top = document.createElement('img')
+          top.src = 'actual/' + name
+          top.className = 'top'
+          const handle = document.createElement('div')
+          handle.className = 'handle'
+          wrap.appendChild(bot)
+          wrap.appendChild(top)
+          wrap.appendChild(handle)
+          lbViewer.appendChild(wrap)
+
+          const sizeWrap = () => {
+            const nw = bot.naturalWidth, nh = bot.naturalHeight
+            if (!nw || !nh) return
+            if (state.zoom) {
+              wrap.style.width = nw + 'px'
+              wrap.style.height = nh + 'px'
+            } else {
+              const pad = 32
+              const vw = lbViewer.clientWidth - pad
+              const vh = lbViewer.clientHeight - pad
+              const scale = Math.min(vw / nw, vh / nh, 1)
+              wrap.style.width = Math.floor(nw * scale) + 'px'
+              wrap.style.height = Math.floor(nh * scale) + 'px'
+            }
+          }
+          if (bot.complete) sizeWrap()
+          else bot.onload = sizeWrap
+          window.addEventListener('resize', sizeWrap)
+
+          const onMove = (e) => {
+            const rect = wrap.getBoundingClientRect()
+            const x = (e.touches ? e.touches[0].clientX : e.clientX) - rect.left
+            const pct = Math.max(0, Math.min(100, (x / rect.width) * 100))
+            wrap.style.setProperty('--split', pct + '%')
+          }
+          let dragging = false
+          wrap.addEventListener('mousedown', (e) => { dragging = true; onMove(e); e.preventDefault() })
+          window.addEventListener('mousemove', (e) => { if (dragging) onMove(e) })
+          window.addEventListener('mouseup', () => { dragging = false })
+          wrap.addEventListener('touchstart', (e) => { onMove(e); e.preventDefault() }, { passive: false })
+          wrap.addEventListener('touchmove', (e) => { onMove(e); e.preventDefault() }, { passive: false })
+        } else {
+          lbViewer.innerHTML = '<img src="' + state.mode + '/' + name + '" alt="' + name + '" />'
+        }
+        applyZoom()
+      }
+
+      function open(name) {
+        refreshRows()
+        const i = state.rows.findIndex(r => r.dataset.name === name)
+        state.idx = i >= 0 ? i : 0
+        state.mode = 'diff'
+        lb.classList.add('open')
+        lb.setAttribute('aria-hidden', 'false')
+        render()
+      }
+
+      function close() {
+        lb.classList.remove('open')
+        lb.setAttribute('aria-hidden', 'true')
+        lbViewer.innerHTML = ''
+      }
+
+      document.querySelectorAll('.thumb').forEach(img => {
+        img.addEventListener('click', () => open(img.dataset.name))
+      })
+      document.getElementById('lb-close').addEventListener('click', close)
+      document.getElementById('lb-prev').addEventListener('click', () => {
+        if (!state.rows.length) return
+        state.idx = (state.idx - 1 + state.rows.length) % state.rows.length
+        render()
+      })
+      document.getElementById('lb-next').addEventListener('click', () => {
+        if (!state.rows.length) return
+        state.idx = (state.idx + 1) % state.rows.length
+        render()
+      })
+      document.querySelectorAll('#lb-modes button').forEach(b => {
+        b.addEventListener('click', () => { state.mode = b.dataset.mode; render() })
+      })
+      lbZoomBtn.addEventListener('click', () => { state.zoom = !state.zoom; render() })
+    })()
+  </script>
+</body></html>`
+}
+
+function run(args: Args): number {
+  const { actualDir, baselineDir, outputDir, threshold, failOnMissingBaseline } = args
+
+  mkdirSync(outputDir, { recursive: true })
+  const actuals = indexByName(walk(actualDir))
+  const baselines = indexByName(walk(baselineDir))
+
+  const results: Result[] = []
+  const allNames = new Set([...actuals.keys(), ...baselines.keys()])
+
+  for (const name of [...allNames].sort()) {
+    const a = actuals.get(name)
+    const b = baselines.get(name)
+
+    if (a && !b) {
+      copyInto(a.path, join(outputDir, 'actual'), name)
+      results.push({ name, status: 'added' })
+      continue
+    }
+    if (!a && b) {
+      copyInto(b.path, join(outputDir, 'baseline'), name)
+      results.push({ name, status: 'removed' })
+      continue
+    }
+    if (!a || !b) continue
+
+    copyInto(a.path, join(outputDir, 'actual'), name)
+    copyInto(b.path, join(outputDir, 'baseline'), name)
+
+    const baseline = loadPng(b.path)
+    const actual = loadPng(a.path)
+    const { diff, numDiff, sizeMismatch } = diffPair(baseline, actual, threshold)
+    mkdirSync(join(outputDir, 'diff'), { recursive: true })
+    writeFileSync(join(outputDir, 'diff', name), PNG.sync.write(diff))
+
+    const status: Status = numDiff === 0 && !sizeMismatch ? 'unchanged' : 'changed'
+    results.push({ name, status, numDiff, sizeMismatch })
+  }
+
+  const summary = {
+    total: results.length,
+    unchanged: results.filter(r => r.status === 'unchanged').length,
+    changed: results.filter(r => r.status === 'changed').length,
+    added: results.filter(r => r.status === 'added').length,
+    removed: results.filter(r => r.status === 'removed').length
+  }
+
+  writeFileSync(
+    join(outputDir, 'summary.json'),
+    JSON.stringify({ summary, results }, null, 2)
+  )
+  let meta: Meta | null = null
+  if (args.meta && existsSync(args.meta)) {
+    try {
+      meta = JSON.parse(readFileSync(args.meta, 'utf8'))
+    } catch {
+      meta = null
+    }
+  }
+
+  writeFileSync(
+    join(outputDir, 'index.html'),
+    renderHtml(results, summary, args.prNumber, args.prUrl, meta, args.sourceBaseUrl)
+  )
+
+  console.log(
+    `Total: ${summary.total} | OK: ${summary.unchanged} | Changed: ${summary.changed} | New: ${summary.added} | Removed: ${summary.removed}`
+  )
+
+  const missingBaseline = summary.added > 0 && failOnMissingBaseline
+  const hasRegressions = summary.changed > 0 || summary.removed > 0
+  return hasRegressions || missingBaseline ? 1 : 0
+}
+
+export default {
+  command: 'visual-diff',
+  desc: 'Diff visual regression screenshots and generate an HTML report',
+  builder: {
+    'actual-dir': {
+      type: 'string',
+      describe: 'Directory containing the newly captured screenshots',
+      default: 'cypress/screenshots'
+    },
+    'baseline-dir': {
+      type: 'string',
+      describe: 'Directory containing the baseline screenshots to diff against',
+      default: '.baselines'
+    },
+    'output-dir': {
+      type: 'string',
+      describe: 'Directory to write the HTML report, diff PNGs, and summary.json',
+      default: 'visual-report'
+    },
+    threshold: {
+      type: 'number',
+      describe: 'pixelmatch color threshold (0-1)',
+      default: 0.1
+    },
+    'fail-on-missing-baseline': {
+      type: 'boolean',
+      describe: 'Exit non-zero if actual screenshots have no matching baseline',
+      default: true
+    },
+    'pr-number': {
+      type: 'string',
+      describe: 'Pull request number to display in the report header'
+    },
+    'pr-url': {
+      type: 'string',
+      describe: 'Pull request URL to link from the report header'
+    },
+    meta: {
+      type: 'string',
+      describe: 'Path to a JSON file mapping screenshot slug to the visited URL path'
+    },
+    'source-base-url': {
+      type: 'string',
+      describe: 'Base URL for source-file links in the report (e.g. GitHub blob URL of the app root)'
+    }
+  },
+  handler: (argv: Args) => {
+    process.exit(run(argv))
+  }
+}

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -30,6 +30,8 @@
     "lerna": "9.0.7",
     "lodash.isplainobject": "^4.0.6",
     "mocha": "^10.7.3",
+    "pixelmatch": "^6.0.0",
+    "pngjs": "^7.0.0",
     "semver": "^7.7.4",
     "style-dictionary": "4.4.0",
     "webpack-cli": "^7.0.2",
@@ -45,6 +47,8 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.5",
     "fantasticon": "^3.0.0",
     "svgo": "^3.3.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3785,6 +3785,12 @@ importers:
       mocha:
         specifier: ^10.7.3
         version: 10.8.2
+      pixelmatch:
+        specifier: ^6.0.0
+        version: 6.0.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       semver:
         specifier: ^7.7.4
         version: 7.7.4
@@ -3801,6 +3807,12 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@types/pixelmatch':
+        specifier: ^5.2.6
+        version: 5.2.6
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       fantasticon:
         specifier: ^3.0.0
         version: 3.0.0
@@ -7460,6 +7472,12 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/pixelmatch@5.2.6':
+    resolution: {integrity: sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
 
@@ -7690,7 +7708,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -11875,6 +11893,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pixelmatch@6.0.0:
+    resolution: {integrity: sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==}
+    hasBin: true
+
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
     engines: {node: '>=6'}
@@ -11886,6 +11908,10 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
@@ -16367,6 +16393,14 @@ snapshots:
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
+
+  '@types/pixelmatch@5.2.6':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/prettier@2.7.3': {}
 
@@ -21677,6 +21711,10 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pixelmatch@6.0.0:
+    dependencies:
+      pngjs: 7.0.0
+
   pkg-dir@3.0.0:
     dependencies:
       find-up: 3.0.0
@@ -21693,6 +21731,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  pngjs@7.0.0: {}
 
   portfinder@1.0.38:
     dependencies:

--- a/regression-test/.gitignore
+++ b/regression-test/.gitignore
@@ -16,6 +16,7 @@
 /build
 /src/.next/
 /.next/
+/out/
 
 
 # misc
@@ -39,6 +40,12 @@ next-env.d.ts
 # cypress
 /cypress/downloads
 /cypress/screenshots
+/cypress/meta.json
+
+# visual regression local runs
+/.actual
+/.baselines
+/.report
 
 # claude
 .claude/settings.local.json

--- a/regression-test/README.md
+++ b/regression-test/README.md
@@ -1,9 +1,12 @@
 # Regression testing app
 
-This is a simple Next.js app importing (locally) @instructure/ui. This allows us to test a couple of different things:
+A small Next.js app that imports `@instructure/ui` locally and exposes one page per component. Cypress visits each page to:
 
-- With Cypress and Chromatic we can detect visual changes in our components (e.g. the `<Button/>` component got a larger padding)
-- With Cypress and axe-core we can detect a11y issues (e.g. the `<Button/>` component is missing an `aria-label`)
+- **Detect visual changes** — screenshots are diffed against baselines by the `ui-scripts visual-diff` command; an interactive HTML report is published to GitHub Pages on every PR.
+- **Detect a11y issues** — axe-core runs against every page.
+- **Detect unexpected console errors** — the spec's `afterEach` hook asserts `console.error` was not called.
+
+See the [visual regression testing guide](../docs/testing/visual-regression.md) for the full CI pipeline, the diff report UI, and tuning notes.
 
 ## Why npm instead of pnpm?
 
@@ -11,33 +14,33 @@ This app uses **npm** for package management, while the main InstUI monorepo use
 
 Since most external users install packages via npm, using it here helps us:
 
-- Test the package as it would be consumed in real-world scenarios
-- Catch potential issues with dependency resolution that differ between npm and pnpm
-- Ensure published packages work correctly with npm's installation behavior
+- Test the package as it would be consumed in real-world scenarios.
+- Catch potential issues with dependency resolution that differ between npm and pnpm.
+- Ensure published packages work correctly with npm's installation behavior.
 
-## Development
+## Running locally
 
-### To run this app and cypress tests locally
+From the repo root:
 
-1. Run `pnpm install` and `pnpm run bootstrap` from the project root.
-2. Then open the regression test folder: `cd regression-test`
-3. Install dependencies: `npm install`
-4. Run the dev server with `npm run dev`
-5. The dev server will be accessible at `localhost:3000`
-6. Once the dev server is running, you can start the Cypress e2e tests with the `npm run cypress` command. Run `npm run cypress-chrome` to open the Cypress GUI where you can see detailed error logs, snapshots etc.
-
-### To add a new component
-
-1. Create a new subfolder under `src/app` with the name of your new component and add an empty `page.tsx` file. E.g. if you want to create a page for `<Avatar/>`, create the page at `instructure-ui/regression-test/src/app/avatar/page.tsx`
-2. Add some examples for your component that are meaningfully different. This usually means setting some props like `disabled` or `renderLabel`. Your goal is to make a page that can be screenshotted by Chromatic and if an unexpected change happens in that component, the screenshot will have a pixel difference.
-3. After you have created an example page for the component, navigate to `instructure-ui/regression-test/cypress/e2e/spec.cy.ts` and add a new test block like this:
-
-```typescript
-it('check MyComponent', () => {
-  cy.visit('http://localhost:3000/my-component')
-  cy.injectAxe()
-  cy.checkA11y(undefined, undefined, terminalLog)
-})
+```sh
+pnpm install && pnpm run bootstrap
+cd regression-test
+npm install
 ```
 
-4. This should be it. Commit your changes and push it to remote. The CI tool should now include your new component in the Chromatic tests and also run Axe a11y checks on it.
+Then either:
+
+- `npm run dev` — Next dev server on `localhost:3000`, hot-reloads, great for authoring new pages.
+- `npm run build && npm start` — builds a static export to `out/` and serves it with `http-server` on `localhost:3000`. This is what CI uses.
+
+Run the Cypress suite against the running server:
+
+- `npm run cypress` — headless.
+- `npm run cypress-chrome` — opens the Cypress GUI.
+
+## Adding a new component
+
+1. Create `src/app/<component-name>/page.tsx`. Start the file with `'use client'` and wrap the rendered markup in an element with the `axe-test` class — that's what the axe-core check selects against.
+2. Add a corresponding `it(...)` block in `cypress/e2e/spec.cy.ts` that visits `http://localhost:3000/<component-name>`, calls `cy.injectAxe()`, and `cy.checkA11y('.axe-test', axeOptions, terminalLog)`.
+3. If the component animates or loads content asynchronously, add a `cy.wait(<ms>)` before `injectAxe()`.
+4. Commit and push. The first PR run will show the new screenshot as "New"; merging the PR promotes it to a baseline automatically.

--- a/regression-test/cypress.config.ts
+++ b/regression-test/cypress.config.ts
@@ -22,19 +22,21 @@
  * SOFTWARE.
  */
 import { defineConfig } from 'cypress'
-import { installPlugin } from '@chromatic-com/cypress'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+const META_FILE = 'cypress/meta.json'
 
 export default defineConfig({
-  env: {
-    delay: 100 // Chromatic snapshot delay time
-  },
+  screenshotsFolder: 'cypress/screenshots',
+  trashAssetsBeforeRuns: true,
+  video: false,
   e2e: {
+    viewportWidth: 1280,
+    viewportHeight: 800,
     setupNodeEvents(on, config) {
-      installPlugin(on, config)
-
-      // This registers a log task as seen in the Cypress docs for cy.task as well
-      // as a table task for sending tabular data to the terminal.
-      // More info: https://www.npmjs.com/package/cypress-axe
+      on('before:run', () => {
+        writeFileSync(META_FILE, '{}')
+      })
       on('task', {
         log(message) {
           console.log(message)
@@ -42,6 +44,14 @@ export default defineConfig({
         },
         table(message) {
           console.table(message)
+          return null
+        },
+        recordMeta({ name, pagePath }: { name: string; pagePath: string }) {
+          const data = existsSync(META_FILE)
+            ? JSON.parse(readFileSync(META_FILE, 'utf8'))
+            : {}
+          data[name] = pagePath
+          writeFileSync(META_FILE, JSON.stringify(data, null, 2))
           return null
         }
       })

--- a/regression-test/cypress/e2e/spec.cy.ts
+++ b/regression-test/cypress/e2e/spec.cy.ts
@@ -276,7 +276,7 @@ describe('visual regression test', () => {
 
   it('TreeBrowser', () => {
     cy.visit('http://localhost:3000/treebrowser')
-    cy.wait(600) // large timeout is needed for CI (to finish animation?)
+    cy.wait(1000) // large timeout is needed for CI (to finish animation?)
     // TODO axe fails with color contrast issues, try to remove animations from TreeBrowser
     //cy.injectAxe()
     //cy.checkA11y('.axe-test', axeOptions, terminalLog)

--- a/regression-test/cypress/support/e2e.ts
+++ b/regression-test/cypress/support/e2e.ts
@@ -40,9 +40,28 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-import '@chromatic-com/cypress/support'
-
 import 'cypress-axe'
+
+function slugify(s: string) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+afterEach(function () {
+  const test = this.currentTest
+  if (!test || test.state === 'failed') return
+  const name = slugify(test.title)
+  cy.location('pathname', { log: false }).then((pagePath) => {
+    cy.task('recordMeta', { name, pagePath }, { log: false })
+  })
+  cy.screenshot(name, {
+    capture: 'fullPage',
+    overwrite: true,
+    disableTimersAndAnimations: true
+  })
+})
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/regression-test/next.config.mjs
+++ b/regression-test/next.config.mjs
@@ -30,6 +30,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Fully static export: no SSR, no hydration mismatches that can cause
+  // screenshot flakiness. `next build` writes a plain static site to `out/`.
+  output: 'export',
+  // Emits out/<route>/index.html so any static server (including http-server)
+  // resolves /route without needing a .html fallback config.
+  trailingSlash: true,
+  images: { unoptimized: true },
   // strict mode needs to be disabled, so deterministic ID generation
   // works. If its enabled, client side double rendering causes IDs to
   // come out of sync. TODO fix

--- a/regression-test/package-lock.json
+++ b/regression-test/package-lock.json
@@ -10,12 +10,12 @@
       "dependencies": {
         "@instructure/ui": "file:../packages/ui",
         "@instructure/ui-icons": "file:../packages/ui-icons",
+        "@instructure/ui-scripts": "file:../packages/ui-scripts",
         "next": "16.2.3",
         "react": "19.2.5",
         "react-dom": "19.2.5"
       },
       "devDependencies": {
-        "@chromatic-com/cypress": "0.12.0",
         "@instructure/browserslist-config-instui": "11.7.1",
         "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "25.5.2",
@@ -23,11 +23,11 @@
         "@types/react-dom": "19.2.3",
         "autoprefixer": "10.4.27",
         "axe-core": "4.11.2",
-        "chromatic": "16.1.0",
         "cypress": "15.13.1",
         "cypress-axe": "1.7.0",
         "eslint": "9.39.4",
         "eslint-config-next": "16.2.3",
+        "http-server": "14.1.1",
         "postcss": "8.5.9",
         "tailwindcss": "4.2.2",
         "typescript": "5.9.3"
@@ -35,7 +35,7 @@
     },
     "../packages/ui": {
       "name": "@instructure/ui",
-      "version": "11.7.1",
+      "version": "11.7.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
@@ -123,7 +123,7 @@
     },
     "../packages/ui-icons": {
       "name": "@instructure/ui-icons",
-      "version": "11.7.1",
+      "version": "11.7.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
@@ -143,12 +143,43 @@
         "react": ">=18 <=19"
       }
     },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
+    "../packages/ui-scripts": {
+      "name": "@instructure/ui-scripts",
+      "version": "11.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/cli": "^7.27.2",
+        "@instructure/command-utils": "workspace:*",
+        "@instructure/pkg-utils": "workspace:*",
+        "@lerna/project": "^6.4.1",
+        "dprint": "^0.53.2",
+        "http-server": "^14.1.1",
+        "jscodeshift": "^0.16.1",
+        "lerna": "9.0.7",
+        "lodash.isplainobject": "^4.0.6",
+        "mocha": "^10.7.3",
+        "pixelmatch": "^6.0.0",
+        "pngjs": "^7.0.0",
+        "semver": "^7.7.4",
+        "style-dictionary": "4.4.0",
+        "webpack-cli": "^7.0.2",
+        "webpack-dev-server": "^5.2.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "ui-scripts": "lib/index.js"
+      },
+      "devDependencies": {
+        "@types/pixelmatch": "^5.2.6",
+        "@types/pngjs": "^6.0.5",
+        "fantasticon": "^3.0.0",
+        "svgo": "^3.3.2"
+      },
+      "peerDependencies": {
+        "eslint": "^9",
+        "react": ">=18 <=19",
+        "webpack": "^5"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -194,7 +225,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -389,16 +419,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -445,34 +465,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@chromatic-com/cypress": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@chromatic-com/cypress/-/cypress-0.12.0.tgz",
-      "integrity": "sha512-MUv1U4o2S5jU0T0Ngvp/M9JDpQOnOg67bYUjGOEs3RVgGhmhhOP/SeqX2LhWgzAeIdbrSdQBPNRwK6NxPWOPgg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
-        "@segment/analytics-node": "2.1.3",
-        "chrome-remote-interface": "^0.33.0",
-        "storybook": "10.2.13"
-      },
-      "bin": {
-        "archive-storybook": "dist/bin/archive-storybook.js",
-        "build-archive-storybook": "dist/bin/build-archive-storybook.js"
-      }
-    },
-    "node_modules/@chromaui/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18-noAbsolute",
-      "resolved": "https://registry.npmjs.org/@chromaui/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18-noAbsolute.tgz",
-      "integrity": "sha512-glB+dgHTLLiDS8ljwYDBb2EPNe/sPxz2uOWjm11PoDYmVw204VKzyq07jredeHs9nUocb47RyDcZWCa5Cbw3yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^8.4.38"
       }
     },
     "node_modules/@cypress/request": {
@@ -557,448 +549,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1740,6 +1290,10 @@
       "resolved": "../packages/ui-icons",
       "link": true
     },
+    "node_modules/@instructure/ui-scripts": {
+      "resolved": "../packages/ui-scripts",
+      "link": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1788,29 +1342,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@lukeed/uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lukeed/csprng": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2024,66 +1555,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@segment/analytics-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.7.0.tgz",
-      "integrity": "sha512-0DHSriS/oAB/2bIgOMv3fFV9/ivp39ibdOTTf+dDOhf+vlciBv0+MHw47k/6PRobbuls27cKkKZAKc4DDC2+gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.2.0",
-        "dset": "^3.1.4",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@segment/analytics-generic-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
-      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@segment/analytics-node": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.1.3.tgz",
-      "integrity": "sha512-xwMkyXgr7xgPsP0w79nzCwRHYi9jzj9ps4Im7xWGK8AKKE4eox39tMZOdRtpDbvXQlrs9fh64ZC0w/yZZDM/9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.7.0",
-        "@segment/analytics-generic-utils": "1.2.0",
-        "buffer": "^6.0.3",
-        "jose": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "tslib": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@storybook/global": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
-      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@storybook/icons": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.1.tgz",
-      "integrity": "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2317,6 +1788,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -2365,77 +1900,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2446,31 +1910,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
-      }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2509,7 +1948,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2601,7 +2039,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3069,71 +2506,12 @@
         "win32"
       ]
     },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3465,29 +2843,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/ast-types": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3504,6 +2859,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -3608,7 +2970,6 @@
       "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -3665,6 +3026,26 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -3736,7 +3117,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3751,31 +3131,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -3784,22 +3139,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cachedir": {
@@ -3899,23 +3238,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3944,54 +3266,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/chromatic": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.1.0.tgz",
-      "integrity": "sha512-7xyOUXe8jfY6c+g9S/U/cbvzVXMjdhh9cVZYvDp8dDGonjiKSbWO1dzWApdYHIiF2xj29pvWQB7N5LT6967IDw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
-      },
-      "peerDependencies": {
-        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@chromatic-com/cypress": {
-          "optional": true
-        },
-        "@chromatic-com/playwright": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/chrome-remote-interface": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
-      "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "2.11.x",
-        "ws": "^7.2.0"
-      },
-      "bin": {
-        "chrome-remote-interface": "bin/client.js"
       }
     },
     "node_modules/ci-info": {
@@ -4123,13 +3397,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -4161,6 +3428,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4175,13 +3452,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4404,52 +3674,12 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -4467,19 +3697,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -4510,16 +3727,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4541,23 +3748,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -4630,7 +3820,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -4817,48 +4006,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4888,7 +4035,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5029,7 +4175,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5353,20 +4498,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -5417,6 +4548,13 @@
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
       "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5655,6 +4793,27 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -6086,6 +5245,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -6101,6 +5270,62 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/http-signature": {
@@ -6126,6 +5351,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -6366,22 +5604,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6449,25 +5671,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -6728,22 +5931,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -6791,16 +5978,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -7406,13 +6583,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7421,16 +6591,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7484,6 +6644,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -7515,16 +6688,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7711,27 +6874,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -7901,23 +7043,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -8051,16 +7184,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8104,6 +7227,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8134,7 +7271,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8173,41 +7309,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -8301,7 +7402,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8311,7 +7411,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8325,37 +7424,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/recast": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
-      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.16.1",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tiny-invariant": "^1.3.3",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8410,6 +7478,13 @@
       "dependencies": {
         "throttleit": "^1.0.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8483,19 +7558,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -8618,6 +7680,13 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -8848,16 +7917,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8912,64 +7971,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/storybook": {
-      "version": "10.2.13",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.13.tgz",
-      "integrity": "sha512-heMfJjOfbHvL+wlCAwFZlSxcakyJ5yQDam6e9k2RRArB1veJhRnsjO6lO1hOXjJYrqxfHA/ldIugbBVlCDqfvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.1",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
-        "open": "^10.2.0",
-        "recast": "^0.23.5",
-        "semver": "^7.7.3",
-        "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "storybook": "dist/bin/dispatcher.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "prettier": "^2 || ^3"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/storybook/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/string-width": {
@@ -9140,19 +8141,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9283,13 +8271,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -9331,32 +8312,11 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9414,13 +8374,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -9581,7 +8534,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9639,6 +8591,18 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -9736,15 +8700,12 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -9771,22 +8732,18 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -9911,44 +8868,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9986,7 +8905,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/regression-test/package.json
+++ b/regression-test/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "dev": "next dev --webpack",
     "build": "next build --webpack",
-    "start": "next start",
+    "start": "http-server out -p 3000 -s --no-dotfiles",
     "lint": "next lint",
     "cypress": "ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=9222 cypress run",
-    "cypress-chrome": "cypress open --browser chrome"
+    "cypress-chrome": "cypress open --browser chrome",
+    "visual-diff": "ui-scripts visual-diff --actual-dir cypress/screenshots --baseline-dir .baselines --output-dir .report"
   },
   "keywords": [],
   "devDependencies": {
-    "@chromatic-com/cypress": "0.12.0",
     "@instructure/browserslist-config-instui": "11.7.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "25.5.2",
@@ -21,9 +21,9 @@
     "@types/react-dom": "19.2.3",
     "autoprefixer": "10.4.27",
     "axe-core": "4.11.2",
-    "chromatic": "16.1.0",
     "cypress": "15.13.1",
     "cypress-axe": "1.7.0",
+    "http-server": "14.1.1",
     "eslint": "9.39.4",
     "eslint-config-next": "16.2.3",
     "postcss": "8.5.9",
@@ -33,6 +33,7 @@
   "dependencies": {
     "@instructure/ui": "file:../packages/ui",
     "@instructure/ui-icons": "file:../packages/ui-icons",
+    "@instructure/ui-scripts": "file:../packages/ui-scripts",
     "next": "16.2.3",
     "react": "19.2.5",
     "react-dom": "19.2.5"

--- a/regression-test/src/app/treebrowser/page.tsx
+++ b/regression-test/src/app/treebrowser/page.tsx
@@ -58,6 +58,7 @@ export default function TreeBrowserPage() {
     <main className="flex gap-12 p-8 flex-col items-start axe-test">
       <section>
         <TreeBrowser
+          animation={false}
           size="large"
           collections={{
             1: {
@@ -106,6 +107,7 @@ export default function TreeBrowserPage() {
       {/* Customizing icons example */}
       <section>
         <TreeBrowser
+          animation={false}
           collections={{
             1: { id: 1, name: 'Grades', collections: [], items: [1, 2, 3] }
           }}
@@ -126,6 +128,7 @@ export default function TreeBrowserPage() {
       {/* Different icons per item via getItemProps */}
       <section>
         <TreeBrowser
+          animation={false}
           collections={{
             1: { id: 1, name: 'Saved', collections: [], items: [1, 2, 3] }
           }}


### PR DESCRIPTION
## Summary

Replaces the Chromatic-based visual regression flow with a self-hosted pipeline that runs entirely on GitHub infrastructure.

**What changed**

- New `ui-scripts visual-diff` command (`packages/ui-scripts/lib/commands/visual-diff.ts`) compares screenshot directories with `pixelmatch` and generates a self-contained HTML report.
- `.github/workflows/visual-regression.yml` runs on every PR: builds InstUI, builds and serves the `regression-test` Next.js app, captures screenshots with Cypress, fetches baselines from the new `visual-baselines` branch, diffs, and publishes the report to `gh-pages` under `visual-regression/pr-<N>/`.
- `.github/workflows/visual-baselines.yml` runs on every push to `master` and force-pushes the fresh capture set to the `visual-baselines` branch. No manual review step — merging is the approval.
- `regression-test` now uses `next build` with `output: 'export'` and is served by `http-server`. No SSR, no hydration mismatches, byte-deterministic captures.
- Captures are full-page at a fixed 1280×800 viewport, with timers and animations disabled.
- Sticky PR comment summarizes the run and inlines each changed row's diff image inside a collapsed `<details>` block.
- Report UI: lightbox viewer with Baseline/Actual/Diff toggle, draggable slider overlay, 1:1/Fit zoom, prev/next navigation, highlighted active filter, debounced search, per-row source-file link to the component page.
- `docs/testing/visual-regression.md` documents the pipeline, local dev loop, CLI flags, report controls, and tuning advice. `testing-overview.md` updated, `regression-test/README.md` rewritten.
- Chromatic deps (`chromatic`, `@chromatic-com/cypress`) removed from `regression-test/package.json`. `CHROMATIC_APP_CODE` secret is no longer used.

**Not merged to master**

- `.github/workflows/seed-baselines-temp.yml` — throwaway workflow that seeds the `visual-baselines` branch before this PR lands, so diffing can be exercised end-to-end. **Delete before merge.**
- `regression-test/src/app/button/page.tsx` contains a visible test change to trigger the Changed state. **Revert before merge.**

## Test plan

- [ ] `Capture, diff, and publish report` job runs and publishes to `https://instructure.design/visual-regression/pr-2522/`.
- [ ] Sticky PR comment lists `⚠️ Changes detected`, `Changed: 1, Unchanged: 31`, and the collapsed `Diff images` block shows the inline diff for `button-and-derivatives.png`.
- [ ] Open the report URL — confirm:
  - [ ] Top bar shows `PR #2522` link back to this PR.
  - [ ] Filter buttons (All / Changed / New / Removed / Unchanged) highlight the active one when clicked.
  - [ ] Search box filters rows live (debounced ~150ms) and combines with the active filter.
  - [ ] Each row header shows a GitHub link to the corresponding `page.tsx` in this PR's branch.
  - [ ] Click a thumbnail — lightbox opens, Baseline/Actual/Diff tabs switch correctly, Slider mode overlays with an aligned drag handle, 1:1/Fit zoom toggle works, prev/next navigate between visible rows.
- [ ] Revert the test-break commit locally; push again — diff count returns to 0 and the check goes green.
- [ ] `Cypress component tests`, `Vitest unit tests`, `Lint commit msg + code`, `Analyze (javascript)`, `CodeQL` pass.

## Follow-ups before merging

- [ ] Delete `.github/workflows/seed-baselines-temp.yml`.
- [ ] Revert `test: break button to exercise diffing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
