### PR TITLE
docs: remove version alert from theme override doc pages

### DIFF
--- a/docs/theming/legacy-theme-overrides.md
+++ b/docs/theming/legacy-theme-overrides.md
@@ -7,15 +7,6 @@ relevantForAI: true
 
 ## Using theme overrides
 
-```js
----
-type: embed
----
-<Alert variant="warning" margin="0 0 medium">
-  The examples on this page use the <strong>legacy theming system</strong> and are designed for <strong>v11.6</strong> components. If you are viewing the v11.7 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_6') : `/v11_6${window.location.pathname}`}>switch to v11.6</Link> to see the examples working correctly.
-</Alert>
-```
-
 This document gives an overview on how you can customize Instructure UI components by tweaking their theme variables.
 While this gives you a level of flexibility on the look and feel of the components you should be aware of 2 things:
 

--- a/docs/theming/new-theme-overrides.md
+++ b/docs/theming/new-theme-overrides.md
@@ -7,15 +7,6 @@ relevantForAI: true
 
 ## New Theme Override Patterns
 
-```js
----
-type: embed
----
-<Alert variant="warning" margin="0 0 medium">
-  The examples on this page use the <strong>new theming system</strong> and require <strong>v11.7+</strong> components. If you are viewing the v11.6 version, <Link href={window.location.pathname.match(/v\d+_\d+/) ? window.location.pathname.replace(/v\d+_\d+/, 'v11_7') : `/v11_7${window.location.pathname}`}>switch to v11.7</Link> to see the examples working correctly.
-</Alert>
-```
-
 This guide covers all the override patterns available in the new theming system (v11.7+). The new system uses a layered token architecture: **primitives** (raw values) -> **semantics** (meaning) -> **components** (per-component tokens).
 
 Overrides are applied via the `themeOverride` prop on `InstUISettingsProvider`, which is separate from the `theme` prop. The `theme` prop replaces the active theme entirely; `themeOverride` layers modifications on top.


### PR DESCRIPTION
INSTUI-5080

## Summary
The theme override docs pages automatically load the correct version, so there is no need to display the version alert.

## Changes
Version alert removed from:
- New theme overrides
- Legacy theme overrides

## Test plan
Verify that the alert is no longer displayed at the top of either page.
