### PR TITLE
feat(ui-scripts): add publish-private command for private-registry releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Private-registry publishing (`pnpm run publish-private`).
+# Both must be set; the command exits 1 if either is missing.
+INSTUI_PRIVATE_REGISTRY=https://<host>/<path>/
+INSTUI_PRIVATE_REGISTRY_TOKEN=

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "create-component-version": "ui-scripts create-component-version",
     "bump": "ui-scripts bump",
     "release": "ui-scripts publish",
+    "publish-private": "ui-scripts publish-private",
     "husky:pre-commit": "lint-staged && node scripts/checkTSReferences.js",
     "postinstall": "husky",
     "ts:check": "pnpm -r --stream ts:check"

--- a/packages/ui-scripts/lib/commands/index.js
+++ b/packages/ui-scripts/lib/commands/index.js
@@ -27,6 +27,7 @@ import server from './server.js'
 import tag from './tag.js'
 import deprecate from './deprecate.js'
 import publish from './publish.js'
+import publishPrivate from './publish-private.js'
 import visualDiff from './visual-diff.ts'
 import lint from '../test/lint.js'
 import bundle from '../build/webpack.js'
@@ -43,6 +44,7 @@ export const yargCommands = [
   tag,
   deprecate,
   publish,
+  publishPrivate,
   visualDiff,
   lint,
   bundle,

--- a/packages/ui-scripts/lib/commands/publish-private.js
+++ b/packages/ui-scripts/lib/commands/publish-private.js
@@ -1,0 +1,199 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import readline from 'node:readline/promises'
+
+import pkgUtils from '@instructure/pkg-utils'
+import { error, info, runCommandAsync } from '@instructure/command-utils'
+
+const PRIVATE_TAG = 'security'
+
+export default {
+  command: 'publish-private',
+  desc: 'publishes ALL non-private packages to a private npm-compatible registry. Reads INSTUI_PRIVATE_REGISTRY and INSTUI_PRIVATE_REGISTRY_TOKEN from the environment.',
+  builder: (yargs) => {
+    yargs.option('yes', {
+      type: 'boolean',
+      describe: 'Skip the interactive registry-hostname confirmation prompt',
+      default: false
+    })
+  },
+  handler: async (argv) => {
+    try {
+      await publishPrivate({ skipConfirm: argv.yes })
+    } catch (err) {
+      error(err)
+      process.exit(1)
+    }
+  }
+}
+
+async function publishPrivate({ skipConfirm }) {
+  const registry = process.env.INSTUI_PRIVATE_REGISTRY
+  const token = process.env.INSTUI_PRIVATE_REGISTRY_TOKEN
+
+  if (!registry || !token) {
+    error(
+      'INSTUI_PRIVATE_REGISTRY and INSTUI_PRIVATE_REGISTRY_TOKEN must both be set in your environment.'
+    )
+    process.exit(1)
+  }
+
+  let registryUrl
+  try {
+    registryUrl = new URL(registry)
+  } catch {
+    error(`INSTUI_PRIVATE_REGISTRY is not a valid URL: ${registry}`)
+    process.exit(1)
+  }
+
+  // Hard guard: this command must never publish to npmjs.
+  if (/(^|\.)npmjs\.org$/i.test(registryUrl.hostname)) {
+    error(
+      `Refusing to publish-private to ${registryUrl.hostname}. Use \`pnpm run release\` for public npmjs releases.`
+    )
+    process.exit(1)
+  }
+
+  const packages = pkgUtils.getPackages().filter((pkg) => !pkg.private)
+  if (packages.length === 0) {
+    error('No publishable (non-private) packages found.')
+    process.exit(1)
+  }
+
+  const sampleVersion = packages[0].version
+
+  info('')
+  info('📦  Private (embargoed) publish')
+  info(`    Registry: ${registryUrl.hostname}`)
+  info(`    Tag:      ${PRIVATE_TAG}`)
+  info(`    Packages: ${packages.length} packages at version ${sampleVersion}`)
+  info('')
+
+  if (!skipConfirm) {
+    await confirmHostname(registryUrl.hostname)
+  }
+
+  const npmrcPath = writeTempNpmrc(registryUrl, token)
+
+  try {
+    for (let i = 0; i < packages.length; i++) {
+      const pkg = packages[i]
+      await publishPackage(pkg, npmrcPath)
+      info(
+        `📦  ${pkg.name}@${pkg.version} published to ${registryUrl.hostname}`
+      )
+      // Throttle to avoid registry rate-limiting on bulk publishes.
+      if (i < packages.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      }
+    }
+  } finally {
+    cleanupTempNpmrc(npmrcPath)
+  }
+
+  info('')
+  info(
+    `✅  Done. ${packages.length} packages published to ${registryUrl.hostname} under tag "${PRIVATE_TAG}".`
+  )
+}
+
+async function confirmHostname(hostname) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+  try {
+    const answer = await rl.question(
+      `Type the registry hostname to confirm (${hostname}): `
+    )
+    if (answer.trim() !== hostname) {
+      error('Confirmation did not match. Aborting.')
+      process.exit(1)
+    }
+  } finally {
+    rl.close()
+  }
+}
+
+function writeTempNpmrc(registryUrl, token) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'instui-publish-private-'))
+  const file = path.join(dir, '.npmrc')
+  const authPath = registryUrl.pathname.endsWith('/')
+    ? registryUrl.pathname
+    : `${registryUrl.pathname}/`
+  const authLine = `//${registryUrl.host}${authPath}:_authToken=${token}`
+  const registryLine = `registry=${registryUrl.toString()}`
+  fs.writeFileSync(file, `${registryLine}\n${authLine}\n`, { mode: 0o600 })
+  return file
+}
+
+function cleanupTempNpmrc(npmrcPath) {
+  try {
+    fs.rmSync(path.dirname(npmrcPath), { recursive: true, force: true })
+  } catch {
+    // best effort — temp dir cleanup failure is not fatal
+  }
+}
+
+async function publishPackage(pkg, npmrcPath) {
+  const childEnv = { NPM_CONFIG_USERCONFIG: npmrcPath }
+
+  // Skip if this version is already on the private registry.
+  let versions = []
+  try {
+    const { stdout } = await runCommandAsync(
+      'pnpm',
+      ['info', pkg.name, '--json'],
+      childEnv,
+      { stdio: 'pipe' }
+    )
+    versions = JSON.parse(stdout).versions || []
+  } catch {
+    // Package not yet in the registry — fall through and publish.
+  }
+
+  if (versions.includes(pkg.version)) {
+    throw new Error(
+      `📦  ${pkg.name}@${pkg.version} is already published to the private registry.`
+    )
+  }
+
+  await runCommandAsync(
+    'pnpm',
+    [
+      'publish',
+      pkg.location,
+      '--tag',
+      PRIVATE_TAG,
+      '--no-git-checks'
+      // Provenance is npmjs-only; omitted for non-npmjs registries.
+      // Registry + auth come from the temp .npmrc via NPM_CONFIG_USERCONFIG.
+    ],
+    childEnv
+  )
+}


