### PR TITLE
feat(ui-popover): add shouldScrollContent prop

### DIFF
--- a/packages/ui-popover/src/Popover/__tests__/Popover.test.tsx
+++ b/packages/ui-popover/src/Popover/__tests__/Popover.test.tsx
@@ -306,4 +306,43 @@ describe('<Popover />', () => {
 
     expect(popover).toHaveStyle('display: block')
   })
+
+  describe('shouldScrollContent', () => {
+    it('does not wrap content when the prop is unset', async () => {
+      render(
+        <Popover
+          isShowingContent
+          on="click"
+          renderTrigger={<button>Trigger</button>}
+        >
+          <h2 data-testid="content">Popover content</h2>
+        </Popover>
+      )
+      const content = await screen.findByTestId('content')
+      expect(
+        content.closest('[class*="popover__scrollContainer"]')
+      ).toBeNull()
+    })
+
+    it('wraps content in an overflow:auto + auto-fit max-height container when set', async () => {
+      render(
+        <Popover
+          isShowingContent
+          on="click"
+          renderTrigger={<button>Trigger</button>}
+          shouldScrollContent
+        >
+          <h2 data-testid="content">Popover content</h2>
+        </Popover>
+      )
+      const content = await screen.findByTestId('content')
+      const wrapper = content.closest(
+        '[class*="popover__scrollContainer"]'
+      ) as HTMLElement
+      expect(wrapper).not.toBeNull()
+      const computed = getComputedStyle(wrapper)
+      expect(computed.overflowY).toBe('auto')
+      expect(computed.maxHeight).toContain('--ui-position-available-height')
+    })
+  })
 })

