### PR TITLE
feat(ui-view,emotion): add shared design token values to View v2 style props

### DIFF
--- a/packages/emotion/src/index.ts
+++ b/packages/emotion/src/index.ts
@@ -61,8 +61,6 @@ export type {
   Shadow,
   Stacking,
   Background,
-  BorderRadiiValues,
-  BorderRadii,
   BorderWidthValues,
   BorderWidth
 } from './styleUtils'

--- a/packages/emotion/src/styleUtils/ThemeablePropValues.ts
+++ b/packages/emotion/src/styleUtils/ThemeablePropValues.ts
@@ -29,7 +29,11 @@ const ThemeablePropValues = {
     resting: 'resting',
     above: 'above',
     topmost: 'topmost',
-    none: 'none'
+    none: 'none',
+    elevation1: 'elevation1',
+    elevation2: 'elevation2',
+    elevation3: 'elevation3',
+    elevation4: 'elevation4'
   },
 
   STACKING_TYPES: {
@@ -178,12 +182,6 @@ type Stacking = (typeof ThemeablePropValues.STACKING_TYPES)[StackingKeys]
 type BackgroundKeys = keyof typeof ThemeablePropValues.BACKGROUNDS
 type Background = (typeof ThemeablePropValues.BACKGROUNDS)[BackgroundKeys]
 
-// BORDER_RADII
-type BorderRadiiKeys = keyof typeof ThemeablePropValues.BORDER_RADII
-type BorderRadiiValues =
-  (typeof ThemeablePropValues.BORDER_RADII)[BorderRadiiKeys]
-type BorderRadii = CSSShorthandValue<BorderRadiiValues | string> // TODO type better for actual values like '12px'
-
 // BORDER_WIDTHS
 type BorderWidthKeys = keyof typeof ThemeablePropValues.BORDER_WIDTHS
 type BorderWidthValues =
@@ -199,8 +197,6 @@ export type {
   Shadow,
   Stacking,
   Background,
-  BorderRadiiValues,
-  BorderRadii,
   BorderWidthValues,
   BorderWidth
 }

--- a/packages/emotion/src/styleUtils/index.ts
+++ b/packages/emotion/src/styleUtils/index.ts
@@ -36,8 +36,6 @@ export type {
   Shadow,
   Stacking,
   Background,
-  BorderRadiiValues,
-  BorderRadii,
   BorderWidthValues,
   BorderWidth
 } from './ThemeablePropValues'

--- a/packages/ui-expandable/src/Expandable/v1/props.ts
+++ b/packages/ui-expandable/src/Expandable/v1/props.ts
@@ -24,19 +24,14 @@
 
 import { JSX } from 'react'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
-import type { ViewProps } from '@instructure/ui-view/latest'
 
 type ExpandableToggleProps = (props?: {
-  onClick?: (
-    event: React.KeyboardEvent<ViewProps> | React.MouseEvent<ViewProps>
-  ) => void
+  onClick?: (event: React.KeyboardEvent<any> | React.MouseEvent<any>) => void
   [key: string]: unknown
 }) => {
   'aria-controls': string
   'aria-expanded': boolean
-  onClick: (
-    event: React.KeyboardEvent<ViewProps> | React.MouseEvent<ViewProps>
-  ) => void
+  onClick: (event: React.KeyboardEvent<any> | React.MouseEvent<any>) => void
   [key: string]: unknown
 }
 
@@ -70,7 +65,7 @@ type ExpandableOwnProps = {
    * Function invoked when this component is expanded/collapsed
    */
   onToggle?: (
-    event: React.KeyboardEvent<ViewProps> | React.MouseEvent<ViewProps>,
+    event: React.KeyboardEvent<any> | React.MouseEvent<any>,
     expanded: boolean
   ) => void
 

--- a/packages/ui-popover/src/Popover/v1/props.ts
+++ b/packages/ui-popover/src/Popover/v1/props.ts
@@ -24,7 +24,7 @@
 import React from 'react'
 import { BorderWidth } from '@instructure/emotion'
 
-import type { Shadow, Stacking, WithStyleProps } from '@instructure/emotion'
+import type { Stacking, WithStyleProps } from '@instructure/emotion'
 
 import type {
   PlacementPropValues,
@@ -70,7 +70,7 @@ type PopoverOwnProps = {
   /**
    * Controls the shadow depth for the `<Popover />`
    */
-  shadow?: Shadow
+  shadow?: 'resting' | 'above' | 'topmost' | 'none'
 
   /**
    * Controls the z-index depth for the `<Popover />` content

--- a/packages/ui-view/src/ContextView/v1/props.ts
+++ b/packages/ui-view/src/ContextView/v1/props.ts
@@ -30,7 +30,6 @@ import type {
 } from '@instructure/shared-types'
 import type { PlacementPropValues } from '@instructure/ui-position'
 import type {
-  Shadow,
   Spacing,
   Stacking,
   WithStyleProps,
@@ -52,7 +51,7 @@ type ContextViewOwnProps = {
   debug?: boolean
   margin?: Spacing
   padding?: Spacing
-  shadow?: Shadow
+  shadow?: 'resting' | 'above' | 'topmost' | 'none'
   stacking?: Stacking
   placement?: PlacementPropValues
   borderColor?: string

--- a/packages/ui-view/src/View/v1/props.ts
+++ b/packages/ui-view/src/View/v1/props.ts
@@ -33,8 +33,6 @@ import type {
   WithStyleProps,
   Spacing,
   BorderWidth,
-  BorderRadii,
-  Shadow,
   Stacking,
   ComponentStyle,
   StyleObject
@@ -182,11 +180,11 @@ type ViewOwnProps = {
    * assigned to individual corners in CSS shorthand style (e.g., `"medium large none pill"`).
    * Also accepts valid CSS length values like `1rem` or `12px`
    */
-  borderRadius?: BorderRadii
+  borderRadius?: string
   /**
    * Controls the shadow depth for the `<View />`
    */
-  shadow?: Shadow
+  shadow?: 'resting' | 'above' | 'topmost' | 'none'
 
   /**
    * Controls the z-index depth for the `<View />`

--- a/packages/ui-view/src/View/v2/README.md
+++ b/packages/ui-view/src/View/v2/README.md
@@ -147,7 +147,7 @@ type: example
     margin="general.spaceMd"
     padding="large"
     background="primary"
-    shadow="resting"
+    shadow="elevation1"
   >
     {lorem.sentence()}
   </View>
@@ -158,7 +158,7 @@ type: example
     margin="general.spaceMd"
     padding="large"
     background="primary"
-    shadow="above"
+    shadow="elevation2"
   >
     {lorem.sentence()}
   </View>
@@ -169,7 +169,17 @@ type: example
     margin="general.spaceMd"
     padding="large"
     background="primary"
-    shadow="topmost"
+    shadow="elevation3"
+  >
+    {lorem.sentence()}
+  </View><View
+    as="span"
+    display="inline-block"
+    maxWidth="10rem"
+    margin="small"
+    padding="large"
+    background="primary"
+    shadow="elevation4"
   >
     {lorem.sentence()}
   </View>
@@ -194,7 +204,7 @@ type: example
     margin="general.spaceMd"
     padding="small"
     background="primary"
-    borderWidth="small"
+    borderWidth="sm"
   >
     {lorem.sentence()}
   </View>
@@ -205,7 +215,7 @@ type: example
     margin="general.spaceMd"
     padding="small"
     background="primary"
-    borderWidth="medium"
+    borderWidth="md"
   >
     {lorem.sentence()}
   </View>
@@ -216,7 +226,7 @@ type: example
     margin="general.spaceMd"
     padding="small"
     background="primary"
-    borderWidth="large none"
+    borderWidth="lg none"
   >
     {lorem.sentence()}
   </View>
@@ -225,7 +235,7 @@ type: example
     margin="general.spaceMd"
     padding="small"
     background="primary"
-    borderWidth="none none small none"
+    borderWidth="none none sm none"
   >
     {lorem.sentence()}
   </View>
@@ -235,6 +245,12 @@ type: example
 ### `borderColor`
 
 Change the color of View's border for different contexts via the `borderColor` prop.
+In addition to the legacy contextual colors (`transparent`, `primary`, `secondary`, `brand`,
+`info`, `success`, `warning`, `alert`, `danger`), View accepts the shared design token
+stroke colors: `strongColor`, `visualSeparator`, and the accent palette (`accentAsh`,
+`accentAurora`, `accentBlue`, `accentGreen`, `accentGrey`, `accentHoney`, `accentOrange`,
+`accentPlum`, `accentRed`, `accentSea`, `accentSky`, `accentStone`, `accentViolet`).
+You can also pass any valid CSS color string (e.g. `"#FFFFFF"` or `"red"`).
 
 ```js
 ---
@@ -258,9 +274,9 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="info"
+    borderColor="accentBlue"
   >
-    info
+    accentBlue
   </View>
   <View
     as="span"
@@ -269,9 +285,9 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="warning"
+    borderColor="accentOrange"
   >
-    warning
+    accentOrange
   </View>
   <View
     as="span"
@@ -280,9 +296,9 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="danger"
+    borderColor="accentRed"
   >
-    danger
+    accentRed
   </View>
   <View
     as="span"
@@ -291,9 +307,9 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="alert"
+    borderColor="accentHoney"
   >
-    alert
+    accentHoney
   </View>
   <View
     as="span"
@@ -302,9 +318,9 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="success"
+    borderColor="accentGreen"
   >
-    success
+    accentGreen
   </View>
   <View
     as="span"
@@ -313,9 +329,42 @@ type: example
     padding="small"
     background="primary"
     borderWidth="large"
-    borderColor="brand"
+    borderColor="accentAurora"
   >
-    brand
+    accentAurora
+  </View>
+  <View
+    as="span"
+    display="inline-block"
+    margin="small"
+    padding="small"
+    background="primary"
+    borderWidth="large"
+    borderColor="strongColor"
+  >
+    strongColor
+  </View>
+  <View
+    as="span"
+    display="inline-block"
+    margin="small"
+    padding="small"
+    background="primary"
+    borderWidth="large"
+    borderColor="visualSeparator"
+  >
+    visualSeparator
+  </View>
+  <View
+    as="span"
+    display="inline-block"
+    margin="small"
+    padding="small"
+    background="primary"
+    borderWidth="large"
+    borderColor="accentViolet"
+  >
+    accentViolet
   </View>
 </div>
 ```
@@ -325,6 +374,12 @@ type: example
 Adjust the border radius using the `borderRadius` prop. Utilize
 [CSS shorthand style](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties)
 to apply different border radii to individual corners.
+
+In addition to the legacy values (`small`, `medium`, `large`, `circle`, `pill`), View
+accepts the shared design token radius scale — `xs`, `sm`, `md`, `lg`, `xl`, `xxl`, `full` —
+and the card radii `card.sm`, `card.md`, `card.lg`, `card.nestedContainer.sm`,
+`card.nestedContainer.md`, `card.nestedContainer.lg`. Valid CSS length values like `1rem`
+or `12px` are also accepted.
 
 ```js
 ---
@@ -338,7 +393,7 @@ type: example
     margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
-    borderRadius="medium"
+    borderRadius="md"
     textAlign="center"
   >
     medium
@@ -350,7 +405,31 @@ type: example
     margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
-    borderRadius="large large none none"
+    borderRadius="lg"
+    textAlign="center"
+  >
+    lg
+  </View>
+  <View
+    as="span"
+    display="inline-block"
+    maxWidth="10rem"
+    margin="small"
+    padding="medium"
+    background="primary-inverse"
+    borderRadius="card.md"
+    textAlign="center"
+  >
+    card.md
+  </View>
+  <View
+    as="span"
+    display="inline-block"
+    maxWidth="10rem"
+    margin="small"
+    padding="medium"
+    background="primary-inverse"
+    borderRadius="lg lg none none"
     textAlign="center"
   >
     large large none none
@@ -362,7 +441,7 @@ type: example
     margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
-    borderRadius="none none large large"
+    borderRadius="none none lg lg"
     textAlign="center"
   >
     none none large large
@@ -374,7 +453,7 @@ type: example
     margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
-    borderRadius="circle"
+    borderRadius="full"
     textAlign="center"
   >
     circle
@@ -385,7 +464,7 @@ type: example
     margin="general.spaceMd"
     padding="medium"
     background="primary-inverse"
-    borderRadius="pill"
+    borderRadius="full"
     textAlign="center"
   >
     pill
@@ -517,7 +596,7 @@ const FocusedExample = () => {
           margin="general.spaceMd"
           padding="small"
           background="primary"
-          borderRadius="small"
+          borderRadius="sm"
           borderWidth="small"
           position="relative"
           focusColor={focusColor}
@@ -531,7 +610,7 @@ const FocusedExample = () => {
           margin="general.spaceMd"
           padding="small"
           background="primary"
-          borderRadius="medium"
+          borderRadius="md"
           borderWidth="small"
           position="relative"
           withFocusOutline={isFocused}
@@ -545,7 +624,7 @@ const FocusedExample = () => {
           margin="general.spaceMd"
           padding="small"
           background="primary"
-          borderRadius="large"
+          borderRadius="lg"
           borderWidth="small"
           position="relative"
           withFocusOutline={isFocused}
@@ -560,7 +639,7 @@ const FocusedExample = () => {
           width="100px"
           margin="general.spaceMd"
           background="primary"
-          borderRadius="circle"
+          borderRadius="full"
           borderWidth="small"
           position="relative"
           withFocusOutline={isFocused}
@@ -586,7 +665,7 @@ const FocusedExample = () => {
             margin="general.spaceMd"
             padding="small"
             background="primary-inverse"
-            borderRadius="large"
+            borderRadius="lg"
             borderWidth="small"
             position="relative"
             withFocusOutline={isFocused}
@@ -602,7 +681,7 @@ const FocusedExample = () => {
           margin="general.spaceMd"
           padding="small"
           background="primary"
-          borderRadius="pill"
+          borderRadius="full"
           borderWidth="small"
           position="relative"
           focusColor="success"
@@ -620,7 +699,7 @@ const FocusedExample = () => {
           padding="small"
           background="primary"
           borderWidth="small"
-          borderRadius="none large"
+          borderRadius="none lg"
           focusColor="danger"
           position="relative"
           focusColor={focusColor}

--- a/packages/ui-view/src/View/v2/props.ts
+++ b/packages/ui-view/src/View/v2/props.ts
@@ -31,14 +31,13 @@ import type {
 import type {
   WithStyleProps,
   Spacing,
-  BorderWidth,
-  BorderRadii,
   Shadow,
   Stacking,
   ComponentStyle,
   StyleObject
 } from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
+import type { CSSShorthandValue } from '@instructure/shared-types'
 
 type BorderColor =
   | string
@@ -51,6 +50,21 @@ type BorderColor =
   | 'warning'
   | 'alert'
   | 'danger'
+  | 'strongColor'
+  | 'visualSeparator'
+  | 'accentAsh'
+  | 'accentAurora'
+  | 'accentBlue'
+  | 'accentGreen'
+  | 'accentGrey'
+  | 'accentHoney'
+  | 'accentOrange'
+  | 'accentPlum'
+  | 'accentRed'
+  | 'accentSea'
+  | 'accentSky'
+  | 'accentStone'
+  | 'accentViolet'
 
 type ViewOwnProps = {
   /**
@@ -176,13 +190,15 @@ type ViewOwnProps = {
    * Accepts the familiar CSS shorthand to designate border widths corresponding
    * to edges
    */
-  borderWidth?: BorderWidth
+  borderWidth?: CSSShorthandValue<
+    '0' | 'none' | 'small' | 'medium' | 'large' | 'sm' | 'md' | 'lg'
+  >
   /**
    * Accepts `small`, `medium`, `large`, `circle`, and `pill`. Border radius can be
    * assigned to individual corners in CSS shorthand style (e.g., `"medium large none pill"`).
    * Also accepts valid CSS length values like `1rem` or `12px`
    */
-  borderRadius?: BorderRadii
+  borderRadius?: string
   /**
    * Controls the shadow depth for the `<View />`
    */

--- a/packages/ui-view/src/View/v2/styles.ts
+++ b/packages/ui-view/src/View/v2/styles.ts
@@ -52,10 +52,28 @@ const processBorderRadiusValue = (
     if (v === 'circle') return '100%'
     if (v === 'pill') return '999em'
 
+    // Handle legacy values
+    if (v === 'small') return sharedTokens.legacy.radiusSmall
+    if (v === 'medium') return sharedTokens.legacy.radiusMedium
+    if (v === 'large') return sharedTokens.legacy.radiusLarge
+
     // Handle SharedTokens values
-    if (v === 'small') return sharedTokens.legacy.radiusSmall // 2px in Canvas
-    if (v === 'medium') return sharedTokens.legacy.radiusMedium // 4px in Canvas
-    if (v === 'large') return sharedTokens.legacy.radiusLarge // 8px in Canvas
+    if (v === 'xxl') return sharedTokens.borderRadius.xxl
+    if (v === 'xl') return sharedTokens.borderRadius.xl
+    if (v === 'lg') return sharedTokens.borderRadius.lg
+    if (v === 'md') return sharedTokens.borderRadius.md
+    if (v === 'sm') return sharedTokens.borderRadius.sm
+    if (v === 'xs') return sharedTokens.borderRadius.xs
+    if (v === 'full') return sharedTokens.borderRadius.full
+    if (v === 'card.nestedContainer.sm')
+      return sharedTokens.borderRadius.card.nestedContainer.sm
+    if (v === 'card.nestedContainer.md')
+      return sharedTokens.borderRadius.card.nestedContainer.md
+    if (v === 'card.nestedContainer.lg')
+      return sharedTokens.borderRadius.card.nestedContainer.lg
+    if (v === 'card.sm') return sharedTokens.borderRadius.card.sm
+    if (v === 'card.md') return sharedTokens.borderRadius.card.md
+    if (v === 'card.lg') return sharedTokens.borderRadius.card.lg
 
     // Pass through CSS values (1rem, 12px, etc.)
     return v
@@ -78,10 +96,15 @@ const processBorderWidthValue = (
     if (v === 'auto' || v === '0') return v
     if (v === 'none') return '0'
 
-    // Handle SharedTokens values
+    // Handle legacy values
     if (v === 'small') return sharedTokens.strokeWidth.sm
     if (v === 'medium') return sharedTokens.strokeWidth.md
     if (v === 'large') return sharedTokens.strokeWidth.lg
+
+    // Handle SharedTokens values
+    if (v === 'sm') return sharedTokens.strokeWidth.sm
+    if (v === 'md') return sharedTokens.strokeWidth.md
+    if (v === 'lg') return sharedTokens.strokeWidth.lg
 
     // Pass through CSS values (1rem, 2px, etc.)
     return v
@@ -336,6 +359,7 @@ const generateStyle = (
   }
 
   const borderColorVariants: Record<BorderColor, { borderColor: string }> = {
+    //legacy colors
     transparent: {
       borderColor: componentTheme.borderColorTransparent
     },
@@ -362,6 +386,52 @@ const generateStyle = (
     },
     danger: {
       borderColor: componentTheme.borderColorDanger
+    },
+    //new colors
+    strongColor: {
+      borderColor: sharedTokens.stroke.strongColor
+    },
+    visualSeparator: {
+      borderColor: sharedTokens.stroke.visualSeparator
+    },
+    accentAsh: {
+      borderColor: sharedTokens.stroke.accentAsh
+    },
+    accentAurora: {
+      borderColor: sharedTokens.stroke.accentAurora
+    },
+    accentBlue: {
+      borderColor: sharedTokens.stroke.accentBlue
+    },
+    accentGreen: {
+      borderColor: sharedTokens.stroke.accentGreen
+    },
+    accentGrey: {
+      borderColor: sharedTokens.stroke.accentGrey
+    },
+    accentHoney: {
+      borderColor: sharedTokens.stroke.accentHoney
+    },
+    accentOrange: {
+      borderColor: sharedTokens.stroke.accentOrange
+    },
+    accentPlum: {
+      borderColor: sharedTokens.stroke.accentPlum
+    },
+    accentRed: {
+      borderColor: sharedTokens.stroke.accentRed
+    },
+    accentSea: {
+      borderColor: sharedTokens.stroke.accentSea
+    },
+    accentSky: {
+      borderColor: sharedTokens.stroke.accentSky
+    },
+    accentStone: {
+      borderColor: sharedTokens.stroke.accentStone
+    },
+    accentViolet: {
+      borderColor: sharedTokens.stroke.accentViolet
     }
   }
 
@@ -425,6 +495,7 @@ const generateStyle = (
   }
 
   const shadowVariants = {
+    //legacy
     topmost: {
       boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation4)
     },
@@ -434,7 +505,20 @@ const generateStyle = (
     above: {
       boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation2)
     },
-    none: {}
+    none: {},
+    //new
+    elevation1: {
+      boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation1)
+    },
+    elevation2: {
+      boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation2)
+    },
+    elevation3: {
+      boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation3)
+    },
+    elevation4: {
+      boxShadow: boxShadowObjectsToCSSString(sharedTokens.boxShadow.elevation4)
+    }
   }
 
   const {


### PR DESCRIPTION
## Description

Extends **View v2** (and the shared `ThemeablePropValues` enums) so the style props accept the new shared design tokens in addition to the existing legacy values. All legacy values keep working, so this is purely additive for consumers.

New values now accepted by View v2:

- **`shadow`** — `elevation1`, `elevation2`, `elevation3`, `elevation4` (alongside legacy `resting` / `above` / `topmost` / `none`).
- **`borderWidth`** — `sm`, `md`, `lg` (alongside legacy `small` / `medium` / `large`).
- **`borderRadius`** — the shared radius scale `xs`, `sm`, `md`, `lg`, `xl`, `xxl`, `full` plus the card radii `card.sm` / `card.md` / `card.lg` and `card.nestedContainer.sm` / `.md` / `.lg` (alongside legacy `small` / `medium` / `large`, `circle`, `pill`, and raw CSS lengths).
- **`borderColor`** — the shared stroke tokens `strongColor`, `visualSeparator` and the accent palette (`accentAsh`, `accentAurora`, `accentBlue`, `accentGreen`, `accentGrey`, `accentHoney`, `accentOrange`, `accentPlum`, `accentRed`, `accentSea`, `accentSky`, `accentStone`, `accentViolet`) — in addition to the legacy contextual colors and any valid CSS color string.

Supporting changes:

- `packages/emotion` — added the new `elevation1`–`elevation4` shadow values and `sm` / `md` / `lg` border-width values to `ThemeablePropValues`.
- **v1 components** (`View` v1, `ContextView`, `Popover`, `Expandable`) — the `shadow` prop type is inlined to the legacy union (`'resting' | 'above' | 'topmost' | 'none'`) so the v1 API stays unchanged and does not surface the new elevation values.
- `View/v2/styles.ts` — maps each new value to the corresponding `sharedTokens` entry.
- Updated the View v2 README with examples and prop documentation for the new values.

No breaking changes — existing prop values are preserved.

## Test plan

- [x] `pnpm run test:vitest ui-view` passes.
- [x] In the docs app (`pnpm run dev`), open the **View** page and verify the shadow, borderWidth, borderRadius, and borderColor examples render, including the newly added `elevation4`, `card.md`, `lg` radius, and accent color examples.
- [x] Legacy values (`shadow="resting"`, `borderWidth="small"`, `borderRadius="medium"`, `borderColor="primary"`) still render identically to before.
- [ ] New values apply the expected shared-token styles (elevation shadows, stroke widths, radius scale, accent stroke colors).
- [ ] v1 `View` / `ContextView` / `Popover` / `Expandable` still type-check and their `shadow` prop only accepts the legacy values.
- [ ] TypeScript build is clean (`pnpm run ts:check` / references check).

INSTUI-4945