### PR TITLE
fix(ui-modal): skip Modal.Body tab stop when it has focusable children

### DIFF
--- a/packages/ui-dom-utils/src/findTabbable.ts
+++ b/packages/ui-dom-utils/src/findTabbable.ts
@@ -41,6 +41,10 @@ import { UIElement } from '@instructure/shared-types'
  * @param { boolean } shouldSearchRootNode - should the root node be included in the search
  * @returns { Array } array of all tabbable children
  */
+// Attributes that affect tabbability:
+//   tabindex, href, type, contenteditable, disabled - read directly by findFocusable
+//   class, style, hidden - read indirectly, via the computed display/position
+//                          (visibility) checks in findFocusable
 function findTabbable(el?: UIElement, shouldSearchRootNode?: boolean) {
   return findFocusable(
     el,

--- a/packages/ui-modal/src/Modal/__tests__/ModalBody.test.tsx
+++ b/packages/ui-modal/src/Modal/__tests__/ModalBody.test.tsx
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
 
-import { render } from '@testing-library/react'
-import { vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom'
 
 import { color2hex } from '@instructure/ui-color-utils'
@@ -112,6 +112,102 @@ describe('<ModalBody />', () => {
           consoleErrorSpy.mockRestore()
         })
       }
+    })
+  })
+
+  describe('tab stop on a scrollable body', () => {
+    let scrollHeightSpy: ReturnType<typeof vi.spyOn>
+    let rectSpy: ReturnType<typeof vi.spyOn>
+    let originalResizeObserver: typeof globalThis.ResizeObserver
+
+    const mockScrollable = (scrollable: boolean) => {
+      scrollHeightSpy = vi
+        .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+        .mockReturnValue(scrollable ? 500 : 50)
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          height: 50,
+          width: 100,
+          top: 0,
+          left: 0,
+          right: 100,
+          bottom: 50,
+          x: 0,
+          y: 0,
+          toJSON: () => {}
+        } as DOMRect)
+    }
+
+    beforeEach(() => {
+      originalResizeObserver = globalThis.ResizeObserver
+      globalThis.ResizeObserver = class {
+        cb: ResizeObserverCallback
+        constructor(cb: ResizeObserverCallback) {
+          this.cb = cb
+        }
+        observe() {
+          Promise.resolve().then(() =>
+            this.cb([], this as unknown as ResizeObserver)
+          )
+        }
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof globalThis.ResizeObserver
+    })
+
+    afterEach(() => {
+      scrollHeightSpy?.mockRestore()
+      rectSpy?.mockRestore()
+      globalThis.ResizeObserver = originalResizeObserver
+    })
+
+    it('is a tab stop when scrollable and it has no focusable children', async () => {
+      mockScrollable(true)
+      const { findByText } = render(<ModalBody>{BODY_TEXT}</ModalBody>)
+      const body = await findByText(BODY_TEXT)
+
+      await waitFor(() => expect(body).toHaveAttribute('tabindex', '0'))
+    })
+
+    it('is not a tab stop when scrollable but it has a focusable child', async () => {
+      mockScrollable(true)
+      const { findByText } = render(
+        <ModalBody>
+          <button>focusable</button>
+          {BODY_TEXT}
+        </ModalBody>
+      )
+      const body = await findByText(BODY_TEXT)
+
+      await waitFor(() => expect(body).not.toHaveAttribute('tabindex'))
+    })
+
+    it('is not a tab stop when it is not scrollable', async () => {
+      mockScrollable(false)
+      const { findByText } = render(<ModalBody>{BODY_TEXT}</ModalBody>)
+      const body = await findByText(BODY_TEXT)
+
+      await waitFor(() => expect(body).toBeInTheDocument())
+      expect(body).not.toHaveAttribute('tabindex')
+    })
+
+    it('drops the tab stop when a focusable child is added later', async () => {
+      mockScrollable(true)
+      const { findByText, rerender } = render(
+        <ModalBody>{BODY_TEXT}</ModalBody>
+      )
+      const body = await findByText(BODY_TEXT)
+      await waitFor(() => expect(body).toHaveAttribute('tabindex', '0'))
+
+      rerender(
+        <ModalBody>
+          <button>focusable</button>
+          {BODY_TEXT}
+        </ModalBody>
+      )
+
+      await waitFor(() => expect(body).not.toHaveAttribute('tabindex'))
     })
   })
 })

--- a/packages/ui-modal/src/Modal/v1/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/v1/ModalBody/index.tsx
@@ -26,7 +26,7 @@ import { Component } from 'react'
 
 import { View } from '@instructure/ui-view/v11_6'
 import { omitProps } from '@instructure/ui-react-utils'
-import { getCSSStyleDeclaration } from '@instructure/ui-dom-utils'
+import { getCSSStyleDeclaration, findTabbable } from '@instructure/ui-dom-utils'
 
 import { withStyle } from '@instructure/emotion'
 import generateStyle from './styles.js'
@@ -56,6 +56,8 @@ class ModalBody extends Component<ModalBodyProps> {
   }
 
   ref: UIElement | null = null
