### PR TITLE
Fix tab focusring to make it more distinct

### DIFF
--- a/packages/ui-tabs/src/Tabs/v2/Tab/index.tsx
+++ b/packages/ui-tabs/src/Tabs/v2/Tab/index.tsx
@@ -112,7 +112,7 @@ class Tab extends Component<TabsTabProps> {
         aria-controls={controls}
         tabIndex={isSelected && !isDisabled ? 0 : undefined}
         position="relative"
-        focusPosition="inset"
+        focusPosition="offset"
       >
         {callRenderProp(children)}
       </View>

--- a/packages/ui-tabs/src/Tabs/v2/Tab/styles.ts
+++ b/packages/ui-tabs/src/Tabs/v2/Tab/styles.ts
@@ -123,20 +123,6 @@ const generateStyle = (
     }
   }
 
-  // overrides for View default focus ring
-  const focusRingStyles = {
-    '&:before': {
-      inset: '0.5rem',
-      borderRadius: '0.25rem'
-    },
-
-    '&:focus': {
-      '&:before': {
-        inset: '0.375rem'
-      }
-    }
-  }
-
   return {
     tab: {
       label: 'tab',
@@ -150,8 +136,6 @@ const generateStyle = (
 
       ...((isSelected || isDisabled) && { cursor: 'default' }),
       ...(isDisabled && { opacity: 0.5 }),
-
-      ...focusRingStyles,
 
       ...variants[variant!]
     }


### PR DESCRIPTION
* Made the tab focus ring more distinct by replacing the inset with an offset, so it no longer blends into the tab color.
* Removed the unused focus ring styles.