### PR TITLE
feat(ui-modal): add margin to fullscreen modal

### DIFF
--- a/docs/upgrading/upgrade-guide.md
+++ b/docs/upgrading/upgrade-guide.md
@@ -962,6 +962,7 @@ type: embed
   added={[
     {name:"borderWidth",note:""},
     {name:"inverseBorderColor",note:""},
+    {name:"fullScreenMargin",note:""},
   ]}
   changed={[
     {oldName:"background",newName:"backgroundColor",note:""},

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lerna": "9.0.7",
     "lint-staged": "^17.0.8",
     "moment-timezone": "^0.6.2",
+    "prettier": "2.8.8",
     "react": "18.3.1",
     "read-package-up": "^12.0.0",
     "typescript": "6.0.3",

--- a/packages/ui-modal/src/Modal/v2/README.md
+++ b/packages/ui-modal/src/Modal/v2/README.md
@@ -148,8 +148,8 @@ const Example = () => {
         background="primary-inverse"
         margin="medium auto none"
         display="block"
-        width="25rem"
-        height="25rem"
+        width="30rem"
+        height="30rem"
         borderWidth="large"
         id="constrainExample"
       ></View>
@@ -464,6 +464,9 @@ const Example = () => {
       <Modal
         open={open}
         size={smallViewport ? 'fullscreen' : 'small'}
+        // Simulate real small-screen behavior by themeOverride.
+        // On actual small screens this happens automatically, so no theme override is needed.
+        themeOverride={smallViewport ? { fullScreenMargin: '0', borderRadius: '0' } : undefined}
         onDismiss={(event) => {
           if (event.target.id !== 'toggleViewportButton') {
             setOpen(false)

--- a/packages/ui-modal/src/Modal/v2/styles.ts
+++ b/packages/ui-modal/src/Modal/v2/styles.ts
@@ -23,7 +23,7 @@
  */
 
 import { boxShadowObjectsToCSSString } from '@instructure/ui-themes'
-import type { NewComponentTypes } from '@instructure/ui-themes'
+import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
 import type { ModalProps, ModalStyle } from './props'
 
 /**
@@ -39,9 +39,11 @@ import type { ModalProps, ModalStyle } from './props'
  */
 const generateStyle = (
   componentTheme: ReturnType<NewComponentTypes['Modal']>,
-  props: ModalProps
+  props: ModalProps,
+  sharedTokens: SharedTokens
 ): ModalStyle => {
   const { size, variant, overflow } = props
+  const boxShadow = boxShadowObjectsToCSSString(componentTheme.boxShadow)
 
   const commonSizeStyleExceptForFullscreen = {
     maxWidth: '95%',
@@ -75,7 +77,17 @@ const generateStyle = (
       height: '100%',
       boxShadow: 'none',
       border: 'none',
-      borderRadius: 0
+      borderRadius: 0,
+      // On larger screens, inset the fullscreen modal from the viewport edge
+      // for a11y: the Mask flex-centers it, so `flex: 1` + `alignSelf: stretch`
+      // (auto height) gap it evenly via the margin; corners/shadow restored too.
+      [`@media screen and (min-width: ${sharedTokens.breakpoints.md})`]: {
+        margin: componentTheme.fullScreenMargin,
+        height: 'auto',
+        alignSelf: 'stretch',
+        borderRadius: componentTheme.borderRadius,
+        boxShadow
+      }
     }
   }
   const backgroundStyles =
@@ -100,7 +112,7 @@ const generateStyle = (
       flexDirection: 'column',
       position: 'relative',
       boxSizing: 'border-box',
-      boxShadow: boxShadowObjectsToCSSString(componentTheme.boxShadow),
+      boxShadow,
       borderRadius: componentTheme.borderRadius,
       overflow: 'hidden',
       ...sizeStyles[size!],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       moment-timezone:
         specifier: ^0.6.2
         version: 0.6.2
+      prettier:
+        specifier: 2.8.8
+        version: 2.8.8
       react:
         specifier: 18.3.1
         version: 18.3.1


### PR DESCRIPTION
INSTUI-5067

## Summary
A `size="fullscreen"` Modal previously covered the entire viewport edge-to-edge, making it hard to tell it was a modal. 

## Changes
- Modal applies `fullScreenMargin` (new token) based on `sharedTokens.breakpoints` (new token).
- The Small viewports docs example now uses a theme override to simulate the small viewport media query behavior.
- The Constraining Modal to a parent element section example was updated to fix the scrollbar introduced by the new margin changes by increasing its size.
- `prettier@3.8.1` pulled by new `style-dictionary@4.4.0` caused conflicts with ui-codemods. Fixed by adding "prettier": "2.8.8" to the root package.json.

## Test plan
Check the Modal page Media Modal example with default (fullscreen, cover) settings.
- Large screen (≥ 768px): it is inset on all sides, rounded corners + shadow, backdrop visible around it.
- Small screen (< 768px): edge-to-edge, no margin/radius.

Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)