### PR TITLE
docs: better multiversion support for docs v2

### DIFF
--- a/docs/guides/accessing-the-dom.md
+++ b/docs/guides/accessing-the-dom.md
@@ -1,7 +1,7 @@
 ---
 title: Accessing the DOM
 category: Guides
-order: 3
+order: 4
 relevantForAI: true
 ---
 

--- a/docs/guides/component-versioning.md
+++ b/docs/guides/component-versioning.md
@@ -1,0 +1,95 @@
+---
+title: Component versioning
+category: Guides
+order: 2
+---
+
+## Why components are versioned
+
+When InstUI needs to make a breaking change to a component (renamed props, changed behaviour, etc.), the old version is **kept alongside the new one** instead of being replaced. Upgrading the library no longer forces you to immediately rewrite every component usage — you can migrate to new versions on your own schedule.
+
+New component versions appear with InstUI **minor** version bumps (e.g. `11.7` → `11.8`). Patch releases never include breaking changes.
+
+> The docs UI "Component version" selector labels library `v11_6` as **`v1 (legacy)`** and library `v11_7` as **`v2`**. This page uses the `v11_X` form because it matches the actual NPM import paths.
+
+## Import paths
+
+Every InstUI component package supports three import styles:
+
+### Default — `@instructure/ui-<name>`
+
+Always points to the **oldest** still-supported component version. Upgrading the library without changing your imports will keep your code working without surprises.
+
+```js
+---
+type: code
+---
+import { Alert } from '@instructure/ui-alerts'
+```
+
+### Pinned — `@instructure/ui-<name>/v11_X`
+
+Locks the import to a specific InstUI minor version of the component. When you are ready to adopt a breaking change, update the path to the next pinned version.
+
+```js
+---
+type: code
+---
+import { Alert } from '@instructure/ui-alerts/v11_7'
+```
+
+### Latest — `@instructure/ui-<name>/latest`
+
+Always points to the newest component version. This may bring breaking changes when you upgrade InstUI itself.
+
+```js
+---
+type: code
+---
+import { Alert } from '@instructure/ui-alerts/latest'
+```
+
+### Per-package or umbrella package
+
+InstUI also ships an umbrella package, `@instructure/ui`, which re-exports every component from the individual `@instructure/ui-*` packages. Two equivalent import styles work — both resolve to the same component:
+
+```js
+---
+type: code
+---
+// per-package import
+import { Alert } from '@instructure/ui-alerts/v11_7'
+
+// umbrella package import
+import { Alert } from '@instructure/ui/v11_7'
+```
+
+The same three path styles (default / `/v11_X` / `/latest`) work on the umbrella package as well. Pick per-package imports when you want better tree-shaking and only pull in what you use, or the umbrella package when you'd rather depend on a single `@instructure/ui` entry in your `package.json`.
+
+## Versions and theming engines
+
+InstUI is in the middle of a transition between two theming systems. Which engine a component uses depends on which version you import:
+
+- **`v1`** (library `v11_6` and earlier) — legacy theming. Components are configured through the Canvas theme variables and the `themeOverride` prop, which accepts a function or object that maps to the component's own theme map. See the [Legacy theme overrides](legacy-theme-overrides) guide.
+
+- **`v2`** (library `v11_7` and newer) — new theming system. Components consume pre-resolved design tokens, and theming is done through the new token override structure. See the [New theme overrides](new-theme-overrides) guide.
+
+Mixing imports from both groups in the same app is fully supported — the two engines run side-by-side without conflict.
+
+### Supported themes per version
+
+Each version of the library is only compatible with the themes built for its theming engine:
+
+- **`v1`** (library `v11_6` and earlier) supports the legacy themes:
+
+  - `canvas`
+  - `canvasHighContrast`
+
+- **`v2`** (library `v11_7` and newer) supports themes built on the new token system. The legacy Canvas looks are preserved (re-implemented on the new engine) and two brand-new themes are added:
+
+  - `legacyCanvas` — same visual style as the old `canvas`, but on the new engine
+  - `legacyCanvasHighContrast` — same visual style as the old `canvasHighContrast`, on the new engine
+  - `light` — new light theme
+  - `dark` — new dark theme
+
+This means that when you move a component import from `/v11_6` to `/v11_7` you don't have to change anything visually — you can stay on the `legacyCanvas` theme and opt in to `light` or `dark` only when you're ready.

