### PR TITLE
fix(ui-motion,ui-alerts): capture child DOM via elementRef in Transition to avoid React 'ref is not a prop' warning

### DIFF
--- a/packages/ui-alerts/src/Alert/v1/index.tsx
+++ b/packages/ui-alerts/src/Alert/v1/index.tsx
@@ -99,6 +99,10 @@ class Alert extends Component<AlertProps, AlertState> {
 
   handleRef = (el: Element | null) => {
     this.ref = el
+    const { elementRef } = this.props
+    if (typeof elementRef === 'function') {
+      elementRef(el)
+    }
   }
 
   handleTimeout = () => {

--- a/packages/ui-alerts/src/Alert/v1/props.ts
+++ b/packages/ui-alerts/src/Alert/v1/props.ts
@@ -109,6 +109,11 @@ type AlertOwnProps = {
    * An icon, or function that returns an icon. Setting it will override the variant's icon.
    */
   renderCustomIcon?: Renderable
+
+  /**
+   * provides a reference to the underlying html root element
+   */
+  elementRef?: (element: Element | null) => void
 }
 
 type PropKeys = keyof AlertOwnProps
@@ -137,7 +142,8 @@ const allowedProps: AllowedPropKeys = [
   'transition',
   'open',
   'hasShadow',
-  'renderCustomIcon'
+  'renderCustomIcon',
+  'elementRef'
 ]
 
 type AlertState = {

--- a/packages/ui-alerts/src/Alert/v2/index.tsx
+++ b/packages/ui-alerts/src/Alert/v2/index.tsx
@@ -98,6 +98,10 @@ class Alert extends Component<AlertProps, AlertState> {
 
   handleRef = (el: Element | null) => {
     this.ref = el
+    const { elementRef } = this.props
+    if (typeof elementRef === 'function') {
+      elementRef(el)
+    }
   }
 
   handleTimeout = () => {

--- a/packages/ui-alerts/src/Alert/v2/props.ts
+++ b/packages/ui-alerts/src/Alert/v2/props.ts
@@ -110,6 +110,11 @@ type AlertOwnProps = {
    * An icon, or function that returns an icon. Setting it will override the variant's icon.
    */
   renderCustomIcon?: Renderable
+
+  /**
+   * provides a reference to the underlying html root element
+   */
+  elementRef?: (element: Element | null) => void
 }
 
 type PropKeys = keyof AlertOwnProps
@@ -138,7 +143,8 @@ const allowedProps: AllowedPropKeys = [
   'transition',
   'open',
   'hasShadow',
-  'renderCustomIcon'
+  'renderCustomIcon',
+  'elementRef'
 ]
 
 type AlertState = {

--- a/packages/ui-motion/src/Transition/BaseTransition/index.ts
+++ b/packages/ui-motion/src/Transition/BaseTransition/index.ts
@@ -22,13 +22,14 @@
  * SOFTWARE.
  */
 
-import { Component, ReactElement } from 'react'
+import { Component, ReactElement, ReactInstance } from 'react'
 
 import { getClassList, findDOMNode } from '@instructure/ui-dom-utils'
 import {
   ensureSingleChild,
   safeCloneElement
 } from '@instructure/ui-react-utils'
+import { createChainedFunction } from '@instructure/ui-utils'
 
 import { allowedProps } from './props.js'
 import type {
@@ -334,19 +335,43 @@ class BaseTransition extends Component<
   }
 
   renderChildren() {
-    return this.props.children
-      ? safeCloneElement(
-          ensureSingleChild(this.props.children) as ReactElement,
-          {
-            'aria-hidden': !this.props.in ? true : undefined,
-            ref: (el: React.ReactInstance | null) => {
-              const ref = (findDOMNode(el) as Element) || null
+    if (!this.props.children) {
+      return null
+    }
 
-              this.handleRef(ref)
-            }
+    const child = ensureSingleChild(this.props.children) as ReactElement
+
+    const elementOnlyRef = (el: ReactInstance | Element | null) => {
+      if (el instanceof Element) {
+        this.handleRef(el)
+      }
+    }
+
+    // `typeof type === 'object'` => forwardRef wrapper (withStyle-decorated InstUI components)
+    const refProps =
+      typeof child.type === 'object'
+        ? {
+            // chain so the child's own elementRef still fires instead of being overwritten
+            elementRef: createChainedFunction(
+              (child.props as { elementRef?: (el: Element | null) => void })
+                ?.elementRef,
+              this.handleRef
+            ),
+            // fallback for forwardRef children that expose their node via `ref`, not elementRef
+            ref: elementOnlyRef
           }
-        )
-      : null
+        : {
+            // for host el / plain class|fn: findDOMNode is the fallback
+            ref: (el: ReactInstance | Element | null) =>
+              this.handleRef(
+                el instanceof Element ? el : (findDOMNode(el) as Element) ?? null
+              )
+          }
+
+    return safeCloneElement(child, {
+      'aria-hidden': !this.props.in ? true : undefined,
+      ...refProps
+    })
   }
 
   render() {


### PR DESCRIPTION
## Summary
- `BaseTransition` now captures the child DOM node by branching on `typeof child.type`: forwardRef/withStyle children go through the `elementRef` convention (chained so a consumer `elementRef` still fires), so React no longer reads `ref` as a prop and stops warning.
- Host elements and plain class/fn children keep a `ref` callback with `findDOMNode` as the last-resort fallback.


## How it works (reviewer guide)

The lifecycle is unchanged — only *how* `this.ref` (the child's DOM node) gets captured in `renderChildren()` changed. Everything downstream still needs a real DOM `Element` by the time `transition()` runs:

```
render() -> renderChildren()          [clone child + attach ref-capture]
        |
        v
  React attaches ref/elementRef -> handleRef(el) -> this.ref = <DOM node>
        |                                            + chains consumer elementRef
        v
  componentDidMount() -> startTransition() -> transition()
        |                                          |
        +-------- getClassList(this.ref) <---------+   [needs a real Element here]
```

The one changed decision — how the node is captured, keyed on `typeof child.type`:

```
                 ensureSingleChild(children)
                            |
              typeof child.type === 'object' ?
                            |
        YES (forwardRef / withStyle)          NO (host "div" / plain class|fn)
                    |                                       |
   elementRef: chain(child.elementRef,        ref: (el) =>
                     handleRef)                  el instanceof Element
     (primary: InstUI convention;                 ? el
      NOT reading child's `ref` =>                 : findDOMNode(el)   <- last-resort
      no "ref is not a prop" warning)                                     legacy fallback
   ref: elementOnlyRef                                    |
     (fallback for forwardRef kids that                   v
      expose the node via `ref`, not               handleRef(el)
      elementRef; keeps Element only)
                    |
                    v
              handleRef(el) -> this.ref
```


## Reproduction

Confirmed on this repo's **React 18.3.1** (captured `console.error` in a scratch test, run against master's `BaseTransition` vs this branch):

| Transition child | master | this PR |
|---|---|---|
| real `withStyle` InstUI component (`View`, `Alert` content, …) | `` `ref` is not a prop `` warning | none |
| bare host `<div>` / plain `forwardRef` | none | none |

Two conditions are both required — a static host child, or a mount that never runs a transition, will **not** show it:
1. The child is a real InstUI (`withStyle`-wrapped) component, so `safeCloneElement` re-clones it.
2. A transition actually runs — mount with `in={false}`, or toggle `in` (a static `in={true}` mount with `transitionOnMount={false}` won't).

```tsx
import { useState } from 'react'
import { Transition } from '@instructure/ui-motion'
import { Alert } from '@instructure/ui-alerts'

function Repro() {
  const [open, setOpen] = useState(true)
  const [mounted, setMounted] = useState(true)

  const dismiss = () => {
    setOpen(false)                          // starts the exit transition
    setTimeout(() => setMounted(false), 500) // then actually unmounts it
  }

  if (!mounted) return null

  return (
    <Transition in={open} type="fade" transitionOnMount>
      <Alert variant="success" renderCloseButtonLabel="Close" onDismiss={dismiss}>
        Watch the console after dismissing
      </Alert>
    </Transition>
  )
}

```

On master, initiating the transition logs ``Warning: … `ref` is not a prop. Trying to access it will result in `undefined` being returned.``; with this PR the warning is gone and the transition still animates.

## Test Plan
- Reproduce per the snippet above and confirm the `` `ref` is not a prop `` warning is gone after the change (needs a `withStyle` child + an actually-run transition).
- Confirm animations still play for InstUI children (elementRef path) and host-element children (ref path).

Fixes LX-4014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

