### PR TITLE
chore(release): 11.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+### Bug Fixes
+
+- **[v11.7] ui-buttons:** fix textAlign center on Buttons without icon ([b46ddb7](https://github.com/instructure/instructure-ui/commit/b46ddb788696bf1c556291d3a09a1ba659c6959f))
+- **[v11.6, v11.7] ui-date-time-input,ui-date-input,ui-calendar:** set missing aria-selected on calendar days, BREAKING CHANGE: add mandatory prop selectedLabel, change datePickerDialog prop to mandatory ([08abed5](https://github.com/instructure/instructure-ui/commit/08abed5e8c8b29aecab0368e01e8e4ffd0c7fda7))
+- **[v11.7] ui-tabs:** fix tabs panel layout when `unmountOnExit` is false ([826ff62](https://github.com/instructure/instructure-ui/commit/826ff62fba56bc0cadd6995b366e3ca505b1b6c1))
+- **[v11.6, v11.7] ui-tree-browser,ui-top-nav-bar,ui-form-field:** add back some missing exports
+
+### Features
+
+- **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+- **[v11.7] many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+- **[v11.7] ui-checkbox:** add `data-checked` attribute to reflect checked state ([a790019](https://github.com/instructure/instructure-ui/commit/a790019ed2b47064a01b7ec532494cc723943241))
+- **[v11.6, v11.7] ui-color-picker:** improve ColorPicker paste behavior ([e5c279d](https://github.com/instructure/instructure-ui/commit/e5c279dbf8ac9918f104e223b9625b3b50322f23))
+- **[v11.7] ui-range-input:** remove deprecated thumb variant ([ca4a3fb](https://github.com/instructure/instructure-ui/commit/ca4a3fb45885fbcc9807566dadd3d027a17b8f72))
+- **[v11.7] ui-select,ui-date-time-input:** rework DateTimeInput and replace DateInput v1 with DateInput v2 in DateTimeInput ([7717fc6](https://github.com/instructure/instructure-ui/commit/7717fc6db4d2a733c8349eb583d37a85a4137cf7))
+- **ui-scripts:** use design tokens from external repo and convert JS to TS ([a03e0cb](https://github.com/instructure/instructure-ui/commit/a03e0cb24cdf1a2f5debbe707f73ce50ec4a666a))
+
+### BREAKING CHANGES
+
+- **[v11.7] ui-select,ui-date-time-input:** `renderWeekdayLabels` prop removed, `calendarIcon` is a new required prop
+- **[v11.7] ui-range-input:** `thumbVariant` prop removed from RangeInput
+- **[v11.7] ui-select,ui-date-time-input:** `prevMonthLabel` prop removed (use `screenReaderLabels.prevMonthButton` instead)
+  - `nextMonthLabel` prop removed (use screenReaderLabels.nextMonthButton instead)
+  - `renderWeekdayLabels` prop removed
+  - `dateFormat` type changed
+  - `screenReaderLabels` is a new required prop
+  - `dateFormat` default changed: Moment's 'LL' (long month name) → locale's default date format
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.7.2",
+  "version": "11.7.3",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "instructure-ui",
   "description": "A design system by Instructure Inc.",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "author": "Instructure, Inc. Engineering and Product Design",
   "repository": {
     "type": "git",

--- a/packages/__docs__/CHANGELOG.md
+++ b/packages/__docs__/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-app",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Documentation and showcase application for Instructure-UI.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "repository": {

--- a/packages/babel-plugin-transform-imports/CHANGELOG.md
+++ b/packages/babel-plugin-transform-imports/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+**Note:** Version bump only for package @instructure/babel-plugin-transform-imports
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/babel-plugin-transform-imports

--- a/packages/babel-plugin-transform-imports/package.json
+++ b/packages/babel-plugin-transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/babel-plugin-transform-imports",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A babel plugin made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./lib/index.js",

--- a/packages/browserslist-config-instui/CHANGELOG.md
+++ b/packages/browserslist-config-instui/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+**Note:** Version bump only for package @instructure/browserslist-config-instui
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/browserslist-config-instui

--- a/packages/browserslist-config-instui/package.json
+++ b/packages/browserslist-config-instui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/browserslist-config-instui",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A shared browserslist config made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./index.js",

--- a/packages/canvas-high-contrast-theme/CHANGELOG.md
+++ b/packages/canvas-high-contrast-theme/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/canvas-high-contrast-theme

--- a/packages/canvas-high-contrast-theme/package.json
+++ b/packages/canvas-high-contrast-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/canvas-high-contrast-theme",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A high contrast theme for Canvas LMS made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/canvas-theme/CHANGELOG.md
+++ b/packages/canvas-theme/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/canvas-theme

--- a/packages/canvas-theme/package.json
+++ b/packages/canvas-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/canvas-theme",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A theme for Canvas LMS made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/command-utils/CHANGELOG.md
+++ b/packages/command-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+**Note:** Version bump only for package @instructure/command-utils
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/command-utils

--- a/packages/command-utils/package.json
+++ b/packages/command-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/command-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Node CLI utilities made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./lib/index.js",

--- a/packages/console/CHANGELOG.md
+++ b/packages/console/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/console

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/console",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A babel macro made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/debounce/CHANGELOG.md
+++ b/packages/debounce/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/debounce

--- a/packages/debounce/package.json
+++ b/packages/debounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/debounce",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A debounce util made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/emotion/CHANGELOG.md
+++ b/packages/emotion/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/emotion",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/pkg-utils/CHANGELOG.md
+++ b/packages/pkg-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+**Note:** Version bump only for package @instructure/pkg-utils
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/pkg-utils

--- a/packages/pkg-utils/package.json
+++ b/packages/pkg-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/pkg-utils",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Utilities for managing node packages in a monorepo.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./lib/index.js",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+**Note:** Version bump only for package @instructure/shared-types
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/shared-types

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/shared-types",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Shared TypeScript typings for Instructure UI packages.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-a11y-content/CHANGELOG.md
+++ b/packages/ui-a11y-content/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-a11y-content

--- a/packages/ui-a11y-content/package.json
+++ b/packages/ui-a11y-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-a11y-content",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Utility components that enhance the user experience of those that navigate the web with a screen reader or keyboard.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-a11y-utils/CHANGELOG.md
+++ b/packages/ui-a11y-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-a11y-utils/package.json
+++ b/packages/ui-a11y-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-a11y-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A collection of utilities for managing focus and screen reader behavior",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-alerts/CHANGELOG.md
+++ b/packages/ui-alerts/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-alerts/package.json
+++ b/packages/ui-alerts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-alerts",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "An alert component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-avatar/CHANGELOG.md
+++ b/packages/ui-avatar/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-avatar",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "An image or letters that represents a user.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-axe-check/CHANGELOG.md
+++ b/packages/ui-axe-check/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-axe-check

--- a/packages/ui-axe-check/package.json
+++ b/packages/ui-axe-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-axe-check",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI a11y testing library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-babel-preset/CHANGELOG.md
+++ b/packages/ui-babel-preset/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-babel-preset

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/ui-babel-preset",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI babel preset made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./lib/index.js",
@@ -17,18 +17,18 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.29.2",
     "@babel/core": "^7.29.0",
-    "babel-loader": "^10.1.1",
-    "@babel/plugin-transform-runtime": "^7.29.0",
-    "core-js": "3.49.0",
-    "@babel/preset-env": "^7.29.3",
-    "@babel/preset-typescript": "^7.28.5",
-    "@babel/preset-react": "^7.28.5",
     "@babel/plugin-proposal-decorators": "^7.29.0",
-    "babel-plugin-transform-remove-console": "^6.9.4",
+    "@babel/plugin-transform-runtime": "^7.29.0",
+    "@babel/preset-env": "^7.29.3",
+    "@babel/preset-react": "^7.28.5",
+    "@babel/preset-typescript": "^7.28.5",
+    "@babel/runtime": "^7.29.2",
     "@instructure/babel-plugin-transform-imports": "workspace:*",
-    "@instructure/browserslist-config-instui": "workspace:*"
+    "@instructure/browserslist-config-instui": "workspace:*",
+    "babel-loader": "^10.1.1",
+    "babel-plugin-transform-remove-console": "^6.9.4",
+    "core-js": "3.49.0"
   },
   "//dependency-comments": {
     "core-js": "If you upgrade coreJS, you must also upgrade the version in the Babel preset"

--- a/packages/ui-badge/CHANGELOG.md
+++ b/packages/ui-badge/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-badge

--- a/packages/ui-badge/package.json
+++ b/packages/ui-badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-badge",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A badge component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-billboard/CHANGELOG.md
+++ b/packages/ui-billboard/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-billboard

--- a/packages/ui-billboard/package.json
+++ b/packages/ui-billboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-billboard",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component to display empty states, 404 pages, redirects, etc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-breadcrumb/CHANGELOG.md
+++ b/packages/ui-breadcrumb/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-breadcrumb

--- a/packages/ui-breadcrumb/package.json
+++ b/packages/ui-breadcrumb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-breadcrumb",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A breadcrumb component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-buttons/CHANGELOG.md
+++ b/packages/ui-buttons/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+* **ui-buttons:** fix textAlign center on Buttons without icon ([b46ddb7](https://github.com/instructure/instructure-ui/commit/b46ddb788696bf1c556291d3a09a1ba659c6959f))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-buttons/package.json
+++ b/packages/ui-buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-buttons",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Accessible button components",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-byline/CHANGELOG.md
+++ b/packages/ui-byline/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-byline/package.json
+++ b/packages/ui-byline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-byline",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A Byline component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-calendar/CHANGELOG.md
+++ b/packages/ui-calendar/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+* **ui-date-time-input,ui-date-input,ui-calendar:** set missing aria-selected on calendar days, BREAKING CHANGE: add mandatory prop selectedLabel, change datePickerDialog prop to mandatory ([08abed5](https://github.com/instructure/instructure-ui/commit/08abed5e8c8b29aecab0368e01e8e4ffd0c7fda7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-calendar/package.json
+++ b/packages/ui-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-calendar",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A calendar component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-checkbox/CHANGELOG.md
+++ b/packages/ui-checkbox/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **ui-checkbox:** add data-checked attribute to reflect checked state ([a790019](https://github.com/instructure/instructure-ui/commit/a790019ed2b47064a01b7ec532494cc723943241))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-checkbox",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": " styled HTML input type='checkbox' component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-codemods/CHANGELOG.md
+++ b/packages/ui-codemods/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-codemods/package.json
+++ b/packages/ui-codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-codemods",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Codemod scripts to help upgrade Instructure UI libraries.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./lib/index.ts",

--- a/packages/ui-color-picker/CHANGELOG.md
+++ b/packages/ui-color-picker/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **ui-color-picker:** improve ColorPicker paste behavior ([e5c279d](https://github.com/instructure/instructure-ui/commit/e5c279dbf8ac9918f104e223b9625b3b50322f23))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-color-picker/package.json
+++ b/packages/ui-color-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-color-picker",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-color-utils/CHANGELOG.md
+++ b/packages/ui-color-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-color-utils

--- a/packages/ui-color-utils/package.json
+++ b/packages/ui-color-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-color-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A color utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-date-input/CHANGELOG.md
+++ b/packages/ui-date-input/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+* **ui-date-time-input,ui-date-input,ui-calendar:** set missing aria-selected on calendar days, BREAKING CHANGE: add mandatory prop selectedLabel, change datePickerDialog prop to mandatory ([08abed5](https://github.com/instructure/instructure-ui/commit/08abed5e8c8b29aecab0368e01e8e4ffd0c7fda7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-date-input/package.json
+++ b/packages/ui-date-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-date-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-date-time-input/CHANGELOG.md
+++ b/packages/ui-date-time-input/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+* **ui-date-time-input,ui-date-input,ui-calendar:** set missing aria-selected on calendar days, BREAKING CHANGE: add mandatory prop selectedLabel, change datePickerDialog prop to mandatory ([08abed5](https://github.com/instructure/instructure-ui/commit/08abed5e8c8b29aecab0368e01e8e4ffd0c7fda7))
+
+
+### Features
+
+* **ui-select,ui-date-time-input:** rework DateTimeInput and replace DateInput v1 with DateInput v2 in DateTimeInput ([5a9405c](https://github.com/instructure/instructure-ui/commit/5a9405c0a19ea9fc6a34b2f34c60c582f96ec2af))
+
+
+### BREAKING CHANGES
+
+* **ui-select,ui-date-time-input:** prevMonthLabel prop removed (use screenReaderLabels.prevMonthButton instead)
+
+nextMonthLabel prop removed (use screenReaderLabels.nextMonthButton instead)
+
+renderWeekdayLabels prop removed
+
+dateFormat type changed: string → string
+
+{ parser: (input: string) => Date
+
+null, formatter: (date: Date) => string }
+
+screenReaderLabels is a new required prop
+
+dateFormat default changed: Moment's 'LL' (long month name) → locale's default date format
+
+INSTUI-4791
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-date-time-input

--- a/packages/ui-date-time-input/package.json
+++ b/packages/ui-date-time-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-date-time-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component that allows to select date and time.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-decorator/CHANGELOG.md
+++ b/packages/ui-decorator/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-decorator

--- a/packages/ui-decorator/package.json
+++ b/packages/ui-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-decorator",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A utility to wrap (decorates) a React component class adding functionality.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-dialog/CHANGELOG.md
+++ b/packages/ui-dialog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-dialog",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A utility component for managing keyboard accessibility and screen reader behavior",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-dom-utils/CHANGELOG.md
+++ b/packages/ui-dom-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-dom-utils

--- a/packages/ui-dom-utils/package.json
+++ b/packages/ui-dom-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-dom-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A DOM utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-drawer-layout/CHANGELOG.md
+++ b/packages/ui-drawer-layout/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-drawer-layout/package.json
+++ b/packages/ui-drawer-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-drawer-layout",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A main-content-plus-tray layout component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-drilldown/CHANGELOG.md
+++ b/packages/ui-drilldown/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-drilldown/package.json
+++ b/packages/ui-drilldown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-drilldown",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A drilldown menu component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-editable/CHANGELOG.md
+++ b/packages/ui-editable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-editable/package.json
+++ b/packages/ui-editable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-editable",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-expandable/CHANGELOG.md
+++ b/packages/ui-expandable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-expandable/package.json
+++ b/packages/ui-expandable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-expandable",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A utility component for show/hide functionality",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-file-drop/CHANGELOG.md
+++ b/packages/ui-file-drop/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-file-drop

--- a/packages/ui-file-drop/package.json
+++ b/packages/ui-file-drop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-file-drop",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A flexible facade for an HTML file input",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-flex/CHANGELOG.md
+++ b/packages/ui-flex/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-flex/package.json
+++ b/packages/ui-flex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-flex",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component that makes it easy to align content using flexbox CSS",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-focusable/CHANGELOG.md
+++ b/packages/ui-focusable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-focusable

--- a/packages/ui-focusable/package.json
+++ b/packages/ui-focusable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-focusable",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A utility used to identify when an element receives focus.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-form-field/CHANGELOG.md
+++ b/packages/ui-form-field/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-form-field/package.json
+++ b/packages/ui-form-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-form-field",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Form layout components.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-grid/CHANGELOG.md
+++ b/packages/ui-grid/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-grid

--- a/packages/ui-grid/package.json
+++ b/packages/ui-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-grid",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A Grid component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-heading/CHANGELOG.md
+++ b/packages/ui-heading/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-heading/package.json
+++ b/packages/ui-heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-heading",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for creating typographic headings",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-i18n/CHANGELOG.md
+++ b/packages/ui-i18n/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-i18n

--- a/packages/ui-i18n/package.json
+++ b/packages/ui-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-i18n",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Helper components and utilities for internationalization.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-icons/CHANGELOG.md
+++ b/packages/ui-icons/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-icons/package.json
+++ b/packages/ui-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-icons",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Icon set for Instructure, Inc. products",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-img/CHANGELOG.md
+++ b/packages/ui-img/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-img/package.json
+++ b/packages/ui-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-img",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "An accessible image component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-instructure/CHANGELOG.md
+++ b/packages/ui-instructure/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-instructure/package.json
+++ b/packages/ui-instructure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-instructure",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Collection of specific components for Instructure products",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-link/CHANGELOG.md
+++ b/packages/ui-link/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-link/package.json
+++ b/packages/ui-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-link",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for creating links",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-list/CHANGELOG.md
+++ b/packages/ui-list/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-list

--- a/packages/ui-list/package.json
+++ b/packages/ui-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-list",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Components for displaying vertical or horizontal lists.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-menu/CHANGELOG.md
+++ b/packages/ui-menu/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-menu",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A dropdown menu component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-metric/CHANGELOG.md
+++ b/packages/ui-metric/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-metric

--- a/packages/ui-metric/package.json
+++ b/packages/ui-metric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-metric",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component for displaying Metrics",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-modal/CHANGELOG.md
+++ b/packages/ui-modal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-modal/package.json
+++ b/packages/ui-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-modal",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for displaying content in a dialog overlay",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-motion/CHANGELOG.md
+++ b/packages/ui-motion/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-motion

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-motion",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-navigation/CHANGELOG.md
+++ b/packages/ui-navigation/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-navigation

--- a/packages/ui-navigation/package.json
+++ b/packages/ui-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-navigation",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Main and application level navigational components",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-number-input/CHANGELOG.md
+++ b/packages/ui-number-input/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-number-input/package.json
+++ b/packages/ui-number-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-number-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-options/CHANGELOG.md
+++ b/packages/ui-options/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-options/package.json
+++ b/packages/ui-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-options",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A view-only component for composing interactive lists and menus.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-overlays/CHANGELOG.md
+++ b/packages/ui-overlays/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-overlays/package.json
+++ b/packages/ui-overlays/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-overlays",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-pages/CHANGELOG.md
+++ b/packages/ui-pages/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-pages

--- a/packages/ui-pages/package.json
+++ b/packages/ui-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-pages",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-pagination/CHANGELOG.md
+++ b/packages/ui-pagination/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-pagination

--- a/packages/ui-pagination/package.json
+++ b/packages/ui-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-pagination",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-pill/CHANGELOG.md
+++ b/packages/ui-pill/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-pill

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-pill",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component to communicate concise status.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/Pill/11_5/index.js",

--- a/packages/ui-popover/CHANGELOG.md
+++ b/packages/ui-popover/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-popover/package.json
+++ b/packages/ui-popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-popover",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for hiding or showing content based on user interaction.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-portal/CHANGELOG.md
+++ b/packages/ui-portal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-portal

--- a/packages/ui-portal/package.json
+++ b/packages/ui-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-portal",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-position/CHANGELOG.md
+++ b/packages/ui-position/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-position

--- a/packages/ui-position/package.json
+++ b/packages/ui-position/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-position",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for positioning content with respect to a designated target.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-progress/CHANGELOG.md
+++ b/packages/ui-progress/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-progress

--- a/packages/ui-progress/package.json
+++ b/packages/ui-progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-progress",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Styled HTML <progress /> elements for showing completion of a task",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-radio-input/CHANGELOG.md
+++ b/packages/ui-radio-input/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-radio-input/package.json
+++ b/packages/ui-radio-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-radio-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled HTML input type='radio' element",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-range-input/CHANGELOG.md
+++ b/packages/ui-range-input/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **ui-range-input:** remove deprecated thumb variant ([ca4a3fb](https://github.com/instructure/instructure-ui/commit/ca4a3fb45885fbcc9807566dadd3d027a17b8f72))
+
+
+### BREAKING CHANGES
+
+* **ui-range-input:** `thumbVariant` prop removed from RangeInput
+
+INSTUI-5016
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-range-input

--- a/packages/ui-range-input/package.json
+++ b/packages/ui-range-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-range-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled HTML range input",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-rating/CHANGELOG.md
+++ b/packages/ui-rating/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-rating/package.json
+++ b/packages/ui-rating/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-rating",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A static rating component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-react-utils/CHANGELOG.md
+++ b/packages/ui-react-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-react-utils

--- a/packages/ui-react-utils/package.json
+++ b/packages/ui-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-react-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A React utility library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-responsive/CHANGELOG.md
+++ b/packages/ui-responsive/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-responsive

--- a/packages/ui-responsive/package.json
+++ b/packages/ui-responsive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-responsive",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component that allows for rendering a component differently based on either the element or the viewport size",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-scripts/CHANGELOG.md
+++ b/packages/ui-scripts/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Features
+
+* **ui-scripts:** use tokens from external repo and convert JS to TS ([a03e0cb](https://github.com/instructure/instructure-ui/commit/a03e0cb24cdf1a2f5debbe707f73ce50ec4a666a))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/ui-scripts",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI build scripts library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./lib/index.js",

--- a/packages/ui-select/CHANGELOG.md
+++ b/packages/ui-select/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **ui-select,ui-date-time-input:** rework DateTimeInput and replace DateInput v1 with DateInput v2 in DateTimeInput ([5a9405c](https://github.com/instructure/instructure-ui/commit/5a9405c0a19ea9fc6a34b2f34c60c582f96ec2af))
+
+
+### BREAKING CHANGES
+
+* **ui-select,ui-date-time-input:** prevMonthLabel prop removed (use screenReaderLabels.prevMonthButton instead)
+
+nextMonthLabel prop removed (use screenReaderLabels.nextMonthButton instead)
+
+renderWeekdayLabels prop removed
+
+dateFormat type changed: string → string
+
+{ parser: (input: string) => Date
+
+null, formatter: (date: Date) => string }
+
+screenReaderLabels is a new required prop
+
+dateFormat default changed: Moment's 'LL' (long month name) → locale's default date format
+
+INSTUI-4791
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-select",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for select and autocomplete behavior.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-selectable/CHANGELOG.md
+++ b/packages/ui-selectable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-selectable

--- a/packages/ui-selectable/package.json
+++ b/packages/ui-selectable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-selectable",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-side-nav-bar/CHANGELOG.md
+++ b/packages/ui-side-nav-bar/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-side-nav-bar

--- a/packages/ui-side-nav-bar/package.json
+++ b/packages/ui-side-nav-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-side-nav-bar",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Main and application level navigational components",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-simple-select/CHANGELOG.md
+++ b/packages/ui-simple-select/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-simple-select/package.json
+++ b/packages/ui-simple-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-simple-select",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for standard select element behavior.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-source-code-editor/CHANGELOG.md
+++ b/packages/ui-source-code-editor/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-source-code-editor/package.json
+++ b/packages/ui-source-code-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-source-code-editor",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-spinner/CHANGELOG.md
+++ b/packages/ui-spinner/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-spinner

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-spinner",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A spinner/loading component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-svg-images/CHANGELOG.md
+++ b/packages/ui-svg-images/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-svg-images

--- a/packages/ui-svg-images/package.json
+++ b/packages/ui-svg-images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-svg-images",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-table/CHANGELOG.md
+++ b/packages/ui-table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-table",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled HTML table component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-tabs/CHANGELOG.md
+++ b/packages/ui-tabs/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+* **ui-tabs:** fix tabs panel layout when unmountOnExit is false ([826ff62](https://github.com/instructure/instructure-ui/commit/826ff62fba56bc0cadd6995b366e3ca505b1b6c1))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-tabs

--- a/packages/ui-tabs/package.json
+++ b/packages/ui-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-tabs",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-tag/CHANGELOG.md
+++ b/packages/ui-tag/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-tag

--- a/packages/ui-tag/package.json
+++ b/packages/ui-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-tag",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A tag component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-text-area/CHANGELOG.md
+++ b/packages/ui-text-area/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+### Features
+
+* **many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-text-area/package.json
+++ b/packages/ui-text-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-text-area",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled HTML text area component",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-text-input/CHANGELOG.md
+++ b/packages/ui-text-input/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-text-input/package.json
+++ b/packages/ui-text-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-text-input",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled HTML text input component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-text/CHANGELOG.md
+++ b/packages/ui-text/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-text/package.json
+++ b/packages/ui-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-text",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for styling textual content",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-theme-tokens/CHANGELOG.md
+++ b/packages/ui-theme-tokens/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-theme-tokens

--- a/packages/ui-theme-tokens/package.json
+++ b/packages/ui-theme-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-theme-tokens",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Cross-platform theme tokens for Instructure products",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-themes/CHANGELOG.md
+++ b/packages/ui-themes/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-themes/package.json
+++ b/packages/ui-themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-themes",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A library of instructure themes",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-time-select/CHANGELOG.md
+++ b/packages/ui-time-select/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-time-select/package.json
+++ b/packages/ui-time-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-time-select",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for selecting time values.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-toggle-details/CHANGELOG.md
+++ b/packages/ui-toggle-details/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-toggle-details

--- a/packages/ui-toggle-details/package.json
+++ b/packages/ui-toggle-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-toggle-details",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A styled toggleable, accordion-like component.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-tooltip/CHANGELOG.md
+++ b/packages/ui-tooltip/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-tooltip

--- a/packages/ui-tooltip/package.json
+++ b/packages/ui-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-tooltip",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for showing small text-only overlays on hover/focus.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-top-nav-bar/CHANGELOG.md
+++ b/packages/ui-top-nav-bar/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-top-nav-bar/package.json
+++ b/packages/ui-top-nav-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-top-nav-bar",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A UI component library made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-tray/CHANGELOG.md
+++ b/packages/ui-tray/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-tray/package.json
+++ b/packages/ui-tray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-tray",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "Tray component for secondary/menu content",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-tree-browser/CHANGELOG.md
+++ b/packages/ui-tree-browser/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-tree-browser

--- a/packages/ui-tree-browser/package.json
+++ b/packages/ui-tree-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-tree-browser",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for displaying a hierarchical view of information",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-truncate-list/CHANGELOG.md
+++ b/packages/ui-truncate-list/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-truncate-list

--- a/packages/ui-truncate-list/package.json
+++ b/packages/ui-truncate-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-truncate-list",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A TruncateList component made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-truncate-text/CHANGELOG.md
+++ b/packages/ui-truncate-text/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-truncate-text/package.json
+++ b/packages/ui-truncate-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-truncate-text",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A TruncateText component made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-utils/CHANGELOG.md
+++ b/packages/ui-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-utils

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-utils",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A collection of utilities for UI components",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-view/CHANGELOG.md
+++ b/packages/ui-view/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 

--- a/packages/ui-view/package.json
+++ b/packages/ui-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui-view",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A component for basic styles including spacing, sizing, borders, display, positioning, and focus states.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/ui-webpack-config/CHANGELOG.md
+++ b/packages/ui-webpack-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/ui-webpack-config

--- a/packages/ui-webpack-config/package.json
+++ b/packages/ui-webpack-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/ui-webpack-config",
   "private": true,
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A shared webpack config made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "main": "./config/index.js",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 ### Bug Fixes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/ui",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A meta package exporting all UI components",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",

--- a/packages/uid/CHANGELOG.md
+++ b/packages/uid/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.7.3](https://github.com/instructure/instructure-ui/compare/v11.7.2...v11.7.3) (2026-05-07)
+
+
+### Bug Fixes
+
+* **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
+
+
+
+
+
 ## [11.7.2](https://github.com/instructure/instructure-ui/compare/v11.7.1...v11.7.2) (2026-04-23)
 
 **Note:** Version bump only for package @instructure/uid

--- a/packages/uid/package.json
+++ b/packages/uid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instructure/uid",
-  "version": "11.7.2",
+  "version": "11.7.3",
   "description": "A unique (CSS-safe) id generator made by Instructure Inc.",
   "author": "Instructure, Inc. Engineering and Product Design",
   "module": "./es/index.js",


### PR DESCRIPTION
### Bug Fixes

- **[v11.7] ui-buttons:** fix textAlign center on Buttons without icon ([b46ddb7](https://github.com/instructure/instructure-ui/commit/b46ddb788696bf1c556291d3a09a1ba659c6959f))
- **[v11.6, v11.7] ui-date-time-input,ui-date-input,ui-calendar:** set missing aria-selected on calendar days, BREAKING CHANGE: add mandatory prop selectedLabel, change datePickerDialog prop to mandatory ([08abed5](https://github.com/instructure/instructure-ui/commit/08abed5e8c8b29aecab0368e01e8e4ffd0c7fda7))
- **[v11.7] ui-tabs:** fix tabs panel layout when `unmountOnExit` is false ([826ff62](https://github.com/instructure/instructure-ui/commit/826ff62fba56bc0cadd6995b366e3ca505b1b6c1))
- **[v11.6, v11.7] ui-tree-browser,ui-top-nav-bar,ui-form-field:** add back some missing exports

### Features

- **many:** update dependencies, remove lots of Babel plugins, remove Webpack 4 support ([f916fca](https://github.com/instructure/instructure-ui/commit/f916fcafdddcb2d7de401f93e8ff92cfdfa47bba))
- **[v11.7] many:** add a way for consumers to pass their own component theme definition so they can build their own components with InstUI ([ce01c3e](https://github.com/instructure/instructure-ui/commit/ce01c3eedc46aa2588f4c8309a6eabf4461aaec7))
- **[v11.7] ui-checkbox:** add `data-checked` attribute to reflect checked state ([a790019](https://github.com/instructure/instructure-ui/commit/a790019ed2b47064a01b7ec532494cc723943241))
- **[v11.6, v11.7] ui-color-picker:** improve ColorPicker paste behavior ([e5c279d](https://github.com/instructure/instructure-ui/commit/e5c279dbf8ac9918f104e223b9625b3b50322f23))
- **[v11.7] ui-range-input:** remove deprecated thumb variant ([ca4a3fb](https://github.com/instructure/instructure-ui/commit/ca4a3fb45885fbcc9807566dadd3d027a17b8f72))
- **[v11.7] ui-select,ui-date-time-input:** rework DateTimeInput and replace DateInput v1 with DateInput v2 in DateTimeInput ([7717fc6](https://github.com/instructure/instructure-ui/commit/7717fc6db4d2a733c8349eb583d37a85a4137cf7))
- **ui-scripts:** use design tokens from external repo and convert JS to TS ([a03e0cb](https://github.com/instructure/instructure-ui/commit/a03e0cb24cdf1a2f5debbe707f73ce50ec4a666a))

### BREAKING CHANGES

- **[v11.7] ui-select,ui-date-time-input:** `renderWeekdayLabels` prop removed, `calendarIcon` is a new required prop
- **[v11.7] ui-range-input:** `thumbVariant` prop removed from RangeInput
- **[v11.7] ui-select,ui-date-time-input:** `prevMonthLabel` prop removed (use `screenReaderLabels.prevMonthButton` instead)
  - `nextMonthLabel` prop removed (use screenReaderLabels.nextMonthButton instead)
  - `renderWeekdayLabels` prop removed
  - `dateFormat` type changed
  - `screenReaderLabels` is a new required prop
  - `dateFormat` default changed: Moment's 'LL' (long month name) → locale's default date format