### PR TITLE
feat(many): support current spacing tokens in the margin prop for v2 components

### DIFF
--- a/docs/guides/layout-spacing.md
+++ b/docs/guides/layout-spacing.md
@@ -7,18 +7,19 @@ relevantForAI: true
 
 ## Layout Spacing
 
-```js
----
-type: embed
----
-<Alert variant="warning" margin="0 0 medium">
-  The spacing tokens documented on this page (such as <code>general.spaceMd</code>) require <strong>v11.7+</strong> components and are applied through the <code>margin</code> and <code>padding</code> props. If you are viewing the v11.6 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_7') : `/v11_7${window.location.pathname}`}>switch to v11.7</Link> to see the examples working correctly.
-</Alert>
-```
+The spacing tokens documented on this page (such as `general.spaceMd`) require **v11.7+** components and are applied through the `margin` and `padding` props.
 
 Our design system provides a set of spacing tokens for consistent layouts and components. The current tokens are organized into a general t-shirt scale plus a handful of semantic tokens. Some tokens share a value but carry different meaning — prefer the semantically correct token for the context (e.g. use `gap.buttons` for spacing between buttons).
 
 The `margin` and `padding` props on InstUI components accept these tokens via **dot-path notation** (for example `margin="general.spaceMd"` or `padding="padding.card.lg"`), and support the familiar CSS-like 1–4 value shorthand.
+
+### Where these tokens come from
+
+A prop like `margin="general.spaceMd"` is resolved at runtime against the active theme's `sharedTokens.spacing` object. `sharedTokens` doesn't hold spacing values of its own — it reshapes the theme's **semantic** tokens into the flat, prop-facing structure shown below. The full pipeline is:
+
+`primitives` (raw `rem` values) → `semantics.spacing` (named tokens per theme) → `sharedTokens.spacing` (the dot-paths this page documents) → the `margin` / `padding` prop.
+
+Because the values originate in each theme's semantic tokens, they are **theme-dependent** in principle — a theme can resolve `general.spaceMd` to a different value. In practice all themes InstUI currently ships resolve these tokens to the same values (those listed in the tables below).
 
 ## Tokens
 

--- a/docs/guides/layout-spacing.md
+++ b/docs/guides/layout-spacing.md
@@ -1,0 +1,95 @@
+---
+title: Layout Spacing
+category: Guides
+order: 7
+relevantForAI: true
+---
+
+## Layout Spacing
+
+```js
+---
+type: embed
+---
+<Alert variant="warning" margin="0 0 medium">
+  The spacing tokens documented on this page (such as <code>general.spaceMd</code>) require <strong>v11.7+</strong> components and are applied through the <code>margin</code> and <code>padding</code> props. If you are viewing the v11.6 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_7') : `/v11_7${window.location.pathname}`}>switch to v11.7</Link> to see the examples working correctly.
+</Alert>
+```
+
+Our design system provides a set of spacing tokens for consistent layouts and components. The current tokens are organized into a general t-shirt scale plus a handful of semantic tokens. Some tokens share a value but carry different meaning — prefer the semantically correct token for the context (e.g. use `gap.buttons` for spacing between buttons).
+
+The `margin` and `padding` props on InstUI components accept these tokens via **dot-path notation** (for example `margin="general.spaceMd"` or `padding="padding.card.lg"`), and support the familiar CSS-like 1–4 value shorthand.
+
+## Tokens
+
+### General scale
+
+| Key               | Value    | Value in pixels |
+| ----------------- | -------- | --------------- |
+| general.spaceNone | 0rem     | 0px             |
+| general.space2xs  | 0.125rem | 2px             |
+| general.spaceXs   | 0.25rem  | 4px             |
+| general.spaceSm   | 0.5rem   | 8px             |
+| general.spaceMd   | 0.75rem  | 12px            |
+| general.spaceLg   | 1rem     | 16px            |
+| general.spaceXl   | 1.5rem   | 24px            |
+| general.space2xl  | 2rem     | 32px            |
+
+### Semantic tokens
+
+| Key                           | Value   | Value in pixels |
+| ----------------------------- | ------- | --------------- |
+| gap.sections                  | 3rem    | 48px            |
+| gap.buttons                   | 0.75rem | 12px            |
+| gap.cards.sm                  | 0.75rem | 12px            |
+| gap.cards.md                  | 1rem    | 16px            |
+| gap.cards.lg                  | 1.5rem  | 24px            |
+| gap.cards.nestedContainers.sm | 0.5rem  | 8px             |
+| gap.cards.nestedContainers.md | 0.75rem | 12px            |
+| gap.cards.nestedContainers.lg | 1rem    | 16px            |
+| gap.inputs.horizontal         | 0.75rem | 12px            |
+| gap.inputs.vertical           | 1rem    | 16px            |
+| padding.card.sm               | 0.5rem  | 8px             |
+| padding.card.md               | 0.75rem | 12px            |
+| padding.card.lg               | 1rem    | 16px            |
+
+## Applying spacing
+
+### Using the `margin` prop
+
+Most components support a `margin` prop that works like the CSS `margin` property. Pass a single token or use the 1–4 value shorthand to fine-tune individual edges.
+
+```js
+---
+type: example
+---
+<View as="div" display="block" borderWidth="small" padding="general.spaceSm">
+  <Button margin="0 general.spaceSm 0 0">Button 1</Button>
+  <Button>Button 2</Button>
+</View>
+```
+
+### Using the `padding` prop
+
+Components that render their own surface accept a `padding` prop, which resolves the same tokens. Semantic `padding.card.*` tokens are a good fit for card-like containers.
+
+```js
+---
+type: example
+---
+<View as="div" display="block" borderWidth="small" padding="padding.card.lg">
+  This container uses <code>padding.card.lg</code>.
+</View>
+```
+
+## Deprecated tokens
+
+For compatibility reasons we still resolve two earlier generations of spacing tokens at runtime, but they should **not** be used when creating new layouts — prefer the current tokens above.
+
+### Phased-out tokens
+
+The flat `space0`–`space60` scale and the flat semantic tokens (`sections`, `buttons`, `paddingCardLarge`, `selects`, `tags`, etc.) were an interim set and have been superseded by the current general scale and dot-path semantic tokens.
+
+### Legacy tokens
+
+The original legacy keywords (`xxxSmall`, `small`, `medium`, `large`, `xxLarge`, etc.) remain so old layouts don't break when updating InstUI.

--- a/packages/emotion/src/styleUtils/ThemeablePropValues.ts
+++ b/packages/emotion/src/styleUtils/ThemeablePropValues.ts
@@ -90,7 +90,18 @@ const ThemeablePropValues = {
 
 // SPACING
 type OldSpacingKeys = keyof typeof ThemeablePropValues.SPACING
+/**
+ * @deprecated Era-1 (legacy) spacing keywords. Still resolved at runtime, but
+ * prefer the current `CurrentSpacingValues` dot-path tokens (e.g. `general.spaceMd`).
+ * See https://instructure.design/layout-spacing.
+ */
 type OldSpacingValues = (typeof ThemeablePropValues.SPACING)[OldSpacingKeys]
+/**
+ * @deprecated Era-2 spacing tokens (the `space0`–`space60` and flat semantic set)
+ * have been phased out. Still resolved at runtime, but prefer the current
+ * `CurrentSpacingValues` dot-path tokens (e.g. `general.spaceMd`, `gap.cards.md`).
+ * See https://instructure.design/layout-spacing.
+ */
 type NewSpacingValues =
   | 'space0'
   | 'space2'
@@ -120,7 +131,38 @@ type NewSpacingValues =
   | 'tags'
   | 'statusIndicators'
   | 'dataPoints'
-type SpacingValues = OldSpacingValues | NewSpacingValues
+/**
+ * Current (era-3) spacing tokens. Referenced via dot-path notation and resolved
+ * against the new theme's `sharedTokens.spacing` map (see
+ * `@instructure/ui-themes` `newThemeTokens`). These are the recommended values
+ * for the `margin`/`padding` props. See https://instructure.design/layout-spacing.
+ */
+type CurrentSpacingValues =
+  // general t-shirt scale
+  | 'general.spaceNone'
+  | 'general.space2xs'
+  | 'general.spaceXs'
+  | 'general.spaceSm'
+  | 'general.spaceMd'
+  | 'general.spaceLg'
+  | 'general.spaceXl'
+  | 'general.space2xl'
+  // semantic gap tokens
+  | 'gap.sections'
+  | 'gap.buttons'
+  | 'gap.cards.sm'
+  | 'gap.cards.md'
+  | 'gap.cards.lg'
+  | 'gap.cards.nestedContainers.sm'
+  | 'gap.cards.nestedContainers.md'
+  | 'gap.cards.nestedContainers.lg'
+  | 'gap.inputs.horizontal'
+  | 'gap.inputs.vertical'
+  // semantic padding tokens
+  | 'padding.card.sm'
+  | 'padding.card.md'
+  | 'padding.card.lg'
+type SpacingValues = CurrentSpacingValues | OldSpacingValues | NewSpacingValues
 // adding `(string & {})` allows to use any string while still allowing specific string values to be suggested by IDEs
 type Spacing = SpacingValues | (string & {})
 
@@ -152,6 +194,7 @@ export default ThemeablePropValues
 export { ThemeablePropValues }
 export type {
   SpacingValues,
+  CurrentSpacingValues,
   Spacing,
   Shadow,
   Stacking,

--- a/packages/emotion/src/styleUtils/__tests__/calcSpacingFromShorthand.test.tsx
+++ b/packages/emotion/src/styleUtils/__tests__/calcSpacingFromShorthand.test.tsx
@@ -239,4 +239,70 @@ describe('calcSpacingFromShorthand', () => {
       consoleWarnSpy.mockRestore()
     })
   })
+
+  // Era-3 (current) tokens are referenced via dot-path notation and resolved
+  // against the new theme's nested `sharedTokens.spacing` map. This block mirrors
+  // that shape to verify the real consumer syntax (e.g. `margin="general.spaceMd"`).
+  describe('era-3 (current) spacing tokens', () => {
+    const eraThreeMap = {
+      general: {
+        spaceNone: '0rem',
+        space2xs: '0.125rem',
+        spaceXs: '0.25rem',
+        spaceSm: '0.5rem',
+        spaceMd: '0.75rem',
+        spaceLg: '1rem',
+        spaceXl: '1.5rem',
+        space2xl: '2rem'
+      },
+      gap: {
+        sections: '3rem',
+        buttons: '0.75rem',
+        cards: {
+          sm: '0.75rem',
+          md: '1rem',
+          lg: '1.5rem',
+          nestedContainers: { sm: '0.5rem', md: '0.75rem', lg: '1rem' }
+        },
+        inputs: { horizontal: '0.75rem', vertical: '1rem' }
+      },
+      padding: {
+        card: { sm: '0.5rem', md: '0.75rem', lg: '1rem' }
+      }
+    }
+
+    it('resolves a general scale token', () => {
+      expect(calcSpacingFromShorthand('general.spaceMd', eraThreeMap)).toBe('0.75rem')
+    })
+
+    it('resolves general.spaceNone', () => {
+      expect(calcSpacingFromShorthand('general.spaceNone', eraThreeMap)).toBe('0rem')
+    })
+
+    it('resolves a deeply nested semantic gap token', () => {
+      expect(
+        calcSpacingFromShorthand('gap.cards.nestedContainers.md', eraThreeMap)
+      ).toBe('0.75rem')
+    })
+
+    it('resolves a semantic padding token', () => {
+      expect(calcSpacingFromShorthand('padding.card.lg', eraThreeMap)).toBe('1rem')
+    })
+
+    it('handles CSS-like shorthand mixing the general scale with auto', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      expect(
+        calcSpacingFromShorthand('general.spaceLg auto general.spaceXl', eraThreeMap)
+      ).toBe('1rem auto 1.5rem')
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('mixes semantic gap and padding tokens', () => {
+      expect(
+        calcSpacingFromShorthand('gap.cards.sm padding.card.md', eraThreeMap)
+      ).toBe('0.75rem 0.75rem')
+    })
+  })
 })

--- a/packages/ui-alerts/src/Alert/v2/README.md
+++ b/packages/ui-alerts/src/Alert/v2/README.md
@@ -24,7 +24,7 @@ type: example
   <Alert
     variant="success"
     renderCloseButtonLabel="Close"
-    margin="small"
+    margin="general.spaceMd"
     transition="none"
     variantScreenReaderLabel="Success, "
   >
@@ -33,7 +33,7 @@ type: example
   <Alert
     variant="info"
     renderCloseButtonLabel="Close"
-    margin="small"
+    margin="general.spaceMd"
     variantScreenReaderLabel="Information, "
   >
     Sample info text. I will fade out if you close me.
@@ -41,7 +41,7 @@ type: example
   <Alert
     variant="error"
     renderCloseButtonLabel="Close"
-    margin="small"
+    margin="general.spaceMd"
     variantScreenReaderLabel="Error, "
   >
     Sample error text that continues for a while
@@ -51,7 +51,7 @@ type: example
   </Alert>
   <Alert
     variant="warning"
-    margin="small"
+    margin="general.spaceMd"
     variantScreenReaderLabel="Warning, "
   >
     Sample warning text. This alert is not dismissible and cannot be closed.
@@ -67,7 +67,7 @@ type: example
 ---
 <Alert
   variant="info"
-  margin="small"
+  margin="general.spaceMd"
   timeout={5000}
   variantScreenReaderLabel="Information, "
 >
