### PR TITLE
fix(ui-babel-preset): fix Cannot find package 'core-js' errors

### DIFF
--- a/packages/ui-babel-preset/lib/index.js
+++ b/packages/ui-babel-preset/lib/index.js
@@ -34,9 +34,6 @@ module.exports = function (
     targets: {
       browsers: require('@instructure/browserslist-config-instui')
     },
-    useBuiltIns: 'usage',
-    // this version has to match the version in package.json
-    corejs: '3.49.0',
     modules: opts.esModules ? false : 'commonjs'
     // debug: true, // un-comment if you want to see what browsers are being targeted and what plugins that means it will activate
   }

--- a/packages/ui-babel-preset/package.json
+++ b/packages/ui-babel-preset/package.json
@@ -27,11 +27,7 @@
     "@instructure/babel-plugin-transform-imports": "workspace:*",
     "@instructure/browserslist-config-instui": "workspace:*",
     "babel-loader": "^10.1.1",
-    "babel-plugin-transform-remove-console": "^6.9.4",
-    "core-js": "3.49.0"
-  },
-  "//dependency-comments": {
-    "core-js": "If you upgrade coreJS, you must also upgrade the version in the Babel preset"
+    "babel-plugin-transform-remove-console": "^6.9.4"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,9 +1076,6 @@ importers:
       babel-plugin-transform-remove-console:
         specifier: ^6.9.4
         version: 6.9.4
-      core-js:
-        specifier: 3.49.0
-        version: 3.49.0
 
   packages/ui-badge:
     dependencies:
@@ -7812,7 +7809,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8741,9 +8738,6 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
-
-  core-js@3.49.0:
-    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -17760,8 +17754,6 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
-
-  core-js@3.49.0: {}
 
   core-util-is@1.0.2: {}
 


### PR DESCRIPTION
core-js was fixing really niche bugs in the code e.g. `map.getOrInsertComputed`, `map.getOrInsert` not working perfectly in browsers and an exotic Safari bug https://bugs.webkit.org/show_bug.cgi?id=309342 that is fixed in Webkit nightly.

Remove core-js because its no longer needed

To test:
Build the lib and check files in the /es/ and /lib/ folders, they should not contain any core-js imports. Its **bad** in the latest PROD version, see https://www.npmjs.com/package/@instructure/ui-dom-utils/v/11.7.3?activeTab=code -> here open `/@instructure/ui-dom-utils/es/isDefinedCustomElement.js`