--- a/docs/guides/component-versioning.md
+++ b/docs/guides/component-versioning.md
@@ -10,8 +10,6 @@ When InstUI needs to make a breaking change to a component (renamed props, chang
 
 New component versions appear with InstUI **minor** version bumps (e.g. `11.7` → `11.8`). Patch releases never include breaking changes.
 
-> The docs UI "Component version" selector labels library `v11_6` as **`v1 (legacy)`** and library `v11_7` as **`v2`**. This page uses the `v11_X` form because it matches the actual NPM import paths.
-
 ## Import paths
 
 Every InstUI component package supports three import styles:
@@ -70,26 +68,41 @@ The same three path styles (default / `/v11_X` / `/latest`) work on the umbrella
 
 InstUI is in the middle of a transition between two theming systems. Which engine a component uses depends on which version you import:
 
-- **`v1`** (library `v11_6` and earlier) — legacy theming. Components are configured through the Canvas theme variables and the `themeOverride` prop, which accepts a function or object that maps to the component's own theme map. See the [Legacy theme overrides](legacy-theme-overrides) guide.
+- **`v11_6` and earlier** — legacy theming. Components are configured through the Canvas theme variables and the `themeOverride` prop, which accepts a function or object that maps to the component's own theme map. See the [Legacy theme overrides](legacy-theme-overrides) guide.
 
-- **`v2`** (library `v11_7` and newer) — new theming system. Components consume pre-resolved design tokens, and theming is done through the new token override structure. See the [New theme overrides](new-theme-overrides) guide.
+- **`v11_7` and newer** — new theming system. Components consume pre-resolved design tokens, and theming is done through the new token override structure. See the [New theme overrides](new-theme-overrides) guide.
 
 Mixing imports from both groups in the same app is fully supported — the two engines run side-by-side without conflict.
 
 ### Supported themes per version
 
-Each version of the library is only compatible with the themes built for its theming engine:
+You import themes the same way as before — from `@instructure/ui-themes` — and pass them to `InstUISettingsProvider`:
 
-- **`v1`** (library `v11_6` and earlier) supports the legacy themes:
+```js
+---
+type: code
+---
+import { canvas } from '@instructure/ui-themes'
 
-  - `canvas`
-  - `canvasHighContrast`
+<InstUISettingsProvider theme={canvas}>
+  <App />
+</InstUISettingsProvider>
+```
 
-- **`v2`** (library `v11_7` and newer) supports themes built on the new token system. The legacy Canvas looks are preserved (re-implemented on the new engine) and two brand-new themes are added:
+The `canvas` (and `canvasHighContrast`) export works for **both `v11_6` and `v11_7+` components in the same app** — internally it carries the data each engine needs. You don't need to switch theme objects when you bump a component import to `/v11_7`.
 
-  - `legacyCanvas` — same visual style as the old `canvas`, but on the new engine
-  - `legacyCanvasHighContrast` — same visual style as the old `canvasHighContrast`, on the new engine
+- **`v11_6` and earlier** — supports the original two themes:
+
+  - `canvas` — default theme used by Canvas products
+  - `canvasHighContrast` — same as `canvas`, with colors WCAG-tuned for high-contrast accessibility
+
+- **`v11_7` and newer** — supports the same two themes (rendered through the new engine, labelled `(legacy)` in the docs UI Theme selector) plus two brand-new ones:
+
+  - `canvas` — same import as above, now driven by the new engine (labelled as `(legacy)`)
+  - `canvasHighContrast` — same import as above, now driven by the new engine (labelled as `(legacy)`)
   - `light` — new light theme
   - `dark` — new dark theme
 
-This means that when you move a component import from `/v11_6` to `/v11_7` you don't have to change anything visually — you can stay on the `legacyCanvas` theme and opt in to `light` or `dark` only when you're ready.
+This means that when you move a component import from `/v11_6` to `/v11_7`, you can continue using the `canvas` theme to maintain a familiar look and feel, and opt in to `light` or `dark` only when you're ready.
+
+> The `@instructure/ui-themes` package also exports `legacyCanvas` and `legacyCanvasHighContrast`. These are the raw new-engine forms that `canvas` / `canvasHighContrast` wrap internally — most consumers don't need to import them directly.

--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -1,7 +1,7 @@
 ---
 title: Forms
 category: Guides
-order: 4
+order: 5
 relevantForAI: true
 ---
 

--- a/docs/guides/module-federation.md
+++ b/docs/guides/module-federation.md
@@ -1,7 +1,7 @@
 ---
 title: Module federation
 category: Guides
-order: 2
+order: 3
 relevantForAI: true
 ---
 

--- a/docs/theming/legacy-theme-overrides.md
+++ b/docs/theming/legacy-theme-overrides.md
@@ -7,15 +7,6 @@ relevantForAI: true
 
 ## Using theme overrides
 
-```js
----
-type: embed
----
-<Alert variant="warning" margin="0 0 medium">
-  The examples on this page use the <strong>legacy theming system</strong> and are designed for <strong>v11.6</strong> components. If you are viewing the v11.7 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_6') : `/v11_6${window.location.pathname}`}>switch to v11.6</Link> to see the examples working correctly.
-</Alert>
-```
-
 This document gives an overview on how you can customize Instructure UI components by tweaking their theme variables.
 While this gives you a level of flexibility on the look and feel of the components you should be aware of 2 things:
 

--- a/docs/theming/new-theme-overrides.md
+++ b/docs/theming/new-theme-overrides.md
@@ -544,8 +544,8 @@ type: example
     <Table caption="Independent overrides: ColHeader purple, RowHeader deeppink">
       <Table.Head>
         <Table.Row>
-          <Table.ColHeader id="h-row">TableColHeader — purple</Table.ColHeader>
-          <Table.ColHeader id="h-col">TableColHeader — purple</Table.ColHeader>
+          <Table.ColHeader id="row-headers">Row headers column - purple</Table.ColHeader>
+          <Table.ColHeader id="cells">Cells column - purple</Table.ColHeader>
         </Table.Row>
       </Table.Head>
       <Table.Body>
@@ -553,7 +553,7 @@ type: example
           <Table.RowHeader>TableRowHeader — deeppink</Table.RowHeader>
           <Table.Cell>TableCell — unchanged</Table.Cell>
         </Table.Row>
-                <Table.Row>
+        <Table.Row>
           <Table.RowHeader>TableRowHeader — deeppink</Table.RowHeader>
           <Table.Cell>TableCell — unchanged</Table.Cell>
         </Table.Row>

--- a/docs/theming/new-theme-overrides.md
+++ b/docs/theming/new-theme-overrides.md
@@ -7,15 +7,6 @@ relevantForAI: true
 
 ## New Theme Override Patterns
 
-```js
----
-type: embed
----
-<Alert variant="warning" margin="0 0 medium">
-  The examples on this page use the <strong>new theming system</strong> and require <strong>v11.7+</strong> components. If you are viewing the v11.6 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_7') : `/v11_7${window.location.pathname}`}>switch to v11.7</Link> to see the examples working correctly.
-</Alert>
-```
-
 This guide covers all the override patterns available in the new theming system (v11.7+). The new system uses a layered token architecture: **primitives** (raw values) -> **semantics** (meaning) -> **components** (per-component tokens).
 
 Overrides are applied via the `themeOverride` prop on `InstUISettingsProvider`, which is separate from the `theme` prop. The `theme` prop replaces the active theme entirely; `themeOverride` layers modifications on top.
@@ -527,9 +518,52 @@ type: example
 </InstUISettingsProvider>
 ```
 
-### 13. Provider-level overrides cannot target a child component selectively
+### 13. Independent overrides for child parts of compound components
 
-Because `Button` uses `BaseButton`'s theme internally, a `components.Button` entry in the provider's `themeOverride` does **not** override `BaseButton`'s tokens for `Button` instances only. Both `BaseButton` and `Button` share the same `BaseButton` theme variables, so a `components.BaseButton` override affects both, regardless of whether a separate `components.Button` entry is also present.
+Most compound components expose each part as a separate component with its own `componentId`. This means you can independently override each part via `components` — both overrides take effect:
+
+```js
+---
+type: example
+---
+<InstUISettingsProvider theme={canvas}>
+  <InstUISettingsProvider
+    themeOverride={{
+      components: {
+        TableColHeader: {
+          background: 'rebeccapurple',
+          color: 'gold'
+        },
+        TableRowHeader: {
+          background: 'deeppink',
+          color: 'white'
+        }
+      }
+    }}
+  >
+    <Table caption="Independent overrides: ColHeader purple, RowHeader deeppink">
+      <Table.Head>
+        <Table.Row>
+          <Table.ColHeader id="h-row">TableColHeader — purple</Table.ColHeader>
+          <Table.ColHeader id="h-col">TableColHeader — purple</Table.ColHeader>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowHeader>TableRowHeader — deeppink</Table.RowHeader>
+          <Table.Cell>TableCell — unchanged</Table.Cell>
+        </Table.Row>
+                <Table.Row>
+          <Table.RowHeader>TableRowHeader — deeppink</Table.RowHeader>
+          <Table.Cell>TableCell — unchanged</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  </InstUISettingsProvider>
+</InstUISettingsProvider>
+```
+
+**Exception — `Button` and `BaseButton`:** `Button` uses `BaseButton`'s `componentId` internally, so `components.Button` has no effect. A `components.BaseButton` override affects all `BaseButton` instances including those rendered inside `Button` — there is no way to target only one:
 
 ```js
 ---

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -623,9 +623,9 @@ class App extends Component<AppProps, AppState> {
     }
 
     const formatMinorVersion = (version: string) => {
-      if (version === 'v11_6') return 'v1 (legacy)'
-      if (version === 'v11_7') return 'v2'
-      return version.replace(/_/g, '.')
+      const formatted = version.replace(/_/g, '.')
+      if (version === 'v11_6') return `${formatted} (legacy theming)`
+      return formatted
     }
 
     const smallScreen = this.state.layout === 'small'

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -70,6 +70,7 @@ import {
 } from '../versionData'
 import {
   parseCurrentUrl,
+  navigateTo,
   navigateToVersion,
   getDeployBase,
   MINOR_VERSION_REGEX
@@ -699,7 +700,16 @@ class App extends Component<AppProps, AppState> {
     return (
       <Alert variant="info" margin="0 0 medium">
         {subject} is designed for components for <strong>v11.7</strong> and
-        later. <Link href={v11_7Href}>Switch to v11.7</Link>
+        later.{' '}
+        <Link
+          href={v11_7Href}
+          onClick={(e) => {
+            e.preventDefault()
+            this.handleMinorVersionChange('v11_7')
+          }}
+        >
+          Switch to v11.7
+        </Link>
       </Alert>
     )
   }
@@ -832,7 +842,13 @@ class App extends Component<AppProps, AppState> {
             <Alert variant="info" margin="xx-large 0">
               This page is made for the latest version (
               {this.getLatestMinorVersion()?.replace('_', '.')}) of InstUI.{' '}
-              <Link href="component-versioning">
+              <Link
+                href="component-versioning"
+                onClick={(e) => {
+                  e.preventDefault()
+                  navigateTo('component-versioning')
+                }}
+              >
                 Learn more about the versioning system
               </Link>
             </Alert>

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -303,9 +303,10 @@ class App extends Component<AppProps, AppState> {
     fetchMinorVersionData(signal)
       .then((minorVersionsData) => {
         if (minorVersionsData && minorVersionsData.libraryVersions.length > 0) {
-          // If URL has a version, use it; otherwise use default
-          const selectedMinorVersion =
-            urlMinorVersion ?? minorVersionsData.defaultVersion
+          const { libraryVersions } = minorVersionsData
+          const latestVersion = libraryVersions[libraryVersions.length - 1]
+          // If URL has a version, use it; otherwise use the latest version
+          const selectedMinorVersion = urlMinorVersion ?? latestVersion
           // Update globals before fetching docs so renders use correct components
           updateGlobalsForVersion(selectedMinorVersion)
           this.setState({
@@ -342,6 +343,48 @@ class App extends Component<AppProps, AppState> {
       prevState.layout !== this.state.layout
     ) {
       this.handleNavigationFocusRegion()
+    }
+
+    if (prevState.key !== this.state.key) {
+      this.handleMinorVersionForPage(this.state.key)
+    }
+
+    if (!prevState.minorVersionsData && this.state.minorVersionsData) {
+      this.handleMinorVersionForPage(this.state.key)
+    }
+  }
+
+  getLatestMinorVersion = () => {
+    const { minorVersionsData } = this.state
+    if (!minorVersionsData) return undefined
+    const { libraryVersions } = minorVersionsData
+    return libraryVersions[libraryVersions.length - 1]
+  }
+
+  handleMinorVersionForPage = (key: string | undefined) => {
+    const { selectedMinorVersion, minorVersionsData, docsData } = this.state
+    if (!minorVersionsData || !selectedMinorVersion || !key) return
+
+    const latestVersion = this.getLatestMinorVersion()!
+
+    if (key === 'legacy-theme-overrides') {
+      if (selectedMinorVersion !== 'v11_6') {
+        this.handleMinorVersionChange('v11_6')
+      }
+    } else if (key === 'new-theme-overrides') {
+      if (selectedMinorVersion !== latestVersion) {
+        this.handleMinorVersionChange(latestVersion)
+      }
+    } else {
+      const category = docsData?.docs[key]?.category
+      const isGuidePage =
+        !!category &&
+        !category.startsWith('components') &&
+        !category.startsWith('utilities')
+      if (isGuidePage && selectedMinorVersion !== latestVersion) {
+        // Guide pages (.md) always show with the latest version
+        this.handleMinorVersionChange(latestVersion)
+      }
     }
   }
 
@@ -554,8 +597,9 @@ class App extends Component<AppProps, AppState> {
   }
 
   renderThemeSelect() {
+    const { minorVersionsData, selectedMinorVersion } = this.state
     const allThemeKeys = Object.keys(this.state.docsData!.themes)
-    const showNewThemes = this.state.selectedMinorVersion !== 'v11_6'
+    const showNewThemes = selectedMinorVersion !== 'v11_6'
 
     const themeKeys = showNewThemes
       ? allThemeKeys.filter(
@@ -578,17 +622,56 @@ class App extends Component<AppProps, AppState> {
       return themeKey
     }
 
+    const formatMinorVersion = (version: string) => {
+      if (version === 'v11_6') return 'v1 (legacy)'
+      if (version === 'v11_7') return 'v2'
+      return version.replace(/_/g, '.')
+    }
+
     const smallScreen = this.state.layout === 'small'
     const currentThemeKey =
       this.state.themeKey && themeKeys.includes(this.state.themeKey)
         ? this.state.themeKey
         : themeKeys[0]
 
+    const { key, docsData } = this.state
+    const versionLockedPages = ['legacy-theme-overrides', 'new-theme-overrides']
+    if (versionLockedPages.includes(key ?? '')) return null
+
+    // Only show on Components pages — other categories (guides, utilities,
+    // themes, etc.) don't need theme or component-version switching.
+    const category = key ? docsData?.docs[key]?.category : undefined
+    if (!category || !category.startsWith('components')) return null
+
+    const showMinorVersionSelect =
+      minorVersionsData && minorVersionsData.libraryVersions.length > 1
+
     return themeKeys.length > 1 ? (
       <Flex
         margin={smallScreen ? 'none none medium' : 'none none x-small'}
         justifyItems={!smallScreen ? 'end' : 'start'}
+        wrap="wrap"
+        gap="small"
       >
+        {showMinorVersionSelect && (
+          <Flex.Item shouldGrow={smallScreen} shouldShrink={smallScreen}>
+            <Select
+              name="minorVersion"
+              renderLabel="Component version"
+              onChange={(_e, { value }) => {
+                if (value) this.handleMinorVersionChange(value as string)
+              }}
+              value={selectedMinorVersion ?? this.getLatestMinorVersion()}
+              width="16.5rem"
+            >
+              {[...minorVersionsData!.libraryVersions].reverse().map((ver) => (
+                <option key={ver} value={ver}>
+                  {formatMinorVersion(ver)}
+                </option>
+              ))}
+            </Select>
+          </Flex.Item>
+        )}
         <Flex.Item shouldGrow={smallScreen} shouldShrink={smallScreen}>
           <Select
             name="theme"
@@ -740,9 +823,19 @@ class App extends Component<AppProps, AppState> {
     // New-theme components are looked up via themeVariables.newTheme.components
     const themeVariables = themes[themeKey!].resource as ThemeType
     const heading = currentData.extension !== '.md' ? currentData.title : ''
+    const isGuidePage = currentData.extension === '.md'
     const documentContent = (
       <View as="div" padding="x-large none none">
         {this.renderThemeSelect()}
+        {isGuidePage && (
+          <Alert variant="info" margin="xx-large 0">
+            This page is made for the latest version (
+            {this.getLatestMinorVersion()?.replace('_', '.')}) of InstUI.{' '}
+            <Link href="component-versioning">
+              Learn more about the versioning system
+            </Link>
+          </Alert>
+        )}
         <View
           elementRef={this.mainContentRef}
           tabIndex={0}
@@ -996,8 +1089,6 @@ class App extends Component<AppProps, AppState> {
           version={version}
           versionsData={versionsData}
           minorVersionsData={this.state.minorVersionsData}
-          selectedMinorVersion={this.state.selectedMinorVersion}
-          onMinorVersionChange={this.handleMinorVersionChange}
         />
 
         <Nav

--- a/packages/__docs__/src/App/index.tsx
+++ b/packages/__docs__/src/App/index.tsx
@@ -827,15 +827,16 @@ class App extends Component<AppProps, AppState> {
     const documentContent = (
       <View as="div" padding="x-large none none">
         {this.renderThemeSelect()}
-        {isGuidePage && (
-          <Alert variant="info" margin="xx-large 0">
-            This page is made for the latest version (
-            {this.getLatestMinorVersion()?.replace('_', '.')}) of InstUI.{' '}
-            <Link href="component-versioning">
-              Learn more about the versioning system
-            </Link>
-          </Alert>
-        )}
+        {isGuidePage &&
+          (currentData.id as string) !== 'legacy-theme-overrides' && (
+            <Alert variant="info" margin="xx-large 0">
+              This page is made for the latest version (
+              {this.getLatestMinorVersion()?.replace('_', '.')}) of InstUI.{' '}
+              <Link href="component-versioning">
+                Learn more about the versioning system
+              </Link>
+            </Alert>
+          )}
         <View
           elementRef={this.mainContentRef}
           tabIndex={0}

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -293,26 +293,11 @@ class Document extends Component<DocumentProps, DocumentState> {
     const example = `\
 import { ${importName} } from '${versionedPackageName}'`
 
-    const versionLabel =
-      selectedMinorVersion === 'v11_6'
-        ? 'v1 (legacy)'
-        : selectedMinorVersion === 'v11_7'
-        ? 'v2'
-        : selectedMinorVersion?.replace(/_/g, '.')
-
     return (
       <View margin="xx-large 0" display="block">
         <Heading level="h2" as="h3" id={`${id}Usage`} margin="0 0 small 0">
           Usage
         </Heading>
-        <View margin="0 0 small 0" display="block">
-          <SourceCodeEditor
-            label={`How to install ${title}`}
-            defaultValue={`npm install ${packageName}`}
-            language="shell"
-            readOnly
-          />
-        </View>
         <SourceCodeEditor
           label={`How to use ${title}`}
           defaultValue={example}
@@ -320,10 +305,8 @@ import { ${importName} } from '${versionedPackageName}'`
           readOnly
         />
         <View as="div" margin="small 0 0 0">
-          This import is pinned to the selected version (
-          <code>{selectedMinorVersion}</code> ↔ <code>{versionLabel}</code> in
-          the selector above); future breaking changes land at new paths. For
-          other import styles, see the{' '}
+          This import is pinned to the selected component version; future
+          breaking changes land at new paths. For other import styles, see the{' '}
           <Link href="component-versioning">Component versioning</Link> guide.
         </View>
       </View>
@@ -436,9 +419,9 @@ import { ${importName} } from '${versionedPackageName}'`
       >
         {doc.extension !== '.md' && this.renderSrcLink()}
         {pageRef && <TableOfContents doc={doc} pageElement={pageRef} />}
+        {['.js', '.ts', '.tsx'].includes(doc.extension) && this.renderUsage()}
         {this.renderDescription(doc, this.props.description)}
         {details}
-        {['.js', '.ts', '.tsx'].includes(doc.extension) && this.renderUsage()}
         {this.renderEditOnGithub()}
         {repository && layout !== 'small' && (
           <div css={this.props.styles?.githubCorner}>

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -276,7 +276,7 @@ class Document extends Component<DocumentProps, DocumentState> {
   }
 
   renderUsage() {
-    const { esPath, id, displayName, packageName, title, componentVersion } =
+    const { id, displayName, packageName, title, componentVersion } =
       this.props.doc
     const { selectedMinorVersion } = this.props
     const importName = displayName || id
@@ -288,23 +288,17 @@ class Document extends Component<DocumentProps, DocumentState> {
         ? `${packageName}/${selectedMinorVersion}`
         : packageName
 
-    const example = []
+    if (!versionedPackageName) return
 
-    if (versionedPackageName) {
-      example.push(`\
-/*** ES Modules (with tree shaking) ***/
-import { ${importName} } from '${versionedPackageName}'
-`)
-    }
+    const example = `\
+import { ${importName} } from '${versionedPackageName}'`
 
-    if (esPath) {
-      example.push(`\
-/*** ES Modules (without tree shaking) ***/
-import { ${importName} } from '${esPath}'
-`)
-    }
-
-    if (example.length === 0) return
+    const versionLabel =
+      selectedMinorVersion === 'v11_6'
+        ? 'v1 (legacy)'
+        : selectedMinorVersion === 'v11_7'
+        ? 'v2'
+        : selectedMinorVersion?.replace(/_/g, '.')
 
     return (
       <View margin="xx-large 0" display="block">
@@ -321,10 +315,17 @@ import { ${importName} } from '${esPath}'
         </View>
         <SourceCodeEditor
           label={`How to use ${title}`}
-          defaultValue={example.join('\n')}
+          defaultValue={example}
           language="javascript"
           readOnly
         />
+        <View as="div" margin="small 0 0 0">
+          This import is pinned to the selected version (
+          <code>{selectedMinorVersion}</code> ↔ <code>{versionLabel}</code> in
+          the selector above); future breaking changes land at new paths. For
+          other import styles, see the{' '}
+          <Link href="component-versioning">Component versioning</Link> guide.
+        </View>
       </View>
     )
   }

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -43,6 +43,7 @@ import { TableOfContents } from '../TableOfContents'
 import { Heading } from '../Heading'
 
 import { AppContext } from '../appContext'
+import { navigateTo } from '../navigationUtils'
 
 import { allowedProps } from './props'
 import type { DocumentProps, DocumentState, DocDataType } from './props'
@@ -203,7 +204,15 @@ class Document extends Component<DocumentProps, DocumentState> {
           <View margin="small 0" display="block">
             The easiest way to do this is to utilize the{' '}
             <code>themeOverride</code> property. See the{' '}
-            <Link href="#legacy-theme-overrides">Legacy theme overrides</Link>{' '}
+            <Link
+              href="legacy-theme-overrides"
+              onClick={(e) => {
+                e.preventDefault()
+                navigateTo('legacy-theme-overrides')
+              }}
+            >
+              Legacy theme overrides
+            </Link>{' '}
             guide for more info and alternative methods.
           </View>
 
@@ -307,7 +316,16 @@ import { ${importName} } from '${versionedPackageName}'`
         <View as="div" margin="small 0 0 0">
           This import is pinned to the selected component version; future
           breaking changes land at new paths. For other import styles, see the{' '}
-          <Link href="component-versioning">Component versioning</Link> guide.
+          <Link
+            href="component-versioning"
+            onClick={(e) => {
+              e.preventDefault()
+              navigateTo('component-versioning')
+            }}
+          >
+            Component versioning
+          </Link>{' '}
+          guide.
         </View>
       </View>
     )

--- a/packages/__docs__/src/Header/index.tsx
+++ b/packages/__docs__/src/Header/index.tsx
@@ -85,83 +85,12 @@ class Header extends Component<HeaderProps> {
   }
 
   /**
-   * Returns the version string for display: major only (e.g. "v10") when
-   * minor version switcher is active, full semver otherwise.
+   * Returns the full semver string for display (e.g. "11.7.0").
+   * Minor-version switching is handled in the Component version Select
+   * on Components pages, so we always show the precise library version here.
    */
   getDisplayVersion = () => {
-    const { version, minorVersionsData } = this.props
-    if (minorVersionsData && version) {
-      return version.split('.')[0]
-    }
-    return version
-  }
-
-  handleMinorVersionSelect = (
-    _e: React.MouseEvent<any>,
-    updated: (string | number | undefined)[]
-  ) => {
-    const [selectedVersion] = updated
-    if (
-      selectedVersion &&
-      typeof selectedVersion === 'string' &&
-      this.props.onMinorVersionChange
-    ) {
-      this.props.onMinorVersionChange(selectedVersion)
-    }
-  }
-
-  /**
-   * Formats a version key like "v11_5" into display format "v11.5"
-   */
-  formatMinorVersion = (version: string) => {
-    const formatted = version.replace(/_/g, '.')
-    // TODO: Remove the beta label once v11.7 is stable
-    if (version === 'v11_7') {
-      return `${formatted} (beta)`
-    }
-    return formatted
-  }
-
-  renderMinorVersionsBlock = () => {
-    const { minorVersionsData, selectedMinorVersion } = this.props
-
-    return (
-      <View display="block" textAlign="center" margin="none none small">
-        <Menu
-          placement="bottom"
-          label="Select minor version"
-          themeOverride={{ minWidth: '10rem' }}
-          trigger={
-            <CondensedButton>
-              <Text size="small">
-                {selectedMinorVersion
-                  ? this.formatMinorVersion(selectedMinorVersion)
-                  : 'Minor version'}
-              </Text>
-              <IconMiniArrowDownLine size="x-small" />
-            </CondensedButton>
-          }
-        >
-          <Menu.Group
-            selected={selectedMinorVersion ? [selectedMinorVersion] : []}
-            onSelect={this.handleMinorVersionSelect}
-            label={
-              <ScreenReaderContent>Select minor version</ScreenReaderContent>
-            }
-          >
-            {[...minorVersionsData!.libraryVersions]
-              .reverse()
-              .map((ver: string, index: number) => (
-                <Menu.Item key={index} id={`minor-opt-${index}`} value={ver}>
-                  <View textAlign="center" as="div">
-                    {this.formatMinorVersion(ver)}
-                  </View>
-                </Menu.Item>
-              ))}
-          </Menu.Group>
-        </Menu>
-      </View>
-    )
+    return this.props.version
   }
 
   renderVersionsBlock = () => {
@@ -253,7 +182,6 @@ class Header extends Component<HeaderProps> {
               </View>
             </Link>
           )}
-          {this.renderMinorVersionsBlock()}
         </View>
       </View>
     )

--- a/packages/__docs__/src/Header/props.ts
+++ b/packages/__docs__/src/Header/props.ts
@@ -31,8 +31,6 @@ type HeaderOwnProps = {
     previousVersions: string[]
   }
   minorVersionsData?: MinorVersionData
-  selectedMinorVersion?: string
-  onMinorVersionChange?: (version: string) => void
 }
 
 type PropKeys = keyof HeaderOwnProps
@@ -43,9 +41,7 @@ type HeaderProps = HeaderOwnProps
 const allowedProps: AllowedPropKeys = [
   'version',
   'versionsData',
-  'minorVersionsData',
-  'selectedMinorVersion',
-  'onMinorVersionChange'
+  'minorVersionsData'
 ]
 
 export type { HeaderProps }

--- a/packages/__docs__/src/Icons/index.tsx
+++ b/packages/__docs__/src/Icons/index.tsx
@@ -27,6 +27,7 @@ import { Spinner } from '@instructure/ui-spinner'
 import { View } from '@instructure/ui-view'
 import { Alert } from '@instructure/ui-alerts'
 import { Link } from '@instructure/ui-link'
+import { navigateTo } from '../navigationUtils'
 
 // Lazy load icons gallery component
 const IconsGallery = lazy(() => import('./IconsGallery'))
@@ -50,9 +51,17 @@ const IconsPage = () => {
         <Alert variant="info" margin="0 0 medium">
           The version selector does not affect this page. For icons compatible
           with older versions, use{' '}
-          <Link href="/legacy-icons">Legacy Icons</Link>. These icons are only
-          meant to be used with the new theming system, please do not use them
-          with the old (pre v11.7) components.
+          <Link
+            href="legacy-icons"
+            onClick={(e) => {
+              e.preventDefault()
+              navigateTo('legacy-icons')
+            }}
+          >
+            Legacy Icons
+          </Link>
+          . These icons are only meant to be used with the new theming system,
+          please do not use them with the old (pre v11.7) components.
         </Alert>
         <IconsGallery />
       </Suspense>

--- a/packages/__docs__/src/LegacyIcons/index.tsx
+++ b/packages/__docs__/src/LegacyIcons/index.tsx
@@ -42,6 +42,7 @@ import { SourceCodeEditor } from '@instructure/ui-source-code-editor'
 import * as InstIcons from '@instructure/ui-icons'
 import { IconXSolid } from '@instructure/ui-icons'
 import { Link } from '@instructure/ui-link'
+import { navigateTo } from '../navigationUtils'
 import { Flex } from '@instructure/ui-flex'
 import type { Glyph, LegacyIconsData } from '../../buildScripts/DataTypes.mjs'
 
@@ -249,7 +250,16 @@ const LegacyIconsPage = ({ iconData }: LegacyIconsPageProps) => {
       </Alert>
       <Alert variant="info" margin="0 0 medium">
         New icon set is available, please only use it with InstUI v11.7 or newer
-        components: <Link href="/icons">Icons</Link>
+        components:{' '}
+        <Link
+          href="icons"
+          onClick={(e) => {
+            e.preventDefault()
+            navigateTo('icons')
+          }}
+        >
+          Icons
+        </Link>
       </Alert>
       <Alert variant="info" margin="0 0 medium">
         Our legacy icon components are rendered through Emotion, so server-side

--- a/packages/__docs__/src/Theme/index.tsx
+++ b/packages/__docs__/src/Theme/index.tsx
@@ -34,6 +34,7 @@ import { Alert } from '@instructure/ui-alerts'
 import { Spinner } from '@instructure/ui-spinner'
 import { Link } from '@instructure/ui-link'
 
+import { navigateTo } from '../navigationUtils'
 import { Heading } from '../Heading'
 import { Description } from '../Description'
 import { ColorSwatch } from '../ColorSwatch'
@@ -326,7 +327,13 @@ type ThemeState = { showColors: boolean }
           <Alert variant="info" margin="0 0 medium">
             This theme is used by <strong>InstUI v11.6</strong> components. For
             v11.7 and later, use the{' '}
-            <Link href={`#${themeKey.replace('legacy-', '')}`}>
+            <Link
+              href={themeKey.replace('legacy-', '')}
+              onClick={(e) => {
+                e.preventDefault()
+                navigateTo(themeKey.replace('legacy-', ''))
+              }}
+            >
               {themeKey.replace('legacy-', '')}
             </Link>{' '}
             theme instead.

--- a/packages/__docs__/src/compileMarkdown.tsx
+++ b/packages/__docs__/src/compileMarkdown.tsx
@@ -290,16 +290,17 @@ const renderer = (title: string) => ({
         // Markdown links can point to a specific version of a component,
         // e.g. href="/v11_7/DateInput". navigateTo() expects the page
         // name and version as separate arguments, so we need to split
-        // them apart. Plain links like "DateInput" are passed through
-        // as-is.
-        const path = href.replace(/^\/+/, '') // "/v11_7/DateInput" -> "v11_7/DateInput"
+        // them apart. Plain links like "DateInput", "/DateInput", and
+        // legacy hash-routing links like "/#DateInput" are normalised
+        // to the bare page name.
+        const path = href.replace(/^\/+/, '').replace(/^#+/, '')
         const [first, second] = path.split('/')
         const isVersionedLink = MINOR_VERSION_REGEX.test(first) && second
 
         if (isVersionedLink) {
           navigateTo(second, { minorVersion: first })
         } else {
-          navigateTo(href)
+          navigateTo(path || 'index')
         }
       }}
     >

--- a/packages/__docs__/src/withStyleForDocs.tsx
+++ b/packages/__docs__/src/withStyleForDocs.tsx
@@ -132,56 +132,9 @@ const defaultValues = {
  *
  * @module withStyleForDocs
  *
- * A themeable component’s theme can be configured via wrapping it in an
- * [InstUISettingsProvider](InstUISettingsProvider) component, and/or set
- * explicitly via its `themeOverride` prop.
- *
- * InstUISettingsProvider provides a theme object (e.g. the [canvas theme](/#canvas)).
- * These variables are mapped to the component's own variables in `theme.js`.
- *
- * With the `themeOverride` prop you can directly set/override the component theme variables declared in theme.js. It accepts an object or a function. The function has the component's theme and the currently active main theme as its parameter.
- *
- * See more about the overrides on the [Legacy theme overrides](/#legacy-theme-overrides) docs page.
- *
- * ```js-code
- * // ExampleComponent/theme.js
- * const generateComponentTheme = (theme) => {
- *   const { colors } = theme
- *
- *   const componentVariables = {
- *     background: colors?.backgroundMedium,
- *     color: colors?.textDarkest,
- *
- *     hoverColor: colors?.textLightest,
- *     hoverBackground: colors?.backgroundDarkest
- *   }
- *
- *   return componentVariables
- * }
- * export default generateComponentTheme
- * ```
- *
- * ```jsx-code
- * {// global theme override}
- * <InstUISettingsProvider theme={{
- *   colors: { backgroundMedium: '#888' }
- * }}>
- *  {// component theme override}
- *   <ExampleComponent themeOverride={{ hoverColor: '#eee' }} />
- *
- *  {// component theme override with function}
- *   <ExampleComponent themeOverride={(componentTheme, currentTheme) => ({
- *     hoverBackground: componentTheme.background,
- *     activeBackground: currentTheme.colors.backgroundBrand
- *   })} />
- * </InstUISettingsProvider>
- * ```
- *
- * @module withStyleNew
- *
- * @param {function} generateStyle - The function that returns the component's style object
- * @param {function} generateComponentTheme - The function that returns the component's theme variables object
- * @returns {ReactElement} The decorated WithStyle Component
+ * @param {function} generateStyle - Returns the component's style object
+ * @param {function} generateComponentTheme - Returns the component's theme variables object
+ * @returns {ReactElement} The decorated component
  */
 const withStyleForDocs = decorator(
   (

--- a/packages/__docs__/src/withStyleForDocs.tsx
+++ b/packages/__docs__/src/withStyleForDocs.tsx
@@ -132,9 +132,56 @@ const defaultValues = {
  *
  * @module withStyleForDocs
  *
- * @param {function} generateStyle - Returns the component's style object
- * @param {function} generateComponentTheme - Returns the component's theme variables object
- * @returns {ReactElement} The decorated component
+ * A themeable component’s theme can be configured via wrapping it in an
+ * [InstUISettingsProvider](InstUISettingsProvider) component, and/or set
+ * explicitly via its `themeOverride` prop.
+ *
+ * InstUISettingsProvider provides a theme object (e.g. the [canvas theme](/#canvas)).
+ * These variables are mapped to the component's own variables in `theme.js`.
+ *
+ * With the `themeOverride` prop you can directly set/override the component theme variables declared in theme.js. It accepts an object or a function. The function has the component's theme and the currently active main theme as its parameter.
+ *
+ * See more about the overrides on the [Legacy theme overrides](/#legacy-theme-overrides) docs page.
+ *
+ * ```js-code
+ * // ExampleComponent/theme.js
+ * const generateComponentTheme = (theme) => {
+ *   const { colors } = theme
+ *
+ *   const componentVariables = {
+ *     background: colors?.backgroundMedium,
+ *     color: colors?.textDarkest,
+ *
+ *     hoverColor: colors?.textLightest,
+ *     hoverBackground: colors?.backgroundDarkest
+ *   }
+ *
+ *   return componentVariables
+ * }
+ * export default generateComponentTheme
+ * ```
+ *
+ * ```jsx-code
+ * {// global theme override}
+ * <InstUISettingsProvider theme={{
+ *   colors: { backgroundMedium: '#888' }
+ * }}>
+ *  {// component theme override}
+ *   <ExampleComponent themeOverride={{ hoverColor: '#eee' }} />
+ *
+ *  {// component theme override with function}
+ *   <ExampleComponent themeOverride={(componentTheme, currentTheme) => ({
+ *     hoverBackground: componentTheme.background,
+ *     activeBackground: currentTheme.colors.backgroundBrand
+ *   })} />
+ * </InstUISettingsProvider>
+ * ```
+ *
+ * @module withStyleNew
+ *
+ * @param {function} generateStyle - The function that returns the component's style object
+ * @param {function} generateComponentTheme - The function that returns the component's theme variables object
+ * @returns {ReactElement} The decorated WithStyle Component
  */
 const withStyleForDocs = decorator(
   (


### PR DESCRIPTION
INSTUI-5031

## Summary

- Moves the component version (minor version) selector from the side nav to the component pages, displayed alongside the Theme selector
- The Component version and Theme selectors are now only rendered on Components pages
- The `v11.6` option in the Component version Select is labeled `v11.6 (legacy theming)`
- Restores the full library version display in the side nav header
- Legacy Theme Overrides page always redirects to v11.6 
- New Theme Overrides page always redirects to v11.7
- Adds an info alert on all non-component pages explaining that the content reflects the latest versioning
- Modify New theme overrides page "13. Independent overrides for child parts of compound components" section
- Adds a new "Component versioning" guide page



Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)