@@ -119,14 +119,14 @@ const Example = () => {
       <Button onClick={addAlert}>Add Alert</Button>
       {alerts.map((alert) => {
         return (
-          <View key={alert.key} display="block" margin="small 0">
+          <View key={alert.key} display="block" margin="general.spaceMd 0">
             <Alert
               variant={alert.variant}
               renderCloseButtonLabel="Close"
               onDismiss={() => closeAlert(alert.key)}
               liveRegion={() => document.getElementById('flash-messages')}
               liveRegionPoliteness={alert.politeness}
-              margin="small 0"
+              margin="general.spaceMd 0"
             >
               This is {alert.politeness === 'polite' ? 'a' : 'an'}{' '}
               {alert.politeness} {alert.variant} alert
@@ -164,7 +164,7 @@ const Example = () => {
   return (
     <div>
       <Button onClick={changeMessage}>Change Message</Button>
-      <Button onClick={clearMessage} margin="0 0 0 small">
+      <Button onClick={clearMessage} margin="0 0 0 general.spaceMd">
         Clear Message
       </Button>
       <Alert
@@ -194,13 +194,13 @@ type: example
     padding="small medium"
     borderWidth="small"
     borderRadius="small"
-    margin="x-small 0"
+    margin="general.spaceSm 0"
   >
     {lorem.paragraph()}
   </View>
   <Alert
     variant="info"
-    margin="x-small 0"
+    margin="general.spaceSm 0"
     renderCloseButtonLabel="Close"
     hasShadow={false}
   >
@@ -212,7 +212,7 @@ type: example
     padding="small medium"
     borderWidth="small"
     borderRadius="small"
-    margin="x-small 0"
+    margin="general.spaceSm 0"
   >
     {lorem.paragraph()}
   </View>

--- a/packages/ui-alerts/src/Alert/v2/props.ts
+++ b/packages/ui-alerts/src/Alert/v2/props.ts
@@ -79,9 +79,9 @@ type AlertOwnProps = {
    */
   timeout?: number
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-avatar/src/Avatar/v2/props.ts
+++ b/packages/ui-avatar/src/Avatar/v2/props.ts
@@ -81,7 +81,7 @@ type AvatarOwnProps = {
   /**
    * Valid values are `0`, `none`, `auto`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `margin="small auto large"`.
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-badge/src/Badge/v2/README.md
+++ b/packages/ui-badge/src/Badge/v2/README.md
@@ -16,7 +16,7 @@ type: example
     <Badge
       count={99}
       pulse
-      margin="0 medium 0 0"
+      margin="0 general.spaceXl 0 0"
       formatOutput={function (formattedCount) {
         return (
           <AccessibleContent alt={`You have ${formattedCount} new edits to review`}>
@@ -59,7 +59,7 @@ Use the `countUntil` prop to set a limit for the count. The default for `formatO
 type: example
 ---
 <div>
-  <Badge count={105} countUntil={100} margin="0 medium 0 0">
+  <Badge count={105} countUntil={100} margin="0 general.spaceXl 0 0">
     <Button>Inbox</Button>
   </Badge>
   <Badge count={250} countUntil={100}>
@@ -80,7 +80,7 @@ type: example
 ---
 <div>
   <Flex padding='small' display='inline-flex' alignItems="center">
-    <Badge standalone count={6} margin='0 small 0 0' />
+    <Badge standalone count={6} margin='0 general.spaceMd 0 0' />
     <Badge
       type="notification"
       standalone
@@ -90,7 +90,7 @@ type: example
     />
   </Flex>
   <Flex padding='small' display='inline-flex' alignItems="center">
-    <Badge standalone variant="success" count={12} margin='0 small 0 0' />
+    <Badge standalone variant="success" count={12} margin='0 general.spaceMd 0 0' />
     <Badge
       variant="success"
       type="notification"
@@ -101,7 +101,7 @@ type: example
     />
   </Flex>
   <Flex padding='small' display='inline-flex' alignItems="center">
-    <Badge standalone variant="danger" count={18} countUntil={10} margin='0 small 0 0' />
+    <Badge standalone variant="danger" count={18} countUntil={10} margin='0 general.spaceMd 0 0' />
     <Badge
       variant="danger"
       type="notification"
@@ -113,7 +113,7 @@ type: example
   </Flex>
   <View display='inline-flex' background='primary-inverse'>
     <Flex padding='small' display='inline-flex' alignItems="center" background='primary-inverse'>
-      <Badge standalone variant="inverse" count={8} margin='0 small 0 0' />
+      <Badge standalone variant="inverse" count={8} margin='0 general.spaceMd 0 0' />
       <Badge
         variant="inverse"
         type="notification"
@@ -146,20 +146,20 @@ const EditButton = () => (
 
 const Example = () => (
   <div>
-    <View as="div" margin="0 0 medium">
-      <Badge count={21} margin="0 large 0 0" placement="top start">
+    <View as="div" margin="0 0 general.spaceXl">
+      <Badge count={21} margin="0 general.space2xl 0 0" placement="top start">
         <EditButton />
       </Badge>
-      <Badge count={21} margin="0 large 0 0">
+      <Badge count={21} margin="0 general.space2xl 0 0">
         <EditButton />
       </Badge>
-      <Badge count={21} margin="0 large 0 0" placement="bottom start">
+      <Badge count={21} margin="0 general.space2xl 0 0" placement="bottom start">
         <EditButton />
       </Badge>
-      <Badge count={21} margin="0 large 0 0" placement="bottom end">
+      <Badge count={21} margin="0 general.space2xl 0 0" placement="bottom end">
         <EditButton />
       </Badge>
-      <Badge count={21} margin="0 large 0 0" placement="start center">
+      <Badge count={21} margin="0 general.space2xl 0 0" placement="start center">
         <EditButton />
       </Badge>
       <Badge count={21} placement="end center">
@@ -169,7 +169,7 @@ const Example = () => (
     <View as="div">
       <Badge
         type="notification"
-        margin="0 large 0 0"
+        margin="0 general.space2xl 0 0"
         placement="top start"
         formatOutput={function () {
           return (
@@ -183,7 +183,7 @@ const Example = () => (
       </Badge>
       <Badge
         type="notification"
-        margin="0 large 0 0"
+        margin="0 general.space2xl 0 0"
         formatOutput={function () {
           return (
             <ScreenReaderContent>
@@ -196,7 +196,7 @@ const Example = () => (
       </Badge>
       <Badge
         type="notification"
-        margin="0 large 0 0"
+        margin="0 general.space2xl 0 0"
         placement="bottom start"
         formatOutput={function () {
           return (
@@ -210,7 +210,7 @@ const Example = () => (
       </Badge>
       <Badge
         type="notification"
-        margin="0 large 0 0"
+        margin="0 general.space2xl 0 0"
         placement="bottom end"
         formatOutput={function () {
           return (
@@ -224,7 +224,7 @@ const Example = () => (
       </Badge>
       <Badge
         type="notification"
-        margin="0 large 0 0"
+        margin="0 general.space2xl 0 0"
         placement="start center"
         formatOutput={function () {
           return (

--- a/packages/ui-badge/src/Badge/v2/props.ts
+++ b/packages/ui-badge/src/Badge/v2/props.ts
@@ -71,9 +71,9 @@ type BadgeOwnProps = {
    */
   display?: 'inline-block' | 'block'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-billboard/src/Billboard/v2/README.md
+++ b/packages/ui-billboard/src/Billboard/v2/README.md
@@ -36,7 +36,7 @@ type: example
 ---
 <View as="div" width="400px" withVisualDebug>
   <Billboard
-    margin="large"
+    margin="general.space2xl"
     heading="404"
     message="Billboard is now a button"
     size="small"
@@ -54,7 +54,7 @@ type: example
 ---
 <View as="div" width="600px" withVisualDebug>
   <Billboard
-    margin="large"
+    margin="general.space2xl"
     message="Click this link"
     href="http://instructure.com"
     hero={(size) => <BookCheckInstUIIcon size={size} />}

--- a/packages/ui-billboard/src/Billboard/v2/props.ts
+++ b/packages/ui-billboard/src/Billboard/v2/props.ts
@@ -90,9 +90,9 @@ type BillboardOwnProps = {
    */
   readOnly?: boolean
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-breadcrumb/src/Breadcrumb/v2/README.md
+++ b/packages/ui-breadcrumb/src/Breadcrumb/v2/README.md
@@ -52,7 +52,7 @@ Change the `size` prop to control the font-size of the breadcrumbs (default is `
 type: example
 ---
 <div>
-  <Breadcrumb size="small" label="breadcrumb" margin="none none medium">
+  <Breadcrumb size="small" label="breadcrumb" margin="none none general.spaceXl">
     <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">English 204</Breadcrumb.Link>
       <Breadcrumb.Link
         onClick={function () {
@@ -65,7 +65,7 @@ type: example
     <Breadcrumb.Link>Rabbit Is Rich</Breadcrumb.Link>
   </Breadcrumb>
   <View as="div" width="40rem">
-    <Breadcrumb label="breadcrumb" margin="none none medium">
+    <Breadcrumb label="breadcrumb" margin="none none general.spaceXl">
       <Breadcrumb.Link href="https://instructure.github.io/instructure-ui/">English 204</Breadcrumb.Link>
         <Breadcrumb.Link
           onClick={function () {

--- a/packages/ui-breadcrumb/src/Breadcrumb/v2/props.ts
+++ b/packages/ui-breadcrumb/src/Breadcrumb/v2/props.ts
@@ -42,9 +42,9 @@ type BreadcrumbOwnProps = {
    */
   size?: 'small' | 'medium' | 'large'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-buttons/src/BaseButton/v2/README.md
+++ b/packages/ui-buttons/src/BaseButton/v2/README.md
@@ -9,7 +9,7 @@ Use [Button](Button), [CloseButton](CloseButton), [IconButton](IconButton), or [
 ---
 type: example
 ---
-<View display="block" margin="medium">
+<View display="block" margin="general.spaceXl">
   <BaseButton>Click me</BaseButton>
 </View>
 ```

--- a/packages/ui-buttons/src/BaseButton/v2/props.ts
+++ b/packages/ui-buttons/src/BaseButton/v2/props.ts
@@ -120,9 +120,9 @@ type BaseButtonOwnProps = {
   isCondensed?: boolean
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-buttons/src/Button/v2/README.md
+++ b/packages/ui-buttons/src/Button/v2/README.md
@@ -20,12 +20,12 @@ The `color` prop will change the Button's color scheme.
 type: example
 ---
 <View display="block">
-  <Button color="primary" margin="small">Primary</Button>
-  <Button color="secondary" margin="small">Secondary</Button>
-  <Button color="success" margin="small">Success</Button>
-  <Button color="danger" margin="small">Danger</Button>
-  <Button color="ai-primary" margin="small">AI Primary</Button>
-  <Button color="ai-secondary" margin="small">AI Secondary</Button>
+  <Button color="primary" margin="general.spaceMd">Primary</Button>
+  <Button color="secondary" margin="general.spaceMd">Secondary</Button>
+  <Button color="success" margin="general.spaceMd">Success</Button>
+  <Button color="danger" margin="general.spaceMd">Danger</Button>
+  <Button color="ai-primary" margin="general.spaceMd">AI Primary</Button>
+  <Button color="ai-secondary" margin="general.spaceMd">AI Secondary</Button>
 </View>
 ```
 
@@ -38,7 +38,7 @@ The `primary-inverse` color is designed for use on colored backgrounds. It provi
 type: example
 ---
 <View display="block" background="info" padding="small">
-  <Button color="primary-inverse" margin="small">Primary Inverse</Button>
+  <Button color="primary-inverse" margin="general.spaceMd">Primary Inverse</Button>
 </View>
 ```
 
@@ -51,12 +51,12 @@ There is a specific need for `AI buttons`, which has an icon and gradient colors
 type: example
 ---
 <View display="block">
-  <Button color="ai-primary" renderIcon={IgniteaiLogoInstUIIcon} margin="small">AI Primary</Button>
-  <Button color="ai-secondary" renderIcon={IgniteaiLogoInstUIIcon} margin="small">AI Secondary</Button>
-  <IconButton color="ai-primary" screenReaderLabel="AI button" margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
-  <IconButton  shape='circle' color="ai-secondary" screenReaderLabel="AI button"  margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
-  <IconButton   shape='circle' color="ai-primary" screenReaderLabel="AI button" margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
-  <IconButton color="ai-secondary" screenReaderLabel="AI button"  margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
+  <Button color="ai-primary" renderIcon={IgniteaiLogoInstUIIcon} margin="general.spaceMd">AI Primary</Button>
+  <Button color="ai-secondary" renderIcon={IgniteaiLogoInstUIIcon} margin="general.spaceMd">AI Secondary</Button>
+  <IconButton color="ai-primary" screenReaderLabel="AI button" margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
+  <IconButton  shape='circle' color="ai-secondary" screenReaderLabel="AI button"  margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
+  <IconButton   shape='circle' color="ai-primary" screenReaderLabel="AI button" margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
+  <IconButton color="ai-secondary" screenReaderLabel="AI button"  margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
 </View>
 ```
 
@@ -69,9 +69,9 @@ To specify the Button `size`, set the size prop to `small`, `medium` (default) o
 type: example
 ---
 <View display="block">
-  <Button size="small" margin="small">Small</Button>
-  <Button margin="small">Medium</Button>
-  <Button size="large" margin="small">Large</Button>
+  <Button size="small" margin="general.spaceMd">Small</Button>
+  <Button margin="general.spaceMd">Medium</Button>
+  <Button size="large" margin="general.spaceMd">Large</Button>
 </View>
 ```
 
@@ -82,8 +82,8 @@ There are also two condensed size variants for compact layouts: `condensedSmall`
 type: example
 ---
 <View display="block">
-  <Button size="condensedSmall" margin="small">Condensed Small</Button>
-  <Button size="condensedMedium" margin="small">Condensed Medium</Button>
+  <Button size="condensedSmall" margin="general.spaceMd">Condensed Small</Button>
+  <Button size="condensedMedium" margin="general.spaceMd">Condensed Medium</Button>
 </View>
 ```
 
@@ -109,7 +109,7 @@ type: example
 <View
   display="block"
   width="10rem"
-  margin="small"
+  margin="general.spaceMd"
   padding="small none"
   withVisualDebug
 >
@@ -146,7 +146,7 @@ type: example
       <View
         display="block"
         width="10rem"
-        margin="small"
+        margin="general.spaceMd"
         padding="small none"
         withVisualDebug
       >
@@ -178,7 +178,7 @@ type: example
 <View
   display="block"
   width="30rem"
-  margin="small"
+  margin="general.spaceMd"
   padding="small none"
   withVisualDebug
 >
@@ -202,7 +202,7 @@ Use backgroundless buttons when there is a need to deemphasize the button. Be su
 type: example
 ---
 <View display="block">
-  <Button renderIcon={PlusInstUIIcon} withBackground={false} color="primary" margin="small">Click here</Button>
+  <Button renderIcon={PlusInstUIIcon} withBackground={false} color="primary" margin="general.spaceMd">Click here</Button>
 </View>
 ```
 
@@ -261,7 +261,7 @@ type: example
               onChange={this.toggleWithBackground}
             />
           </FormFieldGroup>
-          <View display="block" margin="small none">
+          <View display="block" margin="general.spaceMd none">
             <RadioInputGroup
               name="color"
               defaultValue="secondary"
@@ -273,7 +273,7 @@ type: example
               <RadioInput label="secondary" value="secondary" />
             </RadioInputGroup>
           </View>
-          <Flex margin="none none medium" gap="medium">
+          <Flex margin="none none general.spaceXl" gap="medium">
             <Flex.Item>
               <Button withBackground={this.state.withBackground}
                       color={this.state.color}

--- a/packages/ui-buttons/src/Button/v2/props.ts
+++ b/packages/ui-buttons/src/Button/v2/props.ts
@@ -98,9 +98,9 @@ type ButtonOwnProps = {
   withBackground?: boolean
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-buttons/src/CloseButton/v2/README.md
+++ b/packages/ui-buttons/src/CloseButton/v2/README.md
@@ -48,7 +48,7 @@ type: example
         size="small"
         withBackground={false}
         withBorder={false}
-        margin="small"
+        margin="general.spaceMd"
       />
     </Flex.Item>
   </Flex>

--- a/packages/ui-buttons/src/CloseButton/v2/props.ts
+++ b/packages/ui-buttons/src/CloseButton/v2/props.ts
@@ -71,9 +71,9 @@ type CloseButtonOwnProps = {
   ) => void
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-buttons/src/CondensedButton/v2/props.ts
+++ b/packages/ui-buttons/src/CondensedButton/v2/props.ts
@@ -70,9 +70,9 @@ type CondensedButtonOwnProps = {
   color?: 'primary' | 'primary-inverse' | 'secondary'
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-buttons/src/IconButton/v2/README.md
+++ b/packages/ui-buttons/src/IconButton/v2/README.md
@@ -19,9 +19,9 @@ type: example
 type: example
 ---
 <View display="block">
-  <IconButton size="small" screenReaderLabel="Add" margin="small"><PlusInstUIIcon /></IconButton>
-  <IconButton size="medium" screenReaderLabel="Add" margin="small"><PlusInstUIIcon /></IconButton>
-  <IconButton size="large" screenReaderLabel="Add" margin="small"><PlusInstUIIcon /></IconButton>
+  <IconButton size="small" screenReaderLabel="Add" margin="general.spaceMd"><PlusInstUIIcon /></IconButton>
+  <IconButton size="medium" screenReaderLabel="Add" margin="general.spaceMd"><PlusInstUIIcon /></IconButton>
+  <IconButton size="large" screenReaderLabel="Add" margin="general.spaceMd"><PlusInstUIIcon /></IconButton>
 </View>
 ```
 
@@ -91,8 +91,8 @@ type: example
 type: example
 ---
 <View display="block">
-  <IconButton color="ai-primary" screenReaderLabel="AI button" margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
-  <IconButton color="ai-secondary" screenReaderLabel="AI button"  margin="small"><IgniteaiLogoInstUIIcon/></IconButton>
+  <IconButton color="ai-primary" screenReaderLabel="AI button" margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
+  <IconButton color="ai-secondary" screenReaderLabel="AI button"  margin="general.spaceMd"><IgniteaiLogoInstUIIcon/></IconButton>
 </View>
 ```
 
@@ -105,8 +105,8 @@ The `shape` prop specifies if the IconButton will render as a `rectangle` or `ci
 type: example
 ---
 <View display="block">
-  <IconButton shape="rectangle" screenReaderLabel="Delete tag" margin="small"><XInstUIIcon /></IconButton>
-  <IconButton shape="circle" screenReaderLabel="Delete tag" margin="small"><XInstUIIcon /></IconButton>
+  <IconButton shape="rectangle" screenReaderLabel="Delete tag" margin="general.spaceMd"><XInstUIIcon /></IconButton>
+  <IconButton shape="circle" screenReaderLabel="Delete tag" margin="general.spaceMd"><XInstUIIcon /></IconButton>
 </View>
 ```
 
@@ -120,7 +120,7 @@ type: example
 ---
 <View display="block">
   <View display="inline-block" background="primary">
-    <IconButton withBackground={false} withBorder={false} screenReaderLabel="Delete tag" margin="large">
+    <IconButton withBackground={false} withBorder={false} screenReaderLabel="Delete tag" margin="general.space2xl">
       <XInstUIIcon />
     </IconButton>
   </View>

--- a/packages/ui-buttons/src/IconButton/v2/props.ts
+++ b/packages/ui-buttons/src/IconButton/v2/props.ts
@@ -109,9 +109,9 @@ type IconButtonOwnProps = {
   withBorder?: boolean
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-byline/src/Byline/v2/README.md
+++ b/packages/ui-byline/src/Byline/v2/README.md
@@ -25,7 +25,7 @@ setting the `alignContent` prop.
 type: example
 ---
 <Byline
-  margin="x-large auto"
+  margin="general.space2xl auto"
   size="small"
   alignContent="top"
   title="Graham Taylor"
@@ -41,7 +41,7 @@ type: example
 ---
 <Byline
   description={
-    <View display="block" margin="0 0 0 x-small">
+    <View display="block" margin="0 0 0 general.spaceSm">
       <Heading level="h2">
         <Link href="#">Clickable Heading</Link>
       </Heading>

--- a/packages/ui-byline/src/Byline/v2/props.ts
+++ b/packages/ui-byline/src/Byline/v2/props.ts
@@ -49,9 +49,9 @@ type BylineOwnProps = {
    */
   alignContent?: 'top' | 'center'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /*

--- a/packages/ui-color-picker/src/ColorIndicator/v2/README.md
+++ b/packages/ui-color-picker/src/ColorIndicator/v2/README.md
@@ -11,34 +11,34 @@ A component displaying a circle with checkerboard background capable of displayi
 type: example
 ---
 <View as="div" background="primary" display='flex'>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color=''/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='#ff0000'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='#ff000088'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='#ff000000'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='yellow'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='rgb(155,55,82)'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='rgba(155,55,82,.5)'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='hsl(30, 100%, 50%)'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='hsla(30, 100%, 50%, .3)'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='hwb(1.5708rad 60% 0%)'/>
   </View>
 </View>
@@ -55,10 +55,10 @@ type: example
 type: example
 ---
 <View as="div" background="primary" display='flex'>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='#ff0000'/>
   </View>
-  <View margin='small'>
+  <View margin='general.spaceMd'>
     <ColorIndicator color='#ff0000' shape='rectangle'/>
   </View>
 </View>

--- a/packages/ui-color-picker/src/ColorPicker/v2/README.md
+++ b/packages/ui-color-picker/src/ColorPicker/v2/README.md
@@ -141,10 +141,10 @@ type: example
           padding="x-small"
           style={{ flexDirection: 'row-reverse' }}
         >
-          <Button onClick={handleAdd} color="primary" margin="xx-small">
+          <Button onClick={handleAdd} color="primary" margin="general.spaceXs">
             Add
           </Button>
-          <Button onClick={handleClose} color="secondary" margin="xx-small">
+          <Button onClick={handleClose} color="secondary" margin="general.spaceXs">
             Close
           </Button>
         </View>

--- a/packages/ui-drawer-layout/src/DrawerLayout/v2/README.md
+++ b/packages/ui-drawer-layout/src/DrawerLayout/v2/README.md
@@ -41,7 +41,7 @@ type: example
               as="div"
               maxWidth="16rem"
               textAlign="center"
-              margin="large auto"
+              margin="general.space2xl auto"
               padding="small"
             >
               <CloseButton
@@ -50,7 +50,7 @@ type: example
                 onClick={handleTrayDismiss}
                 screenReaderLabel="Close"
               />
-              <Avatar name="foo bar" margin="0 0 small 0" />
+              <Avatar name="foo bar" margin="0 0 general.spaceMd 0" />
               <Text as="div" size="x-small">
                 Hello from start tray with a small amount of placeholder content
               </Text>
@@ -64,7 +64,7 @@ type: example
                   <Grid.Row>
                     <Grid.Col>
                       <Button
-                        margin="small 0"
+                        margin="general.spaceMd 0"
                         size="small"
                         onClick={() => {
                           setOpen(true)
@@ -119,7 +119,7 @@ type: example
               as="div"
               maxWidth="48rem"
               textAlign="center"
-              margin="large auto"
+              margin="general.space2xl auto"
               padding="large"
               background="primary"
             >
@@ -150,7 +150,7 @@ type: example
                   as="div"
                   maxWidth="16rem"
                   textAlign="center"
-                  margin="large auto"
+                  margin="general.space2xl auto"
                   padding="small"
                 >
                   <CloseButton
@@ -161,7 +161,7 @@ type: example
                     }}
                     screenReaderLabel="Close"
                   />
-                  <Avatar name="foo bar" margin="0 0 small 0" />
+                  <Avatar name="foo bar" margin="0 0 general.spaceMd 0" />
                   <Text as="div" size="x-small">
                     Hello from start tray with a small amount of placeholder
                     content
@@ -176,7 +176,7 @@ type: example
                       <Grid.Row>
                         <Grid.Col>
                           <Button
-                            margin="small 0"
+                            margin="general.spaceMd 0"
                             size="small"
                             onClick={() => {
                               setStartOpen(true)
@@ -188,7 +188,7 @@ type: example
                         </Grid.Col>
                         <Grid.Col width="auto">
                           <Button
-                            margin="small 0"
+                            margin="general.spaceMd 0"
                             size="small"
                             onClick={() => {
                               setEndOpen(true)

--- a/packages/ui-drilldown/src/Drilldown/v2/README.md
+++ b/packages/ui-drilldown/src/Drilldown/v2/README.md
@@ -1225,7 +1225,7 @@ type: example
       return (
         <span>
           <PlusInstUIIcon />
-          <View as="span" margin="0 0 0 x-small">
+          <View as="span" margin="0 0 0 general.spaceSm">
             New {label}
           </View>
         </span>
@@ -1290,7 +1290,7 @@ type: example
           }}
         >
           <Trash2InstUIIcon size="md"/>
-          <View as="span" margin="0 0 0 x-small">
+          <View as="span" margin="0 0 0 general.spaceSm">
             Delete {label}
           </View>
         </Drilldown.Option>

--- a/packages/ui-editable/src/InPlaceEdit/v2/README.md
+++ b/packages/ui-editable/src/InPlaceEdit/v2/README.md
@@ -105,7 +105,7 @@ type: example
           value={value}
           inline={inline}
         />
-        <View as="div" margin="small 0">
+        <View as="div" margin="general.spaceMd 0">
           <Checkbox label="inline" checked={inline} onChange={onChangeLayout} />
         </View>
       </View>

--- a/packages/ui-file-drop/src/FileDrop/v2/README.md
+++ b/packages/ui-file-drop/src/FileDrop/v2/README.md
@@ -72,7 +72,7 @@ type: example
     }
     display="inline-block"
     width="24rem"
-    margin="x-small"
+    margin="general.spaceSm"
   />
   <FileDrop
     accept="video/*"
@@ -87,7 +87,7 @@ type: example
     }
     display="inline-block"
     width="12rem"
-    margin="x-small"
+    margin="general.spaceSm"
   />
 </div>
 ```
@@ -131,7 +131,7 @@ type: example
     console.log(`Files accepted ${files.map((f) => f.name).join(',')}`)
   }}
   renderLabel={
-    <View as="div" textAlign="center" padding="large" margin="large 0 0 0">
+    <View as="div" textAlign="center" padding="large" margin="general.space2xl 0 0 0">
       <IconAnnotateLine color="brand" size="large" />
       <Text as="div" color="brand">
         Drag and Drop or Click to Browser your Computer
@@ -140,7 +140,7 @@ type: example
   }
   width="18rem"
   height="16rem"
-  margin="x-small"
+  margin="general.spaceSm"
 />
 ```
 

--- a/packages/ui-file-drop/src/FileDrop/v2/props.ts
+++ b/packages/ui-file-drop/src/FileDrop/v2/props.ts
@@ -141,9 +141,9 @@ type FileDropOwnProps = {
    */
   minWidth?: string | number
   /**
-   * Valid values are 0, none, auto, xxx-small, xx-small, x-small, small,
-   * medium, large, x-large, xx-large. Apply these values via familiar
-   * CSS-like shorthand. For example: margin="small auto large".
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-flex/src/Flex/v2/README.md
+++ b/packages/ui-flex/src/Flex/v2/README.md
@@ -19,19 +19,19 @@ Flex defaults to a `direction` of `row`, creating a horizontal layout. Change `d
 type: example
 ---
 <div>
-  <Flex withVisualDebug margin="none none large">
+  <Flex withVisualDebug margin="none none general.space2xl">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
     <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug direction="column" margin="none none large">
+  <Flex withVisualDebug direction="column" margin="none none general.space2xl">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
     <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug direction="row-reverse" margin="none none large">
+  <Flex withVisualDebug direction="row-reverse" margin="none none general.space2xl">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
@@ -55,19 +55,19 @@ Flex items will have no gap by default. You can set the gap between Flex.Items b
 type: example
 ---
 <div>
-  <Flex withVisualDebug margin="none none large" gap="small">
+  <Flex withVisualDebug margin="none none general.space2xl" gap="small">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
     <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug direction="column" margin="none none large" gap="medium">
+  <Flex withVisualDebug direction="column" margin="none none general.space2xl" gap="medium">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
     <Flex.Item><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug direction="row-reverse" margin="none none large" gap="medium">
+  <Flex withVisualDebug direction="row-reverse" margin="none none general.space2xl" gap="medium">
     <Flex.Item><Text>One</Text></Flex.Item>
     <Flex.Item><Text>Two</Text></Flex.Item>
     <Flex.Item><Text>Three</Text></Flex.Item>
@@ -89,25 +89,25 @@ You can also set the gap between rows and columns by using the `gap` property. M
 type: example
 ---
 <div>
-  <Flex withVisualDebug margin="none none large" gap="small" wrap="wrap">
+  <Flex withVisualDebug margin="none none general.space2xl" gap="small" wrap="wrap">
     <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug margin="none none large" gap="small large" wrap="wrap">
+  <Flex withVisualDebug margin="none none general.space2xl" gap="small large" wrap="wrap">
     <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug margin="none none large" gap="small" wrap="wrap-reverse">
+  <Flex withVisualDebug margin="none none general.space2xl" gap="small" wrap="wrap-reverse">
     <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Four</Text></Flex.Item>
   </Flex>
-  <Flex withVisualDebug margin="none none large" gap="small large" wrap="wrap-reverse">
+  <Flex withVisualDebug margin="none none general.space2xl" gap="small large" wrap="wrap-reverse">
     <Flex.Item size='25rem'><Text>One</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Two</Text></Flex.Item>
     <Flex.Item size='25rem'><Text>Three</Text></Flex.Item>
@@ -238,7 +238,7 @@ Use the `justifyItems` property to change the justification of Flex.Items.
 type: example
 ---
 <div>
-  <Flex justifyItems="center" margin="0 0 large" withVisualDebug>
+  <Flex justifyItems="center" margin="0 0 general.space2xl" withVisualDebug>
     <Flex.Item>
       <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
     </Flex.Item>
@@ -250,7 +250,7 @@ type: example
     </Flex.Item>
   </Flex>
 
-  <Flex justifyItems="space-between" withVisualDebug margin="0 0 large">
+  <Flex justifyItems="space-between" withVisualDebug margin="0 0 general.space2xl">
     <Flex.Item>
       <Avatar name="Sarah Robinson" size="large" src={avatarSquare} />
     </Flex.Item>
@@ -316,7 +316,7 @@ type: example
     <Heading>Lorem ipsum dolor sit amet consectetur dolor sit</Heading>
   </Flex.Item>
   <Flex.Item>
-    <Button margin="none x-small none none">
+    <Button margin="none general.spaceSm none none">
       Cancel
     </Button>
     <Button color="success" renderIcon={UserInstUIIcon}>
@@ -335,9 +335,9 @@ type: example
 <Flex height="32rem" justifyItems="center" padding="large" withVisualDebug>
   <Flex.Item shouldShrink shouldGrow textAlign="center">
 
-    <Heading level="h1" margin="0 0 medium">An amazing thing!</Heading>
+    <Heading level="h1" margin="0 0 general.spaceXl">An amazing thing!</Heading>
 
-    <Flex withVisualDebug wrap="wrap" justifyItems="space-around" margin="0 0 medium">
+    <Flex withVisualDebug wrap="wrap" justifyItems="space-around" margin="0 0 general.spaceXl">
       <Flex.Item padding="small">
         <HeartInstUIIcon size="medium" title="Icon Example" color="primary" />
         <Text weight="bold" size="large" as="div">We love you!</Text>

--- a/packages/ui-flex/src/Flex/v2/props.ts
+++ b/packages/ui-flex/src/Flex/v2/props.ts
@@ -65,9 +65,9 @@ type FlexOwnProps = {
   width?: string | number
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-form-field/src/FormFieldLayout/v2/props.ts
+++ b/packages/ui-form-field/src/FormFieldLayout/v2/props.ts
@@ -95,7 +95,7 @@ type FormFieldLayoutOwnProps = {
   /**
    * Valid values are `0`, `none`, `auto`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `margin="small auto large"`.
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-heading/src/Heading/v2/README.md
+++ b/packages/ui-heading/src/Heading/v2/README.md
@@ -13,7 +13,7 @@ Variant covers almost all use cases for headings on pages. Their name reflects t
 type: embed
 ---
 <Alert variant="info">
-  <List margin="0 0 medium">
+  <List margin="0 0 general.spaceXl">
     <List.Item>For legacy reasons, each <code>variant</code> has a default <code>level</code> set. This is not the recommended way and will be removed in a later major release. Please always specify the <code>level</code>!</List.Item>
     <List.Item>When <code>variant</code> is set the <code>as</code> prop is ignored</List.Item>
     <List.Item>A11Y GUIDELINE: There can be only one <code>h1</code> tag in a page</List.Item>
@@ -71,7 +71,7 @@ The `variant` and `level` props sets its appearance in this order.
 type: example
 ---
 <div>
-  <Heading level="h1" as="h3" margin="0 0 x-small">This renders as <code>&lt;h3&gt;</code></Heading>
+  <Heading level="h1" as="h3" margin="0 0 general.spaceSm">This renders as <code>&lt;h3&gt;</code></Heading>
 </div>
 ```
 
@@ -123,7 +123,7 @@ add either `top` or `bottom` borders to your heading.
 type: example
 ---
 <div>
-  <Heading margin="0 0 medium" border="bottom">I have a bottom border</Heading>
+  <Heading margin="0 0 general.spaceXl" border="bottom">I have a bottom border</Heading>
   <Heading border="top">I have a top border</Heading>
 </div>
 ```

--- a/packages/ui-heading/src/Heading/v2/props.ts
+++ b/packages/ui-heading/src/Heading/v2/props.ts
@@ -75,9 +75,9 @@ type HeadingOwnProps = {
    */
   as?: AsElementType
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-img/src/Img/v2/README.md
+++ b/packages/ui-img/src/Img/v2/README.md
@@ -21,9 +21,9 @@ the image a block-level element.
 type: example
 ---
 <View textAlign="center" as="div">
-  <Img margin="small" alt="A placeholder image" src={placeholderImage(300, 200)} />
-  <Img margin="small" src={placeholderImage(200, 200)} />
-  <Img display="block" margin="small auto" src={placeholderImage(400, 200)} />
+  <Img margin="general.spaceMd" alt="A placeholder image" src={placeholderImage(300, 200)} />
+  <Img margin="general.spaceMd" src={placeholderImage(200, 200)} />
+  <Img display="block" margin="general.spaceMd auto" src={placeholderImage(400, 200)} />
 </View>
 ```
 
@@ -40,19 +40,19 @@ type: example
       src={placeholderImage(200, 200)}
       overlay={{color: '#0374B5', opacity: 9, blend: 'overlay'}}
       alt="A placeholder image"
-      margin="x-small"
+      margin="general.spaceSm"
     />
     <Img
       src={placeholderImage(200, 200)}
       overlay={{color: '#0374B5', opacity: 6, blend: 'multiply'}}
       alt="A placeholder image"
-      margin="x-small"
+      margin="general.spaceSm"
     />
     <Img
       src={placeholderImage(200, 200)}
       overlay={{color: '#0374B5', opacity: 3}}
       alt="A placeholder image"
-      margin="x-small"
+      margin="general.spaceSm"
     />
   </View>
 ```
@@ -98,13 +98,13 @@ type: example
       withGrayscale
       src={avatarSquare}
       alt="A placeholder image"
-      margin="x-small"
+      margin="general.spaceSm"
     />
     <Img
       withBlur
       src={avatarSquare}
       alt="A placeholder image"
-      margin="x-small"
+      margin="general.spaceSm"
     />
   </View>
 ```

--- a/packages/ui-img/src/Img/v2/props.ts
+++ b/packages/ui-img/src/Img/v2/props.ts
@@ -39,9 +39,9 @@ type ImgOwnProps = {
    */
   loading?: 'eager' | 'lazy'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-link/src/Link/v2/README.md
+++ b/packages/ui-link/src/Link/v2/README.md
@@ -107,7 +107,7 @@ to add margin to the top or bottom of Link, wrap it inside a `<View />`.
 ---
 type: example
 ---
-<Text>The quick brown fox <Link href="https://instructure.github.io/instructure-ui/" margin="0 small">jumps</Link> over the lazy dog.</Text>
+<Text>The quick brown fox <Link href="https://instructure.github.io/instructure-ui/" margin="0 general.spaceMd">jumps</Link> over the lazy dog.</Text>
 ```
 
 ### Truncating text
@@ -138,12 +138,12 @@ render a Link with just an icon. Don't forget to add text for screen readers, th
 type: example
 ---
 <div>
-  <View as="div" margin="0 0 small">
+  <View as="div" margin="0 0 general.spaceMd">
     <Text>
       <Link href="https://instructure.design" renderIcon={<DiamondInstUIIcon />}>Icon before text</Link> with the quick brown fox
     </Text>
   </View>
-  <View as="div" margin="0 0 small">
+  <View as="div" margin="0 0 general.spaceMd">
     <Text>
       This Link has an icon and displays inline with text.
       <Link

--- a/packages/ui-link/src/Link/v2/props.ts
+++ b/packages/ui-link/src/Link/v2/props.ts
@@ -82,7 +82,7 @@ type LinkOwnProps = {
   /**
    * Valid values are `0`, `none`, `auto`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `margin="small auto large"`.
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-list/src/InlineList/v2/README.md
+++ b/packages/ui-list/src/InlineList/v2/README.md
@@ -26,25 +26,25 @@ The `delimiter` prop lets you display a separator between Items in the List. The
 type: example
 ---
 <div>
-  <InlineList delimiter="none" margin="large 0">
+  <InlineList delimiter="none" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>10pts</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
     <InlineList.Item><Link href="#">No Separator</Link></InlineList.Item>
   </InlineList>
-  <InlineList delimiter="pipe" margin="large 0">
+  <InlineList delimiter="pipe" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>10pts</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
     <InlineList.Item><Link href="#">Pipe Separator</Link></InlineList.Item>
   </InlineList>
-  <InlineList delimiter="slash" margin="large 0">
+  <InlineList delimiter="slash" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>10pts</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
     <InlineList.Item><Link href="#">Slash Separator</Link></InlineList.Item>
   </InlineList>
-  <InlineList delimiter="arrow" margin="large 0">
+  <InlineList delimiter="arrow" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>10pts</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
@@ -62,19 +62,19 @@ The `size` prop lets you adjust the font-size of the List. The predefined values
 type: example
 ---
 <div>
-  <InlineList size="small" margin="large 0">
+  <InlineList size="small" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>Small Size</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
     <InlineList.Item><Link href="#">Submitted</Link></InlineList.Item>
   </InlineList>
-  <InlineList margin="large 0">
+  <InlineList margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>Medium (default) Size</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>
     <InlineList.Item><Link href="#">Submitted</Link></InlineList.Item>
   </InlineList>
-  <InlineList size="large" margin="large 0">
+  <InlineList size="large" margin="general.space2xl 0">
     <InlineList.Item>{lorem.sentence()}</InlineList.Item>
     <InlineList.Item>Large Size</InlineList.Item>
     <InlineList.Item><b>Due:</b> Oct 1, 2019</InlineList.Item>

--- a/packages/ui-list/src/InlineList/v2/props.ts
+++ b/packages/ui-list/src/InlineList/v2/props.ts
@@ -34,9 +34,9 @@ type InlineListOwnProps = {
   children?: React.ReactNode
   as?: 'ul' | 'ol'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   size?: 'small' | 'medium' | 'large'

--- a/packages/ui-list/src/List/v2/README.md
+++ b/packages/ui-list/src/List/v2/README.md
@@ -13,12 +13,12 @@ describes: List
 type: example
 ---
 <div>
-  <List margin="0 0 medium">
+  <List margin="0 0 general.spaceXl">
     <List.Item>List item 1</List.Item>
     <List.Item>List item 2</List.Item>
     <List.Item>List item 3</List.Item>
   </List>
-  <List as="ol" margin="0 0 medium">
+  <List as="ol" margin="0 0 general.spaceXl">
     <List.Item>List item 1</List.Item>
     <List.Item>List item 2</List.Item>
     <List.Item>List item 3</List.Item>
@@ -40,17 +40,17 @@ The `delimiter` lets you set a separator between items of the list. The predefin
 type: example
 ---
 <div>
-  <List delimiter="none" margin="large 0">
+  <List delimiter="none" margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
   </List>
-  <List delimiter="solid" isUnstyled margin="large 0">
+  <List delimiter="solid" isUnstyled margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
   </List>
-  <List delimiter="dashed" as="ol" margin="large 0">
+  <List delimiter="dashed" as="ol" margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>{lorem.sentence()}</List.Item>
@@ -67,17 +67,17 @@ The `size` prop lets you adjust the font-size of the List. The predefined values
 type: example
 ---
 <div>
-  <List size="small" margin="large 0">
+  <List size="small" margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>Small Size</List.Item>
     <List.Item><b>Due:</b> Oct 1, 2019</List.Item>
   </List>
-  <List margin="large 0">
+  <List margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>Medium (default) Size</List.Item>
     <List.Item><b>Due:</b> Oct 1, 2019</List.Item>
   </List>
-  <List size="large" margin="large 0">
+  <List size="large" margin="general.space2xl 0">
     <List.Item>{lorem.sentence()}</List.Item>
     <List.Item>Large Size</List.Item>
     <List.Item><b>Due:</b> Oct 1, 2019</List.Item>
@@ -135,7 +135,7 @@ List.Items also accept the same `margin` prop as List, in the event you need dif
 type: example
 ---
 <List isUnstyled itemSpacing="small">
-  <List.Item margin="x-large 0"><Link href="https://www.canvaslms.com/try-canvas">Canvas by Instructure</Link></List.Item>
+  <List.Item margin="general.space2xl 0"><Link href="https://www.canvaslms.com/try-canvas">Canvas by Instructure</Link></List.Item>
   <List.Item><Link href="https://www.getbridge.com">Bridge by Instructure</Link></List.Item>
   <List.Item><Link href="https://www.arcmedia.com">Arc by Instructure</Link></List.Item>
 </List>

--- a/packages/ui-list/src/List/v2/props.ts
+++ b/packages/ui-list/src/List/v2/props.ts
@@ -47,9 +47,9 @@ type ListOwnProps = {
    */
   isUnstyled?: boolean
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   size?: 'small' | 'medium' | 'large'

--- a/packages/ui-modal/src/Modal/v2/README.md
+++ b/packages/ui-modal/src/Modal/v2/README.md
@@ -65,7 +65,7 @@ const Example = () => {
           <Text lineHeight="double">{fpo}</Text>
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={handleButtonClick} margin="0 x-small 0 0">
+          <Button onClick={handleButtonClick} margin="0 general.spaceSm 0 0">
             Close
           </Button>
           <Button color="primary" type="submit">
@@ -130,13 +130,13 @@ const Example = () => {
           <Heading>This Modal is constrained to a parent</Heading>
         </Modal.Header>
         <Modal.Body>
-          <View as="p" margin="none none small">
+          <View as="p" margin="none none general.spaceMd">
             <Text>{fpo}</Text>
           </View>
           <ModalAutoCompleteExample renderLabel="Choose a state" />
         </Modal.Body>
         <Modal.Footer spacing="compact">
-          <Button onClick={handleButtonClick} margin="0 x-small 0 0">
+          <Button onClick={handleButtonClick} margin="0 general.spaceSm 0 0">
             Close
           </Button>
           <Button onClick={handleButtonClick} color="primary" type="submit">
@@ -146,7 +146,7 @@ const Example = () => {
       </Modal>
       <View
         background="primary-inverse"
-        margin="medium auto none"
+        margin="general.spaceXl auto none"
         display="block"
         width="25rem"
         height="25rem"
@@ -340,7 +340,7 @@ const Example = () => {
           <RadioInput label="auto" value="auto" />
         </RadioInputGroup>
       </FormFieldGroup>
-      <Button onClick={handleButtonClick} margin="medium 0 0">
+      <Button onClick={handleButtonClick} margin="general.spaceXl 0 0">
         {open ? 'Close' : 'Open'} the Modal
       </Button>
       <Modal
@@ -358,7 +358,7 @@ const Example = () => {
           <Flex>
             <Flex.Item shouldGrow shouldShrink>
               <Flex alignItems="center">
-                <Flex.Item margin="0 x-small 0 0">
+                <Flex.Item margin="0 general.spaceSm 0 0">
                   <HeartInstUIIcon size={'xl'} />
                 </Flex.Item>
                 <Flex.Item shouldGrow shouldShrink>
@@ -375,7 +375,7 @@ const Example = () => {
                 withBorder={false}
                 renderIcon={<PrinterInstUIIcon/>}
                 screenReaderLabel="Print This Image"
-                margin="0 x-small 0 0"
+                margin="0 general.spaceSm 0 0"
               />
               <IconButton
                 color="primary-inverse"
@@ -383,7 +383,7 @@ const Example = () => {
                 withBorder={false}
                 renderIcon={<DownloadInstUIIcon/>}
                 screenReaderLabel="Download This Image"
-                margin="0 x-small 0 0"
+                margin="0 general.spaceSm 0 0"
               />
               <IconButton
                 color="primary-inverse"
@@ -456,7 +456,7 @@ const Example = () => {
       </Button>
       <Button
         onClick={toggleViewport}
-        margin="0 0 0 small"
+        margin="0 0 0 general.spaceMd"
         id="toggleViewportButton"
       >
         Toggle viewport
@@ -485,12 +485,12 @@ const Example = () => {
           )}
         </Modal.Header>
         <Modal.Body>
-          <View as="p" margin="none none small">
+          <View as="p" margin="none none general.spaceMd">
             <Text>{fpo}</Text>
           </View>
         </Modal.Body>
         <Modal.Footer spacing={smallViewport ? 'compact' : 'default'}>
-          <Button onClick={toggleOpen} margin="0 x-small 0 0">
+          <Button onClick={toggleOpen} margin="0 general.spaceSm 0 0">
             Close
           </Button>
           <Button onClick={toggleOpen} color="primary" type="submit">
@@ -501,7 +501,7 @@ const Example = () => {
 
       <View
         background="primary-inverse"
-        margin="medium auto none"
+        margin="general.spaceXl auto none"
         display="block"
         width={smallViewport ? '20rem' : '50rem'}
         height="37.5rem"
@@ -579,7 +579,7 @@ class Example extends React.Component {
           </WrappedModalBody>
           <View
             as="div"
-            margin="small"
+            margin="general.spaceMd"
             padding="large"
             background="primary">
             <Heading level='h3'>This View child does not inherit the variant and overflow properties</Heading>

--- a/packages/ui-navigation/src/AppNav/v2/README.md
+++ b/packages/ui-navigation/src/AppNav/v2/README.md
@@ -43,7 +43,7 @@ const AppNavExample = () => {
         <IconButton
           onClick={() => console.log('Add')}
           renderIcon={<PlusInstUIIcon/>}
-          margin="0 0 0 x-small"
+          margin="0 0 0 general.spaceSm"
           screenReaderLabel="Add something"
           withBorder={false}
           withBackground={false}

--- a/packages/ui-navigation/src/AppNav/v2/props.ts
+++ b/packages/ui-navigation/src/AppNav/v2/props.ts
@@ -52,9 +52,9 @@ type AppNavOwnProps = {
    */
   renderAfterItems?: Renderable
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-overlays/src/Mask/v2/README.md
+++ b/packages/ui-overlays/src/Mask/v2/README.md
@@ -10,7 +10,7 @@ type: example
 ---
 <View
   padding="large"
-  margin="medium"
+  margin="general.spaceXl"
   textAlign="center"
   as="div"
   style={{ position: 'relative' }}

--- a/packages/ui-pagination/src/Pagination/v2/README.md
+++ b/packages/ui-pagination/src/Pagination/v2/README.md
@@ -26,7 +26,7 @@ const Example = () => {
   return (
     <Pagination
       as="nav"
-      margin="small"
+      margin="general.spaceMd"
       variant="compact"
       labelNext="Next Page"
       labelPrev="Previous Page"
@@ -54,7 +54,7 @@ const Example = () => {
   return (
     <Pagination
       as="nav"
-      margin="small"
+      margin="general.spaceMd"
       variant="compact"
       labelNext="Next Page"
       labelPrev="Previous Page"
@@ -84,7 +84,7 @@ const Example = () => {
   return (
     <Pagination
       as="nav"
-      margin="small"
+      margin="general.spaceMd"
       variant="full"
       labelNext="Next Page"
       labelPrev="Previous Page"
@@ -114,7 +114,7 @@ const Example = () => {
   return (
     <Pagination
       as="nav"
-      margin="small"
+      margin="general.spaceMd"
       variant="full"
       labelNext="Next Page"
       labelPrev="Previous Page"
@@ -143,7 +143,7 @@ const Example = () => {
   return (
     <Pagination
       as="nav"
-      margin="small"
+      margin="general.spaceMd"
       variant="input"
       labelNext="Next Page"
       labelPrev="Previous Page"
@@ -196,7 +196,7 @@ class Example extends React.Component {
     return (
       <Pagination
         as="nav"
-        margin="small"
+        margin="general.spaceMd"
         variant="compact"
         labelNext="Next Page"
         labelPrev="Previous Page"
@@ -248,7 +248,7 @@ class Example extends React.Component {
     return (
       <Pagination
         as="nav"
-        margin="small"
+        margin="general.spaceMd"
         variant="compact"
         labelNext="Next Page"
         labelPrev="Previous Page"
@@ -304,7 +304,7 @@ class Example extends React.Component {
     return (
       <Pagination
         as="nav"
-        margin="small"
+        margin="general.spaceMd"
         variant="input"
         labelFirst="First Page"
         labelPrev="Previous Page"
@@ -371,7 +371,7 @@ class Example extends React.Component {
 
         <Pagination
           as="nav"
-          margin="large small small"
+          margin="general.space2xl general.spaceMd general.spaceMd"
           variant="compact"
           labelNext="Next Page"
           labelPrev="Previous Page"

--- a/packages/ui-pagination/src/Pagination/v2/props.ts
+++ b/packages/ui-pagination/src/Pagination/v2/props.ts
@@ -121,9 +121,9 @@ type PaginationOwnProps = {
   variant?: 'full' | 'compact' | 'input'
 
   /**
-   * Spacing token values can be found here: [Spacing Tokens](https://instructure.design/#layout-spacing/%23Tokens)
-   *
-   * Apply these values via familiar CSS-like shorthand. For example: `margin="space8 0 space12"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-pill/src/Pill/v2/README.md
+++ b/packages/ui-pill/src/Pill/v2/README.md
@@ -13,14 +13,14 @@ type: example
 ---
 <div>
   <Pill
-    margin="x-small"
+    margin="general.spaceSm"
   >
     Excused
   </Pill>
   <Pill
     statusLabel="Status"
     color="info"
-    margin="x-small"
+    margin="general.spaceSm"
   >
     Draft
   </Pill>
@@ -28,21 +28,21 @@ type: example
     statusLabel="Status"
     renderIcon={<CheckInstUIIcon size="sm" />}
     color="success"
-    margin="x-small"
+    margin="general.spaceSm"
   >
     Checked In
   </Pill>
   <Pill
     renderIcon={<Clock4InstUIIcon size="sm" />}
     color="warning"
-    margin="x-small"
+    margin="general.spaceSm"
   >
     Late
   </Pill>
   <Pill
     renderIcon={<MailInstUIIcon size="sm" />}
     color="error"
-    margin="x-small"
+    margin="general.spaceSm"
   >
     Notification
   </Pill>

--- a/packages/ui-pill/src/Pill/v2/props.ts
+++ b/packages/ui-pill/src/Pill/v2/props.ts
@@ -41,9 +41,9 @@ type PillOwnProps = {
    */
   elementRef?: (element: Element | null) => void
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   children: React.ReactNode

--- a/packages/ui-popover/src/Popover/v2/README.md
+++ b/packages/ui-popover/src/Popover/v2/README.md
@@ -41,7 +41,7 @@ const Example = () => {
           onChange={toggleAlignArrow}
         />
       </FormFieldGroup>
-      <View display="block" margin="small none">
+      <View display="block" margin="general.spaceMd none">
         <RadioInputGroup
           name="color"
           defaultValue="primary"
@@ -54,7 +54,7 @@ const Example = () => {
           <RadioInput label="Primary inverse" value="primary-inverse" />
         </RadioInputGroup>
       </View>
-      <View display="block" as="div" margin="small">
+      <View display="block" as="div" margin="general.spaceMd">
         <Popover
           renderTrigger={
             <Link aria-describedby="tip">Hover or focus me</Link>
@@ -209,7 +209,7 @@ const Example = () => {
       style={{ paddingBottom: 50, display: 'flex', justifyContent: 'center' }}
     >
       <Popover
-        renderTrigger={<Button margin="small">Focus Me</Button>}
+        renderTrigger={<Button margin="general.spaceMd">Focus Me</Button>}
         isShowingContent={isShowingContent}
         onShowContent={() => {
           setIsShowingContent(true)
@@ -221,10 +221,10 @@ const Example = () => {
         shouldContainFocus={false}
         shouldFocusContentOnTriggerBlur={false}
       >
-        <Button margin="small">Focus Me When Trigger Blurs</Button>
+        <Button margin="general.spaceMd">Focus Me When Trigger Blurs</Button>
       </Popover>
       <div id="container" />
-      <Button id="next" margin="small">
+      <Button id="next" margin="general.spaceMd">
         Focus Me Next
       </Button>
     </div>
@@ -320,7 +320,7 @@ const Example = () => {
 
   return (
     <View as="div" background="primary" padding="small">
-      <Flex margin="small small large" justifyItems="space-around">
+      <Flex margin="general.spaceMd general.spaceMd general.space2xl" justifyItems="space-around">
         <Flex.Item align="start">
           <FormFieldGroup description="Popover Example">
             <Checkbox
@@ -358,7 +358,7 @@ const Example = () => {
               ))}
             </SimpleSelect>
           </View>
-          <View as="div" margin="medium none" maxWidth="15rem">
+          <View as="div" margin="general.spaceXl none" maxWidth="15rem">
             <SimpleSelect
               value={shadow}
               onChange={changeShadow}

--- a/packages/ui-progress/src/ProgressBar/v2/README.md
+++ b/packages/ui-progress/src/ProgressBar/v2/README.md
@@ -17,7 +17,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -34,7 +34,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -50,7 +50,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -124,7 +124,7 @@ type: example
     meterColor="info"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -141,7 +141,7 @@ type: example
     meterColor="success"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -158,7 +158,7 @@ type: example
     meterColor="alert"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -175,7 +175,7 @@ type: example
     meterColor="warning"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -192,7 +192,7 @@ type: example
     meterColor="danger"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
     renderValue={({ valueNow, valueMax }) => {
     return (
       <span>
@@ -326,7 +326,7 @@ const Example = () => {
         as="div"
         background="primary"
         padding="medium"
-        margin="0 0 large 0"
+        margin="0 0 general.space2xl 0"
       >
         <FormFieldGroup
           description={<ScreenReaderContent>Settings</ScreenReaderContent>}

--- a/packages/ui-progress/src/ProgressBar/v2/props.ts
+++ b/packages/ui-progress/src/ProgressBar/v2/props.ts
@@ -95,9 +95,9 @@ type ProgressBarOwnProps = {
   shouldAnimate?: boolean
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-progress/src/ProgressCircle/v2/README.md
+++ b/packages/ui-progress/src/ProgressCircle/v2/README.md
@@ -17,7 +17,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 small 0 0"
+    margin="0 general.spaceMd 0 0"
     shouldAnimateOnMount
   />
   <ProgressCircle
@@ -25,7 +25,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 small 0 0"
+    margin="0 general.spaceMd 0 0"
     shouldAnimateOnMount
     animationDelay={2000}
   />
@@ -33,7 +33,7 @@ type: example
     screenReaderLabel="Loading completion"
     valueNow={40}
     valueMax={60}
-    margin="0 small 0 0"
+    margin="0 general.spaceMd 0 0"
     shouldAnimateOnMount
     animationDelay={4000}
     formatScreenReaderValue={function ({ valueNow, valueMax }) {
@@ -114,35 +114,35 @@ type: example
     meterColor="info"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
   />
   <ProgressCircle
     screenReaderLabel="Loading completion"
     meterColor="success"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
   />
   <ProgressCircle
     screenReaderLabel="Loading completion"
     meterColor="alert"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
   />
   <ProgressCircle
     screenReaderLabel="Loading completion"
     meterColor="warning"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
   />
   <ProgressCircle
     screenReaderLabel="Loading completion"
     meterColor="danger"
     valueNow={40}
     valueMax={60}
-    margin="0 0 small"
+    margin="0 0 general.spaceMd"
   />
 </div>
 ```

--- a/packages/ui-progress/src/ProgressCircle/v2/props.ts
+++ b/packages/ui-progress/src/ProgressCircle/v2/props.ts
@@ -82,9 +82,9 @@ type ProgressCircleOwnProps = {
     | ((values: Values) => ProgressCircleMeterColor)
     | ProgressCircleMeterColor
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-radio-input/src/RadioInput/v2/README.md
+++ b/packages/ui-radio-input/src/RadioInput/v2/README.md
@@ -13,7 +13,7 @@ type: example
 ---
 <InstUISettingsProvider>
 <Flex>
-  <Flex direction="column" margin="medium" gap="medium">
+  <Flex direction="column" margin="general.spaceXl" gap="medium">
     <RadioInput
       label="small"
       value="foo"
@@ -46,7 +46,7 @@ type: example
       readOnly
     />
   </Flex>
-  <Flex direction="column" margin="medium" gap="medium">
+  <Flex direction="column" margin="general.spaceXl" gap="medium">
     <RadioInput
       label="small"
       value="foo6"

--- a/packages/ui-range-input/src/RangeInput/v2/README.md
+++ b/packages/ui-range-input/src/RangeInput/v2/README.md
@@ -27,7 +27,7 @@ const Example = () => {
         />
       </View>
 
-      <View as="div" margin="medium 0 0">
+      <View as="div" margin="general.spaceXl 0 0">
         <FormFieldGroup
           description={
             <ScreenReaderContent>

--- a/packages/ui-rating/src/Rating/v2/README.md
+++ b/packages/ui-rating/src/Rating/v2/README.md
@@ -65,7 +65,7 @@ type: example
       iconCount={5}
       valueNow={3.76}
       valueMax={5}
-      margin="small"/>
+      margin="general.spaceMd"/>
     <Text>4/5</Text>
   </Flex>
   <Flex>
@@ -74,7 +74,7 @@ type: example
       iconCount={5}
       valueNow={30}
       valueMax={100}
-      margin="small"
+      margin="general.spaceMd"
     />
     <Text>2/5</Text>
   </Flex>
@@ -86,7 +86,7 @@ type: example
       iconCount={5}
       valueNow={8}
       valueMax={8}
-      margin="small"/>
+      margin="general.spaceMd"/>
     <Text>5/5</Text>
   </Flex>
 </Flex>

--- a/packages/ui-rating/src/Rating/v2/props.ts
+++ b/packages/ui-rating/src/Rating/v2/props.ts
@@ -59,9 +59,9 @@ type RatingOwnProps = {
    */
   animateFill?: boolean
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-select/src/Select/v2/README.md
+++ b/packages/ui-select/src/Select/v2/README.md
@@ -713,7 +713,7 @@ const GroupSelectExample = ({ options }) => {
           type="notification"
           variant={variant}
           standalone
-          margin="0 x-small xxx-small 0"
+          margin="0 general.spaceSm general.space2xs 0"
         />
         {text}
       </span>
@@ -764,7 +764,7 @@ const GroupSelectExample = ({ options }) => {
                 : 'primary'
             }
             standalone
-            margin="0 0 xxx-small 0"
+            margin="0 0 general.space2xs 0"
           />
         }
         inputRef={(el) => {

--- a/packages/ui-source-code-editor/src/SourceCodeEditor/v2/README.md
+++ b/packages/ui-source-code-editor/src/SourceCodeEditor/v2/README.md
@@ -323,7 +323,7 @@ type: example
 
     return (
       <View display="block" padding="medium medium small" background="primary">
-        <View display="block" margin="small none large">
+        <View display="block" margin="general.spaceMd none general.space2xl">
           <FormFieldGroup description="Settings" rowSpacing="small">
             {Object.keys(settings).map((prop) => (
               <Checkbox
@@ -376,7 +376,7 @@ type: example
 
     return (
       <View display="block" padding="medium medium small" background="primary">
-        <View display="block" margin="small none large">
+        <View display="block" margin="general.spaceMd none general.space2xl">
           <FormFieldGroup description="Settings" rowSpacing="small">
             {[
               'lineNumbers',
@@ -488,7 +488,7 @@ type: example
 
     return (
       <View display="block" padding="medium medium small" background="primary">
-        <View display="block" margin="small none large">
+        <View display="block" margin="general.spaceMd none general.space2xl">
           <FormFieldGroup description="Settings">
             <Checkbox
               label="indentWithTab"
@@ -582,7 +582,7 @@ type: example
           padding="medium medium small"
           background="primary"
         >
-          <View display="block" margin="small none large">
+          <View display="block" margin="general.spaceMd none general.space2xl">
             <FormFieldGroup
               description="Settings"
               layout="columns"
@@ -670,7 +670,7 @@ type: example
 
     return (
       <View display="block" padding="medium medium small" background="primary">
-        <View display="block" margin="small none large">
+        <View display="block" margin="general.spaceMd none general.space2xl">
           <Button
             onClick={() => {
               console.log('manual focus')
@@ -723,7 +723,7 @@ type: example
 
     return (
       <View display="block" padding="medium medium small" background="primary">
-        <View display="block" margin="small none large">
+        <View display="block" margin="general.spaceMd none general.space2xl">
           <RadioInputGroup
             name="attachmentExample"
             value={attachment}

--- a/packages/ui-spinner/src/Spinner/v2/props.ts
+++ b/packages/ui-spinner/src/Spinner/v2/props.ts
@@ -40,7 +40,7 @@ type SpinnerOwnProps = {
   /**
    * Valid values are `0`, `none`, `auto`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `gap="small auto large"`.
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-table/src/Table/v2/README.md
+++ b/packages/ui-table/src/Table/v2/README.md
@@ -29,7 +29,7 @@ const Example = () => {
 
   const renderOptions = () => (
     <Flex alignItems="start">
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <RadioInputGroup
           name="layout"
           description="layout"
@@ -41,7 +41,7 @@ const Example = () => {
           <RadioInput label="stacked" value="stacked" />
         </RadioInputGroup>
       </Flex.Item>
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <Checkbox
           label="hover"
           checked={hover}
@@ -312,7 +312,7 @@ const SortableTable = ({ caption, headers, rows }) => {
                   }
                   name={`columnTextAlign_${headerId}`}
                   value={textAlign}
-                  margin="0 0 small"
+                  margin="0 0 general.spaceMd"
                   size="small"
                   onChange={(e, value) =>
                     handleColTextAlignChange(headerId, value)
@@ -346,7 +346,7 @@ const SortableTable = ({ caption, headers, rows }) => {
       {(props) => (
         <div>
           {props.layout !== 'stacked' && (
-            <View display="block" margin="0 0 medium">
+            <View display="block" margin="0 0 general.spaceXl">
               {renderOptions()}
             </View>
           )}
@@ -618,7 +618,7 @@ const PaginatedTable = ({
           variant="compact"
           labelNext="Next Page"
           labelPrev="Previous Page"
-          margin="large"
+          margin="general.space2xl"
         >
           {Array.from(Array(pageCount), (item, index) => (
             <Pagination.Page
@@ -792,7 +792,7 @@ const Example = () => {
 
   const renderOptions = () => (
     <Flex alignItems="start">
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <RadioInputGroup
           name="layout2"
           description="layout2"
@@ -804,7 +804,7 @@ const Example = () => {
           <RadioInput label="stacked" value="stacked" />
         </RadioInputGroup>
       </Flex.Item>
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <Checkbox
           label="hover"
           checked={hover}
@@ -902,7 +902,7 @@ const Example = () => {
 
   const renderOptions = () => (
     <Flex alignItems="start">
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <RadioInputGroup
           name="Layout"
           description="Layout"
@@ -913,7 +913,7 @@ const Example = () => {
           <RadioInput label="fixed" value="fixed" />
         </RadioInputGroup>
       </Flex.Item>
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <Checkbox
           label="hover"
           checked={hover}
@@ -1045,7 +1045,7 @@ const Example = () => {
 
   const renderOptions = () => (
     <Flex alignItems="start">
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <RadioInputGroup
           name="customStackedLayout"
           description="Layout"
@@ -1057,7 +1057,7 @@ const Example = () => {
           <RadioInput label="stacked" value="stacked" />
         </RadioInputGroup>
       </Flex.Item>
-      <Flex.Item margin="small">
+      <Flex.Item margin="general.spaceMd">
         <Checkbox
           label="hover"
           checked={hover}

--- a/packages/ui-table/src/Table/v2/props.ts
+++ b/packages/ui-table/src/Table/v2/props.ts
@@ -47,9 +47,9 @@ type TableOwnProps = {
    */
   caption: TableCaption
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-tabs/src/Tabs/v2/README.md
+++ b/packages/ui-tabs/src/Tabs/v2/README.md
@@ -17,7 +17,7 @@ const Example = () => {
 
   return (
     <Tabs
-      margin="large auto"
+      margin="general.space2xl auto"
       padding="medium"
       onRequestTabChange={handleTabChange}
     >
@@ -139,7 +139,7 @@ const Example = () => {
 
   return (
     <Tabs
-      margin="large auto"
+      margin="general.space2xl auto"
       padding="medium"
       onRequestTabChange={handleTabChange}
       tabOverflow="scroll"
@@ -249,7 +249,7 @@ const Example = () => {
 
   return (
     <>
-      <View display="block" margin="none none medium">
+      <View display="block" margin="none none general.spaceXl">
         <RadioInputGroup
           name="tabsHeightOptions"
           defaultValue="fixHeight: 100%"
@@ -271,7 +271,7 @@ const Example = () => {
 
       <View {...containerProps}>
         <Tabs
-          margin="large auto"
+          margin="general.space2xl auto"
           padding="medium"
           onRequestTabChange={handleTabChange}
           {...heightOptions[heightOption]}
@@ -345,7 +345,7 @@ const Outlet = () => {
 
   return (
     <div>
-      <Heading level="h1" as="h1" margin="0 0 x-small">
+      <Heading level="h1" as="h1" margin="0 0 general.spaceSm">
         {show ? 'Hello Developer' : 'Simulating network call...'}
       </Heading>
       {show ? (
@@ -373,7 +373,7 @@ const Example = () => {
 
   return (
     <Tabs
-      margin="large auto"
+      margin="general.space2xl auto"
       padding="medium"
       onRequestTabChange={handleTabChange}
     >
@@ -439,7 +439,7 @@ const Example = () => {
 
   return (
     <Tabs
-      margin="large auto"
+      margin="general.space2xl auto"
       padding="medium"
       onRequestTabChange={handleTabChange}
     >
@@ -504,7 +504,7 @@ const Example = () => {
 
   return (
     <Tabs
-      margin="large auto"
+      margin="general.space2xl auto"
       padding="medium"
       onRequestTabChange={handleTabChange}
     >

--- a/packages/ui-tabs/src/Tabs/v2/props.ts
+++ b/packages/ui-tabs/src/Tabs/v2/props.ts
@@ -56,9 +56,9 @@ type TabsOwnProps = {
   minHeight?: string | number
   fixHeight?: string | number
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-tag/src/Tag/v2/README.md
+++ b/packages/ui-tag/src/Tag/v2/README.md
@@ -8,7 +8,7 @@ Use `<Tag />` to represent a category or group in a form.
 ---
 type: example
 ---
-<Tag text="Static" margin="0 xx-small 0 0" />
+<Tag text="Static" margin="0 general.spaceXs 0 0" />
 ```
 
 ### Dismissible
@@ -28,7 +28,7 @@ type: example
     </AccessibleContent>
   }
   dismissible
-  margin="0 xx-small 0 0"
+  margin="0 general.spaceXs 0 0"
   onClick={function () {
     alert("This Tag was dismissed")
   }}
@@ -47,7 +47,7 @@ type: example
   text="Dismissible Disabled"
   dismissible
   disabled
-  margin="0 xx-small 0 0"
+  margin="0 general.spaceXs 0 0"
   onClick={function () {
     alert("This Tag was dismissed. This shouldn't happen")
   }}
@@ -63,9 +63,9 @@ type: example
 type: example
 ---
 <div>
-  <Tag text="Small" size="small" margin="0 xx-small 0 0" />
-  <Tag text="Medium" margin="0 xx-small 0 0" />
-  <Tag text="Large" size="large" margin="0 xx-small 0 0" />
+  <Tag text="Small" size="small" margin="0 general.spaceXs 0 0" />
+  <Tag text="Medium" margin="0 general.spaceXs 0 0" />
+  <Tag text="Large" size="large" margin="0 general.spaceXs 0 0" />
 </div>
 ```
 

--- a/packages/ui-tag/src/Tag/v2/props.ts
+++ b/packages/ui-tag/src/Tag/v2/props.ts
@@ -45,9 +45,9 @@ type TagOwnProps = {
   readOnly?: boolean
   dismissible?: boolean
   /**
-   * Valid values are `0`, `none`, `auto`, `xxxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-text-area/src/TextArea/v2/README.md
+++ b/packages/ui-text-area/src/TextArea/v2/README.md
@@ -140,7 +140,7 @@ type: embed
 <Guidelines>
   <Alert
     variant="info"
-    margin="small"
+    margin="general.spaceMd"
   >
     Every non-listed prop will be passed down to the underlying 'textarea' element, such as 'onBlur' and any other prop
   </Alert>

--- a/packages/ui-text-input/src/TextInput/v2/README.md
+++ b/packages/ui-text-input/src/TextInput/v2/README.md
@@ -72,7 +72,7 @@ type: example
             onChange={toggleInline}
           />
         </FormFieldGroup>
-        <View display="block" margin="medium 0 0">
+        <View display="block" margin="general.spaceXl 0 0">
           <TextInput
             renderLabel="What is your favorite band?"
             display={inline ? 'inline-block' : null}
@@ -126,28 +126,28 @@ type: example
                 {this.state.value !== '' && (
                   <Tag
                     text={this.state.value}
-                    margin="xxx-small xx-small xxx-small none"
+                    margin="general.space2xs general.spaceXs general.space2xs none"
                     onClick={() => console.log(this.state.value)}
                   />
                 )}
                 <Tag
                   text="Rocky road"
-                  margin="xxx-small xx-small xxx-small none"
+                  margin="general.space2xs general.spaceXs general.space2xs none"
                   onClick={() => console.log('Rocky road')}
                 />
                 <Tag
                   text="Vanilla"
-                  margin="xxx-small xx-small xxx-small none"
+                  margin="general.space2xs general.spaceXs general.space2xs none"
                   onClick={() => console.log('Vanilla')}
                 />
                 <Tag
                   text="Coffee"
-                  margin="xxx-small xx-small xxx-small none"
+                  margin="general.space2xs general.spaceXs general.space2xs none"
                   onClick={() => console.log('Coffee')}
                 />
                 <Tag
                   text="Strawberry"
-                  margin="xxx-small xx-small xxx-small none"
+                  margin="general.space2xs general.spaceXs general.space2xs none"
                   onClick={() => console.log('Strawberry')}
                 />
               </>
@@ -239,18 +239,18 @@ type: example
     renderAfterInput={<Avatar name="Paula Panda" src={avatarSquare} size="x-small" />}
     shouldNotWrap
   />
-  <View as="div" margin="medium none none">
+  <View as="div" margin="general.spaceXl none none">
     <TextInput
       renderLabel="I will wrap"
       renderBeforeInput={
         <>
           <Tag
             text="English 101"
-            margin="xx-small xxx-small"
+            margin="general.spaceXs general.space2xs"
           />
           <Tag
             text="History 205"
-            margin="xx-small xxx-small"
+            margin="general.spaceXs general.space2xs"
           />
         </>
       }

--- a/packages/ui-text/src/Text/v2/README.md
+++ b/packages/ui-text/src/Text/v2/README.md
@@ -154,7 +154,7 @@ exceed the bounds of their containers.
 type: example
 ---
 <div>
-  <View as="div" maxWidth="300px" margin="none none small" debug>
+  <View as="div" maxWidth="300px" margin="none none general.spaceMd" debug>
     <Text>
       superlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstring
     </Text>

--- a/packages/ui-toggle-details/src/ToggleDetails/v2/README.md
+++ b/packages/ui-toggle-details/src/ToggleDetails/v2/README.md
@@ -162,7 +162,7 @@ const Example = () => {
     return (
       <Flex alignItems="start">
         {options.map(({ name, values }) => (
-          <Flex.Item margin="small" key={name}>
+          <Flex.Item margin="general.spaceMd" key={name}>
             <RadioInputGroup
               name={name}
               description={name}
@@ -175,7 +175,7 @@ const Example = () => {
             </RadioInputGroup>
           </Flex.Item>
         ))}
-        <Flex.Item margin="small">
+        <Flex.Item margin="general.spaceMd">
           <Checkbox
             label="fluidWidth"
             checked={fluidWidth}

--- a/packages/ui-top-nav-bar/src/TopNavBar/v2/README.md
+++ b/packages/ui-top-nav-bar/src/TopNavBar/v2/README.md
@@ -113,9 +113,9 @@ class PlaygroundExample extends React.Component {
           >
             <Heading level="h3">Contact information</Heading>
             <p>{lorem.sentence()}</p>
-            <Button color="primary" margin="x-small 0 small">Help Center</Button>
+            <Button color="primary" margin="general.spaceSm 0 general.spaceMd">Help Center</Button>
             <hr aria-hidden="true" />
-            <View as="div" margin="medium 0 0">
+            <View as="div" margin="general.spaceXl 0 0">
               <Text weight="bold">
                 <div>Contact person</div>
                 <Link href="/#TopNavBar" isWithinText={false}>
@@ -404,10 +404,10 @@ class PlaygroundExample extends React.Component {
     }
 
     return (
-      <View as="div" margin="medium 0 large">
+      <View as="div" margin="general.spaceXl 0 general.space2xl">
         <FormFieldGroup
           description={(
-            <Heading as="p" level="h3" margin="0 0 large">
+            <Heading as="p" level="h3" margin="0 0 general.space2xl">
               Example Settings
             </Heading>
           )}
@@ -479,7 +479,7 @@ class PlaygroundExample extends React.Component {
       <View overflowY='auto' as="div">
         <View as="div" maxWidth="75rem" margin="0 auto">
 
-          <View as="div" margin="large medium small">
+          <View as="div" margin="general.space2xl general.spaceXl general.spaceMd">
             <Button
               onClick={() => { this.setState({ isModalOpen: false }) }}
               renderIcon={XInstUIIcon}
@@ -488,8 +488,8 @@ class PlaygroundExample extends React.Component {
             </Button>
           </View>
 
-          <View as="div" margin="large medium 0">
-            <Heading as="p" level="h2" margin="0 0 x-small">
+          <View as="div" margin="general.space2xl general.spaceXl 0">
+            <Heading as="p" level="h2" margin="0 0 general.spaceSm">
               {this.state.breadcrumbs[this.state.breadcrumbs.length - 1]}
             </Heading>
 
@@ -540,7 +540,7 @@ class PlaygroundExample extends React.Component {
                     padding="small medium medium"
                   >
                     {Array.from(Array(5)).map((_i, idx) => (
-                      <View as="div" margin="medium 0" key={idx}>
+                      <View as="div" margin="general.spaceXl 0" key={idx}>
                         {this.fillerText}
                       </View>
                     ))}
@@ -1094,7 +1094,7 @@ Use the brand logo over the primary brand color.
 type: example
 ---
 <div>
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar>
       {() => (
         <TopNavBar.Layout
@@ -1121,7 +1121,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar>
       {() => (
         <TopNavBar.Layout
@@ -1166,7 +1166,7 @@ In small viewport mode, a link is shown for the last but one element of the `<Br
 type: example
 ---
   <div>
-    <View as="div" margin="medium 0">
+    <View as="div" margin="general.spaceXl 0">
       <TopNavBar inverseColor>
         {() => (
           <TopNavBar.Layout
@@ -1208,7 +1208,7 @@ The current page is highlighted, if it's id is passed via the `currentPageId` pr
 type: example
 ---
 <div>
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1259,7 +1259,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1333,7 +1333,7 @@ Action items can have submenus and popovers too. It is also recommended to add h
 type: example
 ---
 <div>
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar>
       {() => (
         <TopNavBar.Layout
@@ -1441,7 +1441,7 @@ type: example
 type: example
 ---
 <div>
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1465,7 +1465,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1490,7 +1490,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1528,7 +1528,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1567,7 +1567,7 @@ type: example
     </TopNavBar>
   </View>
 
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -1650,7 +1650,7 @@ class LayoutExample extends React.Component {
           </FormFieldGroup>
         </View>
 
-        <View as="div" margin="medium 0 0" width={this.state.exampleWidth}>
+        <View as="div" margin="general.spaceXl 0 0" width={this.state.exampleWidth}>
           <div
             style={{
               height: '100%',
@@ -1814,7 +1814,7 @@ class LayoutExample extends React.Component {
             />
 
             <View background="primary" as="div" minHeight='10rem' padding="medium">
-              <Heading as="p" level="h2" margin="medium 0">
+              <Heading as="p" level="h2" margin="general.spaceXl 0">
                 Page Content
               </Heading>
 
@@ -1974,7 +1974,7 @@ type: example
 ---
 
 <div>
-  <View as="div" margin="medium 0">
+  <View as="div" margin="general.spaceXl 0">
     <TopNavBar breakpoint="10rem">
       {() => (
         <TopNavBar.Layout
@@ -2064,9 +2064,9 @@ type: example
                     >
                       <Heading level="h3">Contact information</Heading>
                       <p>{lorem.sentence()}</p>
-                      <Button color="primary" margin="x-small 0 small">Help Center</Button>
+                      <Button color="primary" margin="general.spaceSm 0 general.spaceMd">Help Center</Button>
                       <hr aria-hidden="true" />
-                      <View as="div" margin="medium 0 0">
+                      <View as="div" margin="general.spaceXl 0 0">
                         <Text weight="bold">
                           <div>Contact person</div>
                           <Link href="/#TopNavBar" isWithinText={false}>
@@ -2115,7 +2115,7 @@ class InPlaceDialogExample extends React.Component {
 
   render() {
     return (
-      <View as="div" margin="medium 0" maxWidth="29rem">
+      <View as="div" margin="general.spaceXl 0" maxWidth="29rem">
         <TopNavBar breakpoint="30rem" mediaQueryMatch="element">
           {({ currentLayout }) => (
             <TopNavBar.Layout
@@ -2234,7 +2234,7 @@ type: example
     },
   }
 }}>
-  <View as="div" margin="medium 0 0" width={1000}>
+  <View as="div" margin="general.spaceXl 0 0" width={1000}>
     <TopNavBar
       breakpoint='650'
       mediaQueryMatch='element'

--- a/packages/ui-tree-browser/src/TreeBrowser/v2/README.md
+++ b/packages/ui-tree-browser/src/TreeBrowser/v2/README.md
@@ -21,7 +21,7 @@ const Example = () => {
 
   return (
     <>
-      <View display="block" margin="none none medium">
+      <View display="block" margin="none none general.spaceXl">
         <RadioInputGroup
           name="treeBrowserSize"
           defaultValue="medium"
@@ -317,7 +317,7 @@ type: example
     if (props.level > 1) {
       return <div style={{ display: 'flex', alignItems: 'flex-end', padding: '0.6rem 0 0.6rem 1rem', color: 'darkorange' }}>
         <span>{props.name}</span>
-        <Tag text="done" size="small" margin="0 xx-small 0 xx-small"/>
+        <Tag text="done" size="small" margin="0 general.spaceXs 0 general.spaceXs"/>
         <Tag text="class A" size="small"/>
       </div>
     }
@@ -387,7 +387,7 @@ const Example = () => {
             screenReaderLabel="Cancel"
             onClick={(e) => handleExpandToggle(e, false)}
             onKeyDown={(e) => handleKeyPress(e, false)}
-            margin="0 0 0 small"
+            margin="0 0 0 general.spaceMd"
           >
             <XInstUIIcon />
           </IconButton>
@@ -395,7 +395,7 @@ const Example = () => {
             screenReaderLabel="Add new group"
             onClick={(e) => handleExpandToggle(e, false)}
             onKeyDown={(e) => handleKeyPress(e, false)}
-            margin="0 0 0 small"
+            margin="0 0 0 general.spaceMd"
           >
             <CheckInstUIIcon />
           </IconButton>
@@ -480,7 +480,7 @@ const Example = () => {
 
   return (
     <>
-      <View display="block" margin="none none medium">
+      <View display="block" margin="none none general.spaceXl">
         <FormFieldGroup description="Turn on/off sorting">
           <Checkbox checked={sorted} label="Sort" onChange={toggleSort} />
         </FormFieldGroup>
@@ -633,7 +633,7 @@ const Example = () => {
 
   return (
     <>
-      <View display="block" margin="none none medium">
+      <View display="block" margin="none none general.spaceXl">
         <Checkbox
           label="showRootCollection"
           variant="toggle"

--- a/packages/ui-view/src/ContextView/v2/README.md
+++ b/packages/ui-view/src/ContextView/v2/README.md
@@ -17,14 +17,14 @@ type: example
 <div>
   <ContextView
     padding="small"
-    margin="large"
+    margin="general.space2xl"
     placement="end top"
     shadow="resting"
   >
     <Heading level="h3">Hello World</Heading>
   </ContextView>
   <ContextView
-    margin="0 large 0 0"
+    margin="0 general.space2xl 0 0"
     padding="small"
     placement="top"
   >
@@ -32,7 +32,7 @@ type: example
     <Text size="small">Some informational text that is helpful</Text>
   </ContextView>
   <ContextView
-    margin="0 large 0 0"
+    margin="0 general.space2xl 0 0"
     padding="small"
     textAlign="end"
     placement="start"
@@ -45,7 +45,7 @@ type: example
     padding="medium"
     background="inverse"
     width="30rem"
-    margin="x-large 0 0"
+    margin="general.space2xl 0 0"
   >
       This ContextView uses the inverse background and medium padding. Its width prop is set to `30rem`, which causes long strings like this to wrap. It also has top margin to separate it from the ContextViews above it.
   </ContextView>

--- a/packages/ui-view/src/View/__tests__/View.test.tsx
+++ b/packages/ui-view/src/View/__tests__/View.test.tsx
@@ -233,6 +233,45 @@ describe('<View />', () => {
     expect(newStyles.maxWidth).toEqual('200px')
   })
 
+  it('should resolve current (era-3) spacing tokens for the margin prop', () => {
+    const { container } = render(
+      <View margin="general.spaceMd">
+        <h1>View Content</h1>
+      </View>
+    )
+
+    const view = container.querySelector("span[class$='-view']")
+    const styles = getComputedStyle(view!)
+
+    // general.spaceMd resolves to 0.75rem (12px)
+    expect(styles.marginTop).toEqual('0.75rem')
+    expect(styles.marginRight).toEqual('0.75rem')
+    expect(styles.marginBottom).toEqual('0.75rem')
+    expect(styles.marginLeft).toEqual('0.75rem')
+
+    // a known token should not emit the "not found in theme" warning
+    expect(consoleWarningMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('not found in theme')
+    )
+  })
+
+  it('should resolve era-3 tokens via CSS-like shorthand for the margin prop', () => {
+    const { container } = render(
+      <View margin="general.spaceLg auto general.spaceXl">
+        <h1>View Content</h1>
+      </View>
+    )
+
+    const view = container.querySelector("span[class$='-view']")
+    const styles = getComputedStyle(view!)
+
+    // 3-value shorthand: top | left+right | bottom
+    expect(styles.marginTop).toEqual('1rem') // general.spaceLg
+    expect(styles.marginRight).toEqual('auto')
+    expect(styles.marginBottom).toEqual('1.5rem') // general.spaceXl
+    expect(styles.marginLeft).toEqual('auto')
+  })
+
   it('should meet a11y standards', async () => {
     const { container } = render(<View>View Content</View>)
 

--- a/packages/ui-view/src/View/v2/README.md
+++ b/packages/ui-view/src/View/v2/README.md
@@ -20,7 +20,7 @@ type: example
 ---
 <View
   as="div"
-  margin="small"
+  margin="general.spaceMd"
   padding="large"
   textAlign="center"
   background="primary"
@@ -42,7 +42,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="transparent"
   >
@@ -52,7 +52,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
   >
@@ -62,7 +62,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="secondary"
   >
@@ -72,7 +72,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary-inverse"
   >
@@ -82,7 +82,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="brand"
   >
@@ -92,7 +92,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="alert"
   >
@@ -102,7 +102,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="success"
   >
@@ -112,7 +112,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="danger"
   >
@@ -122,7 +122,7 @@ type: example
     as="div"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="warning"
   >
@@ -144,7 +144,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="large"
     background="primary"
     shadow="resting"
@@ -155,7 +155,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="large"
     background="primary"
     shadow="above"
@@ -166,7 +166,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="large"
     background="primary"
     shadow="topmost"
@@ -191,7 +191,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="small"
@@ -202,7 +202,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="medium"
@@ -213,7 +213,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large none"
@@ -222,7 +222,7 @@ type: example
   </View>
   <View
     as="div"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="none none small none"
@@ -244,7 +244,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -254,7 +254,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -265,7 +265,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -276,7 +276,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -287,7 +287,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -298,7 +298,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -309,7 +309,7 @@ type: example
   <View
     as="span"
     display="inline-block"
-    margin="small"
+    margin="general.spaceMd"
     padding="small"
     background="primary"
     borderWidth="large"
@@ -335,7 +335,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
     borderRadius="medium"
@@ -347,7 +347,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
     borderRadius="large large none none"
@@ -359,7 +359,7 @@ type: example
     as="span"
     display="inline-block"
     maxWidth="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
     borderRadius="none none large large"
@@ -371,7 +371,7 @@ type: example
     display="inline-block"
     width="6rem"
     height="6rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
     borderRadius="circle"
@@ -382,7 +382,7 @@ type: example
   <View
     display="inline-block"
     width="10rem"
-    margin="small"
+    margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
     borderRadius="pill"
@@ -471,7 +471,7 @@ const FocusedExample = () => {
         as="div"
         background="primary"
         padding="small"
-        margin="0 0 small"
+        margin="0 0 general.spaceMd"
         borderWidth="small"
       >
         <FormFieldGroup
@@ -514,7 +514,7 @@ const FocusedExample = () => {
         <code>borderRadius =</code>
         <View
           display="inline-block"
-          margin="small"
+          margin="general.spaceMd"
           padding="small"
           background="primary"
           borderRadius="small"
@@ -528,7 +528,7 @@ const FocusedExample = () => {
         </View>
         <View
           display="inline-block"
-          margin="small"
+          margin="general.spaceMd"
           padding="small"
           background="primary"
           borderRadius="medium"
@@ -542,7 +542,7 @@ const FocusedExample = () => {
         </View>
         <View
           display="inline-block"
-          margin="small"
+          margin="general.spaceMd"
           padding="small"
           background="primary"
           borderRadius="large"
@@ -558,7 +558,7 @@ const FocusedExample = () => {
           display="inline-block"
           height="100px"
           width="100px"
-          margin="small"
+          margin="general.spaceMd"
           background="primary"
           borderRadius="circle"
           borderWidth="small"
@@ -583,7 +583,7 @@ const FocusedExample = () => {
         >
           <View
             display="block"
-            margin="small"
+            margin="general.spaceMd"
             padding="small"
             background="primary-inverse"
             borderRadius="large"
@@ -599,7 +599,7 @@ const FocusedExample = () => {
         </View>
         <View
           display="inline-block"
-          margin="small"
+          margin="general.spaceMd"
           padding="small"
           background="primary"
           borderRadius="pill"
@@ -616,7 +616,7 @@ const FocusedExample = () => {
         </View>
         <View
           display="inline-block"
-          margin="small"
+          margin="general.spaceMd"
           padding="small"
           background="primary"
           borderWidth="small"
@@ -695,7 +695,7 @@ const OverflowExample = () => {
         as="div"
         height="7rem"
         width="20rem"
-        margin="medium none x-large"
+        margin="general.spaceXl none general.space2xl"
         overflowY={overflowY}
         overflowX={overflowX}
         withVisualDebug
@@ -736,7 +736,7 @@ type: example
   >
     <View
       as="div"
-      margin="small"
+      margin="general.spaceMd"
       padding="small"
       withVisualDebug
     >
@@ -744,7 +744,7 @@ type: example
     </View>
     <View
       as="div"
-      margin="small"
+      margin="general.spaceMd"
       padding="small"
       withVisualDebug
     >
@@ -772,7 +772,7 @@ type: example
 >
   <View
     as="header"
-    margin="0 0 medium"
+    margin="0 0 general.spaceXl"
     withVisualDebug
   >
     <Text>
@@ -799,7 +799,7 @@ type: example
     display="inline-block"
     withVisualDebug
     textAlign="end"
-    margin="large auto"
+    margin="general.space2xl auto"
     padding="0 small 0 0"
   >
     <Text>

--- a/packages/ui-view/src/View/v2/props.ts
+++ b/packages/ui-view/src/View/v2/props.ts
@@ -163,7 +163,7 @@ type ViewOwnProps = {
   /**
    * Valid values are `0`, `none`, `auto`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `margin="small auto large"`.
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/regression-test/src/app/view/page.tsx
+++ b/regression-test/src/app/view/page.tsx
@@ -271,6 +271,27 @@ export default function ViewPage() {
           <div>Paragraph-like content</div>
         </section>
       </section>
+
+      {/* Current (era-3) spacing tokens via dot-path notation */}
+      <section>
+        <View as="div" margin="general.spaceMd" padding="small" withVisualDebug>
+          margin=&quot;general.spaceMd&quot;
+        </View>
+        <View
+          as="div"
+          margin="general.spaceLg auto general.spaceXl"
+          padding="small"
+          withVisualDebug
+        >
+          margin=&quot;general.spaceLg auto general.spaceXl&quot;
+        </View>
+        <View as="div" margin="gap.cards.md" padding="small" withVisualDebug>
+          margin=&quot;gap.cards.md&quot;
+        </View>
+        <View as="div" margin="padding.card.lg" padding="small" withVisualDebug>
+          margin=&quot;padding.card.lg&quot;
+        </View>
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
## What & why

The **current (era-3) spacing tokens** — `general.*`, `gap.*`, `padding.card.*` (dot-path notation, e.g. `margin="general.spaceMd"`) — already resolved at runtime in View v2, but the `Spacing` prop type and the docs only advertised the two older token eras. So the new tokens had no autocomplete, no type hints, and weren't documented.

This PR makes them first-class on the `margin` prop of v2 components. **Non-breaking** — the older tokens still resolve at runtime and are only marked `@deprecated`.

## What changed

| Area | Change |
| --- | --- |
| **Types** (`emotion`) | Add `CurrentSpacingValues` (era-3 dot-paths) to the `Spacing` union; mark era-1 / era-2 unions `@deprecated`. |
| **v2 components** | Sync the `margin` JSDoc across all v2 `props.ts` files — link to the spacing guide + current-token example. |
| **v2 READMEs** | Convert legacy spacing keywords in `margin` examples to `general.*` tokens (value-preserving mapping). |
| **Docs guide** | Re-add the *Layout Spacing* page (removed on master during the docs rework) as a **v11.7+ version-gated page**, following the `theme-overrides` version-banner pattern. |
| **Tests** | era-3 dot-path resolution in `calcSpacingFromShorthand`; View v2 integration test (`general.spaceMd` → `0.75rem`); regression-test page examples. |

## Reviewer notes

- **Legacy → era-3 example mapping is value-preserving** where an equivalent exists (`small`→`general.spaceMd`, `medium`→`general.spaceXl`, …). `large`/`x-large` have no `general` equivalent (scale tops out at 2rem) and compress to `general.space2xl` — the only intentional visual change, limited to doc examples.
- **Live doc examples use `margin`/`padding` only.** These resolve era-3 dot-paths via `calcSpacingFromShorthand`. The `Flex` `gap` prop uses a separate flat-key resolver that doesn't understand dot-paths, so it's intentionally not shown with them.
- **Scope:** v2 components only; the dot-path resolver / token-merge logic is unchanged.

## Testing

- `pnpm run test:vitest emotion` → 78 passed
- `pnpm run test:vitest ui-view` → 16 passed
- Visual regression (Cypress/Chromatic) not run; doc/regression page examples added for it.

## Follow-ups (not in this PR)

- `padding` prop examples still use legacy tokens (kept out of scope; easy identical sweep).
- Misspelled tokens compile (type ends in `(string & {})`) and only warn at runtime — a louder dev-mode warning could be added later.
