### PR TITLE
fix(ui-scripts): route publish-private to the private registry even when ~/.npmrc has an @instructure scope mapping

### DIFF
--- a/packages/ui-scripts/lib/commands/publish-private.js
+++ b/packages/ui-scripts/lib/commands/publish-private.js
@@ -103,7 +103,7 @@ async function publishPrivate({ skipConfirm }) {
   try {
     for (let i = 0; i < packages.length; i++) {
       const pkg = packages[i]
-      await publishPackage(pkg, npmrcPath)
+      await publishPackage(pkg, npmrcPath, registryUrl)
       info(
         `📦  ${pkg.name}@${pkg.version} published to ${registryUrl.hostname}`
       )
@@ -146,9 +146,18 @@ function writeTempNpmrc(registryUrl, token) {
   const authPath = registryUrl.pathname.endsWith('/')
     ? registryUrl.pathname
     : `${registryUrl.pathname}/`
-  const authLine = `//${registryUrl.host}${authPath}:_authToken=${token}`
-  const registryLine = `registry=${registryUrl.toString()}`
-  fs.writeFileSync(file, `${registryLine}\n${authLine}\n`, { mode: 0o600 })
+  const registryStr = registryUrl.toString()
+  const lines = [
+    `registry=${registryStr}`,
+    // Override the @instructure scope mapping in case the operator's
+    // ~/.npmrc has `@instructure:registry=https://registry.npmjs.org/`
+    // from a prior `npm login`. Without this line, pnpm's scoped lookup
+    // for @instructure/* finds the npmjs mapping first and silently
+    // retargets the publish to npmjs (where auth then fails).
+    `@instructure:registry=${registryStr}`,
+    `//${registryUrl.host}${authPath}:_authToken=${token}`
+  ]
+  fs.writeFileSync(file, lines.join('\n') + '\n', { mode: 0o600 })
   return file
 }
 
@@ -160,15 +169,16 @@ function cleanupTempNpmrc(npmrcPath) {
   }
 }
 
-async function publishPackage(pkg, npmrcPath) {
+async function publishPackage(pkg, npmrcPath, registryUrl) {
   const childEnv = { NPM_CONFIG_USERCONFIG: npmrcPath }
+  const registryStr = registryUrl.toString()
 
   // Skip if this version is already on the private registry.
   let versions = []
   try {
     const { stdout } = await runCommandAsync(
       'pnpm',
-      ['info', pkg.name, '--json'],
+      ['info', pkg.name, '--registry', registryStr, '--json'],
       childEnv,
       { stdio: 'pipe' }
     )
@@ -188,11 +198,16 @@ async function publishPackage(pkg, npmrcPath) {
     [
       'publish',
       pkg.location,
+      '--registry',
+      registryStr,
       '--tag',
       PRIVATE_TAG,
       '--no-git-checks'
       // Provenance is npmjs-only; omitted for non-npmjs registries.
-      // Registry + auth come from the temp .npmrc via NPM_CONFIG_USERCONFIG.
+      // --registry is passed explicitly so the publish lands at the
+      // private registry regardless of any scope/registry mapping in
+      // the operator's ~/.npmrc. Auth still resolves from the temp
+      // .npmrc via NPM_CONFIG_USERCONFIG (matched by host).
     ],
     childEnv
   )


### PR DESCRIPTION
## Summary

`ui-scripts publish-private` was routing publishes to npmjs when the operator's `~/.npmrc` had an `@instructure:registry=https://registry.npmjs.org/` mapping (common after any prior `npm login` against npmjs).

The temp `.npmrc` that `publish-private` writes only set the default registry (`registry=...`). It did not set the scoped mapping (`@instructure:registry=...`). pnpm's scoped-package resolution checks the scope-specific mapping first, found the operator's npmjs one (inherited from the operator's `~/.npmrc`), and silently retargeted the publish to npmjs — where auth then failed with `ENEEDAUTH`.

## Fix

Two defenses in `packages/ui-scripts/lib/commands/publish-private.js`:

1. **Add `@instructure:registry=<INSTUI_PRIVATE_REGISTRY>` to the temp `.npmrc`** so pnpm's scoped lookup also points at the private registry. This is the *correct* fix — it matches the resolution path pnpm actually uses for scoped packages.
2. **Pass `--registry=<INSTUI_PRIVATE_REGISTRY>` explicitly to `pnpm publish` and `pnpm info`**. CLI flags override every config source, so the publish lands at the right host even if some other config layer behaves unexpectedly. Belt-and-suspenders.

Auth still flows through the temp `.npmrc` via `NPM_CONFIG_USERCONFIG`, matched by host in the `//host/:_authToken=` line — unchanged.

## Test Plan

- [x] Reproduced the bug locally by writing `@instructure:registry=https://registry.npmjs.org/` into a `.npmrc` and pointing `NPM_CONFIG_GLOBALCONFIG` at it. Unpatched `publish-private` routed the publish to npmjs (matching the original failure).
- [x] Patched `publish-private` under the same simulated config routed to the configured `INSTUI_PRIVATE_REGISTRY` instead.
- [ ] One-package smoke test against a real private registry from a machine that has `@instructure:registry=https://registry.npmjs.org/` in its `~/.npmrc` — confirm the publish lands at the private registry, not npmjs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
