### PR TITLE
ci: allow documentation deployment in test, beta and prod

### DIFF
--- a/scripts/InstUI.Jenkinsfile
+++ b/scripts/InstUI.Jenkinsfile
@@ -83,8 +83,7 @@ pipeline {
                         echo "Building documentation for ${params.PROJECT_REPO} with refspec: ${env.GIT_COMMIT} ==> Deploying to ${targetEnv}"
                         build(job: 'Restructure/Documentation Portal/Workers/DocSync',
                             parameters: [
-                                string(name: 'TARGET_ENV', value: "test"),
-                                // string(name: 'TARGET_ENV', value: targetEnv),
+                                string(name: 'TARGET_ENV', value: targetEnv),
                                 string(name: 'SOURCE_KIND', value: "git"),
                                 string(name: 'SOURCE_PROJECT', value: "${params.PROJECT_REPO}"),
                                 string(name: 'SOURCE_PROJECT_REFSPEC', value: env.GIT_COMMIT),


### PR DESCRIPTION
After the documentation portal connector [jenkinsfile](https://github.com/instructure/instructure-ui/blob/master/scripts/InstUI.Jenkinsfile), creating a [Jenkins job](https://jenkins.inst-ci.net/job/Restructure/job/Documentation%20Portal/job/Connectors/job/InstUI%20Github%20Connector/) for it and preparing the portal in the [api-docu-portal](https://github.com/instructure/api-docu-portal/commit/5a4c64d492840e61c19c6204c4f1e1e8e02b4ba0), the InstUI docs are now successfully on [test](https://test.developerdocs.inscloudgate.net/services/instui). 

Now we can enable deployment by environment. After this, commits containing changes in the openapi folder will publish new documentation versions to test and beta, and new release tags will publish to prod and internal.