### PR TITLE
FIRE-4085: use GitHub App cred for in-pipeline clone

### DIFF
--- a/scripts/InstUI.Jenkinsfile
+++ b/scripts/InstUI.Jenkinsfile
@@ -120,7 +120,7 @@ def isChangeRelevant(String projectUrl, String refSpec, String docFolder) {
     sh "mkdir -p ${tempDir}"
 
     echo "Cloning ${projectUrl} with refspec: ${refSpec}. Checking for changes in ${docFolder} folder"
-    withCredentials([gitUsernamePassword(credentialsId: 'github-api-credentials', gitToolName: 'git-tool')]) {
+    withCredentials([gitUsernamePassword(credentialsId: 'instructure-jenkins-instructure-org', gitToolName: 'git-tool')]) {
         sh "git clone ${projectUrl} ${tempDir} && cd ${tempDir} && git checkout ${refSpec}"
     }
 


### PR DESCRIPTION
Swaps the in-pipeline `gitUsernamePassword` credential in `scripts/InstUI.Jenkinsfile` from `github-api-credentials` (broad instructure-ci PAT) to the org-scoped GitHub App cred `instructure-jenkins-instructure-org`.

The pipeline clones `PROJECT_REPO` which is in the **same org**, so the org-scoped App cred is sufficient. Part of the PAT→GitHub-App migration (branch source already switched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)