### PR TITLE
refactor: unify deploy base path handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,18 +30,24 @@ jobs:
           case "${{ github.ref }}" in
             "refs/heads/master")
               echo "::set-output name=deploy_dir::./"
+              echo "::set-output name=public_path::/"
               ;;
             "refs/heads/v8_maintenance")
               echo "::set-output name=deploy_dir::v8"
+              echo "::set-output name=public_path::/v8/"
               ;;
             "refs/heads/v9_maintenance")
               echo "::set-output name=deploy_dir::v9"
+              echo "::set-output name=public_path::/v9/"
               ;;
             "refs/heads/v10_maintenance")
               echo "::set-output name=deploy_dir::v10"
+              echo "::set-output name=public_path::/v10/"
               ;;
           esac
       - name: Build docs-app
+        env:
+          PUBLIC_PATH: ${{ steps.set-build-dir.outputs.public_path }}
         run: pnpm run build:docs
       - name: Copy index.html to 404.html for GitHub Pages
         run: cp ./packages/__docs__/__build__/index.html ./packages/__docs__/__build__/404.html

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PULL_REQUEST_PREVIEW: 'true'
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PUBLIC_PATH: /pr-preview/pr-${{ github.event.pull_request.number }}/
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -70,7 +70,7 @@ import {
 import {
   parseCurrentUrl,
   navigateToVersion,
-  getAssetBasePath,
+  getDeployBase,
   MINOR_VERSION_REGEX
 } from '../navigationUtils'
 
@@ -136,7 +136,7 @@ class App extends Component<AppProps, AppState> {
   }
 
   getDocsBasePath = () => {
-    const base = getAssetBasePath()
+    const base = getDeployBase()
     const { selectedMinorVersion } = this.state
     if (selectedMinorVersion) {
       return `${base}/docs/${selectedMinorVersion}/`
@@ -212,13 +212,13 @@ class App extends Component<AppProps, AppState> {
     navigateToVersion(newVersion)
 
     this.fetchMainDocsData(
-      `${getAssetBasePath()}/docs/${newVersion}/markdown-and-sources-data.json`,
+      `${getDeployBase()}/docs/${newVersion}/markdown-and-sources-data.json`,
       signal
     ).catch(errorHandler)
 
     // Icons are not version-specific; only re-fetch if not already loaded
     if (!this.state.legacyIconsData) {
-      fetch(`${getAssetBasePath()}/legacy-icons-data.json`, { signal })
+      fetch(`${getDeployBase()}/legacy-icons-data.json`, { signal })
         .then((response) => response.json())
         .then((legacyIconsData) => {
           this.setState({ legacyIconsData })
@@ -282,7 +282,7 @@ class App extends Component<AppProps, AppState> {
     this.fetchVersionData(signal).catch(errorHandler)
     document.addEventListener('keydown', this.handleTabKey)
 
-    fetch(`${getAssetBasePath()}/legacy-icons-data.json`, { signal })
+    fetch(`${getDeployBase()}/legacy-icons-data.json`, { signal })
       .then((response) => response.json())
       .then((iconsData) => this.setState({ legacyIconsData: iconsData }))
       .catch(errorHandler)
@@ -304,13 +304,13 @@ class App extends Component<AppProps, AppState> {
             selectedMinorVersion
           })
           return this.fetchMainDocsData(
-            `${getAssetBasePath()}/docs/${selectedMinorVersion}/markdown-and-sources-data.json`,
+            `${getDeployBase()}/docs/${selectedMinorVersion}/markdown-and-sources-data.json`,
             signal
           )
         }
         // No minor versions available, fetch from root path
         return this.fetchMainDocsData(
-          `${getAssetBasePath()}/markdown-and-sources-data.json`,
+          `${getDeployBase()}/markdown-and-sources-data.json`,
           signal
         )
       })
@@ -360,23 +360,21 @@ class App extends Component<AppProps, AppState> {
   getPathInfo = () => {
     const { hash, pathname } = window.location
 
-    const cleanPath = pathname.replace(/^\/+|\/+$/g, '')
+    // Strip the deploy base (e.g. '/latest', '/pr-preview/pr-123',
+    // '/<repo>/pr-preview/pr-N') before parsing app segments.
+    const deployBase = getDeployBase()
+    let rest = pathname
+    if (
+      deployBase &&
+      (rest === deployBase || rest.startsWith(deployBase + '/'))
+    ) {
+      rest = rest.slice(deployBase.length)
+    }
+
+    const cleanPath = rest.replace(/^\/+|\/+$/g, '')
     const segments = cleanPath.split('/').filter(Boolean)
 
-    // Skip PR preview prefix
     let idx = 0
-    if (
-      segments.length >= 2 &&
-      segments[0] === 'pr-preview' &&
-      segments[1].startsWith('pr-')
-    ) {
-      idx = 2
-    }
-
-    // Skip /latest/ prefix
-    if (idx === 0 && segments[idx] === 'latest') {
-      idx++
-    }
 
     // Skip minor version prefix (e.g. v11_7)
     if (idx < segments.length && MINOR_VERSION_REGEX.test(segments[idx])) {

--- a/packages/__docs__/src/index.html
+++ b/packages/__docs__/src/index.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
-    <base href="/" />
-    <!-- GitHub Pages SPA redirect for subdirectory deployments.
-         When serving this page as 404.html, redirect deep links under
-         /pr-preview/pr-N/ or /latest/ back to the subdirectory root with
-         the route encoded as a query parameter. No-op for root paths. -->
+    <base href="<%= PUBLIC_PATH %>" />
+    <!-- When GH Pages serves this as 404.html, redirect the deep link to the
+         deploy base -->
     <script>
       ;(function () {
+        var base = '<%= PUBLIC_PATH %>'
         var l = window.location
-        var m = l.pathname.match(/^(\/pr-preview\/pr-\d+|\/latest)(\/.*)$/)
-        if (m && m[2] !== '/') {
-          l.replace(
-            m[1] + '/?__spa_route=' + encodeURIComponent(m[2] + l.hash)
-          )
-        }
+        if (l.pathname === base) return
+        if (l.pathname + '/' === base) return
+        if (l.pathname.indexOf(base) !== 0) return
+        var rest = l.pathname.slice(base.length)
+        l.replace(
+          base + '?__spa_route=' + encodeURIComponent('/' + rest + l.hash)
+        )
       })()
     </script>
     <meta charset="utf-8" />

--- a/packages/__docs__/src/index.html
+++ b/packages/__docs__/src/index.html
@@ -6,14 +6,15 @@
          deploy base -->
     <script>
       ;(function () {
-        var base = '<%= PUBLIC_PATH %>'
-        var l = window.location
-        if (l.pathname === base) return
-        if (l.pathname + '/' === base) return
-        if (l.pathname.indexOf(base) !== 0) return
-        var rest = l.pathname.slice(base.length)
-        l.replace(
-          base + '?__spa_route=' + encodeURIComponent('/' + rest + l.hash)
+        const base = '<%= PUBLIC_PATH %>'
+        const { pathname, search, hash } = window.location
+        if (pathname === base || pathname + '/' === base) return
+        if (!pathname.startsWith(base)) return
+        const rest = pathname.slice(base.length)
+        window.location.replace(
+          base +
+            '?__spa_route=' +
+            encodeURIComponent('/' + rest + search + hash)
         )
       })()
     </script>

--- a/packages/__docs__/src/index.tsx
+++ b/packages/__docs__/src/index.tsx
@@ -31,8 +31,9 @@ import { InstUISettingsProvider } from '@instructure/emotion'
 import '../globals'
 
 // Restore the original URL after a GitHub Pages 404 -> SPA redirect.
-// The 404.html (built in deploy.yml) redirects PR preview sub-routes to
-// /pr-preview/pr-{N}/?__spa_route=/path, and this code restores the clean URL.
+// 404.html (a copy of index.html, made in deploy.yml) rewrites any deep
+// link under the deploy base (e.g. /latest/, /v10/, /pr-preview/pr-N/) to
+// <PUBLIC_PATH>?__spa_route=/path. This restores the clean URL on load.
 const spaRouteParam = new URLSearchParams(window.location.search).get(
   '__spa_route'
 )

--- a/packages/__docs__/src/navigationUtils.ts
+++ b/packages/__docs__/src/navigationUtils.ts
@@ -29,16 +29,14 @@ declare const __webpack_public_path__: string
 const MINOR_VERSION_REGEX = /^v\d+_\d+$/
 
 type ParsedUrl = {
-  basePrefix: string
   minorVersion: string | null
   page: string
   sectionId: string | undefined
 }
 
 /**
- * Returns '' for a root deploy, '/latest' on instructure.design,
- * '/pr-preview/pr-<n>' for PR previews. For sub-host deployments it can be
- * '/<repo>/pr-preview/pr-<n>'.
+ * Returns webpack's `output.publicPath` with the trailing slash stripped.
+ * Always begins with `/`, or is empty for a root deploy.
  */
 function getDeployBase(): string {
   if (typeof __webpack_public_path__ === 'string' && __webpack_public_path__) {
@@ -52,20 +50,17 @@ function parseCurrentUrl(): ParsedUrl {
 
   const deployBase = getDeployBase()
   let rest = pathname
-  if (deployBase && rest.startsWith(deployBase)) {
+  if (
+    deployBase &&
+    (rest === deployBase || rest.startsWith(deployBase + '/'))
+  ) {
     rest = rest.slice(deployBase.length)
   }
 
   const cleanPath = rest.replace(/^\/+|\/+$/g, '')
   const segments = cleanPath.split('/').filter(Boolean)
 
-  let appPrefix = ''
   let idx = 0
-
-  if (segments[idx] === 'latest') {
-    appPrefix = '/latest'
-    idx++
-  }
 
   // Detect minor version prefix: /v11_7
   let minorVersion: string | null = null
@@ -83,7 +78,7 @@ function parseCurrentUrl(): ParsedUrl {
     sectionId = decodeURI(hash.replace(/^#+/, ''))
   }
 
-  return { basePrefix: deployBase + appPrefix, minorVersion, page, sectionId }
+  return { minorVersion, page, sectionId }
 }
 
 type BuildUrlOptions = {
@@ -98,7 +93,7 @@ function buildUrl(targetPage: string, options?: BuildUrlOptions): string {
       ? options.minorVersion
       : parsed.minorVersion
 
-  let url = parsed.basePrefix
+  let url = getDeployBase()
 
   if (minorVersion) {
     url += `/${minorVersion}`
@@ -130,20 +125,12 @@ function navigateToVersion(version: string | null): void {
   window.dispatchEvent(new PopStateEvent('popstate'))
 }
 
-/**
- * Returns the base path prefix for fetching static assets.
- * On PR previews this is e.g. `/pr-preview/pr-2425`, otherwise empty string.
- */
-function getAssetBasePath(): string {
-  return getDeployBase()
-}
-
 export {
   parseCurrentUrl,
   buildUrl,
   navigateTo,
   navigateToVersion,
-  getAssetBasePath,
+  getDeployBase,
   MINOR_VERSION_REGEX
 }
 export type { ParsedUrl }

--- a/packages/__docs__/src/navigationUtils.ts
+++ b/packages/__docs__/src/navigationUtils.ts
@@ -22,36 +22,48 @@
  * SOFTWARE.
  */
 
+// Webpack-injected; equals output.publicPath.
+// Examples: '/', '/latest/', '/pr-preview/pr-123/'.
+declare const __webpack_public_path__: string
+
 const MINOR_VERSION_REGEX = /^v\d+_\d+$/
 
 type ParsedUrl = {
-  prPrefix: string
+  basePrefix: string
   minorVersion: string | null
   page: string
   sectionId: string | undefined
 }
 
+/**
+ * Returns '' for a root deploy, '/latest' on instructure.design,
+ * '/pr-preview/pr-<n>' for PR previews. For sub-host deployments it can be
+ * '/<repo>/pr-preview/pr-<n>'.
+ */
+function getDeployBase(): string {
+  if (typeof __webpack_public_path__ === 'string' && __webpack_public_path__) {
+    return __webpack_public_path__.replace(/\/+$/, '')
+  }
+  return ''
+}
+
 function parseCurrentUrl(): ParsedUrl {
   const { pathname, hash } = window.location
-  const cleanPath = pathname.replace(/^\/+|\/+$/g, '')
-  const segments = cleanPath.split('/').filter(Boolean)
 
-  let prPrefix = ''
-  let idx = 0
-
-  // Detect PR preview prefix: /pr-preview/pr-123
-  if (
-    segments.length >= 2 &&
-    segments[0] === 'pr-preview' &&
-    segments[1].startsWith('pr-')
-  ) {
-    prPrefix = `/${segments[0]}/${segments[1]}`
-    idx = 2
+  const deployBase = getDeployBase()
+  let rest = pathname
+  if (deployBase && rest.startsWith(deployBase)) {
+    rest = rest.slice(deployBase.length)
   }
 
-  // Detect /latest/ prefix
-  if (idx === 0 && segments[idx] === 'latest') {
-    prPrefix = '/latest'
+  const cleanPath = rest.replace(/^\/+|\/+$/g, '')
+  const segments = cleanPath.split('/').filter(Boolean)
+
+  let appPrefix = ''
+  let idx = 0
+
+  if (segments[idx] === 'latest') {
+    appPrefix = '/latest'
     idx++
   }
 
@@ -71,7 +83,7 @@ function parseCurrentUrl(): ParsedUrl {
     sectionId = decodeURI(hash.replace(/^#+/, ''))
   }
 
-  return { prPrefix, minorVersion, page, sectionId }
+  return { basePrefix: deployBase + appPrefix, minorVersion, page, sectionId }
 }
 
 type BuildUrlOptions = {
@@ -80,13 +92,13 @@ type BuildUrlOptions = {
 }
 
 function buildUrl(targetPage: string, options?: BuildUrlOptions): string {
-  const { prPrefix } = parseCurrentUrl()
+  const parsed = parseCurrentUrl()
   const minorVersion =
     options?.minorVersion !== undefined
       ? options.minorVersion
-      : parseCurrentUrl().minorVersion
+      : parsed.minorVersion
 
-  let url = prPrefix
+  let url = parsed.basePrefix
 
   if (minorVersion) {
     url += `/${minorVersion}`
@@ -123,7 +135,7 @@ function navigateToVersion(version: string | null): void {
  * On PR previews this is e.g. `/pr-preview/pr-2425`, otherwise empty string.
  */
 function getAssetBasePath(): string {
-  return parseCurrentUrl().prPrefix
+  return getDeployBase()
 }
 
 export {

--- a/packages/__docs__/src/versionData.ts
+++ b/packages/__docs__/src/versionData.ts
@@ -55,7 +55,7 @@ const fetchVersionData = async (signal: AbortSignal) => {
 }
 
 import type { MinorVersionData } from '../buildScripts/DataTypes.mts'
-import { getAssetBasePath } from './navigationUtils'
+import { getDeployBase } from './navigationUtils'
 
 /**
  * Fetches minor version data from docs-versions.json.
@@ -66,7 +66,9 @@ const fetchMinorVersionData = async (
   signal: AbortSignal
 ): Promise<MinorVersionData | undefined> => {
   try {
-    const result = await fetch(`${getAssetBasePath()}/docs-versions.json`, { signal })
+    const result = await fetch(`${getDeployBase()}/docs-versions.json`, {
+      signal
+    })
     if (!result.ok) {
       return undefined
     }

--- a/packages/__docs__/webpack.config.mjs
+++ b/packages/__docs__/webpack.config.mjs
@@ -32,7 +32,14 @@ const ENV = process.env.NODE_ENV || 'production'
 const DEBUG = process.env.DEBUG || ENV === 'development'
 const GITHUB_PULL_REQUEST_PREVIEW = process.env.GITHUB_PULL_REQUEST_PREVIEW || 'false'
 const PR_NUMBER = process.env.PR_NUMBER
-const PUBLIC_PATH = process.env.PUBLIC_PATH
+// The URL prefix this build is deployed under. Must end with a trailing
+// slash. Fed into output.publicPath (which webpack exposes at runtime as
+// __webpack_public_path__) and into the HTML template's <base href> and
+// 404 SPA-redirect script. Keeping a single source here means a new deploy
+// target only needs to set this one env var.
+const PUBLIC_PATH =
+  process.env.PUBLIC_PATH ||
+  (PR_NUMBER ? `/pr-preview/pr-${PR_NUMBER}/` : '/')
 
 const outputPath = resolvePath(import.meta.dirname, '__build__')
 
@@ -51,9 +58,7 @@ const config = merge(baseConfig, {
   output: {
     path: outputPath,
     filename: '[name].js',
-    // Builds deployed to subdirectories on GitHub Pages (e.g. /pr-preview/pr-123/
-    // or /latest/) need a matching publicPath so script tags resolve correctly.
-    publicPath: PUBLIC_PATH || (PR_NUMBER ? `/pr-preview/pr-${PR_NUMBER}/` : '/'),
+    publicPath: PUBLIC_PATH,
   },
   devServer: {
     static: {
@@ -69,6 +74,7 @@ const config = merge(baseConfig, {
     new HtmlWebpackPlugin({
       template: './src/index.html',
       chunks: ['main'],
+      templateParameters: { PUBLIC_PATH },
     }),
     new webpack.DefinePlugin({
       'process.env.GITHUB_PULL_REQUEST_PREVIEW': JSON.stringify(GITHUB_PULL_REQUEST_PREVIEW),

--- a/packages/__docs__/webpack.config.mjs
+++ b/packages/__docs__/webpack.config.mjs
@@ -31,15 +31,19 @@ import webpack from 'webpack'
 const ENV = process.env.NODE_ENV || 'production'
 const DEBUG = process.env.DEBUG || ENV === 'development'
 const GITHUB_PULL_REQUEST_PREVIEW = process.env.GITHUB_PULL_REQUEST_PREVIEW || 'false'
-const PR_NUMBER = process.env.PR_NUMBER
-// The URL prefix this build is deployed under. Must end with a trailing
+// The URL prefix this build is deployed under. Must begin and end with a
 // slash. Fed into output.publicPath (which webpack exposes at runtime as
 // __webpack_public_path__) and into the HTML template's <base href> and
-// 404 SPA-redirect script. Keeping a single source here means a new deploy
-// target only needs to set this one env var.
-const PUBLIC_PATH =
-  process.env.PUBLIC_PATH ||
-  (PR_NUMBER ? `/pr-preview/pr-${PR_NUMBER}/` : '/')
+// 404 SPA-redirect script. Every CI workflow sets this explicitly; the
+// fallback to '/' only exists for local dev (`pnpm dev`).
+const PUBLIC_PATH = process.env.PUBLIC_PATH || '/'
+
+if (!/^\/([^?#]*\/)?$/.test(PUBLIC_PATH)) {
+  throw new Error(
+    `PUBLIC_PATH must begin and end with a slash and contain no query or fragment (got: "${PUBLIC_PATH}"). ` +
+    `Examples: "/", "/latest/", "/pr-preview/pr-123/", "/repo/pr-preview/pr-123/"`
+  )
+}
 
 const outputPath = resolvePath(import.meta.dirname, '__build__')
 


### PR DESCRIPTION
This change is needed to be able to host PR previews on Github pages of `instructure-design-tokens` repo.

**Unify docs-app deploy base path handling**

  Make `PUBLIC_PATH` (env var → webpack `output.publicPath`) the single source of truth for "where this build lives" and thread it through every layer:

  - **`webpack.config.mjs`** — resolve `PUBLIC_PATH` once and pass it to both `output.publicPath` and `HtmlWebpackPlugin`'s `templateParameters`.
  - **`index.html`** — `<base href>` and the inline 404 SPA-redirect script both read the template parameter; the redirect is now generic instead of pattern-matching `pr-preview`/`latest`.
  - **`navigationUtils.ts`** — new `getDeployBase()` reads `__webpack_public_path__` at runtime. `parseCurrentUrl` strips it before parsing the in-app route; `getAssetBasePath` returns it directly. Renamed
  `prPrefix` → `basePrefix` and de-duplicated a double `parseCurrentUrl()` call in `buildUrl`.

  No behavior change for current `instructure.design` deploys. Unlocks hosting the docs-app at any base path — other repos (e.g. design-tokens previews) or arbitrary sub-hosts — by setting `PUBLIC_PATH` at
  build time.

**Test plan**: try if everything works well on dev server locally, open docs page also check the pr preview here in the PR. 