### PR TITLE
Calendar accessibility fix

### DIFF
--- a/cypress/component/DateTimeInput.cy.tsx
+++ b/cypress/component/DateTimeInput.cy.tsx
@@ -42,7 +42,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Choose date',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         dateRenderLabel="date-input label"
         timeRenderLabel="time-input label"
@@ -106,7 +108,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -134,7 +138,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -169,7 +175,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         dateRenderLabel="date-input"
         timeRenderLabel="time-input"
@@ -199,7 +207,9 @@ describe('<DateInput/>', () => {
       screenReaderLabels: {
         calendarIcon: 'Open calendar',
         prevMonthButton: 'Previous month',
-        nextMonthButton: 'Next month'
+        nextMonthButton: 'Next month',
+        datePickerDialog: 'Date picker',
+        selectedLabel: 'selected'
       },
       timeRenderLabel: 'time-input',
       invalidDateTimeMessage: 'whoops',
@@ -249,7 +259,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"
@@ -286,7 +298,9 @@ describe('<DateInput/>', () => {
         screenReaderLabels={{
           calendarIcon: 'Open calendar',
           prevMonthButton: 'Previous month',
-          nextMonthButton: 'Next month'
+          nextMonthButton: 'Next month',
+          datePickerDialog: 'Date picker',
+          selectedLabel: 'selected'
         }}
         timeRenderLabel="time-input"
         invalidDateTimeMessage="whoops"

--- a/packages/__docs__/src/Nav/index.tsx
+++ b/packages/__docs__/src/Nav/index.tsx
@@ -451,9 +451,8 @@ class Nav extends Component<NavProps, NavState> {
         themeSelected = themeSelected || isSelected
 
         const renderThemeName = (rawName: string) => {
-          if (rawName !== 'canvas' && rawName !== 'canvas-high-contrast') {
-            return `${rawName} (beta)`
-          }
+          if (rawName === 'canvas') return 'legacy-canvas'
+          if (rawName === 'canvas-high-contrast') return 'legacy-canvas-high-contrast'
           return rawName
         }
 

--- a/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.tsx
+++ b/packages/ui-calendar/src/Calendar/__tests__/Calendar.test.tsx
@@ -294,8 +294,12 @@ describe('<Calendar />', () => {
         {generateDays()}
       </Calendar>
     )
-    const defaultPrevButton = screen.getByText('Previous month')
-    const defaultNextButton = screen.getByText('Next month')
+    const defaultPrevButton = screen.getByRole('button', {
+      name: /^Previous month/
+    })
+    const defaultNextButton = screen.getByRole('button', {
+      name: /^Next month/
+    })
 
     expect(defaultPrevButton).toBeInTheDocument()
     expect(defaultNextButton).toBeInTheDocument()
@@ -535,5 +539,53 @@ describe('<Calendar />', () => {
 
     expect(calendar.tagName).toBe('UL')
     expect(calendar).toHaveTextContent(weekdayLabels.join(''))
+  })
+
+  describe('navigation button targetMonthSrLabel', () => {
+    it('should include the target month in the default button screen reader labels', () => {
+      render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          visibleMonth="2023-12-01"
+          locale="en"
+          selectedLabel="Selected"
+        >
+          {generateDays()}
+        </Calendar>
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Previous month, November 2023' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Next month, January 2024' })
+      ).toBeInTheDocument()
+    })
+
+    it('should pass targetMonthSrLabel to function render props', () => {
+      render(
+        <Calendar
+          renderWeekdayLabels={weekdayLabels}
+          visibleMonth="2023-12-01"
+          locale="en"
+          selectedLabel="Selected"
+          renderPrevMonthButton={({ targetMonthSrLabel }) => (
+            <button aria-label={`Go to ${targetMonthSrLabel}`}>prev</button>
+          )}
+          renderNextMonthButton={({ targetMonthSrLabel }) => (
+            <button aria-label={`Go to ${targetMonthSrLabel}`}>next</button>
+          )}
+        >
+          {generateDays()}
+        </Calendar>
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Go to November 2023' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Go to January 2024' })
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/packages/ui-calendar/src/Calendar/v1/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v1/index.tsx
@@ -175,28 +175,41 @@ class Calendar extends Component<CalendarProps, CalendarState> {
 
   renderMonthNavigationButtons = () => {
     const { renderNextMonthButton, renderPrevMonthButton } = this.props
+    const { visibleMonth } = this.state
+    const prevMonthName = visibleMonth
+      .clone()
+      .subtract({ months: 1 })
+      .format('MMMM YYYY')
+    const nextMonthName = visibleMonth
+      .clone()
+      .add({ months: 1 })
+      .format('MMMM YYYY')
 
     return {
       prevButton: renderPrevMonthButton ? (
-        callRenderProp(renderPrevMonthButton)
+        callRenderProp(renderPrevMonthButton, {
+          targetMonthSrLabel: prevMonthName
+        })
       ) : (
         <IconButton
           size="small"
           withBackground={false}
           withBorder={false}
           renderIcon={<IconArrowOpenStartSolid color="primary" />}
-          screenReaderLabel="Previous month"
+          screenReaderLabel={`Previous month, ${prevMonthName}`}
         />
       ),
       nextButton: renderNextMonthButton ? (
-        callRenderProp(renderNextMonthButton)
+        callRenderProp(renderNextMonthButton, {
+          targetMonthSrLabel: nextMonthName
+        })
       ) : (
         <IconButton
           size="small"
           withBackground={false}
           withBorder={false}
           renderIcon={<IconArrowOpenEndSolid color="primary" />}
-          screenReaderLabel="Next month"
+          screenReaderLabel={`Next month, ${nextMonthName}`}
         />
       )
     }
@@ -299,12 +312,12 @@ class Calendar extends Component<CalendarProps, CalendarState> {
           {renderNavigationLabel ? (
             callRenderProp(renderNavigationLabel)
           ) : (
-            <span>
+            <div aria-live="polite" aria-atomic="true">
               <div>{visibleMonth.format('MMMM')}</div>
               {!withYearPicker ? (
                 <div>{visibleMonth.format('YYYY')}</div>
               ) : null}
-            </span>
+            </div>
           )}
           {nextButton &&
             cloneButton(nextButton, this.handleMonthChange('next'))}

--- a/packages/ui-calendar/src/Calendar/v1/props.ts
+++ b/packages/ui-calendar/src/Calendar/v1/props.ts
@@ -98,19 +98,23 @@ type CalendarOwnProps = {
    */
   renderNavigationLabel?: Renderable
   /**
-   * A button to render in the navigation header. The recommendation is to
-   * compose it with the [IconButton](IconButton) component by setting the `size`
-   * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
-   * `renderIcon` to [IconArrowOpenEnd](icons).
+   * A button to render in the navigation header.
+   * When passed as a function, receives `{ targetMonthSrLabel }` —
+   * a pre-formatted screen reader label for the target month (e.g. "November 2023").
+   * The recommendation is to compose it with the [IconButton](Button) component
+   * by setting the `size` prop to `small`, `withBorder` and `withBackground` to `false`,
+   * and setting `renderIcon` to [IconArrowOpenStart](icons).
    */
-  renderNextMonthButton?: Renderable
+  renderNextMonthButton?: Renderable<{ targetMonthSrLabel: string }>
   /**
-   * A button to render in the navigation header. The recommendation is to
-   * compose it with the [IconButton](Button) component by setting the `size`
-   * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
-   * `renderIcon` to [IconArrowOpenStart](icons).
+   * A button to render in the navigation header.
+   * When passed as a function, receives `{ targetMonthSrLabel }` —
+   * a pre-formatted screen reader label for the target month (e.g. "November 2023").
+   * The recommendation is to compose it with the [IconButton](Button) component
+   * by setting the `size` prop to `small`, `withBorder` and `withBackground` to `false`,
+   * and setting `renderIcon` to [IconArrowOpenStart](icons).
    */
-  renderPrevMonthButton?: Renderable
+  renderPrevMonthButton?: Renderable<{ targetMonthSrLabel: string }>
   /**
    * An array of labels containing the name of each day of the week. The visible
    * portion of the label should be abbreviated (no longer than three characters).

--- a/packages/ui-calendar/src/Calendar/v2/README.md
+++ b/packages/ui-calendar/src/Calendar/v2/README.md
@@ -174,23 +174,26 @@ type: example
 
     const date = parseDate(renderedDate)
 
-    const buttonProps = (type = 'prev') => ({
-      size: 'small',
-      withBackground: false,
-      withBorder: false,
-      renderIcon:
-        type === 'prev' ? (
-          <ChevronLeftInstUIIcon color="baseColor" />
-        ) : (
-          <ChevronRightInstUIIcon color="baseColor" />
-        ),
-      screenReaderLabel: type === 'prev' ? 'Previous month' : 'Next month'
-    })
+    const renderMonthButton = (type = 'prev') => ({ targetMonthSrLabel }) => (
+      <IconButton
+        size="small"
+        withBackground={false}
+        withBorder={false}
+        renderIcon={
+          type === 'prev' ? (
+            <ChevronLeftInstUIIcon color="baseColor" />
+          ) : (
+            <ChevronRightInstUIIcon color="baseColor" />
+          )
+        }
+        screenReaderLabel={`${type === 'prev' ? 'Previous month' : 'Next month'}, ${targetMonthSrLabel}`}
+      />
+    )
 
     return (
       <Calendar
-        renderPrevMonthButton={<IconButton {...buttonProps('prev')} />}
-        renderNextMonthButton={<IconButton {...buttonProps('next')} />}
+        renderPrevMonthButton={renderMonthButton('prev')}
+        renderNextMonthButton={renderMonthButton('next')}
         renderNavigationLabel={
           <span>
             <div>{date.format('MMMM')}</div>
@@ -251,7 +254,4 @@ the abbreviation. ex. `[<AccessibleContent alt="Sunday">Sun</AccessibleContent>,
 
 #### Rendering next and previous month buttons
 
-The `renderNextMonthButton` and `renderPrevMonthButton` can be supplied using the
-[IconButton](IconButton) component with the `size` prop set to
-`small`, the `withBackground` and `withBorder` props both set to `false`, and the `renderIcon` prop set to `ChevronLeftInstUIIcon` or
-`ChevronRightInstUIIcon`.
+The `renderNextMonthButton` and `renderPrevMonthButton` can be supplied as a function that receives `{ targetMonthSrLabel }` — a pre-formatted screen reader label for the target month (e.g. "November 2023"). Use this to compose an [IconButton](IconButton) component with the `size` prop set to `small`, the `withBackground` and `withBorder` props both set to `false`, and the `renderIcon` prop set to `ChevronLeftInstUIIcon` or `ChevronRightInstUIIcon`. The `screenReaderLabel` should include the target month for better accessibility: e.g. "Previous month, November 2023".

--- a/packages/ui-calendar/src/Calendar/v2/index.tsx
+++ b/packages/ui-calendar/src/Calendar/v2/index.tsx
@@ -174,28 +174,41 @@ class Calendar extends Component<CalendarProps, CalendarState> {
 
   renderMonthNavigationButtons = () => {
     const { renderNextMonthButton, renderPrevMonthButton } = this.props
+    const { visibleMonth } = this.state
+    const prevMonthName = visibleMonth
+      .clone()
+      .subtract({ months: 1 })
+      .format('MMMM YYYY')
+    const nextMonthName = visibleMonth
+      .clone()
+      .add({ months: 1 })
+      .format('MMMM YYYY')
 
     return {
       prevButton: renderPrevMonthButton ? (
-        callRenderProp(renderPrevMonthButton)
+        callRenderProp(renderPrevMonthButton, {
+          targetMonthSrLabel: prevMonthName
+        })
       ) : (
         <IconButton
           size="small"
           withBackground={false}
           withBorder={false}
           renderIcon={<ChevronLeftInstUIIcon color="baseColor" />}
-          screenReaderLabel="Previous month"
+          screenReaderLabel={`Previous month, ${prevMonthName}`}
         />
       ),
       nextButton: renderNextMonthButton ? (
-        callRenderProp(renderNextMonthButton)
+        callRenderProp(renderNextMonthButton, {
+          targetMonthSrLabel: nextMonthName
+        })
       ) : (
         <IconButton
           size="small"
           withBackground={false}
           withBorder={false}
           renderIcon={<ChevronRightInstUIIcon color="baseColor" />}
-          screenReaderLabel="Next month"
+          screenReaderLabel={`Next month, ${nextMonthName}`}
         />
       )
     }
@@ -298,12 +311,16 @@ class Calendar extends Component<CalendarProps, CalendarState> {
           {renderNavigationLabel ? (
             callRenderProp(renderNavigationLabel)
           ) : (
-            <span>
-              <div>{visibleMonth.format('MMMM')}</div>
+            <h2
+              aria-live="polite"
+              aria-atomic="true"
+              css={styles?.navigationLabel}
+            >
+              <span>{visibleMonth.format('MMMM')}</span>
               {!withYearPicker ? (
-                <div>{visibleMonth.format('YYYY')}</div>
+                <span>{visibleMonth.format('YYYY')}</span>
               ) : null}
-            </span>
+            </h2>
           )}
           {nextButton &&
             cloneButton(nextButton, this.handleMonthChange('next'))}
@@ -312,7 +329,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
         {withYearPicker ? (
           <div css={styles?.yearPicker}>
             <SimpleSelect
-              width="90px"
+              width="95px"
               renderLabel=""
               placeholder="--"
               assistiveText={withYearPicker.screenReaderLabel}

--- a/packages/ui-calendar/src/Calendar/v2/props.ts
+++ b/packages/ui-calendar/src/Calendar/v2/props.ts
@@ -98,19 +98,23 @@ type CalendarOwnProps = {
    */
   renderNavigationLabel?: Renderable
   /**
-   * A button to render in the navigation header. The recommendation is to
-   * compose it with the [IconButton](IconButton) component by setting the `size`
-   * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
-   * `renderIcon` to [IconArrowOpenEnd](icons).
+   * A button to render in the navigation header.
+   * When passed as a function, receives `{ targetMonthSrLabel }` —
+   * a pre-formatted screen reader label for the target month (e.g. "January 2024").
+   * The recommendation is to compose it with the [IconButton](Button) component
+   * by setting the `size` prop to `small`, `withBorder` and `withBackground` to `false`,
+   * and setting `renderIcon` to [IconArrowOpenEnd](icons).
    */
-  renderNextMonthButton?: Renderable
+  renderNextMonthButton?: Renderable<{ targetMonthSrLabel: string }>
   /**
-   * A button to render in the navigation header. The recommendation is to
-   * compose it with the [IconButton](Button) component by setting the `size`
-   * prop to `small`, `withBorder` and `withBackground` to `false`, and setting
-   * `renderIcon` to [IconArrowOpenStart](icons).
+   * A button to render in the navigation header.
+   * When passed as a function, receives `{ targetMonthSrLabel }` —
+   * a pre-formatted screen reader label for the target month (e.g. "November 2023").
+   * The recommendation is to compose it with the [IconButton](Button) component
+   * by setting the `size` prop to `small`, `withBorder` and `withBackground` to `false`,
+   * and setting `renderIcon` to [IconArrowOpenStart](icons).
    */
-  renderPrevMonthButton?: Renderable
+  renderPrevMonthButton?: Renderable<{ targetMonthSrLabel: string }>
   /**
    * An array of labels containing the name of each day of the week. The visible
    * portion of the label should be abbreviated (no longer than three characters).
@@ -182,7 +186,11 @@ type CalendarProps = CalendarOwnProps &
   WithDeterministicIdProps
 
 type CalendarStyle = ComponentStyle<
-  'navigation' | 'navigationWithButtons' | 'weekdayHeader' | 'yearPicker'
+  | 'navigation'
+  | 'navigationWithButtons'
+  | 'navigationLabel'
+  | 'weekdayHeader'
+  | 'yearPicker'
 >
 const allowedProps: AllowedPropKeys = [
   'as',

--- a/packages/ui-calendar/src/Calendar/v2/styles.ts
+++ b/packages/ui-calendar/src/Calendar/v2/styles.ts
@@ -63,6 +63,15 @@ const generateStyle = (
       maxWidth: componentTheme.maxHeaderWidth,
       lineHeight: componentTheme.lineHeight
     },
+    navigationLabel: {
+      label: 'calendar__navigation-label',
+      margin: 0,
+      fontSize: 'inherit',
+      fontWeight: 'inherit',
+      '& span': {
+        display: 'block'
+      }
+    },
     yearPicker: {
       display: 'flex',
       justifyContent: 'center',

--- a/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.tsx
+++ b/packages/ui-date-input/src/DateInput/__tests__/DateInput.test.tsx
@@ -220,20 +220,14 @@ describe('<DateInput />', () => {
 
     await waitFor(() => {
       const prevMonthButton = screen.getByRole('button', {
-        name: prevMonthLabel
+        name: new RegExp(`^${prevMonthLabel}`)
       })
       const nextMonthButton = screen.getByRole('button', {
-        name: nextMonthLabel
+        name: new RegExp(`^${nextMonthLabel}`)
       })
 
       expect(prevMonthButton).toBeInTheDocument()
       expect(nextMonthButton).toBeInTheDocument()
-
-      const prevButtonLabel = screen.getByText(prevMonthLabel)
-      const nextButtonLabel = screen.getByText(nextMonthLabel)
-
-      expect(prevButtonLabel).toBeInTheDocument()
-      expect(nextButtonLabel).toBeInTheDocument()
 
       const prevMonthIcon = prevMonthButton.querySelector(
         'svg[name="ChevronLeft"]'

--- a/packages/ui-date-input/src/DateInput/v2/index.tsx
+++ b/packages/ui-date-input/src/DateInput/v2/index.tsx
@@ -311,24 +311,24 @@ const DateInput = forwardRef(
               visibleMonth={selectedDate}
               locale={userLocale}
               timezone={userTimezone}
-              renderNextMonthButton={
+              renderNextMonthButton={({ targetMonthSrLabel }) => (
                 <IconButton
                   size="small"
                   withBackground={false}
                   withBorder={false}
                   renderIcon={<ChevronRightInstUIIcon color="baseColor" />}
-                  screenReaderLabel={screenReaderLabels.nextMonthButton}
+                  screenReaderLabel={`${screenReaderLabels.nextMonthButton}, ${targetMonthSrLabel}`}
                 />
-              }
-              renderPrevMonthButton={
+              )}
+              renderPrevMonthButton={({ targetMonthSrLabel }) => (
                 <IconButton
                   size="small"
                   withBackground={false}
                   withBorder={false}
                   renderIcon={<ChevronLeftInstUIIcon color="baseColor" />}
-                  screenReaderLabel={screenReaderLabels.prevMonthButton}
+                  screenReaderLabel={`${screenReaderLabels.prevMonthButton}, ${targetMonthSrLabel}`}
                 />
-              }
+              )}
             />
           </Popover>
         }

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -168,6 +168,9 @@ class Dialog extends Component<DialogProps> {
         {...omitProps(this.props, Dialog.allowedProps)}
         role={role}
         aria-label={this.props.label}
+        aria-modal={
+          role === 'dialog' && this.props.shouldContainFocus ? true : undefined
+        }
         className={this.props.className} // TODO in V2 remove className, there is no usage of it.
         style={{ borderRadius: 'inherit' }} // ensure the dialog inherits border radius from View
         ref={this.getRef}


### PR DESCRIPTION
INSTUI-5009
INSTUI-5010
INSTUI-5014

Improve date picker calendar accessibility

## Changes

- Add aria-live="polite" aria-atomic="true" to the month/year header in
  Calendar v1 and v2. Previously the container was a ```<span>``` wrapping ```<div>```
  children (invalid HTML), causing screen readers to lose track of the live
  region subtree and skip announcements on month navigation. Changed to ```<div>```.

- Add target month name to navigation button screen reader labels in Calendar
  v1 and v2. Default buttons now announce e.g. "Previous month, November 2023"
  instead of the generic "Previous month".

- Extend renderPrevMonthButton/renderNextMonthButton prop type from Renderable
  to ```Renderable<{ targetMonthSrLabel: string }>``` in Calendar v1 and v2. When
  passed as a function, the render prop receives the pre-formatted target month
  label so consumers can build descriptive accessible names for custom buttons.

- Update DateInput v2 to use function render props for navigation buttons,
  appending targetMonthSrLabel to the consumer-provided label string so the
  full announcement reads e.g. "Next month, January 2024".

- Add aria-modal to Dialog when role="dialog" and shouldContainFocus is true,
  scoping the screen reader virtual cursor to the dialog content. Guarded by
  shouldContainFocus so non-modal Dialog usages (Tray without containment,
  DrawerTray during transitions, etc.) are unaffected.
  
  ## Test plan
  

- [x]   Open a DateInput date picker with VoiceOver (macOS) or NVDA (Windows): verify the popover is announced as a dialog with its label (e.g. "Date picker, dialog")

- [x]  The calendar heading displaying the year and month should use an h2

- [x]  The last number in the yearPicker always fully visible

- [x]  With the calendar open, press Tab past the last focusable element and Shift+Tab before the first: verify focus stays inside the picker and does not escape

- [x]  Open a Modal, Tray, and Popover (non–date picker usage): verify aria-modal appears only when shouldContainFocus is true and does not appear on non-modal usages

- [x]  Navigate to the next/previous month using the arrow buttons: verify the screen reader announces the new month and year (e.g. "January 2024") via the aria-live region without requiring the user to move focus

- [x]  Check the previous and next month button accessible names: verify they include the target month (e.g. "Previous month, November 2023" / "Next month, January 2024") and not just the generic label

- [x]  Pass a function to renderPrevMonthButton / renderNextMonthButton on Calendar v2: verify targetMonthSrLabel is received 

```
  <Calendar
  renderPrevMonthButton={({ targetMonthSrLabel }) => (
    <IconButton
      size="small"
      renderIcon={<ChevronLeftInstUIIcon color="baseColor" />}
      screenReaderLabel={`Go to, ${targetMonthSrLabel}`}
    />
  )}
  renderNextMonthButton={({ targetMonthSrLabel }) => (
    <IconButton
      size="small"
      renderIcon={<ChevronRightInstUIIcon color="baseColor" />}
      screenReaderLabel={`Go to, ${targetMonthSrLabel}`}
    />
  )}
  selectedLabel="Selected"
 />
```


 

Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)