### PR TITLE
refactor(ui-scripts): Update design token version to 1.3.0

### DIFF
--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/cli": "^7.27.2",
     "@instructure/command-utils": "workspace:*",
-    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.1.0",
+    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.3.0",
     "@instructure/pkg-utils": "workspace:*",
     "@lerna/project": "^6.4.1",
     "dprint": "^0.54.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   react-dom: 18.3.1
   '@types/react': 18.3.26
   git-raw-commits>dargs: 7.0.0
+  browserslist: 4.28.4
 
 importers:
 
@@ -76,7 +77,7 @@ importers:
         version: 4.7.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(terser@5.48.0)(yaml@2.8.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.14
-        version: 1.6.14(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3))
+        version: 1.6.14(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3))
       babel-loader:
         specifier: ^10.1.1
         version: 10.1.1(@babel/core@7.29.0)(webpack@5.106.2(esbuild@0.28.0))
@@ -142,7 +143,7 @@ importers:
         version: 9.1.7
       jsdom:
         specifier: ^26.1.0
-        version: 26.1.0
+        version: 26.1.0(supports-color@8.1.1)
       lerna:
         specifier: 9.0.7
         version: 9.0.7(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
@@ -163,7 +164,7 @@ importers:
         version: 8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
       webpack:
         specifier: ^5.106.2
         version: 5.106.2(esbuild@0.28.0)
@@ -433,7 +434,7 @@ importers:
         version: link:../ui-view
       babel-loader:
         specifier: ^10.1.1
-        version: 10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.0))
+        version: 10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -482,7 +483,7 @@ importers:
         version: 3.6.0
       css-loader:
         specifier: 7.1.4