--- a/packages/ui-popover/src/Popover/v2/README.md
+++ b/packages/ui-popover/src/Popover/v2/README.md
@@ -425,6 +425,37 @@ const Example = () => {
 render(<Example />)
 ```
 
+#### Scrolling content (`shouldScrollContent`)
+
+When the popover content can grow taller than the available viewport space, set `shouldScrollContent` to wrap the content in a scroll container that fits to the room between the trigger element and the viewport edge. To try the example below, zoom in until the available space becomes small enough that a scrollbar is displayed in the Popover.
+
+```js
+---
+type: example
+---
+const fpo = lorem.paragraphs(8)
+class Example extends React.Component {
+  state = { isOpen: false }
+  render () {
+    return (
+      <Popover
+        on="click"
+        placement="bottom start"
+        isShowingContent={this.state.isOpen}
+        onShowContent={() => this.setState({ isOpen: true })}
+        onHideContent={() => this.setState({ isOpen: false })}
+        shouldScrollContent
+        screenReaderLabel="A long popover"
+        renderTrigger={<Button>Open scrollable popover</Button>}
+      >
+        <View as="div" padding="small" maxWidth="22rem">{fpo}</View>
+      </Popover>
+    )
+  }
+}
+render(<Example />)
+```
+
 ### Guidelines
 
 ```js

--- a/packages/ui-popover/src/Popover/v2/index.tsx
+++ b/packages/ui-popover/src/Popover/v2/index.tsx
@@ -519,6 +519,12 @@ class Popover extends Component<PopoverProps, PopoverState> {
   renderContent() {
     let content = callRenderProp(this.props.children)
 
+    if (this.props.shouldScrollContent) {
+      content = (
+        <div css={this.props.styles?.scrollContainer}>{content}</div>
+      )
+    }
+
     if (this.shown && !this.isTooltip) {
       // if popover is NOT being used as a tooltip, create a Dialog
       // to manage the content FocusRegion, when showing

--- a/packages/ui-popover/src/Popover/v2/props.ts
+++ b/packages/ui-popover/src/Popover/v2/props.ts
@@ -25,7 +25,12 @@ import React from 'react'
 import { BorderWidth } from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 
-import type { Shadow, Stacking, WithStyleProps } from '@instructure/emotion'
+import type {
+  Shadow,
+  Stacking,
+  StyleObject,
+  WithStyleProps
+} from '@instructure/emotion'
 
 import type {
   PlacementPropValues,
@@ -284,6 +289,12 @@ type PopoverOwnProps = {
    * otherwise its calculated automatically based on whether the content is shown.
    */
   shouldSetAriaExpanded?: boolean
+  /**
+   * When `true`, wraps the popover content in a container that caps its
+   * height to the available viewport space and scrolls when content
+   * overflows.
+   */
+  shouldScrollContent?: boolean
 }
 
 type PopoverProps = PopoverOwnProps &
@@ -302,7 +313,11 @@ type PropKeys = keyof PopoverOwnProps
 
 type AllowedPropKeys = Readonly<Array<PropKeys>>
 
-type PopoverStyle = { borderRadius: string; borderColor: string }
+type PopoverStyle = {
+  borderRadius: string
+  borderColor: string
+  scrollContainer: StyleObject
+}
 const allowedProps: AllowedPropKeys = [
   'isShowingContent',
   'defaultIsShowingContent',
@@ -347,7 +362,8 @@ const allowedProps: AllowedPropKeys = [
   'children',
   'elementRef',
   'borderWidth',
-  'shouldSetAriaExpanded'
+  'shouldSetAriaExpanded',
+  'shouldScrollContent'
 ]
 
 export type { PopoverOwnProps, PopoverProps, PopoverState, PopoverStyle }

--- a/packages/ui-popover/src/Popover/v2/styles.ts
+++ b/packages/ui-popover/src/Popover/v2/styles.ts
@@ -38,7 +38,13 @@ const generateStyle = (
 ): PopoverStyle => {
   return {
     borderColor: componentTheme.borderColor,
-    borderRadius: componentTheme.borderRadius
+    borderRadius: componentTheme.borderRadius,
+    scrollContainer: {
+      label: 'popover__scrollContainer',
+      maxHeight: 'var(--ui-position-available-height, 100vh)',
+      overflowY: 'auto',
+      overflowX: 'hidden'
+    }
   }
 }
 

--- a/packages/ui-position/src/calculateElementPosition.ts
+++ b/packages/ui-position/src/calculateElementPosition.ts
@@ -562,9 +562,9 @@ class PositionData {
   }
 
   /**
-   * Maximum height/width (in CSS px) the positioned element can occupy in
-   * the resolved placement before crossing the constraint. Drives the
-   * `--ui-position-available-{height,width}` CSS variables
+   * Maximum height/width (in CSS px) an *inner* box inside the positioned
+   * element can occupy before the wrapper crosses the constraint edge.
+   * Drives the `--ui-position-available-{height,width}` CSS variables.
    */
   get availableSpace(): { height: number; width: number } {
     const targetNode = this.target?.node as Element | undefined
@@ -622,11 +622,29 @@ class PositionData {
       width = constraintRect.width
     }
 
-    // Floor at 16px so a consumer's `max-height` doesn't collapse to 0 in the
-    // frame(s) before placement flips when the trigger sits right at the edge.
+    // Measure the wrapper's frame
+    let vFrame = 0
+    let hFrame = 0
+    if (elementNode && 'ownerDocument' in elementNode) {
+      const view = (elementNode as Element).ownerDocument?.defaultView
+      if (view) {
+        const cs = view.getComputedStyle(elementNode as Element)
+        vFrame =
+          (parseFloat(cs.borderTopWidth) || 0) +
+          (parseFloat(cs.borderBottomWidth) || 0) +
+          (parseFloat(cs.paddingTop) || 0) +
+          (parseFloat(cs.paddingBottom) || 0)
+        hFrame =
+          (parseFloat(cs.borderLeftWidth) || 0) +
+          (parseFloat(cs.borderRightWidth) || 0) +
+          (parseFloat(cs.paddingLeft) || 0) +
+          (parseFloat(cs.paddingRight) || 0)
+      }
+    }
+
     return {
-      height: Math.max(16, height),
-      width: Math.max(16, width)
+      height: Math.max(0, Math.floor(height - vFrame - 1)),
+      width: Math.max(0, Math.floor(width - hFrame - 1))
     }
   }
 }


### PR DESCRIPTION
This PR depends on  ui-position-available-space PR, the newly added CSS vars are needed to be able to add shouldScrollContent prop to Popover.

**Test:** use the new example in the Popover docs page. Zoom in and see if a scrollbar appears in the dialog.