### PR TITLE
INSTUI-5072 Restore Modal open/close transition animation

### DIFF
--- a/packages/ui-modal/src/Modal/v1/index.tsx
+++ b/packages/ui-modal/src/Modal/v1/index.tsx
@@ -107,6 +107,14 @@ class Modal extends Component<ModalProps, ModalState> {
   componentDidUpdate(prevProps: ModalProps) {
     if (this.props.open !== prevProps.open) {
       this.setState({ transitioning: true, open: !!this.props.open })
+      // When closing, release focus from the Dialog.
+      // The Dialog stays open so its content can fade out, but the
+      // Transition marks the exiting subtree aria-hidden -- keeping focus inside
+      // it would hide a focused element from assistive tech resulting in a
+      // console warning
+      if (prevProps.open && !this.props.open) {
+        this._content?.blur()
+      }
     }
     this.props.makeStyles?.()
   }
@@ -284,31 +292,31 @@ class Modal extends Component<ModalProps, ModalState> {
         onOpen={this.handlePortalOpen}
         data-cid="Modal"
       >
-        <Transition
-          in={open}
-          transitionOnMount
-          type={transition}
-          onEnter={onEnter}
-          onEntering={onEntering}
-          onEntered={createChainedFunction(
-            this.handleTransitionComplete,
-            onEntered,
-            onOpen
-          )}
-          onExit={onExit}
-          onExiting={onExiting}
-          onExited={createChainedFunction(
-            this.handleTransitionComplete,
-            onExited,
-            onClose
-          )}
+        <ModalContext.Provider
+          value={{
+            bodyScrollAriaLabel: this.state.bodyScrollAriaLabel,
+            setBodyScrollAriaLabel: (txt: string) =>
+              this.setState({ bodyScrollAriaLabel: txt })
+          }}
         >
-          <ModalContext.Provider
-            value={{
-              bodyScrollAriaLabel: this.state.bodyScrollAriaLabel,
-              setBodyScrollAriaLabel: (txt: string) =>
-                this.setState({ bodyScrollAriaLabel: txt })
-            }}
+          <Transition
+            in={open}
+            transitionOnMount
+            type={transition}
+            onEnter={onEnter}
+            onEntering={onEntering}
+            onEntered={createChainedFunction(
+              this.handleTransitionComplete,
+              onEntered,
+              onOpen
+            )}
+            onExit={onExit}
+            onExiting={onExiting}
+            onExited={createChainedFunction(
+              this.handleTransitionComplete,
+              onExited,
+              onClose
+            )}
           >
             {constrain === 'parent' ? (
               <span css={this.props.styles?.constrainContext}>
@@ -317,8 +325,8 @@ class Modal extends Component<ModalProps, ModalState> {
             ) : (
               this.renderDialog(passthroughProps)
             )}
-          </ModalContext.Provider>
-        </Transition>
+          </Transition>
+        </ModalContext.Provider>
       </Portal>
     )
   }

--- a/packages/ui-modal/src/Modal/v2/README.md
+++ b/packages/ui-modal/src/Modal/v2/README.md
@@ -618,16 +618,14 @@ You can do this with the `insertAt` prop or a theme override:
   type: code
 ---
 <InstUISettingsProvider
-      theme={{
-        themeOverrides: {
-            componentOverrides: {
-              Mask: {
-                zIndex: 555,
-              }
-            }
-          }
-      }}
-    >
+  themeOverride={{
+    components: {
+      Mask: {
+        zIndex: 555
+      }
+    }
+  }}
+>
   <Modal />
 </InstUISettingsProvider>
 ```

--- a/packages/ui-modal/src/Modal/v2/index.tsx
+++ b/packages/ui-modal/src/Modal/v2/index.tsx
@@ -106,6 +106,14 @@ class Modal extends Component<ModalProps, ModalState> {
   componentDidUpdate(prevProps: ModalProps) {
     if (this.props.open !== prevProps.open) {
       this.setState({ transitioning: true, open: !!this.props.open })
+      // When closing, release focus from the Dialog.
+      // The Dialog stays open so its content can fade out, but the
+      // Transition marks the exiting subtree aria-hidden -- keeping focus inside
+      // it would hide a focused element from assistive tech resulting in a
+      // console warning
+      if (prevProps.open && !this.props.open) {
+        this._content?.blur()
+      }
     }
     this.props.makeStyles?.()
   }
@@ -205,8 +213,7 @@ class Modal extends Component<ModalProps, ModalState> {
       | keyof ModalPropsForTransition
       | 'constrain'
       | 'overflow'
-    >,
-    open?: boolean
+    >
   ) {
     const {
       onDismiss,
@@ -225,7 +232,7 @@ class Modal extends Component<ModalProps, ModalState> {
       <Dialog
         {...passthroughProps(props)}
         as={as}
-        open={open && !this.state.transitioning}
+        open
         label={label}
         defaultFocusElement={this.defaultFocusElement}
         shouldCloseOnDocumentClick={shouldCloseOnDocumentClick}
@@ -284,41 +291,41 @@ class Modal extends Component<ModalProps, ModalState> {
         onOpen={this.handlePortalOpen}
         data-cid="Modal"
       >
-        <Transition
-          in={open}
-          transitionOnMount
-          type={transition}
-          onEnter={onEnter}
-          onEntering={onEntering}
-          onEntered={createChainedFunction(
-            this.handleTransitionComplete,
-            onEntered,
-            onOpen
-          )}
-          onExit={onExit}
-          onExiting={onExiting}
-          onExited={createChainedFunction(
-            this.handleTransitionComplete,
-            onExited,
-            onClose
-          )}
+        <ModalContext.Provider
+          value={{
+            bodyScrollAriaLabel: this.state.bodyScrollAriaLabel,
+            setBodyScrollAriaLabel: (txt: string) =>
+              this.setState({ bodyScrollAriaLabel: txt })
+          }}
         >
-          <ModalContext.Provider
-            value={{
-              bodyScrollAriaLabel: this.state.bodyScrollAriaLabel,
-              setBodyScrollAriaLabel: (txt: string) =>
-                this.setState({ bodyScrollAriaLabel: txt })
-            }}
+          <Transition
+            in={open}
+            transitionOnMount
+            type={transition}
+            onEnter={onEnter}
+            onEntering={onEntering}
+            onEntered={createChainedFunction(
+              this.handleTransitionComplete,
+              onEntered,
+              onOpen
+            )}
+            onExit={onExit}
+            onExiting={onExiting}
+            onExited={createChainedFunction(
+              this.handleTransitionComplete,
+              onExited,
+              onClose
+            )}
           >
             {constrain === 'parent' ? (
               <span css={this.props.styles?.constrainContext}>
-                {this.renderDialog(passthroughProps, open)}
+                {this.renderDialog(passthroughProps)}
               </span>
             ) : (
-              this.renderDialog(passthroughProps, open)
+              this.renderDialog(passthroughProps)
             )}
-          </ModalContext.Provider>
-        </Transition>
+          </Transition>
+        </ModalContext.Provider>
       </Portal>
     )
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9467,8 +9467,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.376:
-    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
+  electron-to-chromium@1.5.378:
+    resolution: {integrity: sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -11647,8 +11647,8 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  node-releases@2.0.48:
-    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+  node-releases@2.0.49:
+    resolution: {integrity: sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==}
     engines: {node: '>=18'}
 
   nopt@8.1.0:
@@ -17514,8 +17514,8 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.376
-      node-releases: 2.0.48
+      electron-to-chromium: 1.5.378
+      node-releases: 2.0.49
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-alloc-unsafe@1.1.0: {}
@@ -18550,7 +18550,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.376: {}
+  electron-to-chromium@1.5.378: {}
 
   emoji-regex@10.6.0: {}
 
@@ -21249,7 +21249,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  node-releases@2.0.48: {}
+  node-releases@2.0.49: {}
 
   nopt@8.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Move `ModalContext.Provider` outside `Transition` (v1 + v2) so the dialog/Mask is `Transition`'s direct child again and the fade lifecycle runs.
- v2: pass `open` to the `Dialog` unconditionally (was gated on `!transitioning`) so the window renders during the transition and fades together with the Mask.
- v1 + v2: release focus from the `Dialog` at the start of the exit transition so focus isn't retained inside the `aria-hidden` fading subtree (fixes the retained-focus console warning).
- docs: fix the `Mask` z-index theme-override example in the v2 README.

## Test Plan
- On the Modal docs page, open and close the first example: both the Mask and the window should fade in and out together (~300ms), not appear/disappear instantly.
- Close the Modal via the Close button (or Esc / click-away) with focus inside it and confirm no `aria-hidden`/retained-focus warning in the console, and that focus returns to the trigger.
- Spot-check with a screen reader that focus moves into the Modal on open and back to the trigger on close.

Fixes INSTUI-5072

🤖 Generated with [Claude Code](https://claude.com/claude-code)
