### PR TITLE
fix(ui-side-nav-bar): show focus ring on selected item

### DIFF
--- a/packages/ui-side-nav-bar/src/SideNavBar/v2/SideNavBarItem/styles.ts
+++ b/packages/ui-side-nav-bar/src/SideNavBar/v2/SideNavBarItem/styles.ts
@@ -70,7 +70,7 @@ const generateStyle = (
             },
             '&:focus': {
               backgroundColor: componentTheme.selectedBackgroundColor,
-              boxShadow: `${componentTheme.selectedOuterFocusOutlineColor}, ${componentTheme.selectedInnerFocusOutlineColor}`,
+              boxShadow: `inset 0 0 0 0.125rem ${componentTheme.selectedOuterFocusOutlineColor}, inset 0 0 0 0.25rem ${componentTheme.selectedInnerFocusOutlineColor}`,
               outline: 'none'
             }
           }


### PR DESCRIPTION
INSTUI-5078

**ISSUE:**
- the selected item in SideNavBar (v2) showed no focus ring when focused — the a11y team flagged that users couldn't tell which item was selected/focused 

**TEST PLAN:**
- check the example in the v2 version of the SideNavBar in the 4 different themes 
- using the Tab, go through the SideNavBar items, each item should have a visible focus ring including the selected "Dashboard" element