+  private resizeObserver?: ResizeObserver
+  private mutationObserver?: MutationObserver
 
   handleRef = (el: UIElement | null) => {
     const { elementRef } = this.props
@@ -87,10 +89,37 @@ class ModalBody extends Component<ModalBodyProps> {
     if (isFirefox) {
       this.setState({ isFirefox })
     }
+
+    const finalRef = this.getFinalRef(this.ref)
+    if (finalRef && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.forceUpdate())
+      this.resizeObserver.observe(finalRef)
+      this.mutationObserver = new MutationObserver(() => this.forceUpdate())
+      this.mutationObserver.observe(finalRef, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [
+          'disabled',
+          'tabindex',
+          'hidden',
+          'href',
+          'contenteditable',
+          'type',
+          'class',
+          'style'
+        ]
+      })
+    }
   }
 
   componentDidUpdate() {
     this.props.makeStyles?.()
+  }
+
+  componentWillUnmount() {
+    this.resizeObserver?.disconnect()
+    this.mutationObserver?.disconnect()
   }
 
   getFinalRef(el: UIElement): Element | undefined {
@@ -125,6 +154,8 @@ class ModalBody extends Component<ModalBodyProps> {
         (finalRef.scrollHeight ?? 0) -
           (finalRef.getBoundingClientRect()?.height ?? 0)
       ) > 1
+    const hasTabbableChildren = !!finalRef && findTabbable(finalRef).length > 0
+    const needsTabIndex = hasScrollbar && !hasTabbableChildren
     return (
       <ModalContext.Consumer>
         {(value) => (
@@ -138,8 +169,9 @@ class ModalBody extends Component<ModalBodyProps> {
             as={as}
             css={this.props.styles?.modalBody}
             padding={padding}
-            // check if there is a scrollbar, if so, the element has to be tabbable
-            {...(hasScrollbar
+            // check if there is a scrollbar and no focusable children, if so, the
+            // element has to be tabbable
+            {...(needsTabIndex
               ? {
                   tabIndex: 0,
                   'aria-label': value.bodyScrollAriaLabel

--- a/packages/ui-modal/src/Modal/v1/README.md
+++ b/packages/ui-modal/src/Modal/v1/README.md
@@ -672,6 +672,7 @@ type: embed
     <Figure.Item>Modals should be able to be closed by clicking away, esc key and/or a close button</Figure.Item>
     <Figure.Item>We recommend that modals begin with a heading (typically H2)</Figure.Item>
     <Figure.Item>The Modal's header currently becomes non-sticky when the window height is too small, improving navigation of the Modal.Body, e.g., at higher zoom levels</Figure.Item>
+    <Figure.Item>`Modal.Body` automatically becomes a keyboard tab stop (its `tabIndex` is set to `0`) when it is vertically scrollable and contains no focusable elements, so it can be scrolled by keyboard-only users. This is re-evaluated dynamically as the body's content or size changes.</Figure.Item>
   </Figure>
 </Guidelines>
 ```

--- a/packages/ui-modal/src/Modal/v2/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/v2/ModalBody/index.tsx
@@ -26,7 +26,7 @@ import { Component } from 'react'
 
 import { View } from '@instructure/ui-view/latest'
 import { omitProps } from '@instructure/ui-react-utils'
-import { getCSSStyleDeclaration } from '@instructure/ui-dom-utils'
+import { getCSSStyleDeclaration, findTabbable } from '@instructure/ui-dom-utils'
 
 import { withStyleNew } from '@instructure/emotion'
 import generateStyle from './styles.js'
@@ -56,6 +56,8 @@ class ModalBody extends Component<ModalBodyProps> {
   }
 
   ref: UIElement | null = null
+  private resizeObserver?: ResizeObserver
+  private mutationObserver?: MutationObserver
 
   handleRef = (el: UIElement | null) => {
     const { elementRef } = this.props
@@ -87,10 +89,37 @@ class ModalBody extends Component<ModalBodyProps> {
     if (isFirefox) {
       this.setState({ isFirefox })
     }
+
+    const finalRef = this.getFinalRef(this.ref)
+    if (finalRef && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.forceUpdate())
+      this.resizeObserver.observe(finalRef)
+      this.mutationObserver = new MutationObserver(() => this.forceUpdate())
+      this.mutationObserver.observe(finalRef, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [
+          'disabled',
+          'tabindex',
+          'hidden',
+          'href',
+          'contenteditable',
+          'type',
+          'class',
+          'style'
+        ]
+      })
+    }
   }
 
   componentDidUpdate() {
     this.props.makeStyles?.()
+  }
+
+  componentWillUnmount() {
+    this.resizeObserver?.disconnect()
+    this.mutationObserver?.disconnect()
   }
 
   getFinalRef(el: UIElement): Element | undefined {
@@ -133,6 +162,8 @@ class ModalBody extends Component<ModalBodyProps> {
         (finalRef.scrollHeight ?? 0) -
           (finalRef.getBoundingClientRect()?.height ?? 0)
       ) > 1
+    const hasTabbableChildren = !!finalRef && findTabbable(finalRef).length > 0
+    const needsTabIndex = hasScrollbar && !hasTabbableChildren
     return (
       <ModalContext.Consumer>
         {(value) => (
@@ -146,8 +177,9 @@ class ModalBody extends Component<ModalBodyProps> {
             as={as}
             css={this.props.styles?.modalBody}
             padding={spacing ? undefined : padding}
-            // check if there is a scrollbar, if so, the element has to be tabbable
-            {...(hasScrollbar
+            // check if there is a scrollbar and no focusable children, if so, the
+            // element has to be tabbable
+            {...(needsTabIndex
               ? {
                   tabIndex: 0,
                   'aria-label': value.bodyScrollAriaLabel

--- a/packages/ui-modal/src/Modal/v2/README.md
+++ b/packages/ui-modal/src/Modal/v2/README.md
@@ -668,6 +668,7 @@ type: embed
     <Figure.Item>Modals should be able to be closed by clicking away, esc key and/or a close button</Figure.Item>
     <Figure.Item>We recommend that modals begin with a heading (typically H2)</Figure.Item>
     <Figure.Item>The Modal's header currently becomes non-sticky when the window height is too small, improving navigation of the Modal.Body, e.g., at higher zoom levels</Figure.Item>
+    <Figure.Item>`Modal.Body` automatically becomes a keyboard tab stop (its `tabIndex` is set to `0`) when it is vertically scrollable and contains no focusable elements, so it can be scrolled by keyboard-only users. This is re-evaluated dynamically as the body's content or size changes.</Figure.Item>
   </Figure>
 </Guidelines>
 ```


### PR DESCRIPTION
INSTUI-5046

**ISSUE:**
- Modal.Body gets a redundant tabIndex={0} when it's scrollable but already contains focusable elements, creating a redundant tab stop. It should only get a tabIndex={0}  when it has no interactive elements.

**TEST PLAN:**
- Copy the code below into the documentation.
- Open the modal using only the keyboard.
   - Navigate to the modal body using the Tab key.
   - The modal body should receive focus.
   - Once focused, the body should be scrollable using the Down Arrow and Up Arrow keys.
- Keep the modal open.
   - Navigate to the "Scrollable body" toggle and turn it off.
   - While the modal remains open, navigate back to the modal body.
   - This time, the modal body should not receive focus.
- Keep the modal open.
   - Turn the "Scrollable body" toggle back on.
   - Verify that the modal body can be focused again.
   - While the modal is open, turn on the "Focusable element in body" toggle.
   - Navigate to the modal body again — this time, the whole body should not be focused. Instead, focus should jump only to the button inside the body.
- Turn the "Focusable element in body" toggle back off.
   - The modal body should once again be focusable.

- Check that Modal.Body gets tabIndex={0} when it contains no focusable elements.
- Check that Modal.Body does NOT get tabIndex={0} when it contains at least one focusable element.
- should work in v1 and v2 too

```
const longText = lorem.paragraphs(100)
const shortText = lorem.paragraphs(1)

const Example = () => {
  const [open, setOpen] = useState(false)
  const [scrollable, setScrollable] = useState(true)
  const [hasFocusable, setHasFocusable] = useState(false)

  const handleButtonClick = () => {
    setOpen((state) => !state)
  }

  const renderCloseButton = () => {
    return (
      <CloseButton
        placement="end"
        offset="small"
        onClick={handleButtonClick}
        screenReaderLabel="Close"
      />
    )
  }

  return (
    <div style={{ padding: '0 0 11rem 0', margin: '0 auto' }}>
      <Button onClick={handleButtonClick}>
        {open ? 'Close' : 'Open'} the Modal
      </Button>
      <Modal
        open={open}
        onDismiss={() => {
          setOpen(false)
        }}
        size="medium"
        label="Hello World"
        shouldCloseOnDocumentClick
      >
        <Modal.Header>
          {renderCloseButton()}
          <Heading>Hello World</Heading>
        </Modal.Header>
        <Modal.Body>
          {hasFocusable && (
            <View as="div" margin="0 0 small 0">
              <Button>A focusable element inside the body</Button>
            </View>
          )}
          <Text lineHeight="double">{scrollable ? longText : shortText}</Text>
        </Modal.Body>
        <Modal.Footer>
          <View as="div" margin="0 auto 0 0">
            <View as="div" display="block" margin="0 0 small 0">
              <Checkbox
                label="Scrollable body"
                variant="toggle"
                size="small"
                checked={scrollable}
                onChange={() => setScrollable((v) => !v)}
              />
            </View>
            <Checkbox
              label="Focusable element in body"
              variant="toggle"
              size="small"
              checked={hasFocusable}
              onChange={() => setHasFocusable((v) => !v)}
            />
          </View>
          <Button onClick={handleButtonClick}>Close</Button>
        </Modal.Footer>
      </Modal>
    </div>
  )
}

render(<Example />)
```