### PR DESCRIPTION
## Summary

Adds `pnpm run publish-private` for publishing all non-private packages to an npm-compatible private registry. Used to ship pre-release builds of security fixes to selected consumers ahead of the public release.

Reads `INSTUI_PRIVATE_REGISTRY` and `INSTUI_PRIVATE_REGISTRY_TOKEN` from the environment. The existing public release path (`pnpm run release`, OIDC, GitHub workflows) is untouched.

## Why a separate command

`pnpm run release` is invoked on master push and OIDC-publishes to npmjs. Overloading it would mean a mis-set env var could leak embargoed code to the public registry. A distinct command isolates the private path and its guard rails.

## Safety

- Refuses any host matching `*.npmjs.org`.
- Exits 1 if either env var is missing.
- Operator must type the registry hostname to confirm (skippable with `--yes`).
- Writes a temp `.npmrc` for the publish subprocesses only — user/project `.npmrc` untouched, cleaned up in `finally`.
- Publishes under dist-tag `security` so `pnpm install` won't resolve a private build by accident.
- Skips packages whose version already exists on the target registry.
- 500ms delay between publishes to stay under registry rate limits.

## Usage

```sh
export INSTUI_PRIVATE_REGISTRY=https://<host>/<path>/
export INSTUI_PRIVATE_REGISTRY_TOKEN=<token>
pnpm run publish-private
```

## What this PR does NOT do

- No version bumping — handled separately.
- No changes to the public release flow, OIDC auth, GitHub workflows, or `publish.js`.
- No documentation update yet — coming once the surrounding bump-script work lands and the end-to-end flow is settled.

## Test Plan

- [x] Smoke-tested against a real private registry — auth, tag, and versions all land correctly.
- [ ] `pnpm run publish-private --help` shows the `--yes` flag.
- [ ] Missing env vars and npmjs hostname both exit 1.

Draft until the version-bump PR lands and the end-to-end flow can be walked through.
