### PR TITLE
fix(ui-buttons): fix textAlign center on Buttons without icon

### DIFF
--- a/packages/ui-buttons/src/BaseButton/v2/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/v2/styles.ts
@@ -496,6 +496,7 @@ const generateStyle = (
       width: '100%',
       display: 'flex',
       alignItems: 'center',
+      justifyContent: textAlign === 'center' ? 'center' : 'flex-start',
       direction: 'inherit',
       userSelect: 'none',
       transition: 'background 0.2s, transform 0.2s',


### PR DESCRIPTION
## Summary

- In v11.7 the v2 BaseButton's `content` wrapper was changed from `display: block` to `display: flex`. As a flex container with a single shrunk-to-content child span, `textAlign: center` no longer had anything to center — buttons without an icon stayed left-aligned. Buttons with an icon kept working because their extra `childrenLayout` wrapper has `width: 100%` and an explicit `justifyContent: center`.
- Fix: add `justifyContent: textAlign === 'center' ? 'center' : 'flex-start'` to the `content` flex container in `packages/ui-buttons/src/BaseButton/v2/styles.ts`, mirroring the logic already used in `childrenLayout`.

## Test Plan

- [ ] Render a `Button` with `textAlign="center"` and `display="block"` (no `renderIcon`) — label should be horizontally centered.
- [ ] Render the same `Button` with a `renderIcon` — label + icon should still be horizontally centered (no regression).
- [ ] Render a `Button` with `textAlign="start"` (default) — label should remain left-aligned, both with and without an icon.
- [ ] `pnpm run test:vitest ui-buttons` passes.
- [ ] Visual regression suite for Button passes.

## Jira Reference

Fixes [INSTUI-5015](https://instructure.atlassian.net/browse/INSTUI-5015)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INSTUI-5015]: https://instructure.atlassian.net/browse/INSTUI-5015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