### PR TITLE
refactor(ui-text): add 'inherit' prop to Text

### DIFF
--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -1175,9 +1175,10 @@ type: embed
 
 ### Text
 
+- The default `color` prop value has been changed from `undefined` (inherit) to `primary` meaning if you don't set any value, it will have the `primary` color instead of the inherited color.
+- Added three new colors: `primary-on` and `secondary-on`, these are used for colored surfaces; `inherit` inherits the color from its ancestor.
 - `alert` color has been removed. Please use `primary` instead.
 - Some prop values have been deprecated, see [Text](/Text) for more details.
-- `color` has 2 new values: `primary-on` and `secondary-on`, these are used for colored surfaces.
 
 ### TextArea
 

--- a/packages/ui-text/src/Text/v2/README.md
+++ b/packages/ui-text/src/Text/v2/README.md
@@ -34,6 +34,9 @@ type: example
 type: example
 ---
 <div>
+  <span style={{color: 'red'}}>
+    <Text color="inherit">I inherit my color from the 'color' CSS property</Text>
+  </span><br/>
   <Text color="primary">I&#39;m primary text</Text><br/>
   <Text color="secondary">I&#39;m secondary text</Text><br/>
   <Text color="brand">I&#39;m brand text</Text><br />

--- a/packages/ui-text/src/Text/v2/props.ts
+++ b/packages/ui-text/src/Text/v2/props.ts
@@ -39,6 +39,7 @@ type TextOwnProps = {
    * Color of the text
    */
   color?:
+    | 'inherit'
     | 'primary'
     | 'secondary'
     | 'brand'

--- a/packages/ui-text/src/Text/v2/styles.ts
+++ b/packages/ui-text/src/Text/v2/styles.ts
@@ -112,6 +112,7 @@ const generateStyle = (
   }
 
   const colorVariants = {
+    inherit: {},
     primary: { color: componentTheme.baseColor },
     secondary: { color: componentTheme.mutedColor },
     'primary-inverse': { color: componentTheme.inverseColor },

--- a/regression-test/src/app/small-components/page.tsx
+++ b/regression-test/src/app/small-components/page.tsx
@@ -134,6 +134,9 @@ export default function SmallComponentsPage() {
         <Text variant="contentImportant"> contentImportant </Text>
       </div>
       <div>
+        <span style={{ color: 'red' }}>
+          <Text color="inherit"> inherit </Text>
+        </span>
         <Text variant="contentQuote"> contentQuote </Text>
         <Text variant="contentSmall"> contentSmall </Text>
         <Text variant="legend"> legend </Text>


### PR DESCRIPTION
The v2 Text component uses the 'primary' color by default, v1 none (inherit). Add an 'inherit' value to v2 Text, so previous behaviour can be emulated.

To test: Check the updated docs that it looks correct