### PR TITLE
fix(ui-a11y-content): prevent ScreenReaderContent text from being copied

### DIFF
--- a/packages/ui-a11y-content/src/ScreenReaderContent/__tests__/ScreenReaderContent.test.tsx
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/__tests__/ScreenReaderContent.test.tsx
@@ -51,4 +51,13 @@ describe('<ScreenReaderContent />', () => {
 
     expect(children).toBeInTheDocument()
   })
+
+  it('should not be selectable so its text is excluded from clipboard copies', async () => {
+    render(
+      <ScreenReaderContent data-testid="src">hidden text</ScreenReaderContent>
+    )
+    const screenReaderContent = screen.getByTestId('src')
+
+    expect(screenReaderContent).toHaveStyle({ userSelect: 'none' })
+  })
 })

--- a/packages/ui-a11y-content/src/ScreenReaderContent/styles.ts
+++ b/packages/ui-a11y-content/src/ScreenReaderContent/styles.ts
@@ -45,7 +45,8 @@ const generateStyle = (): ScreenReaderContentStyle => {
       whiteSpace: 'nowrap',
       overflow: 'hidden !important',
       clip: 'rect(0 0 0 0) !important',
-      border: '0 !important'
+      border: '0 !important',
+      userSelect: 'none'
     }
   }
 }


### PR DESCRIPTION

## Summary
ScreenReaderContent uses the visually-hidden CSS technique. Selecting surrounding text and copying it pulled the hidden text into the clipboard.

## Changes
Add user-select: none so the hidden text is excluded from selection and copies.

## Test plan
Ensure that copied text not containing screen reader content

```
<div>
  visi
  <ScreenReaderContent>
    This content is not visible.
  </ScreenReaderContent>
  ble
</div>
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)