-        version: 7.1.4(webpack@5.107.2(esbuild@0.28.0))
+        version: 7.1.4(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
       globby:
         specifier: ^16.2.0
         version: 16.2.0
@@ -491,7 +492,7 @@ importers:
         version: 4.0.3
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(webpack@5.107.2(esbuild@0.28.0))
+        version: 5.6.7(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
       mkdirp:
         specifier: 3.0.1
         version: 3.0.1
@@ -500,10 +501,10 @@ importers:
         version: 8.0.3
       style-loader:
         specifier: 4.0.0
-        version: 4.0.0(webpack@5.107.2(esbuild@0.28.0))
+        version: 4.0.0(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
       thread-loader:
         specifier: ^4.0.4
-        version: 4.0.4(webpack@5.107.2(esbuild@0.28.0))
+        version: 4.0.4(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
       webpack-bundle-analyzer:
         specifier: 5.3.0
         version: 5.3.0
@@ -642,7 +643,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/pkg-utils:
     dependencies:
@@ -926,7 +927,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-a11y-utils:
     dependencies:
@@ -972,7 +973,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-alerts:
     dependencies:
@@ -1042,7 +1043,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-avatar:
     dependencies:
@@ -1088,7 +1089,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-axe-check:
     dependencies:
@@ -1183,7 +1184,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-billboard:
     dependencies:
@@ -1238,7 +1239,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-breadcrumb:
     dependencies:
@@ -1296,7 +1297,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-buttons:
     dependencies:
@@ -1369,7 +1370,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-byline:
     dependencies:
@@ -1412,7 +1413,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-calendar:
     dependencies:
@@ -1479,7 +1480,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-checkbox:
     dependencies:
@@ -1549,7 +1550,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-codemods:
     dependencies:
@@ -1571,7 +1572,7 @@ importers:
         version: 2.7.3
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-color-picker:
     dependencies:
@@ -1662,7 +1663,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-color-utils:
     dependencies:
@@ -1745,7 +1746,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-date-time-input:
     dependencies:
@@ -1806,7 +1807,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-decorator:
     dependencies:
@@ -1859,7 +1860,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-dom-utils:
     dependencies:
@@ -1890,7 +1891,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-drawer-layout:
     dependencies:
@@ -1960,7 +1961,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-drilldown:
     dependencies:
@@ -2033,7 +2034,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-editable:
     dependencies:
@@ -2097,7 +2098,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-expandable:
     dependencies:
@@ -2140,7 +2141,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-file-drop:
     dependencies:
@@ -2198,7 +2199,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-flex:
     dependencies:
@@ -2241,7 +2242,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-focusable:
     dependencies:
@@ -2284,7 +2285,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-form-field:
     dependencies:
@@ -2342,7 +2343,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-grid:
     dependencies:
@@ -2388,7 +2389,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-heading:
     dependencies:
@@ -2434,7 +2435,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-i18n:
     dependencies:
@@ -2483,7 +2484,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-icons:
     dependencies:
@@ -2569,7 +2570,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-instructure:
     dependencies:
@@ -2633,7 +2634,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-link:
     dependencies:
@@ -2694,7 +2695,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-list:
     dependencies:
@@ -2740,7 +2741,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-menu:
     dependencies:
@@ -2810,7 +2811,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-metric:
     dependencies:
@@ -2853,7 +2854,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-modal:
     dependencies:
@@ -2923,7 +2924,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-motion:
     dependencies:
@@ -2963,7 +2964,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-navigation:
     dependencies:
@@ -3048,7 +3049,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-number-input:
     dependencies:
@@ -3106,7 +3107,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-options:
     dependencies:
@@ -3158,7 +3159,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-overlays:
     dependencies:
@@ -3243,7 +3244,7 @@ importers:
         version: 2.1.2
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-pages:
     dependencies:
@@ -3295,7 +3296,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-pagination:
     dependencies:
@@ -3371,7 +3372,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-pill:
     dependencies:
@@ -3432,7 +3433,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-popover:
     dependencies:
@@ -3505,7 +3506,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-portal:
     dependencies:
@@ -3548,7 +3549,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-position:
     dependencies:
@@ -3600,7 +3601,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-progress:
     dependencies:
@@ -3649,7 +3650,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-radio-input:
     dependencies:
@@ -3701,7 +3702,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-range-input:
     dependencies:
@@ -3762,7 +3763,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-rating:
     dependencies:
@@ -3817,7 +3818,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-react-utils:
     dependencies:
@@ -3866,7 +3867,7 @@ importers:
         version: 3.3.7(@types/react@18.3.26)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-responsive:
     dependencies:
@@ -3909,7 +3910,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-scripts:
     dependencies:
@@ -3920,8 +3921,8 @@ importers:
         specifier: workspace:*
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
-        specifier: github:instructure/instructure-design-tokens#v1.1.0
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/34931443b5e2ef193206d3265263ddc7e384e7be
+        specifier: github:instructure/instructure-design-tokens#v1.3.0
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9247c67f8155f0dc7575bbfb8a284da5b99d5089
       '@instructure/pkg-utils':
         specifier: workspace:*
         version: link:../pkg-utils
@@ -4073,7 +4074,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-selectable:
     dependencies:
@@ -4116,7 +4117,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-side-nav-bar:
     dependencies:
@@ -4177,7 +4178,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-simple-select:
     dependencies:
@@ -4229,7 +4230,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-source-code-editor:
     dependencies:
@@ -4332,7 +4333,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-spinner:
     dependencies:
@@ -4384,7 +4385,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-svg-images:
     dependencies:
@@ -4427,7 +4428,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-table:
     dependencies:
@@ -4488,7 +4489,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-tabs:
     dependencies:
@@ -4561,7 +4562,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-tag:
     dependencies:
@@ -4616,7 +4617,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-text:
     dependencies:
@@ -4717,7 +4718,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-text-input:
     dependencies:
@@ -4775,7 +4776,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-theme-tokens:
     dependencies:
@@ -4813,7 +4814,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-time-select:
     dependencies:
@@ -4862,7 +4863,7 @@ importers:
         version: 0.6.2
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-toggle-details:
     dependencies:
@@ -4929,7 +4930,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-tooltip:
     dependencies:
@@ -4981,7 +4982,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-top-nav-bar:
     dependencies:
@@ -5078,7 +5079,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-tray:
     dependencies:
@@ -5139,7 +5140,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-tree-browser:
     dependencies:
@@ -5191,7 +5192,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-truncate-list:
     dependencies:
@@ -5243,7 +5244,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-truncate-text:
     dependencies:
@@ -5304,7 +5305,7 @@ importers:
         version: 1.0.4
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-utils:
     dependencies:
@@ -5350,7 +5351,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-view:
     dependencies:
@@ -5402,7 +5403,7 @@ importers:
         version: 15.0.7(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
   packages/ui-webpack-config:
     dependencies:
@@ -5436,7 +5437,7 @@ importers:
         version: 6.9.1
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
 
 packages:
 
@@ -7007,8 +7008,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/34931443b5e2ef193206d3265263ddc7e384e7be':
-    resolution: {gitHosted: true, integrity: sha512-xrM7XHclxpG3M32exR8vLA//Kh+FMOO9tE9XGYe3B/laFGFv72wNb91/g9mexWOBN2uysrSYzLZ1R5s87BnZ4A==, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/34931443b5e2ef193206d3265263ddc7e384e7be}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9247c67f8155f0dc7575bbfb8a284da5b99d5089':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9247c67f8155f0dc7575bbfb8a284da5b99d5089}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -8128,7 +8129,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8491,11 +8492,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.13:
-    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
@@ -8569,13 +8565,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.3:
-    resolution: {integrity: sha512-fJuAi3QO096TeMRa/1Z/Z4xVxx2NVXFQc8aOX5huX0gA1V7NkIw+Qv1/Y16MatpJUeYs4mLXAsRs6RUp4sylIQ==}
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -8679,9 +8670,6 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
-
-  caniuse-lite@1.0.30001784:
-    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -9478,9 +9466,6 @@ packages:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
-
-  electron-to-chromium@1.5.331:
-    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
 
   electron-to-chromium@1.5.376:
     resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
@@ -11662,9 +11647,6 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
-
   node-releases@2.0.48:
     resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
     engines: {node: '>=18'}
@@ -13535,7 +13517,7 @@ packages:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.4
 
   update-notifier@2.5.0:
     resolution: {integrity: sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==}
@@ -14072,7 +14054,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -15727,7 +15709,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/34931443b5e2ef193206d3265263ddc7e384e7be':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/9247c67f8155f0dc7575bbfb8a284da5b99d5089':
     dependencies:
       glob: 13.0.6
 
@@ -16025,8 +16007,8 @@ snapshots:
   '@npmcli/agent@3.0.0':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -16035,8 +16017,8 @@ snapshots:
   '@npmcli/agent@4.0.0':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 11.2.7
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -16933,7 +16915,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.6.14(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3))':
+  '@vitest/eslint-plugin@1.6.14(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.0
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
@@ -16941,7 +16923,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@8.1.1))(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -17367,6 +17349,13 @@ snapshots:
     optionalDependencies:
       webpack: 5.106.2(esbuild@0.28.0)
 
+  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
+    dependencies:
+      '@babel/core': 7.29.0
+      find-up: 5.0.0
+    optionalDependencies:
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
+
   babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.107.2(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
@@ -17424,8 +17413,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
-
-  baseline-browser-mapping@2.10.13: {}
 
   baseline-browser-mapping@2.10.38: {}
 
@@ -17523,21 +17510,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.13
-      caniuse-lite: 1.0.30001784
-      electron-to-chromium: 1.5.331
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  browserslist@4.28.3:
+  browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.376
       node-releases: 2.0.48
-      update-browserslist-db: 1.2.3(browserslist@4.28.3)
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-alloc-unsafe@1.1.0: {}
 
@@ -17678,8 +17657,6 @@ snapshots:
   camelcase@4.1.0: {}
 
   camelcase@5.3.1: {}
-
-  caniuse-lite@1.0.30001784: {}
 
   caniuse-lite@1.0.30001799: {}
 
@@ -18096,7 +18073,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
 
   core-util-is@1.0.2: {}
 
@@ -18170,7 +18147,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.106.2(esbuild@0.28.0)
 
-  css-loader@7.1.4(webpack@5.107.2(esbuild@0.28.0)):
+  css-loader@7.1.4(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.8)
       postcss: 8.5.8
@@ -18181,7 +18158,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.28.0)
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
 
   css-select@4.3.0:
     dependencies:
@@ -18573,8 +18550,6 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.331: {}
-
   electron-to-chromium@1.5.376: {}
 
   emoji-regex@10.6.0: {}
@@ -18871,7 +18846,7 @@ snapshots:
     dependencies:
       '@mdn/browser-compat-data': 6.1.5
       ast-metadata-inferer: 0.8.1
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       eslint: 9.39.4(jiti@2.6.1)(supports-color@8.1.1)
       find-up: 5.0.0
       globals: 15.15.0
@@ -19828,7 +19803,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.46.2
 
-  html-webpack-plugin@5.6.7(webpack@5.107.2(esbuild@0.28.0)):
+  html-webpack-plugin@5.6.7(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -19836,7 +19811,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.28.0)
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -19876,7 +19851,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -19935,7 +19910,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -20483,14 +20458,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -21273,8 +21248,6 @@ snapshots:
       which: 6.0.1
     transitivePeerDependencies:
       - supports-color
-
-  node-releases@2.0.37: {}
 
   node-releases@2.0.48: {}
 
@@ -22952,9 +22925,9 @@ snapshots:
     dependencies:
       webpack: 5.106.2(esbuild@0.28.0)
 
-  style-loader@4.0.0(webpack@5.107.2(esbuild@0.28.0)):
+  style-loader@4.0.0(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
     dependencies:
-      webpack: 5.107.2(esbuild@0.28.0)
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
 
   style-mod@4.1.3: {}
 
@@ -23063,6 +23036,17 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.0
 
+  terser-webpack-plugin@5.6.1(esbuild@0.28.0)(postcss@8.5.8)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
+    optionalDependencies:
+      esbuild: 0.28.0
+      postcss: 8.5.8
+
   terser-webpack-plugin@5.6.1(esbuild@0.28.0)(webpack@5.107.2(esbuild@0.28.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -23072,6 +23056,7 @@ snapshots:
       webpack: 5.107.2(esbuild@0.28.0)
     optionalDependencies:
       esbuild: 0.28.0
+    optional: true
 
   terser-webpack-plugin@5.6.1(esbuild@0.28.0)(webpack@5.107.2):
     dependencies:
@@ -23113,13 +23098,13 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.106.2(esbuild@0.28.0)
 
-  thread-loader@4.0.4(webpack@5.107.2(esbuild@0.28.0)):
+  thread-loader@4.0.4(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.2
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      webpack: 5.107.2(esbuild@0.28.0)
+      webpack: 5.107.2(esbuild@0.28.0)(postcss@8.5.8)
 
   throttleit@1.0.1: {}
 
@@ -23405,15 +23390,9 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.3):
-    dependencies:
-      browserslist: 4.28.3
+      browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -23522,7 +23501,7 @@ snapshots:
       terser: 5.48.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0(supports-color@8.1.1))(supports-color@8.1.1)(terser@5.48.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -23549,7 +23528,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23696,7 +23675,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.21.0
       es-module-lexer: 2.1.0
@@ -23726,7 +23705,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.17.0
       acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.3
+      browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.0
       es-module-lexer: 2.1.0
@@ -23755,6 +23734,46 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+    optional: true
+
+  webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.0
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(esbuild@0.28.0)(postcss@8.5.8)(webpack@5.107.2(esbuild@0.28.0)(postcss@8.5.8))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.107.2(esbuild@0.28.0)(webpack-cli@7.0.2):
     dependencies:
@@ -23765,7 +23784,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.17.0
       acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.3
+      browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.0
       es-module-lexer: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,4 @@ overrides:
   "react-dom": "18.3.1"
   "@types/react": "18.3.26"
   "git-raw-commits>dargs": "7.0.0"
+  "browserslist": "4.28.4" # its here only because 4.28.3 is broken. Remove after July 2026

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -48,12 +48,6 @@ const bootstrapStart = Date.now()
 mark('Deleting build artifacts')
 execSync(path.resolve('scripts/clean.js'), opts)
 
-mark('Fetching design tokens')
-execSync(
-  'pnpm --filter @instructure/ui-scripts update @instructure/instructure-design-tokens',
-  opts
-)
-
 mark('Building themes')
 execSync('pnpm run build:themes', opts)
 


### PR DESCRIPTION
also do not run pnpm update on each bootstrap call.

To test: just smoke test the docs app