### PR TITLE
Fullscreen modal margin

### DIFF
--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -172,7 +172,7 @@ class Dialog extends Component<DialogProps> {
           role === 'dialog' && this.props.shouldContainFocus ? true : undefined
         }
         className={this.props.className} // TODO in V2 remove className, there is no usage of it.
-        style={{ borderRadius: 'inherit' }} // ensure the dialog inherits border radius from View
+        style={{ borderRadius: 'inherit', ...this.props.style }}
         ref={this.getRef}
       >
         {this.props.children}

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -172,7 +172,7 @@ class Dialog extends Component<DialogProps> {
           role === 'dialog' && this.props.shouldContainFocus ? true : undefined
         }
         className={this.props.className} // TODO in V2 remove className, there is no usage of it.
-        style={{ borderRadius: 'inherit', ...this.props.style }}
+        style={{ borderRadius: 'inherit', ...this.props.style }} // ensure the dialog inherits border radius from View
         ref={this.getRef}
       >
         {this.props.children}

--- a/packages/ui-dialog/src/Dialog/props.ts
+++ b/packages/ui-dialog/src/Dialog/props.ts
@@ -42,6 +42,11 @@ type DialogOwnProps = {
   as?: AsElementType
   display?: 'auto' | 'block' | 'inline-block'
   /**
+   * Inline styles applied to the root element. Merged with the default
+   * `borderRadius: inherit` so consumers can override it.
+   */
+  style?: React.CSSProperties
+  /**
    * The aria-label to read for screen reader. When specified, it will automatically set role="dialog".
    */
   label?: string
@@ -77,7 +82,8 @@ const allowedProps: AllowedPropKeys = [
   'shouldCloseOnDocumentClick',
   'shouldCloseOnEscape',
   'shouldFocusOnOpen',
-  'elementRef'
+  'elementRef',
+  'style'
 ]
 
 export type { DialogProps }

--- a/packages/ui-modal/src/Modal/v2/index.tsx
+++ b/packages/ui-modal/src/Modal/v2/index.tsx
@@ -213,13 +213,11 @@ class Modal extends Component<ModalProps, ModalState> {
       shouldCloseOnDocumentClick,
       shouldReturnFocus,
       liveRegion,
-      size,
       constrain,
       as,
       styles
     } = this.props
 
-    const isFullScreen = size === 'fullscreen'
     const dialog = (
       <Dialog
         {...passthroughProps(props)}
@@ -234,6 +232,7 @@ class Modal extends Component<ModalProps, ModalState> {
         liveRegion={liveRegion}
         onDismiss={onDismiss}
         css={styles?.modal}
+        style={{ borderRadius: styles?.borderRadius as string }}
         ref={this.contentRef}
         // aria-modal="true" see VO bug https://bugs.webkit.org/show_bug.cgi?id=174667
       >
@@ -242,13 +241,7 @@ class Modal extends Component<ModalProps, ModalState> {
     )
 
     return (
-      <Mask
-        placement={this.maskPlacement}
-        fullscreen={constrain === 'window'}
-        themeOverride={
-          isFullScreen ? { borderRadius: '0em', borderWidth: '0em' } : {}
-        }
-      >
+      <Mask placement={this.maskPlacement} fullscreen={constrain === 'window'}>
         {dialog}
       </Mask>
     )

--- a/packages/ui-modal/src/Modal/v2/index.tsx
+++ b/packages/ui-modal/src/Modal/v2/index.tsx
@@ -84,6 +84,7 @@ class Modal extends Component<ModalProps, ModalState> {
       transitioning: false,
       open: props.open ?? false,
       windowHeight: 99999,
+      windowWidth: 99999,
       bodyScrollAriaLabel: undefined
     }
   }
@@ -99,7 +100,7 @@ class Modal extends Component<ModalProps, ModalState> {
 
   componentDidMount() {
     this.props.makeStyles?.()
-    window.addEventListener('resize', this.updateHeight)
+    window.addEventListener('resize', this.updateSize)
   }
 
   componentDidUpdate(prevProps: ModalProps) {
@@ -110,11 +111,14 @@ class Modal extends Component<ModalProps, ModalState> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.updateHeight)
+    window.removeEventListener('resize', this.updateSize)
   }
 
-  updateHeight = () => {
-    this.setState({ windowHeight: window.innerHeight })
+  updateSize = () => {
+    this.setState({
+      windowHeight: window.innerHeight,
+      windowWidth: window.innerWidth
+    })
   }
 
   get defaultFocusElement() {
@@ -215,8 +219,14 @@ class Modal extends Component<ModalProps, ModalState> {
       liveRegion,
       constrain,
       as,
+      size,
       styles
     } = this.props
+
+    const isFullScreen = size === 'fullscreen'
+    const isSmallScreen = this.state.windowWidth < 480 // 30em at 16px base
+    const borderRadius =
+      isFullScreen && isSmallScreen ? '0' : (styles?.borderRadius as string) // fullscreen modals on small screens remove border radius so the modal fills edge-to-edge
 
     const dialog = (
       <Dialog
@@ -232,7 +242,7 @@ class Modal extends Component<ModalProps, ModalState> {
         liveRegion={liveRegion}
         onDismiss={onDismiss}
         css={styles?.modal}
-        style={{ borderRadius: styles?.borderRadius as string }}
+        style={{ borderRadius }}
         ref={this.contentRef}
         // aria-modal="true" see VO bug https://bugs.webkit.org/show_bug.cgi?id=174667
       >

--- a/packages/ui-modal/src/Modal/v2/props.ts
+++ b/packages/ui-modal/src/Modal/v2/props.ts
@@ -184,7 +184,7 @@ type ModalProps = ModalOwnProps &
   OtherHTMLAttributes<ModalOwnProps>
 
 type ModalStyle = ComponentStyle<
-  'modal' | 'constrainContext' | 'joinedHeaderAndBody'
+  'modal' | 'constrainContext' | 'joinedHeaderAndBody' | 'borderRadius'
 >
 
 type ModalState = {

--- a/packages/ui-modal/src/Modal/v2/props.ts
+++ b/packages/ui-modal/src/Modal/v2/props.ts
@@ -191,6 +191,7 @@ type ModalState = {
   transitioning: boolean
   open: boolean
   windowHeight: number
+  windowWidth: number
   /**
    * The `aria-label` on the Modal's body if it's scrollable.
    */

--- a/packages/ui-modal/src/Modal/v2/styles.ts
+++ b/packages/ui-modal/src/Modal/v2/styles.ts
@@ -73,9 +73,7 @@ const generateStyle = (
       flex: 1,
       width: '100%',
       height: '100%',
-      boxShadow: 'none',
-      border: 'none',
-      borderRadius: 0
+      margin: componentTheme.fullScreenMargin
     }
   }
   const backgroundStyles =
@@ -123,7 +121,8 @@ const generateStyle = (
         overflowY: 'auto',
         maxHeight: '20rem'
       }
-    }
+    },
+    borderRadius: componentTheme.borderRadius
   }
 }
 

--- a/packages/ui-modal/src/Modal/v2/styles.ts
+++ b/packages/ui-modal/src/Modal/v2/styles.ts
@@ -71,9 +71,14 @@ const generateStyle = (
     },
     fullscreen: {
       flex: 1,
-      width: '100%',
-      height: '100%',
-      margin: componentTheme.fullScreenMargin
+      margin: componentTheme.fullScreenMargin,
+      '@media (max-width: 30em)': {
+        // small breakpoint = 480px
+        margin: 0,
+        boxShadow: 'none',
+        border: 'none',
+        borderRadius: 0
+      }
     }
   }
   const backgroundStyles =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3703,7 +3703,7 @@ importers:
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
         specifier: github:instructure/instructure-design-tokens
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9916a91be6b27a8c2d15136d2865e6f69a2d1c08
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/6085eab6b704bbcaf27a1bf6626ae8d092fce4df
       '@instructure/pkg-utils':
         specifier: workspace:*
         version: link:../pkg-utils
@@ -6711,8 +6711,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9916a91be6b27a8c2d15136d2865e6f69a2d1c08':
-    resolution: {tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9916a91be6b27a8c2d15136d2865e6f69a2d1c08}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/6085eab6b704bbcaf27a1bf6626ae8d092fce4df':
+    resolution: {tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/6085eab6b704bbcaf27a1bf6626ae8d092fce4df}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -15459,7 +15459,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9916a91be6b27a8c2d15136d2865e6f69a2d1c08':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/6085eab6b704bbcaf27a1bf6626ae8d092fce4df':
     dependencies:
       glob: 13.0.6
 


### PR DESCRIPTION
**Modal fixes:**
- The fullscreen Modal variant previously covered the entire viewport, making it hard to tell it was a modal. A new `fullScreenMargin` token adds separation from the viewport edge to fix that a11y issue on bigger screen sizes.
- `borderRadius` from the component theme wasn't applying because Dialog's hardcoded inline `borderRadius: inherit` always overrode the Emotion CSS class. Dialog now accepts a style prop so consumers can override that default.