### PR TITLE
fix(many): keep form field messages out of the control's accessible name

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -289,5 +289,35 @@ describe('<Checkbox />', () => {
 
       expect(axeCheck).toBe(true)
     })
+
+    it('associates messages with the checkbox as its description, not its accessible name', async () => {
+      render(
+        <Checkbox
+          label="Accept terms"
+          value="v"
+          messages={[{ type: 'error', text: 'You must accept' }]}
+        />
+      )
+      const input = screen.getByRole('checkbox')
+
+      const describedById = input.getAttribute('aria-describedby')
+      expect(describedById).toBeTruthy()
+      expect(document.getElementById(describedById!)).toHaveTextContent(
+        'You must accept'
+      )
+
+      const labelledById = input.getAttribute('aria-labelledby')
+      expect(labelledById).toBeTruthy()
+      const labelEl = document.getElementById(labelledById!)
+      expect(labelEl).toHaveTextContent('Accept terms')
+      expect(labelEl).not.toHaveTextContent('You must accept')
+    })
+
+    it('does not set aria-labelledby when there are no messages', async () => {
+      render(<Checkbox label="Accept terms" value="v" />)
+      const input = screen.getByRole('checkbox')
+
+      expect(input).not.toHaveAttribute('aria-labelledby')
+    })
   })
 })

--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -84,8 +84,12 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     }
 
     this._defaultId = props.deterministicId!()
+    this._messagesId = props.deterministicId!('Checkbox-messages')
+    this._labelId = props.deterministicId!('Checkbox-label')
   }
   private readonly _defaultId: string
+  private readonly _messagesId: string
+  private readonly _labelId: string
   private _input: HTMLInputElement | null = null
 
   ref: Element | null = null
@@ -186,6 +190,10 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     )
   }
 
+  get hasMessages() {
+    return !!this.props.messages && this.props.messages.length > 0
+  }
+
   get invalid() {
     return !!this.props.messages?.find(
       (m) => m.type === 'newError' || m.type === 'error'
@@ -217,6 +225,24 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
       `[Checkbox] The \`simple\` variant does not support the \`labelPlacement\` property.  Use the \`toggle\` variant instead.`
     )
 
+    // The label text gets its own id so that, when there are messages, the
+    // input's accessible name can point at the label only (via
+    // `aria-labelledby`) instead of also including the message text.
+    const labelContent = (
+      <span id={this._labelId}>
+        {label}
+        {isRequired && label && (
+          <span
+            css={this.invalid ? styles?.requiredInvalid : {}}
+            aria-hidden={true}
+          >
+            {' '}
+            *
+          </span>
+        )}
+      </span>
+    )
+
     if (variant === 'toggle') {
       return (
         <ToggleFacade
@@ -232,16 +258,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
           themeOverride={themeOverride}
           invalid={this.invalid}
         >
-          {label}
-          {isRequired && label && (
-            <span
-              css={this.invalid ? styles?.requiredInvalid : {}}
-              aria-hidden={true}
-            >
-              {' '}
-              *
-            </span>
-          )}
+          {labelContent}
         </ToggleFacade>
       )
     } else {
@@ -257,16 +274,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
           themeOverride={themeOverride}
           invalid={this.invalid}
         >
-          {label}
-          {isRequired && label && (
-            <span
-              css={this.invalid ? styles?.requiredInvalid : {}}
-              aria-hidden={true}
-            >
-              {' '}
-              *
-            </span>
-          )}
+          {labelContent}
         </CheckboxFacade>
       )
     }
@@ -286,7 +294,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             : styles?.indentedError)
         }
       >
-        <FormFieldMessages messages={messages} />
+        <FormFieldMessages id={this._messagesId} messages={messages} />
       </View>
     ) : null
   }
@@ -338,6 +346,24 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             aria-readonly={readOnly ? true : undefined}
             aria-checked={indeterminate ? 'mixed' : undefined}
             aria-invalid={this.invalid ? 'true' : undefined}
