### PR TITLE
fix(ui-drilldown): disabled options no longer show hover/focus styles

### DIFF
--- a/packages/ui-drilldown/src/Drilldown/v1/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/v1/index.tsx
@@ -1258,13 +1258,9 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
         optionProps.role = customRole || 'menuitemcheckbox'
       }
     }
-    // display option as highlighted
-    if (id === this.state.highlightedOptionId) {
+    // display option as highlighted, but never highlight disabled options
+    if (id === this.state.highlightedOptionId && !isOptionDisabled) {
       optionProps.variant = 'highlighted'
-
-      if (isOptionDisabled) {
-        optionProps.variant = 'highlighted-disabled'
-      }
     }
 
     if (href) {

--- a/packages/ui-drilldown/src/Drilldown/v2/index.tsx
+++ b/packages/ui-drilldown/src/Drilldown/v2/index.tsx
@@ -1255,13 +1255,9 @@ class Drilldown extends Component<DrilldownProps, DrilldownState> {
         optionProps.role = customRole || 'menuitemcheckbox'
       }
     }
-    // display option as highlighted
-    if (id === this.state.highlightedOptionId) {
+    // display option as highlighted, but never highlight disabled options
+    if (id === this.state.highlightedOptionId && !isOptionDisabled) {
       optionProps.variant = 'highlighted'
-
-      if (isOptionDisabled) {
-        optionProps.variant = 'highlighted-disabled'
-      }
     }
 
     if (href) {


### PR DESCRIPTION
Closes: INSTUI-5077

**ISSUE:**
- disabled Drilldown options currently look like enabled options when hovered with the mouse or focused with the keyboard, they should not recieve hover of focus styles

**TEST PLAN:**
- in Drilldown v1 and v2 check the first two examples under the 'Options' header with a mouse and keyboard 
- the disabled options should not get styling when they get hovered or keyboard focused