### PR TITLE
fix(ui-scripts): fixed a shallow merge bug in generatesemantics.ts

### DIFF
--- a/packages/ui-scripts/lib/build/buildThemes/generateSemantics.ts
+++ b/packages/ui-scripts/lib/build/buildThemes/generateSemantics.ts
@@ -104,8 +104,27 @@ export const resolveTypeReferences = (semantics: any, key?: any): string => {
   return `${typeof value}, `
 }
 
+const deepMerge = (target: any, source: any): any => {
+  const result = { ...target }
+  for (const key of Object.keys(source)) {
+    if (
+      typeof source[key] === 'object' &&
+      source[key] !== null &&
+      !Array.isArray(source[key]) &&
+      typeof target[key] === 'object' &&
+      target[key] !== null &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = deepMerge(target[key], source[key])
+    } else {
+      result[key] = source[key]
+    }
+  }
+  return result
+}
+
 export const mergeSemanticSets = (semanticList: any[]) =>
-  semanticList.reduce((acc, semantic) => ({ ...acc, ...semantic }), {})
+  semanticList.reduce((acc, semantic) => deepMerge(acc, semantic), {})
 
 const generateSemantics = (data: any): string => {
   const formattedSemantic = formatSemantic(data)


### PR DESCRIPTION
`mergeSemanticSets` used a shallow spread. Every semantic JSON file wraps its contents under a single top-level "semantic" key, so when color and layout files were merged, the layout's semantic object silently overwrote the color one. The deep merge now recursively combines both instead.