### PR TITLE
fix(ui-instructure): align AiInformation lower-section heading levels to h4

### DIFF
--- a/packages/ui-instructure/src/AiInformation/v1/index.tsx
+++ b/packages/ui-instructure/src/AiInformation/v1/index.tsx
@@ -161,7 +161,7 @@ const AiInformation = ({
                     />
                   </div>
                   <div css={styles?.modelNameText}>
-                    <Heading level="h3" variant="label">
+                    <Heading level="h4" variant="label">
                       {' '}
                       {modelNameText}{' '}
                     </Heading>

--- a/packages/ui-instructure/src/AiInformation/v2/index.tsx
+++ b/packages/ui-instructure/src/AiInformation/v2/index.tsx
@@ -160,7 +160,7 @@ const AiInformation = ({
                     />
                   </div>
                   <div css={styles?.modelNameText}>
-                    <Heading level="h3" variant="label">
+                    <Heading level="h4" variant="label">
                       {' '}
                       {modelNameText}{' '}
                     </Heading>


### PR DESCRIPTION
Render AiInformation "Base Model" heading as `<h4>` (was `<h3>`) to match the sibling "Permission Level" heading. Applied to v1 and v2.

**Test Plan**
- Inspect "Base Model" and "Permission Level" in the popover: both `<h4>`

Fixes INSTUI-5030
