### PR TITLE
fix(regression-test): decouple a11y checks from screenshot capture

### DIFF
--- a/regression-test/cypress.config.ts
+++ b/regression-test/cypress.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
   screenshotsFolder: 'cypress/screenshots',
   trashAssetsBeforeRuns: true,
   video: false,
+  // Never capture Cypress' automatic failure screenshots (the error overlay).
+  // Visual regression baselines come solely from the deterministic afterEach
+  // `cy.screenshot`; a failure screenshot has a different filename and would
+  // otherwise leak into the diff as a spurious "new" image.
+  screenshotOnRunFailure: false,
   e2e: {
     viewportWidth: 1280,
     viewportHeight: 800,

--- a/regression-test/cypress/support/e2e.ts
+++ b/regression-test/cypress/support/e2e.ts
@@ -51,7 +51,11 @@ function slugify(s: string) {
 
 afterEach(function () {
   const test = this.currentTest
-  if (!test || test.state === 'failed') return
+  // Capture the screenshot even when the test failed (e.g. an axe a11y
+  // violation). The a11y assertion still fails the run as a gate, but the
+  // page itself rendered fine, so we always want its visual baseline rather
+  // than a missing/blank image.
+  if (!test) return
   const name = slugify(test.title)
   cy.location('pathname', { log: false }).then((pagePath) => {
     cy.task('recordMeta', { name, pagePath }, { log: false })


### PR DESCRIPTION
## Summary
- Always take the deterministic `afterEach` screenshot, even when the test failed — an axe violation no longer leaves a page with a blank/missing baseline.
- Set `screenshotOnRunFailure: false` so Cypress' error-overlay screenshots stop leaking into the diff as spurious "new" images.

## Test Plan
- Latent bug with no prior repro on `master` (no page violated axe until now). To see it exercised, look at the visual-regression report on the dark-theme branch (#2628): after this fix is applied there, every page renders one clean screenshot and the axe run still fails the job as a gate — no blank images, no duplicate "cypress error" entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
