### PR TITLE
fix(ui-select): fix screen reader labels on multiple select

### DIFF
--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -363,6 +363,45 @@ describe('<Select />', () => {
     expect(input).toHaveAttribute('role', 'combobox')
   })
 
+  describe('accessible name with content rendered before the input', () => {
+    it('keeps the "before input" pills out of the combobox accessible name while the pill itself still announces "Remove"', async () => {
+      const { container } = render(
+        <Select
+          renderLabel="Choose an option"
+          renderBeforeInput={
+            // a dismissible Tag renders as a button named "Remove foo"
+            <button type="button">Remove foo</button>
+          }
+        >
+          {getOptions()}
+        </Select>
+      )
+
+      // The combobox name is pointed at a dedicated label element that mirrors
+      // the field label and excludes the pill's "Remove ...".
+      const input = container.querySelector('input')!
+      const labelledby = input.getAttribute('aria-labelledby')
+      expect(labelledby).toBeTruthy()
+
+      const labelEl = document.getElementById(labelledby!)
+      expect(labelEl).toHaveTextContent('Choose an option')
+      expect(labelEl).not.toHaveTextContent('Remove')
+
+      // The pill itself keeps its "Remove ..." accessible name, so a screen
+      // reader announces that it can be removed when the user navigates to it.
+      const pill = screen.getByRole('button', { name: 'Remove foo' })
+      expect(pill).toHaveAccessibleName('Remove foo')
+    })
+
+    it('does not set aria-labelledby when nothing is rendered before the input', async () => {
+      const { container } = render(
+        <Select renderLabel="Choose an option">{getOptions()}</Select>
+      )
+      const input = container.querySelector('input')!
+      expect(input).not.toHaveAttribute('aria-labelledby')
+    })
+  })
+
   it('should render an input and a list', async () => {
     const { container } = render(
       <Select

--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -364,10 +364,26 @@ describe('<Select />', () => {
   })
 
   describe('accessible name with content rendered before the input', () => {
-    it('keeps the "before input" pills out of the combobox accessible name while the pill itself still announces "Remove"', async () => {
+    it('keeps meaningful renderBeforeInput content in the accessible name', async () => {
+      // e.g. a country dial-code prefix rendered before the input: the Select
+      // must not strip it from the name (it is the only place it is exposed).
+      const { container } = render(
+        <Select renderLabel="Country code" renderBeforeInput={<span>+1</span>}>
+          {getOptions()}
+        </Select>
+      )
+      const input = container.querySelector('input')!
+
+      // the component does not force the name to the label only
+      expect(input).not.toHaveAttribute('aria-labelledby')
+      expect(input).toHaveAccessibleName(/\+1/)
+    })
+
+    it('lets a consumer keep decorative pills out of the name via aria-label, while each pill still announces "Remove"', async () => {
       const { container } = render(
         <Select
-          renderLabel="Choose an option"
+          renderLabel="Multiple Select"
+          aria-label="Multiple Select"
           renderBeforeInput={
             // a dismissible Tag renders as a button named "Remove foo"
             <button type="button">Remove foo</button>
@@ -377,28 +393,13 @@ describe('<Select />', () => {
         </Select>
       )
 
-      // The combobox name is pointed at a dedicated label element that mirrors
-      // the field label and excludes the pill's "Remove ...".
+      // the consumer-provided aria-label becomes the name, excluding the pill
       const input = container.querySelector('input')!
-      const labelledby = input.getAttribute('aria-labelledby')
-      expect(labelledby).toBeTruthy()
+      expect(input).toHaveAccessibleName('Multiple Select')
 
-      const labelEl = document.getElementById(labelledby!)
-      expect(labelEl).toHaveTextContent('Choose an option')
-      expect(labelEl).not.toHaveTextContent('Remove')
-
-      // The pill itself keeps its "Remove ..." accessible name, so a screen
-      // reader announces that it can be removed when the user navigates to it.
+      // the pill keeps its own "Remove ..." accessible name
       const pill = screen.getByRole('button', { name: 'Remove foo' })
       expect(pill).toHaveAccessibleName('Remove foo')
-    })
-
-    it('does not set aria-labelledby when nothing is rendered before the input', async () => {
-      const { container } = render(
-        <Select renderLabel="Choose an option">{getOptions()}</Select>
-      )
-      const input = container.querySelector('input')!
-      expect(input).not.toHaveAttribute('aria-labelledby')
     })
   })
 

--- a/packages/ui-select/src/Select/v2/README.md
+++ b/packages/ui-select/src/Select/v2/README.md
@@ -366,6 +366,8 @@ type: example
 
 To mark an option as "highlighted", use the option's `isHighlighted` prop. Note that only one highlighted option is permitted. Similarly, use `isSelected` to mark an option or multiple options as "selected". When allowing multiple selections, it's best to render a [Tag](Tag) with [AccessibleContent](AccessibleContent) for each selected option via the `renderBeforeInput` prop.
 
+> **Accessibility:** always list the selected options in the `assistiveText` (e.g. `"Alaska Selected, …"`), as the example below does, so screen reader users hear what is selected when they reach the `Select`. The `Select` automatically keeps the pills' `"Remove …"` labels out of the combobox's accessible name, so those are only announced when a user navigates to a pill itself.
+
 ```js
 ---
 type: example
@@ -542,11 +544,24 @@ type: example
       ))
     }
 
+    // Announce the current selection as part of the combobox's description, so
+    // navigating to the Select reads "Multiple Select, Alaska Selected, ..."
+    // rather than the "Remove ..." labels of the dismissible pills.
+    const selectedText = selectedOptionId
+      .map((id) => `${getOptionById(id).label} Selected`)
+      .join(', ')
+    const assistiveText = [
+      selectedText,
+      'Type or use arrow keys to navigate options. Multiple selections allowed.'
+    ]
+      .filter(Boolean)
+      .join('. ')
+
     return (
       <div>
         <Select
           renderLabel="Multiple Select"
-          assistiveText="Type or use arrow keys to navigate options. Multiple selections allowed."
+          assistiveText={assistiveText}
           inputValue={inputValue}
           isShowingOptions={isShowingOptions}
           inputRef={(el) => {

--- a/packages/ui-select/src/Select/v2/README.md
+++ b/packages/ui-select/src/Select/v2/README.md
@@ -366,7 +366,7 @@ type: example
 
 To mark an option as "highlighted", use the option's `isHighlighted` prop. Note that only one highlighted option is permitted. Similarly, use `isSelected` to mark an option or multiple options as "selected". When allowing multiple selections, it's best to render a [Tag](Tag) with [AccessibleContent](AccessibleContent) for each selected option via the `renderBeforeInput` prop.
 
-> **Accessibility:** always list the selected options in the `assistiveText` (e.g. `"Alaska Selected, …"`), as the example below does, so screen reader users hear what is selected when they reach the `Select`. The `Select` automatically keeps the pills' `"Remove …"` labels out of the combobox's accessible name, so those are only announced when a user navigates to a pill itself.
+> **Accessibility:** set an explicit `aria-label` on the `Select` (matching `renderLabel`) and list the selected options in the `assistiveText` (e.g. `"Alaska Selected, …"`), as the example below does. This keeps the combobox's accessible name limited to the field label, while screen reader users still hear which options are selected. Each pill's `"Remove …"` label is only announced when that pill receives focus.
 
 ```js
 ---
@@ -561,6 +561,7 @@ type: example
       <div>
         <Select
           renderLabel="Multiple Select"
+          aria-label="Multiple Select"
           assistiveText={assistiveText}
           inputValue={inputValue}
           isShowingOptions={isShowingOptions}

--- a/packages/ui-select/src/Select/v2/index.tsx
+++ b/packages/ui-select/src/Select/v2/index.tsx
@@ -30,8 +30,7 @@ import {
   matchComponentTypes,
   omitProps,
   getInteraction,
-  withDeterministicId,
-  callRenderProp
+  withDeterministicId
 } from '@instructure/ui-react-utils'
 import {
   getBoundingClientRect,
@@ -184,9 +183,6 @@ class Select extends Component<SelectProps> {
   ref: HTMLSpanElement | null = null
   _input: HTMLInputElement | null = null
   private _defaultId = this.props.deterministicId!()
-  // Dedicated id for a hidden label element used as the combobox's accessible
-  // name when content is rendered before the input (e.g. multiple-select pills).
-  private _labelId = this.props.deterministicId!()
   private _inputContainer: HTMLSpanElement | null = null
   private _listView: Element | null = null
   // temporarily stores actionable options
@@ -753,17 +749,6 @@ class Select extends Component<SelectProps> {
       overrideProps.autoComplete = passthroughProps['autoComplete']
     }
 
-    // When content is rendered before the input via `renderBeforeInput` (e.g.
-    // the dismissible Tag "pills" of a multiple select), that content lives
-    // inside the wrapping <label> and would otherwise be pulled into the
-    // combobox's accessible name (announced as e.g.
-    // "Multiple Select Remove Alaska Remove American Samoa ..."). Point the
-    // input's name at a dedicated hidden label element holding only the field
-    // label, so the pills are only read when focused directly.
-    if (renderBeforeInput != null) {
-      overrideProps['aria-labelledby'] = this._labelId
-    }
-
     const inputProps: Partial<TextInputProps> = {
       id: this.id,
       renderLabel,
@@ -869,17 +854,6 @@ class Select extends Component<SelectProps> {
             <span {...getDescriptionProps()} css={styles?.assistiveText}>
               {assistiveText}
             </span>
-            {/* Hidden label referenced via `aria-labelledby` on the input when
-              content (e.g. multiple-select pills) is rendered before the input.
-              It mirrors the field label so the combobox's accessible name does
-              not include the pills. `aria-labelledby` resolves referenced
-              elements even when hidden, so the shared `assistiveText`
-              (display: none) style is reused here. */}
-            {this.props.renderBeforeInput != null && (
-              <span id={this._labelId} css={styles?.assistiveText}>
-                {callRenderProp(this.props.renderLabel)}
-              </span>
-            )}
             <Popover
               constrain={constrain}
               placement={placement}

--- a/packages/ui-select/src/Select/v2/index.tsx
+++ b/packages/ui-select/src/Select/v2/index.tsx
@@ -30,7 +30,8 @@ import {
   matchComponentTypes,
   omitProps,
   getInteraction,
-  withDeterministicId
+  withDeterministicId,
+  callRenderProp
 } from '@instructure/ui-react-utils'
 import {
   getBoundingClientRect,
@@ -111,18 +112,18 @@ const MemoedOption = memo(
   (prevProps, nextProps) => {
     return (
       prevProps.selectOption.props.isHighlighted ===
-      nextProps.selectOption.props.isHighlighted &&
+        nextProps.selectOption.props.isHighlighted &&
       prevProps.selectOption.props.isSelected ===
-      nextProps.selectOption.props.isSelected &&
+        nextProps.selectOption.props.isSelected &&
       prevProps.selectOption.props.isDisabled ===
-      nextProps.selectOption.props.isDisabled &&
+        nextProps.selectOption.props.isDisabled &&
       prevProps.selectOption.props.children ===
-      nextProps.selectOption.props.children &&
+        nextProps.selectOption.props.children &&
       prevProps.selectOption.props.id === nextProps.selectOption.props.id &&
       prevProps.selectOption.props.renderBeforeLabel ===
-      nextProps.selectOption.props.renderBeforeLabel &&
+        nextProps.selectOption.props.renderBeforeLabel &&
       prevProps.selectOption.props.renderAfterLabel ===
-      nextProps.selectOption.props.renderAfterLabel &&
+        nextProps.selectOption.props.renderAfterLabel &&
       prevProps.children === nextProps.children
     )
   }
@@ -183,6 +184,9 @@ class Select extends Component<SelectProps> {
   ref: HTMLSpanElement | null = null
   _input: HTMLInputElement | null = null
   private _defaultId = this.props.deterministicId!()
+  // Dedicated id for a hidden label element used as the combobox's accessible
+  // name when content is rendered before the input (e.g. multiple-select pills).
+  private _labelId = this.props.deterministicId!()
   private _inputContainer: HTMLSpanElement | null = null
   private _listView: Element | null = null
   // temporarily stores actionable options
@@ -334,59 +338,59 @@ class Select extends Component<SelectProps> {
 
     return this.interaction === 'enabled'
       ? {
-        onRequestShowOptions: (event) => {
-          onRequestShowOptions?.(event)
-          const selectedOptionId = this.selectedOptionId
+          onRequestShowOptions: (event) => {
+            onRequestShowOptions?.(event)
+            const selectedOptionId = this.selectedOptionId
 
-          if (selectedOptionId && !Array.isArray(selectedOptionId)) {
-            // highlight selected option on show
-            this.highlightOption(event, selectedOptionId)
-          }
-        },
-        onRequestHideOptions: (event) => {
-          onRequestHideOptions?.(event)
-        },
-        onRequestHighlightOption: (
-          event,
-          { id, direction }: { id?: string; direction?: number }
-        ) => {
-          if (!isShowingOptions) return
+            if (selectedOptionId && !Array.isArray(selectedOptionId)) {
+              // highlight selected option on show
+              this.highlightOption(event, selectedOptionId)
+            }
+          },
+          onRequestHideOptions: (event) => {
+            onRequestHideOptions?.(event)
+          },
+          onRequestHighlightOption: (
+            event,
+            { id, direction }: { id?: string; direction?: number }
+          ) => {
+            if (!isShowingOptions) return
 
-          const highlightedOptionId = this.highlightedOptionId
-          // if id exists, use that
-          let highlightId = this._optionIds.indexOf(id!) > -1 ? id : undefined
-          if (!highlightId) {
-            if (!highlightedOptionId) {
-              // nothing highlighted yet, highlight first option
-              highlightId = this._optionIds[0]
-            } else {
-              // find next id based on direction
-              const index = this._optionIds.indexOf(highlightedOptionId)
-              highlightId =
-                index > -1 ? this._optionIds[index + direction!] : undefined
+            const highlightedOptionId = this.highlightedOptionId
+            // if id exists, use that
+            let highlightId = this._optionIds.indexOf(id!) > -1 ? id : undefined
+            if (!highlightId) {
+              if (!highlightedOptionId) {
+                // nothing highlighted yet, highlight first option
+                highlightId = this._optionIds[0]
+              } else {
+                // find next id based on direction
+                const index = this._optionIds.indexOf(highlightedOptionId)
+                highlightId =
+                  index > -1 ? this._optionIds[index + direction!] : undefined
+              }
+            }
+            if (highlightId) {
+              // only highlight if id exists as a valid option
+              this.highlightOption(event, highlightId)
+            }
+          },
+          onRequestHighlightFirstOption: (event) => {
+            this.highlightOption(event, this._optionIds[0])
+          },
+          onRequestHighlightLastOption: (event) => {
+            this.highlightOption(
+              event,
+              this._optionIds[this._optionIds.length - 1]
+            )
+          },
+          onRequestSelectOption: (event, { id }) => {
+            if (id && this._optionIds.indexOf(id) !== -1) {
+              // only select if id exists as a valid option
+              onRequestSelectOption?.(event, { id })
             }
           }
-          if (highlightId) {
-            // only highlight if id exists as a valid option
-            this.highlightOption(event, highlightId)
-          }
-        },
-        onRequestHighlightFirstOption: (event) => {
-          this.highlightOption(event, this._optionIds[0])
-        },
-        onRequestHighlightLastOption: (event) => {
-          this.highlightOption(
-            event,
-            this._optionIds[this._optionIds.length - 1]
-          )
-        },
-        onRequestSelectOption: (event, { id }) => {
-          if (id && this._optionIds.indexOf(id) !== -1) {
-            // only select if id exists as a valid option
-            onRequestSelectOption?.(event, { id })
-          }
         }
-      }
       : {}
   }
 
@@ -413,12 +417,12 @@ class Select extends Component<SelectProps> {
       return typeof renderOptionLabel === 'function' &&
         !renderOptionLabel?.prototype?.isReactComponent
         ? (renderOptionLabel as any).bind(null, {
-          id,
-          isDisabled,
-          isSelected,
-          isHighlighted,
-          children
-        })
+            id,
+            isDisabled,
+            isSelected,
+            isHighlighted,
+            children
+          })
         : (renderOptionLabel as React.ReactNode)
     }
 
@@ -532,18 +536,18 @@ class Select extends Component<SelectProps> {
 
     const viewProps: Partial<ViewProps> = isShowingOptions
       ? {
-        display: 'block',
-        overflowY: 'auto',
-        maxHeight:
-          optionsMaxHeight ||
-          this._optionHeight * visibleOptionsCount! -
-          // in Chrome, we need to prevent scrolling when the bottom area of last item is hovered
-          (utils.isChromium() ? this.SCROLL_TOLERANCE : 0),
-        maxWidth: optionsMaxWidth || this.width,
-        background: 'primary',
-        elementRef: (node: Element | null) => (this._listView = node),
-        borderRadius: 'inherit'
-      }
+          display: 'block',
+          overflowY: 'auto',
+          maxHeight:
+            optionsMaxHeight ||
+            this._optionHeight * visibleOptionsCount! -
+              // in Chrome, we need to prevent scrolling when the bottom area of last item is hovered
+              (utils.isChromium() ? this.SCROLL_TOLERANCE : 0),
+          maxWidth: optionsMaxWidth || this.width,
+          background: 'primary',
+          elementRef: (node: Element | null) => (this._listView = node),
+          borderRadius: 'inherit'
+        }
       : { maxHeight: 0 }
 
     return (
@@ -553,30 +557,30 @@ class Select extends Component<SelectProps> {
         >
           {isShowingOptions
             ? Children.map(children as SelectChildren, (child, index) => {
-              if (!child || !matchComponentTypes(child, [Group, Option])) {
-                return // ignore invalid children
-              }
-              if (matchComponentTypes<OptionChild>(child, [Option])) {
-                lastWasGroup = false
-                return this.renderOption(child, {
-                  getOptionProps,
-                  getDisabledOptionProps
-                })
-              }
-              if (matchComponentTypes<GroupChild>(child, [Group])) {
-                const afterGroup = lastWasGroup
-                lastWasGroup = true
-                return this.renderGroup(child, {
-                  getOptionProps,
-                  getDisabledOptionProps,
-                  // for rendering separators appropriately
-                  isFirstChild: index === 0,
-                  isLastChild: index === Children.count(children) - 1,
-                  afterGroup
-                })
-              }
-              return
-            })
+                if (!child || !matchComponentTypes(child, [Group, Option])) {
+                  return // ignore invalid children
+                }
+                if (matchComponentTypes<OptionChild>(child, [Option])) {
+                  lastWasGroup = false
+                  return this.renderOption(child, {
+                    getOptionProps,
+                    getDisabledOptionProps
+                  })
+                }
+                if (matchComponentTypes<GroupChild>(child, [Group])) {
+                  const afterGroup = lastWasGroup
+                  lastWasGroup = true
+                  return this.renderGroup(child, {
+                    getOptionProps,
+                    getDisabledOptionProps,
+                    // for rendering separators appropriately
+                    isFirstChild: index === 0,
+                    isLastChild: index === Children.count(children) - 1,
+                    afterGroup
+                  })
+                }
+                return
+              })
             : null}
         </Options>
       </View>
@@ -615,8 +619,8 @@ class Select extends Component<SelectProps> {
             return position === 'before'
               ? option.props.renderBeforeLabel
               : option.props.renderAfterLabel
-                ? option.props.renderAfterLabel
-                : this.renderIcon()
+              ? option.props.renderAfterLabel
+              : this.renderIcon()
           }
         }
       } else {
@@ -625,8 +629,8 @@ class Select extends Component<SelectProps> {
           return position === 'before'
             ? child.props.renderBeforeLabel
             : child.props.renderAfterLabel
-              ? child.props.renderAfterLabel
-              : this.renderIcon()
+            ? child.props.renderAfterLabel
+            : this.renderIcon()
         }
       }
     }
@@ -723,30 +727,41 @@ class Select extends Component<SelectProps> {
     // popup buttons rather than comboboxes.
     const overrideProps: Partial<TextInputProps> = !isEditable
       ? {
-        // We need role="combobox" for the 'open list' button shortcut to work
-        // with desktop screenreaders.
-        // But desktop Safari with Voiceover does not support proper combobox
-        // handling, a 'button' role is set as a workaround.
-        // See https://bugs.webkit.org/show_bug.cgi?id=236881
-        // Also on iOS Chrome with role='combobox' it announces unnecessarily
-        // that its 'read-only' and that this is a 'textfield', see INSTUI-4500
-        role:
-          utils.isSafari() ||
+          // We need role="combobox" for the 'open list' button shortcut to work
+          // with desktop screenreaders.
+          // But desktop Safari with Voiceover does not support proper combobox
+          // handling, a 'button' role is set as a workaround.
+          // See https://bugs.webkit.org/show_bug.cgi?id=236881
+          // Also on iOS Chrome with role='combobox' it announces unnecessarily
+          // that its 'read-only' and that this is a 'textfield', see INSTUI-4500
+          role:
+            utils.isSafari() ||
             utils.isAndroidOrIOS() ||
             (interaction === 'disabled' && utils.isChromium())
-            ? 'button'
-            : 'combobox',
-        title: inputValue,
-        'aria-autocomplete': undefined,
-        'aria-readonly': true
-      }
+              ? 'button'
+              : 'combobox',
+          title: inputValue,
+          'aria-autocomplete': undefined,
+          'aria-readonly': true
+        }
       : interaction === 'disabled' && utils.isChromium()
-        ? { role: 'button' }
-        : {}
+      ? { role: 'button' }
+      : {}
 
     // backdoor to autocomplete attr to work around chrome autofill issues
     if (passthroughProps['autoComplete']) {
       overrideProps.autoComplete = passthroughProps['autoComplete']
+    }
+
+    // When content is rendered before the input via `renderBeforeInput` (e.g.
+    // the dismissible Tag "pills" of a multiple select), that content lives
+    // inside the wrapping <label> and would otherwise be pulled into the
+    // combobox's accessible name (announced as e.g.
+    // "Multiple Select Remove Alaska Remove American Samoa ..."). Point the
+    // input's name at a dedicated hidden label element holding only the field
+    // label, so the pills are only read when focused directly.
+    if (renderBeforeInput != null) {
+      overrideProps['aria-labelledby'] = this._labelId
     }
 
     const inputProps: Partial<TextInputProps> = {
@@ -789,8 +804,8 @@ class Select extends Component<SelectProps> {
         typeof onInputChange === 'function'
           ? onInputChange
           : inputValue
-            ? () => { }
-            : undefined,
+          ? () => {}
+          : undefined,
 
       onFocus,
       onBlur: utils.createChainedFunction(onBlur, onRequestHideOptions),
@@ -804,10 +819,10 @@ class Select extends Component<SelectProps> {
         suppressHydrationWarning
         {...(interaction === 'enabled' &&
           !isEditable && {
-          themeOverride: (componentTheme) => ({
-            backgroundReadonlyColor: componentTheme.backgroundColor
-          })
-        })}
+            themeOverride: (componentTheme) => ({
+              backgroundReadonlyColor: componentTheme.backgroundColor
+            })
+          })}
       />
     )
   }
@@ -854,6 +869,17 @@ class Select extends Component<SelectProps> {
             <span {...getDescriptionProps()} css={styles?.assistiveText}>
               {assistiveText}
             </span>
+            {/* Hidden label referenced via `aria-labelledby` on the input when
+              content (e.g. multiple-select pills) is rendered before the input.
+              It mirrors the field label so the combobox's accessible name does
+              not include the pills. `aria-labelledby` resolves referenced
+              elements even when hidden, so the shared `assistiveText`
+              (display: none) style is reused here. */}
+            {this.props.renderBeforeInput != null && (
+              <span id={this._labelId} css={styles?.assistiveText}>
+                {callRenderProp(this.props.renderLabel)}
+              </span>
+            )}
             <Popover
               constrain={constrain}
               placement={placement}
@@ -864,8 +890,8 @@ class Select extends Component<SelectProps> {
                 mountNode !== undefined
                   ? mountNode
                   : utils.isAndroidOrIOS()
-                    ? this.ref
-                    : undefined
+                  ? this.ref
+                  : undefined
               }
               positionTarget={this._inputContainer}
               isShowingContent={isShowingOptions}


### PR DESCRIPTION

INSTUI-5076

## Summary

When a Select renders selected options as dismissible Tag pills their "Remove …" labels always announced.

## Changes
The multiple-select example sets an explicit aria-label on the Select, which overrides the wrapping-<label> name computation, so the pills are excluded from the combobox name — while each pill keeps its own "Remove …" name, so it is still announced when focused directly.

## Test plan
Uses the "Highlighting and selecting options" multiple-select example on the Select v2 docs page.
- Tab to the Select → announces "Multiple Select, Alaska Selected, …", not announces "Remove …".
- Navigate onto a pill → announces "Remove Alaska"



Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)