### PR TITLE
type the new themeoverride object

### DIFF
--- a/packages/emotion/src/InstUISettingsProvider/index.tsx
+++ b/packages/emotion/src/InstUISettingsProvider/index.tsx
@@ -32,22 +32,61 @@ import { getTheme } from '../getTheme'
 
 import type { ThemeOrLegacyOverride } from '../EmotionTypes'
 import type { DeterministicIdProviderValue } from '@instructure/ui-react-utils'
+import type { NewThemeOverrideObject, Theme } from '@instructure/ui-themes'
 declare const process: Record<string, any> | undefined
 
 type InstUIProviderProps = {
   children?: React.ReactNode
 
   /**
-   * A full theme or an override object
+   * A full theme or an override object. The override only works for legacy
+   * (v11.6 or earlier) themes, for newer ones use the `themeOverride` prop.
    */
   theme?: ThemeOrLegacyOverride
 
-  // TODO-theme-types: fix override typing
-  // TODO explain the usage of this override object. It will be deep merged into theme.themeOverride and the shape has to be a partial of the "newTheme" object
   /**
-   * An override object for the new theming system.
+   * An override object for the new theming system. It will be deep merged into
+   * the theme. One can override primitives, semantics and individual component's
+   * themes, for example:
+   * ```js
+   * themeOverride={{
+   *   semantics: {
+   *     color: {
+   *       stroke: {
+   *         error: 'purple'
+   *       }
+   *     }
+   *   },
+   *   primitives: {
+   *     color: {
+   *       blue: {
+   *         blue100: 'yellow'
+   *       }
+   *     }
+   *   },
+   *   components: {
+   *     Alert: {
+   *       background: 'brown',
+   *       infoIconBackground: 'darkblue',
+   *       borderWidth: '0.5rem'
+   *     },
+   *     Pill: {
+   *       baseTextColor: 'purple',
+   *       baseBorderColor: 'purple'
+   *     }
+   *   },
+   *   sharedTokens: {
+   *     focusOutline: {
+   *       width: '0.55rem',
+   *       infoColor: 'deeppink'
+   *     }
+   *   }
+   * }}
+   * ```
    */
-  themeOverride?: any
+  themeOverride?:
+    | NewThemeOverrideObject
+    | ((theme: Theme) => NewThemeOverrideObject)
 
   /**
    * @deprecated the `instanceCounterMap` prop is deprecated. You don't need to supply the
@@ -100,7 +139,6 @@ function InstUISettingsProvider({
    * For backward compatibility reasons, the old way of passing a partial theme to the theme prop is still supported, however only for
    * legacy (pre v11_7) components. Overriding the newTheme this way could break the system.
    */
-
   let providers = (
     <DeterministicIdContextProvider instanceCounterMap={instanceCounterMap}>
       <ThemeProvider theme={getTheme(theme, themeOverride)}>
@@ -120,3 +158,4 @@ function InstUISettingsProvider({
 
 export default InstUISettingsProvider
 export { InstUISettingsProvider }
+export type { InstUIProviderProps }

--- a/packages/emotion/src/getTheme.ts
+++ b/packages/emotion/src/getTheme.ts
@@ -24,13 +24,14 @@
 import canvas from '@instructure/ui-themes'
 import { isBaseTheme, mergeDeep } from '@instructure/ui-utils'
 
-import type { BaseTheme } from '@instructure/shared-types'
+import type { Theme } from '@instructure/ui-themes'
 
 import type {
   Overrides,
   ThemeOrLegacyOverride,
   SpecificThemeOverride
 } from './EmotionTypes'
+import { InstUIProviderProps } from './InstUISettingsProvider'
 declare const process: Record<string, any> | undefined
 
 /**
@@ -45,14 +46,20 @@ declare const process: Record<string, any> | undefined
  * the overrides merged together.
  *
  * @param themeOrLegacyOverride - A full theme or an override object
- * @param themeOverride - if provided, it means it's a new theming-system override. This will be merged into theme.themeOverride and will be treated separately from the old way of applying overrides. This override will be applied in the withStyle.ts decorator
+ * @param themeOverride - if provided, it means it's a new theming-system override.
+ * This will be merged into theme.themeOverride and will be treated separately
+ * from the old way of applying overrides. This override will be applied in the
+ * `withStyle.ts` decorator
  * @returns A function that returns with the theme object for the [ThemeProvider](https://emotion.sh/docs/theming#themeprovider-reactcomponenttype)
  *    This function is called by Emotion on theme provider creation, where
  *    `ancestorTheme` is a theme object from an ancestor `ThemeProvider`
  */
 const getTheme =
-  (themeOrLegacyOverride: ThemeOrLegacyOverride, themeOverride?: any) =>
-  (ancestorTheme = {} as BaseTheme) => {
+  (
+    themeOrLegacyOverride: ThemeOrLegacyOverride,
+    themeOverride?: InstUIProviderProps['themeOverride']
+  ) =>
+  (ancestorTheme = {} as Theme) => {
     // we need to clone the ancestor theme not to override it
     let currentTheme
     if (Object.keys(ancestorTheme).length === 0) {

--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -43,6 +43,7 @@ export { useStyleLegacy } from './useStyleLegacy'
 export { useStyle } from './useStyle'
 export { useTheme } from './useTheme'
 
+export type { InstUIProviderProps } from './InstUISettingsProvider'
 export type { ComponentStyle, StyleObject, Overrides } from './EmotionTypes'
 export type { WithStyleProps } from './withStyle'
 export type { ThemeOverrideValue } from './useStyle'

--- a/packages/emotion/src/useStyle.ts
+++ b/packages/emotion/src/useStyle.ts
@@ -45,9 +45,9 @@ type GenerateStyleParams =
 type ThemeOverrideValue =
   | Partial<Theme>
   | ((
-    componentTheme: Theme,
-    currentTheme: NewComponentTypes[keyof NewComponentTypes]
-  ) => Partial<Theme>)
+      componentTheme: Theme,
+      currentTheme: NewComponentTypes[keyof NewComponentTypes]
+    ) => Partial<Theme>)
 
 /**
  * new useStyle syntax, use this with v12 themes
@@ -70,42 +70,37 @@ const useStyle = <P extends GenerateStyleParams>(useStyleParams: {
   const themeInContext = useTheme() as Theme
 
   const themeOverrideFromProvider = themeInContext.themeOverride
-  const componentWithTokensId = useTokensFrom ?? componentId
+  const componentWithTokensId =
+    useTokensFrom ?? (componentId as keyof NewComponentTypes)
 
   // resolving the theming functions and applying the overrides
   const primitiveOverrides = themeOverrideFromProvider?.primitives
   const semanticsOverrides = themeOverrideFromProvider?.semantics
-  // @ts-ignore TODO-theme-types: fix typing
   const sharedTokensOverrides = themeOverrideFromProvider?.sharedTokens
   const componentOverridesFromSettingsProvider =
-    // @ts-ignore TODO-theme-types: fix typing
-    themeOverrideFromProvider?.components?.[
-    componentWithTokensId as keyof NewComponentTypes
-    ]
+    themeOverrideFromProvider?.components?.[componentWithTokensId]
 
   const primitives = mergeDeep(
     themeInContext.newTheme.primitives,
-    primitiveOverrides
+    primitiveOverrides!
   )
 
   const semantics = mergeDeep(
     themeInContext.newTheme.semantics?.(primitives),
-    semanticsOverrides
+    semanticsOverrides!
   )
 
   const sharedTokens = mergeDeep(
     themeInContext.newTheme.sharedTokens?.(semantics),
-    sharedTokensOverrides
+    sharedTokensOverrides as Record<string, unknown>
   )
 
   const baseComponentTheme =
-    themeInContext.newTheme.components[
-      componentWithTokensId as keyof NewComponentTypes
-    ]?.(semantics)
+    themeInContext.newTheme.components[componentWithTokensId]?.(semantics)
 
   const componentThemeFromSettingsProvider = mergeDeep(
     baseComponentTheme,
-    componentOverridesFromSettingsProvider
+    componentOverridesFromSettingsProvider as Record<string, unknown>
   )
 
   const componentTheme = mergeDeep(
@@ -113,9 +108,9 @@ const useStyle = <P extends GenerateStyleParams>(useStyleParams: {
     // @ts-ignore TODO-theme-types: fix typing
     typeof themeOverride === 'function'
       ? themeOverride(
-        componentThemeFromSettingsProvider as Theme,
-        themeInContext as any
-      )
+          componentThemeFromSettingsProvider as Theme,
+          themeInContext as any
+        )
       : themeOverride
   )
 

--- a/packages/emotion/src/withStyle.tsx
+++ b/packages/emotion/src/withStyle.tsx
@@ -49,7 +49,11 @@ import type {
   Props
 } from './EmotionTypes'
 
-import type { NewComponentTypes, Theme } from '@instructure/ui-themes'
+import type {
+  NewComponentTypes,
+  SharedTokens,
+  Theme
+} from '@instructure/ui-themes'
 
 // Extract is needed because it would allow number otherwise
 // https://stackoverflow.com/a/51808262/319473
@@ -154,7 +158,7 @@ const withStyle = decorator(
   ) => {
     const displayName = ComposedComponent.displayName || ComposedComponent.name
 
-    const componentId =
+    const componentId: keyof NewComponentTypes =
       useTokensFrom ?? ComposedComponent.componentId?.replace('.', '')
 
     const WithStyle: ForwardRefExoticComponent<
@@ -208,38 +212,34 @@ const withStyle = decorator(
       // resolving the theming functions and applying the overrides
       const primitiveOverrides = themeOverride?.primitives
       const semanticsOverrides = themeOverride?.semantics
-      // @ts-ignore TODO-theme-types: fix typing
       const sharedTokensOverrides = themeOverride?.sharedTokens
       const componentOverridesFromSettingsProvider =
-        // @ts-ignore TODO-theme-types: fix typing
-        themeOverride?.components?.[componentId as keyof NewComponentTypes]
+        themeOverride?.components?.[componentId]
       const componentOverridesFromThemeOverrideProp = (
         componentProps as ThemeOverrideProp
       ).themeOverride
 
       const primitives = mergeDeep(
         theme.newTheme.primitives,
-        primitiveOverrides
+        primitiveOverrides!
       )
 
       const semantics = mergeDeep(
         theme.newTheme.semantics?.(primitives),
-        semanticsOverrides
+        semanticsOverrides!
       )
 
       const sharedTokens = mergeDeep(
         theme.newTheme.sharedTokens?.(semantics),
-        sharedTokensOverrides
-      )
+        sharedTokensOverrides as Record<string, unknown>
+      ) as SharedTokens
       // Note: Some components do not have a theme, e.g., FormFieldMessages
       const baseComponentTheme =
-        theme.newTheme.components[componentId as keyof NewComponentTypes]?.(
-          semantics
-        )
+        theme.newTheme.components[componentId]?.(semantics)
 
       const componentThemeFromSettingsProvider = mergeDeep(
         baseComponentTheme,
-        componentOverridesFromSettingsProvider
+        componentOverridesFromSettingsProvider as Record<string, unknown>
       )
 
       const componentTheme = mergeDeep(

--- a/packages/shared-types/src/BaseTheme.ts
+++ b/packages/shared-types/src/BaseTheme.ts
@@ -175,6 +175,9 @@ type Size = {
 type Radius = Size
 type StrokeWidth = Size
 
+/**
+ * Theme variables used in old (11.6 and earlier) themes
+ */
 type BaseThemeVariables = {
   borders: Border
   breakpoints: Breakpoints
@@ -204,7 +207,6 @@ type BaseThemeVariableKeys = [
 type BaseTheme = {
   key: string
   description?: string
-  themeOverride?: { primitives: any; semantics: any }
 } & BaseThemeVariables
 
 export type {

--- a/packages/ui-themes/src/index.ts
+++ b/packages/ui-themes/src/index.ts
@@ -37,7 +37,8 @@ import type {
   Primitives,
   AdditionalPrimitives,
   DataVisualization,
-  UI
+  UI,
+  DeepPartial
 } from '@instructure/shared-types'
 
 import canvasHighContrast from './themes/canvasHighContrast'
@@ -70,11 +71,23 @@ type ThemeMap = {
 
 type ThemeKeys = keyof ThemeMap
 
+// converts `AA: (semantics: any) => AA` to `AA: AA`
+type NewComponentsAsValue = {
+  [K in keyof NewComponentTypes]: ReturnType<NewComponentTypes[K]>
+}
+
+type NewThemeOverrideObject = {
+  primitives?: Record<string, any>
+  semantics?: Record<string, any>
+  sharedTokens?: DeepPartial<SharedTokens>
+  components?: DeepPartial<NewComponentsAsValue>
+}
+
 type Theme<
   NewThemeType extends NewBaseTheme = NewBaseTheme,
   K extends ThemeKeys = ThemeKeys
-> = BaseTheme & { newTheme: NewThemeType } & {
-  key: K
+> = BaseTheme & { newTheme: NewThemeType } & { key: K } & {
+  themeOverride?: NewThemeOverrideObject
 } & Partial<CanvasBrandVariables>
 
 type ThemeSpecificStyle<ComponentTheme> = {
@@ -113,6 +126,7 @@ export type {
   Light,
   NewComponentTypes,
   NewBaseTheme,
+  NewThemeOverrideObject,
   TokenBoxshadowValueInst,
   TokenTypographyValueInst,
   SharedTokens


### PR DESCRIPTION
To test:

- Add the example to InstUISettingsProvider's `themeOverride` prop from here to some TS code https://github.com/instructure/instructure-ui/pull/2527/changes#diff-10af717b23612235edf3c073a1008b713c7820bf084c2a67ce1e3b481d55488eR48 (use 11.7 imports)
- play around the props, it should not have TS errors and correctly override. Try out other examples from the new themeOverrides document (https://instructure.design/new-theme-overrides ) it should not throw errors and autocomplete should work 