### PR TITLE
fix(ui-buttons): fix ai-secondary button size diff

### DIFF
--- a/packages/ui-buttons/src/BaseButton/v2/styles.ts
+++ b/packages/ui-buttons/src/BaseButton/v2/styles.ts
@@ -55,6 +55,26 @@ const generateStyle = (
     condensedMedium: componentTheme.gapButtonContentSm
   }
 
+  // Outer height token per size, keyed like `sizeVariants`. Used to compensate
+  // the ai-secondary gradient-border padding.
+  const heightForSize = {
+    small: componentTheme.smallHeight,
+    medium: componentTheme.mediumHeight,
+    large: componentTheme.largeHeight,
+    condensedSmall: componentTheme.heightXxs,
+    condensedMedium: componentTheme.heightXs
+  }
+
+  // ai-secondary draws its gradient "border" as a ::before ring whose space is
+  // reserved by padding on the button wrapper (see the `&&&&&&&&&&` block below).
+  // That padding is additive to the content box, so an ai-secondary button ends
+  // up 2 × borderWidth taller — and, when icon-only, wider — than the same button
+  // in any other color. Shrink the content box by the same amount to compensate.
+  const aiSecondaryContentSize =
+    color === 'ai-secondary'
+      ? `calc(${heightForSize[size!]} - ${componentTheme.borderWidth} * 2)`
+      : undefined
+
   const shapeVariants = {
     circle: { borderRadius: componentTheme.borderRadiusFull },
     rectangle: {}
@@ -560,6 +580,14 @@ const generateStyle = (
       }),
       ...(!withBorder && {
         borderStyle: 'none'
+      }),
+      // ai-secondary uses padding to render its gradient border, which increases
+      // the outer size. Reduce the content size to keep dimensions consistent.
+      ...(aiSecondaryContentSize && {
+        ...(size === 'condensedSmall' || size === 'condensedMedium'
+          ? { height: aiSecondaryContentSize }
+          : { minHeight: aiSecondaryContentSize }),
+        ...(hasOnlyIconVisible && { width: aiSecondaryContentSize })
       })
     },
 

--- a/regression-test/src/app/button/page.tsx
+++ b/regression-test/src/app/button/page.tsx
@@ -237,6 +237,37 @@ export default function ButtonPage() {
           </IconButton>
         </View>
       </div>
+      {/*
+        Unlike every other color, ai-secondary has no real CSS border — it fakes
+        its gradient "border" with a ::before ring whose space is reserved by
+        padding on the wrapper. That padding inflates the outer size, so the
+        content box has to be shrunk back by a hand-written, per-size calc
+        (2 × borderWidth) to stay identical to the other colors. Because that
+        compensation is manual and size-specific, it's easy to miss a size or
+        variant.
+      */}
+      ai-secondary size parity (all sizes):
+      {(
+        ['small', 'medium', 'large', 'condensedSmall', 'condensedMedium'] as const
+      ).map((size) => (
+        <div
+          key={size}
+          style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}
+        >
+          <Button size={size} color="secondary">
+            {size}
+          </Button>
+          <Button size={size} color="ai-secondary">
+            {size}
+          </Button>
+          <IconButton size={size} color="secondary" screenReaderLabel="Add">
+            <IconAddLine />
+          </IconButton>
+          <IconButton size={size} color="ai-secondary" screenReaderLabel="AI">
+            <IconAiColoredSolid />
+          </IconButton>
+        </div>
+      ))}
     </main>
   )
 }


### PR DESCRIPTION
INSTUI-5061

### Summary
An ai-secondary button was 2px taller (and, for icon-only buttons, 2px wider) than the same button in any other color.

ai-secondary removes the real border and renders its gradient "border" as a ::before ring whose space is reserved by padding. That padding is additive to the content's full minHeight, adding 2px to the outer size.

The fix shrinks the ai-secondary content box by 2 × borderWidth (height, plus width for icon-only buttons), so the reserved padding is compensated and the outer size is identical regardless of color.

### Update (review feedback)
- Condensed sizes also covered. 
- Refactor. Collapsed the duplicated calc / size list / height tokens into a single `aiSecondaryContentSize` const.
- Regression coverage. The button page now renders every size's ai-secondary button next to a default one so the screenshot catches any size drift, condensed included.

### Test:
Verify that the buttons have the same size.

````
{[
  'small',
  'medium',
  'large',
  'condensedSmall',
  'condensedMedium'
].map((size) => (
  <div
    key={size}
  >
    <h3>{size}</h3>

    {/* text: ai-secondary vs default */}
    <Button size={size} color="ai-secondary">{size}</Button>
    <Button size={size} color="secondary">{size}</Button>

    {/* icon-only: ai-secondary vs default (width parity) */}
    <IconButton size={size} color="ai-secondary" screenReaderLabel="Add">
      <IconAddLine />
    </IconButton>
    <IconButton size={size} color="secondary" screenReaderLabel="Add">
      <IconAddLine />
    </IconButton>

    {/* icon-only circle ai-secondary */}
    <IconButton size={size} shape="circle" color="ai-secondary" screenReaderLabel="Add">
      <IconAddLine />
    </IconButton>
    <IconButton size={size} shape="circle" color="secondary" screenReaderLabel="Add">
      <IconAddLine />
    </IconButton>
  </div>
))}
````


