### PR TITLE
feat(ui-range-input): remove deprecated thumb variant

### DIFF
--- a/docs/guides/upgrade-guide.md
+++ b/docs/guides/upgrade-guide.md
@@ -1100,6 +1100,8 @@ type: embed
 
 ### RangeInput
 
+- `thumbVariant` prop has been removed. The component now always renders the previously-`accessible` thumb (better color contrast, border, and inset focus ring).
+
 ```js
 ---
 type: embed

--- a/packages/ui-range-input/src/RangeInput/v2/README.md
+++ b/packages/ui-range-input/src/RangeInput/v2/README.md
@@ -10,14 +10,9 @@ type: example
 ---
 const Example = () => {
   const [size, setSize] = useState('small')
-  const [thumbVariant, setThumbVariant] = useState('accessible')
 
   const handleSizeChange = (event, value) => {
     setSize(value)
-  }
-
-  const handleThumbVariantChange = (event, value) => {
-    setThumbVariant(value)
   }
 
   return (
@@ -29,7 +24,6 @@ const Example = () => {
           max={100}
           min={0}
           size={size}
-          thumbVariant={thumbVariant}
         />
       </View>
 
@@ -52,16 +46,6 @@ const Example = () => {
             <RadioInput label="small" value="small" />
             <RadioInput label="medium" value="medium" />
             <RadioInput label="large" value="large" />
-          </RadioInputGroup>
-
-          <RadioInputGroup
-            onChange={handleThumbVariantChange}
-            name="thumbVariant"
-            value={thumbVariant}
-            description="Thumb variant"
-          >
-            <RadioInput label="accessible" value="accessible" />
-            <RadioInput label="deprecated" value="deprecated" />
           </RadioInputGroup>
         </FormFieldGroup>
       </View>

--- a/packages/ui-range-input/src/RangeInput/v2/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/v2/index.tsx
@@ -67,8 +67,7 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
     layout: 'stacked',
     displayValue: true,
     disabled: false,
-    readOnly: false,
-    thumbVariant: 'deprecated'
+    readOnly: false
   }
 
   ref: Element | null = null

--- a/packages/ui-range-input/src/RangeInput/v2/props.ts
+++ b/packages/ui-range-input/src/RangeInput/v2/props.ts
@@ -89,14 +89,6 @@ type RangeInputOwnProps = {
   readOnly?: boolean
 
   /**
-   * The "deprecated" variant has an outer shadow on focus.
-   * The "accessible" variant has better color contrast, border and inset focus ring for better accessibility.
-   */
-  thumbVariant?:
-    | 'deprecated' // TODO: deprecated, remove in V9.
-    | 'accessible'
-
-  /**
    * A function that provides a reference to the actual underlying input element
    */
   inputRef?: (inputElement: HTMLInputElement | null) => void
@@ -147,7 +139,6 @@ const allowedProps: AllowedPropKeys = [
   'inline',
   'disabled',
   'readOnly',
-  'thumbVariant',
   'inputRef'
 ]
 

--- a/packages/ui-range-input/src/RangeInput/v2/styles.ts
+++ b/packages/ui-range-input/src/RangeInput/v2/styles.ts
@@ -24,7 +24,6 @@
 
 import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
 import type { RangeInputProps, RangeInputStyle } from './props'
-import { darken, alpha } from '@instructure/ui-color-utils'
 import { boxShadowObjectsToCSSString } from '@instructure/ui-themes'
 
 /**
@@ -42,7 +41,7 @@ const generateStyle = (
   props: RangeInputProps,
   sharedTokens: SharedTokens
 ): RangeInputStyle => {
-  const { size, thumbVariant } = props
+  const { size } = props
   const valueSizeVariants = {
     small: {
       fontSize: componentTheme.valueSmallFontSize,
@@ -76,30 +75,19 @@ const generateStyle = (
 
   const borderedHandleSize = `calc(${componentTheme.handleSize} + (${componentTheme.handleBorderSize} * 2))`
 
-  const thumbVariantStyle = {
-    deprecated: {
-      width: componentTheme.handleSize,
-      height: componentTheme.handleSize,
-      boxShadow: `0 0.0625rem 0 ${darken(componentTheme.handleShadowColor)}`
-    },
-    accessible: {
-      width: borderedHandleSize,
-      height: borderedHandleSize,
-      borderWidth: componentTheme.handleBorderSize,
-      borderColor: componentTheme.handleBorderColor,
-      borderStyle: 'solid',
-      boxSizing: 'border-box',
-      boxShadow: boxShadowObjectsToCSSString(componentTheme.boxShadow)
-    }
-  }
-
   const thumbStyle = {
     appearance: 'none',
     borderRadius: '50%',
     cursor: 'pointer',
     transition: 'all 0.15s ease-in-out',
     background: componentTheme.handleBackground,
-    ...thumbVariantStyle[thumbVariant!],
+    width: borderedHandleSize,
+    height: borderedHandleSize,
+    borderWidth: componentTheme.handleBorderSize,
+    borderColor: componentTheme.handleBorderColor,
+    borderStyle: 'solid',
+    boxSizing: 'border-box',
+    boxShadow: boxShadowObjectsToCSSString(componentTheme.boxShadow),
 
     '&:hover': {
       background: componentTheme.handleHoverBackground
@@ -108,31 +96,15 @@ const generateStyle = (
 
   // Center the thumb vertically on the track by accounting for the track borders
   const thumbPosition = {
-    deprecated: {
-      marginTop: `calc(-1 * ${componentTheme.handleSize} / 4 - ${trackBorderWidth})`
-    },
-    accessible: {
-      marginTop: `calc(-1 * ${borderedHandleSize} / 4 - ${trackBorderWidth})`
-    }
+    marginTop: `calc(-1 * ${borderedHandleSize} / 4 - ${trackBorderWidth})`
   }
 
   const thumbFocusActiveStyle = {
-    deprecated: {
-      background: componentTheme.handleFocusBackground,
-      boxShadow: `0 0.0625rem 0 ${darken(
-        componentTheme.handleShadowColor
-      )}, 0 0 0 ${componentTheme.handleFocusOutlineWidth} ${alpha(
-        componentTheme.handleFocusOutlineColor,
-        40
-      )}`
-    },
-    accessible: {
-      background: componentTheme.handleFocusBackground,
-      boxShadow:
-        `${boxShadowObjectsToCSSString(componentTheme.boxShadow)}, ` +
-        `inset 0 0 0 ${componentTheme.handleFocusInset} ${componentTheme.handleFocusBackground}, ` +
-        `inset 0 0 0 calc(${componentTheme.handleFocusInset} + ${sharedTokens.focusOutline.width}) ${sharedTokens.focusOutline.onColor}`
-    }
+    background: componentTheme.handleFocusBackground,
+    boxShadow:
+      `${boxShadowObjectsToCSSString(componentTheme.boxShadow)}, ` +
+      `inset 0 0 0 ${componentTheme.handleFocusInset} ${componentTheme.handleFocusBackground}, ` +
+      `inset 0 0 0 calc(${componentTheme.handleFocusInset} + ${sharedTokens.focusOutline.width}) ${sharedTokens.focusOutline.onColor}`
   }
 
   return {
@@ -155,13 +127,13 @@ const generateStyle = (
 
       '&::-webkit-slider-thumb': {
         ...thumbStyle,
-        ...thumbPosition[thumbVariant!]
+        ...thumbPosition
       },
       '&::-moz-range-thumb': thumbStyle,
       '&:focus, &:active': {
         outline: 'none',
-        '&::-webkit-slider-thumb': thumbFocusActiveStyle[thumbVariant!],
-        '&::-moz-range-thumb': thumbFocusActiveStyle[thumbVariant!]
+        '&::-webkit-slider-thumb': thumbFocusActiveStyle,
+        '&::-moz-range-thumb': thumbFocusActiveStyle
       },
       // remove outline in FF
       '&::-moz-focus-inner, &::-moz-focus-outer': {


### PR DESCRIPTION
BREAKING CHANGE: `thumbVariant` prop removed from RangeInput

INSTUI-5016

**ISSUE:**
- deprecated thumb variant should be removed from RangeInput

**TEST PLAN:**
- check the example in the documentation it should work and have no errors