+            // Keep messages in the description so the accessible name contains only the label.
+            aria-labelledby={
+              this.hasMessages
+                ? ((props as Record<string, unknown>)[
+                    'aria-labelledby'
+                  ] as string) || this._labelId
+                : ((props as Record<string, unknown>)['aria-labelledby'] as
+                    | string
+                    | undefined)
+            }
+            aria-describedby={
+              [
+                (props as Record<string, unknown>)['aria-describedby'],
+                this.hasMessages ? this._messagesId : null
+              ]
+                .filter(Boolean)
+                .join(' ') || undefined
+            }
             css={styles?.input}
             onClickCapture={(e) => {
               if (readOnly) {

--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -349,16 +349,12 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             // Keep messages in the description so the accessible name contains only the label.
             aria-labelledby={
               this.hasMessages
-                ? ((props as Record<string, unknown>)[
-                    'aria-labelledby'
-                  ] as string) || this._labelId
-                : ((props as Record<string, unknown>)['aria-labelledby'] as
-                    | string
-                    | undefined)
+                ? props['aria-labelledby'] || this._labelId
+                : props['aria-labelledby']
             }
             aria-describedby={
               [
-                (props as Record<string, unknown>)['aria-describedby'],
+                props['aria-describedby'],
                 this.hasMessages ? this._messagesId : null
               ]
                 .filter(Boolean)

--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -225,9 +225,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
       `[Checkbox] The \`simple\` variant does not support the \`labelPlacement\` property.  Use the \`toggle\` variant instead.`
     )
 
-    // The label text gets its own id so that, when there are messages, the
-    // input's accessible name can point at the label only (via
-    // `aria-labelledby`) instead of also including the message text.
+    // Give the label its own id so messages stay out of the accessible name.
     const labelContent = (
       <span id={this._labelId}>
         {label}

--- a/packages/ui-form-field/src/FormField/v2/props.ts
+++ b/packages/ui-form-field/src/FormField/v2/props.ts
@@ -46,6 +46,11 @@ type FormFieldOwnProps = {
    * id for the form field messages
    */
   messagesId?: string
+  /**
+   * id for the label element, so a single form control can reference just the
+   * label text via `aria-labelledby` (keeping messages out of its accessible name)
+   */
+  labelId?: string
   children?: React.ReactNode
   inline?: boolean
   layout?: 'stacked' | 'inline'
@@ -86,6 +91,7 @@ const allowedProps: AllowedPropKeys = [
   'id',
   'messages',
   'messagesId',
+  'labelId',
   'children',
   'inline',
   'layout',

--- a/packages/ui-form-field/src/FormFieldLayout/v2/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/v2/index.tsx
@@ -48,6 +48,7 @@ const FormFieldLayout = forwardRef<Element, FormFieldLayoutProps>(
       label,
       messages,
       messagesId: messagesIdProp,
+      labelId: labelIdProp,
       children,
       width,
       elementRef,
@@ -69,7 +70,12 @@ const FormFieldLayout = forwardRef<Element, FormFieldLayoutProps>(
     }, [])
 
     const messagesId = messagesIdProp || deterministicId
-    const labelId = deterministicId ? `${deterministicId}-Label` : undefined
+    // The label element gets an id so that single form controls can point their
+    // `aria-labelledby` at the label text only. This keeps `messages` (which
+    // live inside the wrapping <label>) out of the control's accessible name
+    // while preserving the native click-on-label focus behavior.
+    const labelId =
+      labelIdProp || (deterministicId ? `${deterministicId}-Label` : undefined)
 
     // Filter out error and success messages when disabled or readOnly
     const filteredMessages =
@@ -183,7 +189,13 @@ const FormFieldLayout = forwardRef<Element, FormFieldLayoutProps>(
             </legend>
           )
         }
-        return <span css={styles?.formFieldLabel}>{labelContent}</span>
+        // `id` lets single form controls reference just the label text via
+        // `aria-labelledby`, keeping `messages` out of their accessible name.
+        return (
+          <span css={styles?.formFieldLabel} id={labelId}>
+            {labelContent}
+          </span>
+        )
       } else if (label) {
         if (ElementType === 'fieldset') {
           return (

--- a/packages/ui-form-field/src/FormFieldLayout/v2/index.tsx
+++ b/packages/ui-form-field/src/FormFieldLayout/v2/index.tsx
@@ -70,10 +70,8 @@ const FormFieldLayout = forwardRef<Element, FormFieldLayoutProps>(
     }, [])
 
     const messagesId = messagesIdProp || deterministicId
-    // The label element gets an id so that single form controls can point their
-    // `aria-labelledby` at the label text only. This keeps `messages` (which
-    // live inside the wrapping <label>) out of the control's accessible name
-    // while preserving the native click-on-label focus behavior.
+    // Give the label an id so controls can reference only the label text via
+    // `aria-labelledby`, keeping messages out of the accessible name.
     const labelId =
       labelIdProp || (deterministicId ? `${deterministicId}-Label` : undefined)
 
@@ -189,8 +187,6 @@ const FormFieldLayout = forwardRef<Element, FormFieldLayoutProps>(
             </legend>
           )
         }
-        // `id` lets single form controls reference just the label text via
-        // `aria-labelledby`, keeping `messages` out of their accessible name.
         return (
           <span css={styles?.formFieldLabel} id={labelId}>
             {labelContent}

--- a/packages/ui-form-field/src/FormFieldLayout/v2/props.ts
+++ b/packages/ui-form-field/src/FormFieldLayout/v2/props.ts
@@ -56,6 +56,11 @@ type FormFieldLayoutOwnProps = {
    * id for the form field messages
    */
   messagesId?: string
+  /**
+   * id for the label element, so a single form control can reference just the
+   * label text via `aria-labelledby` (keeping messages out of its accessible name)
+   */
+  labelId?: string
   children?: React.ReactNode
   /**
    * If `true` use an inline layout -- content will flow on the left/right side
@@ -129,6 +134,7 @@ const allowedProps: AllowedPropKeys = [
   'as',
   'messages',
   'messagesId',
+  'labelId',
   'children',
   'inline',
   'layout',

--- a/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
@@ -304,4 +304,33 @@ describe('<NumberInput />', () => {
       expect(onDecrement).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('associates messages with the input as its description, not its accessible name', async () => {
+    render(
+      <NumberInput
+        renderLabel="Label"
+        messages={[{ type: 'error', text: 'some error message' }]}
+      />
+    )
+    const input = screen.getByRole('spinbutton')
+
+    const describedById = input.getAttribute('aria-describedby')
+    expect(describedById).toBeTruthy()
+    expect(document.getElementById(describedById!)).toHaveTextContent(
+      'some error message'
+    )
+
+    const labelledById = input.getAttribute('aria-labelledby')
+    expect(labelledById).toBeTruthy()
+    const labelEl = document.getElementById(labelledById!)
+    expect(labelEl).toHaveTextContent('Label')
+    expect(labelEl).not.toHaveTextContent('some error message')
+  })
+
+  it('does not override the accessible name with aria-labelledby when there are no messages', async () => {
+    render(<NumberInput renderLabel="Label" />)
+    const input = screen.getByRole('spinbutton')
+
+    expect(input).not.toHaveAttribute('aria-labelledby')
+  })
 })

--- a/packages/ui-number-input/src/NumberInput/v2/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/v2/index.tsx
@@ -124,7 +124,9 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
     // via `aria-describedby` and point the accessible name at the label text
     // only via `aria-labelledby`, so the messages are announced as a
     // description rather than as part of the control's name.
-    const hasMessages = !!messages && messages.length > 0
+    // Only when a message actually renders (has text); FormField skips
+    // empty-text messages, so otherwise aria-describedby would dangle.
+    const hasMessages = !!messages?.some((m) => !!m.text)
     const messagesId = id ? `${id}-messages` : undefined
     const labelId = id ? `${id}-label` : undefined
 
@@ -328,7 +330,9 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
 
     const label = callRenderProp(renderLabel)
 
-    const passedProps = passthroughProps(rest)
+    // `passthroughProps` is typed with `unknown` values; widen once here so the
+    // aria-* reads below don't each need a cast.
+    const passedProps = passthroughProps(rest) as Record<string, any>
 
     // Don't render until we have an ID
     if (!id) {
@@ -366,8 +370,8 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
               }
               aria-labelledby={
                 hasMessages
-                  ? (passedProps['aria-labelledby'] as string) || labelId
-                  : (passedProps['aria-labelledby'] as string | undefined)
+                  ? passedProps['aria-labelledby'] || labelId
+                  : passedProps['aria-labelledby']
               }
               id={id}
               type={allowStringValue ? 'text' : 'number'}

--- a/packages/ui-number-input/src/NumberInput/v2/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/v2/index.tsx
@@ -120,6 +120,14 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
     const success =
       !!messages && messages.some((message) => message.type === 'success')
 
+    // Messages live inside the wrapping <label>. Reference them from the input
+    // via `aria-describedby` and point the accessible name at the label text
+    // only via `aria-labelledby`, so the messages are announced as a
+    // description rather than as part of the control's name.
+    const hasMessages = !!messages && messages.length > 0
+    const messagesId = id ? `${id}-messages` : undefined
+    const labelId = id ? `${id}-label` : undefined
+
     const interaction = getInteraction({ props })
     if (
       interaction === 'disabled' &&
@@ -331,6 +339,8 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
       <FormField
         {...pickProps(props, FormField.allowedProps)}
         label={label}
+        messagesId={messagesId}
+        labelId={labelId}
         inline={display === 'inline-block'}
         id={id}
         elementRef={handleRef}
@@ -346,6 +356,19 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
               {...passedProps}
               css={styles?.input}
               aria-invalid={invalid ? 'true' : undefined}
+              aria-describedby={
+                [
+                  passedProps['aria-describedby'],
+                  hasMessages ? messagesId : null
+                ]
+                  .filter(Boolean)
+                  .join(' ') || undefined
+              }
+              aria-labelledby={
+                hasMessages
+                  ? (passedProps['aria-labelledby'] as string) || labelId
+                  : (passedProps['aria-labelledby'] as string | undefined)
+              }
               id={id}
               type={allowStringValue ? 'text' : 'number'}
               inputMode={inputMode}

--- a/packages/ui-number-input/src/NumberInput/v2/index.tsx
+++ b/packages/ui-number-input/src/NumberInput/v2/index.tsx
@@ -120,12 +120,6 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
     const success =
       !!messages && messages.some((message) => message.type === 'success')
 
-    // Messages live inside the wrapping <label>. Reference them from the input
-    // via `aria-describedby` and point the accessible name at the label text
-    // only via `aria-labelledby`, so the messages are announced as a
-    // description rather than as part of the control's name.
-    // Only when a message actually renders (has text); FormField skips
-    // empty-text messages, so otherwise aria-describedby would dangle.
     const hasMessages = !!messages?.some((m) => !!m.text)
     const messagesId = id ? `${id}-messages` : undefined
     const labelId = id ? `${id}-label` : undefined
@@ -330,8 +324,6 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
 
     const label = callRenderProp(renderLabel)
 
-    // `passthroughProps` is typed with `unknown` values; widen once here so the
-    // aria-* reads below don't each need a cast.
     const passedProps = passthroughProps(rest) as Record<string, any>
 
     // Don't render until we have an ID
@@ -360,6 +352,7 @@ const NumberInput = forwardRef<NumberInputHandle, NumberInputProps>(
               {...passedProps}
               css={styles?.input}
               aria-invalid={invalid ? 'true' : undefined}
+              // Keep messages in the description so the accessible name contains only the label.
               aria-describedby={
                 [
                   passedProps['aria-describedby'],

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
@@ -211,6 +211,41 @@ describe('<RangeInput />', () => {
       expect(axeCheck).toBe(true)
     })
 
+    it('associates messages with the input as its description, not its accessible name', async () => {
+      const { container } = render(
+        <RangeInput
+          label="Opacity"
+          name="opacity"
+          max={100}
+          min={0}
+          defaultValue={50}
+          messages={[{ type: 'error', text: 'some error message' }]}
+        />
+      )
+      const input = container.querySelector('input')!
+
+      const describedById = input.getAttribute('aria-describedby')
+      expect(describedById).toBeTruthy()
+      expect(document.getElementById(describedById!)).toHaveTextContent(
+        'some error message'
+      )
+
+      const labelledById = input.getAttribute('aria-labelledby')
+      expect(labelledById).toBeTruthy()
+      const labelEl = document.getElementById(labelledById!)
+      expect(labelEl).toHaveTextContent('Opacity')
+      expect(labelEl).not.toHaveTextContent('some error message')
+    })
+
+    it('does not override the accessible name with aria-labelledby when there are no messages', async () => {
+      const { container } = render(
+        <RangeInput label="Opacity" name="opacity" max={100} min={0} />
+      )
+      const input = container.querySelector('input')!
+
+      expect(input).not.toHaveAttribute('aria-labelledby')
+    })
+
     it('formats the aria-valuetext attribute', async () => {
       const { container } = render(
         <RangeInput

--- a/packages/ui-range-input/src/RangeInput/v2/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/v2/index.tsx
@@ -186,16 +186,15 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
   render() {
     const { formatValue, disabled, readOnly, messages } = this.props
 
-    const props = omitProps(this.props, RangeInput.allowedProps) as Record<
-      string,
-      unknown
-    >
+    const props = omitProps(this.props, RangeInput.allowedProps)
 
     // Messages live inside the wrapping <label>. Reference them from the input
     // via `aria-describedby` and point the accessible name at the label text
     // only via `aria-labelledby`, so the messages are announced as a
     // description rather than as part of the control's name.
-    const hasMessages = !!messages && messages.length > 0
+    // Only when a message actually renders (has text); FormField skips
+    // empty-text messages, so otherwise aria-describedby would dangle.
+    const hasMessages = !!messages?.some((m) => !!m.text)
     const messagesId = `${this.id}-messages`
     const labelId = `${this.id}-label`
 
@@ -231,8 +230,8 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
             }
             aria-labelledby={
               hasMessages
-                ? (props['aria-labelledby'] as string) || labelId
-                : (props['aria-labelledby'] as string | undefined)
+                ? props['aria-labelledby'] || labelId
+                : props['aria-labelledby']
             }
           />
           {this.renderValue()}

--- a/packages/ui-range-input/src/RangeInput/v2/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/v2/index.tsx
@@ -188,12 +188,6 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
 
     const props = omitProps(this.props, RangeInput.allowedProps)
 
-    // Messages live inside the wrapping <label>. Reference them from the input
-    // via `aria-describedby` and point the accessible name at the label text
-    // only via `aria-labelledby`, so the messages are announced as a
-    // description rather than as part of the control's name.
-    // Only when a message actually renders (has text); FormField skips
-    // empty-text messages, so otherwise aria-describedby would dangle.
     const hasMessages = !!messages?.some((m) => !!m.text)
     const messagesId = `${this.id}-messages`
     const labelId = `${this.id}-label`
@@ -223,6 +217,7 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
             {...props}
             disabled={disabled || readOnly}
             aria-disabled={disabled || readOnly ? 'true' : undefined}
+            // Keep messages in the description so the accessible name contains only the label.
             aria-describedby={
               [props['aria-describedby'], hasMessages ? messagesId : null]
                 .filter(Boolean)

--- a/packages/ui-range-input/src/RangeInput/v2/index.tsx
+++ b/packages/ui-range-input/src/RangeInput/v2/index.tsx
@@ -184,14 +184,27 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
   }
 
   render() {
-    const { formatValue, disabled, readOnly } = this.props
+    const { formatValue, disabled, readOnly, messages } = this.props
 
-    const props = omitProps(this.props, RangeInput.allowedProps)
+    const props = omitProps(this.props, RangeInput.allowedProps) as Record<
+      string,
+      unknown
+    >
+
+    // Messages live inside the wrapping <label>. Reference them from the input
+    // via `aria-describedby` and point the accessible name at the label text
+    // only via `aria-labelledby`, so the messages are announced as a
+    // description rather than as part of the control's name.
+    const hasMessages = !!messages && messages.length > 0
+    const messagesId = `${this.id}-messages`
+    const labelId = `${this.id}-label`
 
     return (
       <FormField
         {...pickProps(this.props, FormField.allowedProps)}
         label={this.props.label}
+        messagesId={messagesId}
+        labelId={labelId}
         id={this.id}
         elementRef={this.handleRef}
         data-cid="RangeInput"
@@ -211,6 +224,16 @@ class RangeInput extends Component<RangeInputProps, RangeInputState> {
             {...props}
             disabled={disabled || readOnly}
             aria-disabled={disabled || readOnly ? 'true' : undefined}
+            aria-describedby={
+              [props['aria-describedby'], hasMessages ? messagesId : null]
+                .filter(Boolean)
+                .join(' ') || undefined
+            }
+            aria-labelledby={
+              hasMessages
+                ? (props['aria-labelledby'] as string) || labelId
+                : (props['aria-labelledby'] as string | undefined)
+            }
           />
           {this.renderValue()}
         </div>

--- a/packages/ui-text-area/src/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/ui-text-area/src/TextArea/__tests__/TextArea.test.tsx
@@ -211,5 +211,35 @@ describe('TextArea', () => {
 
       expect(input).toHaveAttribute('aria-invalid')
     })
+
+    it('associates messages with the textarea as its description, not its accessible name', async () => {
+      render(
+        <TextArea
+          label="Name"
+          autoGrow={false}
+          messages={[{ type: 'error', text: 'some error message' }]}
+        />
+      )
+      const input = screen.getByRole('textbox')
+
+      const describedById = input.getAttribute('aria-describedby')
+      expect(describedById).toBeTruthy()
+      expect(document.getElementById(describedById!)).toHaveTextContent(
+        'some error message'
+      )
+
+      const labelledById = input.getAttribute('aria-labelledby')
+      expect(labelledById).toBeTruthy()
+      const labelEl = document.getElementById(labelledById!)
+      expect(labelEl).toHaveTextContent('Name')
+      expect(labelEl).not.toHaveTextContent('some error message')
+    })
+
+    it('does not override the accessible name with aria-labelledby when there are no messages', async () => {
+      render(<TextArea label="Name" autoGrow={false} />)
+      const input = screen.getByRole('textbox')
+
+      expect(input).not.toHaveAttribute('aria-labelledby')
+    })
   })
 })

--- a/packages/ui-text-area/src/TextArea/v2/index.tsx
+++ b/packages/ui-text-area/src/TextArea/v2/index.tsx
@@ -132,7 +132,9 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
   // via `aria-describedby` and point the accessible name at the label text only
   // via `aria-labelledby`, so the messages are announced as a description
   // rather than as part of the control's name.
-  const hasMessages = !!messages && messages.length > 0
+  // Only when a message actually renders (has text); FormField skips empty-text
+  // messages, so otherwise aria-describedby would dangle.
+  const hasMessages = !!messages?.some((m) => !!m.text)
   const messagesId = `${id}-messages`
   const labelId = `${id}-label`
 
@@ -402,20 +404,14 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
       aria-required={required}
       aria-invalid={isInvalid ? 'true' : undefined}
       aria-describedby={
-        [
-          (rest as Record<string, unknown>)['aria-describedby'],
-          hasMessages ? messagesId : null
-        ]
+        [rest['aria-describedby'], hasMessages ? messagesId : null]
           .filter(Boolean)
           .join(' ') || undefined
       }
       aria-labelledby={
         hasMessages
-          ? ((rest as Record<string, unknown>)['aria-labelledby'] as string) ||
-            labelId
-          : ((rest as Record<string, unknown>)['aria-labelledby'] as
-              | string
-              | undefined)
+          ? rest['aria-labelledby'] || labelId
+          : rest['aria-labelledby']
       }
       disabled={disabled}
       readOnly={readOnly}

--- a/packages/ui-text-area/src/TextArea/v2/index.tsx
+++ b/packages/ui-text-area/src/TextArea/v2/index.tsx
@@ -128,12 +128,6 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
     return { isInvalid, isSuccess }
   }, [messages])
 
-  // Messages live inside the wrapping <label>. Reference them from the textarea
-  // via `aria-describedby` and point the accessible name at the label text only
-  // via `aria-labelledby`, so the messages are announced as a description
-  // rather than as part of the control's name.
-  // Only when a message actually renders (has text); FormField skips empty-text
-  // messages, so otherwise aria-describedby would dangle.
   const hasMessages = !!messages?.some((m) => !!m.text)
   const messagesId = `${id}-messages`
   const labelId = `${id}-label`
@@ -403,6 +397,7 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
       required={required}
       aria-required={required}
       aria-invalid={isInvalid ? 'true' : undefined}
+      // Keep messages in the description so the accessible name contains only the label.
       aria-describedby={
         [rest['aria-describedby'], hasMessages ? messagesId : null]
           .filter(Boolean)

--- a/packages/ui-text-area/src/TextArea/v2/index.tsx
+++ b/packages/ui-text-area/src/TextArea/v2/index.tsx
@@ -128,6 +128,14 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
     return { isInvalid, isSuccess }
   }, [messages])
 
+  // Messages live inside the wrapping <label>. Reference them from the textarea
+  // via `aria-describedby` and point the accessible name at the label text only
+  // via `aria-labelledby`, so the messages are announced as a description
+  // rather than as part of the control's name.
+  const hasMessages = !!messages && messages.length > 0
+  const messagesId = `${id}-messages`
+  const labelId = `${id}-label`
+
   // Use styles
   const styles = useStyleNew({
     generateStyle,
@@ -393,6 +401,22 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
       required={required}
       aria-required={required}
       aria-invalid={isInvalid ? 'true' : undefined}
+      aria-describedby={
+        [
+          (rest as Record<string, unknown>)['aria-describedby'],
+          hasMessages ? messagesId : null
+        ]
+          .filter(Boolean)
+          .join(' ') || undefined
+      }
+      aria-labelledby={
+        hasMessages
+          ? ((rest as Record<string, unknown>)['aria-labelledby'] as string) ||
+            labelId
+          : ((rest as Record<string, unknown>)['aria-labelledby'] as
+              | string
+              | undefined)
+      }
       disabled={disabled}
       readOnly={readOnly}
       css={styles?.textArea}
@@ -404,6 +428,8 @@ const TextArea = forwardRef<TextAreaElement, TextAreaProps>((props, ref) => {
     <FormField
       {...pickProps(props, FormField.allowedProps)}
       label={label}
+      messagesId={messagesId}
+      labelId={labelId}
       vAlign="top"
       id={id}
       elementRef={(el) => {

--- a/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
@@ -182,5 +182,36 @@ describe('<TextInput/>', () => {
 
       expect(input).toHaveAttribute('aria-invalid')
     })
+
+    it('associates messages with the input as its description, not its accessible name', async () => {
+      render(
+        <TextInput
+          renderLabel="Name"
+          messages={[{ type: 'error', text: 'some error message' }]}
+        />
+      )
+      const input = screen.getByRole('textbox')
+
+      // messages are referenced as the input's description
+      const describedById = input.getAttribute('aria-describedby')
+      expect(describedById).toBeTruthy()
+      expect(document.getElementById(describedById!)).toHaveTextContent(
+        'some error message'
+      )
+
+      // the accessible name points at the label text only, excluding messages
+      const labelledById = input.getAttribute('aria-labelledby')
+      expect(labelledById).toBeTruthy()
+      const labelEl = document.getElementById(labelledById!)
+      expect(labelEl).toHaveTextContent('Name')
+      expect(labelEl).not.toHaveTextContent('some error message')
+    })
+
+    it('does not override the accessible name with aria-labelledby when there are no messages', async () => {
+      render(<TextInput renderLabel="Name" />)
+      const input = screen.getByRole('textbox')
+
+      expect(input).not.toHaveAttribute('aria-labelledby')
+    })
   })
 })

--- a/packages/ui-text-input/src/TextInput/v2/index.tsx
+++ b/packages/ui-text-input/src/TextInput/v2/index.tsx
@@ -160,7 +160,12 @@ class TextInput extends Component<TextInputProps> {
   }
 
   get hasMessages() {
-    return !!this.props.messages && this.props.messages.length > 0
+    // FormField only renders messages that have text, so only treat the field
+    // as having messages then. Otherwise the input's `aria-describedby` would
+    // reference a messages element that was never rendered — e.g. DateTimeInput
+    // passes an empty-text error message to its sub-inputs just to force the
+    // invalid styling.
+    return !!this.props.messages?.some((m) => !!m.text)
   }
 
   get invalid() {
@@ -233,12 +238,15 @@ class TextInput extends Component<TextInputProps> {
     if (props['aria-describedby']) {
       descriptionIds = `${props['aria-describedby']}`
     }
-    // When there are messages, associate them with the input as its description
-    // (they are rendered by FormField with `id={this._messagesId}`) and point
-    // the accessible name at the label text only via `aria-labelledby`. This
-    // keeps the messages — which live inside the wrapping <label> — out of the
-    // control's name while preserving the click-on-label focus behavior.
-    // Any consumer-provided `aria-labelledby` takes precedence.
+    // FormField renders this control and its `messages` inside a single wrapping
+    // <label>, so by default the messages' text becomes part of the control's
+    // accessible *name* (e.g. "Password Password must be at least 6 characters"),
+    // which is confusing and repeats on every announcement. Messages should be
+    // the field's *description* instead. So when there are messages, reference
+    // them via `aria-describedby` and pin the name to the label text only via
+    // `aria-labelledby`. Keeping the messages inside the <label> preserves the
+    // native click-on-label focus behavior. A consumer-provided `aria-labelledby`
+    // takes precedence.
     let labelledById = props['aria-labelledby'] as string | undefined
     if (this.hasMessages) {
       descriptionIds = [descriptionIds, this._messagesId]

--- a/packages/ui-text-input/src/TextInput/v2/index.tsx
+++ b/packages/ui-text-input/src/TextInput/v2/index.tsx
@@ -70,6 +70,7 @@ class TextInput extends Component<TextInputProps> {
     super(props)
     this._defaultId = props.deterministicId!()
     this._messagesId = props.deterministicId!('TextInput-messages')
+    this._labelId = props.deterministicId!('TextInput-label')
   }
 
   ref: Element | null = null
@@ -78,6 +79,7 @@ class TextInput extends Component<TextInputProps> {
 
   private readonly _defaultId: string
   private readonly _messagesId: string
+  private readonly _labelId: string
 
   private _focusListener: { remove(): void } | null = null
 
@@ -231,6 +233,19 @@ class TextInput extends Component<TextInputProps> {
     if (props['aria-describedby']) {
       descriptionIds = `${props['aria-describedby']}`
     }
+    // When there are messages, associate them with the input as its description
+    // (they are rendered by FormField with `id={this._messagesId}`) and point
+    // the accessible name at the label text only via `aria-labelledby`. This
+    // keeps the messages — which live inside the wrapping <label> — out of the
+    // control's name while preserving the click-on-label focus behavior.
+    // Any consumer-provided `aria-labelledby` takes precedence.
+    let labelledById = props['aria-labelledby'] as string | undefined
+    if (this.hasMessages) {
+      descriptionIds = [descriptionIds, this._messagesId]
+        .filter(Boolean)
+        .join(' ')
+      labelledById = labelledById || this._labelId
+    }
 
     return (
       <input
@@ -247,6 +262,7 @@ class TextInput extends Component<TextInputProps> {
         disabled={interaction === 'disabled'}
         readOnly={interaction === 'readonly'}
         aria-describedby={descriptionIds !== '' ? descriptionIds : undefined}
+        aria-labelledby={labelledById}
         size={htmlSize}
         onChange={this.handleChange}
         onBlur={this.handleBlur}
@@ -283,6 +299,7 @@ class TextInput extends Component<TextInputProps> {
         id={this.id}
         label={label}
         messagesId={this._messagesId}
+        labelId={this._labelId}
         messages={messages}
         inline={display === 'inline-block'}
         width={width}

--- a/packages/ui-text-input/src/TextInput/v2/index.tsx
+++ b/packages/ui-text-input/src/TextInput/v2/index.tsx
@@ -160,11 +160,6 @@ class TextInput extends Component<TextInputProps> {
   }
 
   get hasMessages() {
-    // FormField only renders messages that have text, so only treat the field
-    // as having messages then. Otherwise the input's `aria-describedby` would
-    // reference a messages element that was never rendered — e.g. DateTimeInput
-    // passes an empty-text error message to its sub-inputs just to force the
-    // invalid styling.
     return !!this.props.messages?.some((m) => !!m.text)
   }
 
@@ -238,15 +233,8 @@ class TextInput extends Component<TextInputProps> {
     if (props['aria-describedby']) {
       descriptionIds = `${props['aria-describedby']}`
     }
-    // FormField renders this control and its `messages` inside a single wrapping
-    // <label>, so by default the messages' text becomes part of the control's
-    // accessible *name* (e.g. "Password Password must be at least 6 characters"),
-    // which is confusing and repeats on every announcement. Messages should be
-    // the field's *description* instead. So when there are messages, reference
-    // them via `aria-describedby` and pin the name to the label text only via
-    // `aria-labelledby`. Keeping the messages inside the <label> preserves the
-    // native click-on-label focus behavior. A consumer-provided `aria-labelledby`
-    // takes precedence.
+    // Keep messages in the description, not the accessible name.
+    // A consumer-provided aria-labelledby wins.
     let labelledById = props['aria-labelledby'] as string | undefined
     if (this.hasMessages) {
       descriptionIds = [descriptionIds, this._messagesId]


### PR DESCRIPTION
INSTUI-4724

## Summary

Form control messages render inside the wrapping <label>, so screen readers were reading them as part of the field's accessible name (e.g. "Password Password must be at least 6 characters") instead of as a description.

Each single form control now points its accessible name at the label text only (aria-labelledby) and references the messages as its description (aria-describedby), so a screen reader announces the label first, then the messages. The wrapping <label> is unchanged, so click-on-label focus is preserved.

## Test plan

Tab through the given exaple and verify in DevTools Accessibility tab that the Name and Description values are correct. With a screen reader enabled, confirm that the label is announced as the field name, followed by a brief pause before the description is announced.

<img width="1503" height="761" alt="image" src="https://github.com/user-attachments/assets/4998c80c-e8a6-4504-93be-69af97e3779a" />



````
const messages = [{ type: 'error', text: 'This field has an error' }]

render(
  <View as="div" display="block" width="24rem">
    <Text as="p">
      Tab through and verify in DevTools Accessibility tab that the Name and Description values are correct. With a screen reader enabled, confirm that the label is announced as the field name, followed by a brief pause before the description is announced.
    </Text>

    <View as="div" margin="medium 0 0">
      <TextInput renderLabel="Text Input" messages={messages} />
    </View>
    <View as="div" margin="medium 0 0">
      <NumberInput renderLabel="Number Input" messages={messages} />
    </View>
    <View as="div" margin="medium 0 0">
      <TextArea label="Text Area" messages={messages} />
    </View>
    <View as="div" margin="medium 0 0">
      <Checkbox label="Checkbox (simple)" value="c1" messages={messages} />
    </View>
    <View as="div" margin="medium 0 0">
      <Checkbox
        label="Checkbox (toggle)"
        variant="toggle"
        value="c2"
        messages={messages}
      />
    </View>
    <View as="div" margin="medium 0 0">
      <RangeInput
        label="Range Input"
        name="range"
        min={0}
        max={100}
        defaultValue={50}
        messages={messages}
      />
    </View>
  </View>
)
````

Co-Authored-By: 🤖 [Claude](https://claude.com/claude-code)