### PR TITLE
fix(pkg-utils): make named exports detectable by cjs-module-lexer

### DIFF
--- a/packages/pkg-utils/lib/index.js
+++ b/packages/pkg-utils/lib/index.js
@@ -28,11 +28,18 @@ const {
   getPackageJSON,
   getPackagePath
 } = require('./get-package')
+// Keep these `require`s out of the `module.exports` object literal below.
+// Inline `require()` calls in the literal defeat cjs-module-lexer's static
+// analysis, so ESM consumers doing `import * as pkgUtils` only see the first
+// export and get `undefined` for the rest (e.g. getPackageJSON).
+const getPackages = require('./get-packages')
+const getChangedPackages = require('./get-changed-packages')
+const readPkgUp = require('read-pkg-up')
 
 module.exports = {
-  getPackages: require('./get-packages'),
-  getChangedPackages: require('./get-changed-packages'),
-  readPkgUp: require('read-pkg-up'),
+  getPackages,
+  getChangedPackages,
+  readPkgUp,
   readPkg: getPackageJSON,
   readPackage,
   getPackage,


### PR DESCRIPTION
## Summary
- Hoist the inline `require()` calls out of `pkg-utils`'s `module.exports` object literal so all named exports are statically detectable by `cjs-module-lexer`.
- Fixes the release failure where `ui-scripts` (ESM/TS since #2578) saw `undefined` for `getPackageJSON`/`getPackage`/`getChangedPackages` via `import * as pkgUtils`, breaking publish/bump/tag/deprecate.

## Test Plan
- Re-run the npm release job — the failed run never published, so a manual release re-run is needed after merge.

Fixes INSTUI-5086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
