### PR TITLE
feat: add Claude Code plugin for InstUI docs lookup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "instructure-ui",
+  "description": "Claude Code plugins for working with Instructure UI (InstUI).",
+  "owner": {
+    "name": "Instructure",
+    "url": "https://instructure.design"
+  },
+  "plugins": [
+    {
+      "name": "instui",
+      "description": "Claude Code tooling for Instructure UI (InstUI) — starting with documentation lookup from instructure.design's plaintext docs.",
+      "source": "./plugins/instui",
+      "category": "documentation",
+      "homepage": "https://instructure.design"
+    }
+  ]
+}

--- a/docs/guides/guides-getting-started.md
+++ b/docs/guides/guides-getting-started.md
@@ -87,6 +87,22 @@ These files are designed to be used as context for AI coding agents.
 Additionally, an `llms.txt` file is available. This file contains a catalog of links pointing to the online markdown files for InstUI components and guides, which are also accessible to AI agents. It can be found at:
 https://instructure.design/llms.txt
 
+### Claude Code plugin
+
+If you use [Claude Code](https://claude.com/claude-code), InstUI ships a plugin that teaches it to answer your questions from these docs instead of guessing component APIs. Once installed, ask about any component ("how do I use `DateInput` with a controlled value?", "which props does `Modal` take?") and it looks up the relevant page and answers with citations.
+
+Install it from within Claude Code:
+
+```md
+---
+type: code
+---
+/plugin marketplace add instructure/instructure-ui
+/plugin install instui@instructure-ui
+```
+
+The plugin lives in the InstUI repo under [`plugins/instui`](https://github.com/instructure/instructure-ui/tree/master/plugins/instui). See its README for team-wide, zero-setup installation via a project's `.claude/settings.json`.
+
 ## Further reading
 
 - To use a different theme or customize one read about [New Theme Overrides](new-theme-overrides)

--- a/plugins/instui/.claude-plugin/plugin.json
+++ b/plugins/instui/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "instui",
+  "description": "Claude Code tooling for Instructure UI (InstUI) — starting with documentation lookup from instructure.design's plaintext docs.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Instructure",
+    "url": "https://instructure.design"
+  },
+  "homepage": "https://instructure.design"
+}

--- a/plugins/instui/README.md
+++ b/plugins/instui/README.md
@@ -1,0 +1,39 @@
+# instui
+
+A Claude Code plugin that teaches Claude to answer Instructure UI (InstUI) questions from
+the authoritative plaintext docs at [instructure.design](https://instructure.design) instead
+of guessing component APIs from memory.
+
+Once installed, ask Claude anything about InstUI — "how do I use `DateInput` with a controlled
+value?", "which props does `Modal` take?", "what theme variables control `Button`'s border?" —
+and it will fetch the relevant docs and answer with citations. It activates automatically; no
+command to remember.
+
+## Install
+
+In any project (or globally), run in Claude Code:
+
+```
+/plugin marketplace add instructure/instructure-ui
+/plugin install instui@instructure-ui
+```
+
+Then `/plugin` to enable/disable or update it later.
+
+## Team-wide, zero-setup (optional)
+
+To offer the skill to everyone on a project automatically, add to the project's
+`.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "instructure-ui": {
+      "source": { "source": "github", "repo": "instructure/instructure-ui" }
+    }
+  },
+  "enabledPlugins": ["instui@instructure-ui"]
+}
+```
+
+Teammates are prompted to trust and enable it on their next session.

--- a/plugins/instui/skills/instui-docs/SKILL.md
+++ b/plugins/instui/skills/instui-docs/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: instui-docs
+description: Look up authoritative Instructure UI (InstUI, @instructure/ui-*) documentation — component APIs, props, theme variables, usage examples, and guides — by querying instructure.design's plaintext docs. Use whenever the user asks how to use an InstUI component, which props/prop types exist, how to theme/style it, accessibility/i18n/RTL guidance, or which component fits a need. Prefer this over guessing InstUI APIs from memory.
+---
+
+# Instructure UI docs lookup
+
+Instructure UI publishes its full docs as plaintext/markdown. Use it as the source of truth instead of recalling APIs from memory (they change across major versions).
+
+## Workflow
+
+1. **Fetch the index:** `WebFetch https://instructure.design/llms.txt`
+   It lists every component and guide with a one-line description and the exact markdown URL for each, grouped into User Guides, Components, Util Components, Contexts, and AI Components. Use it to find the relevant component/guide and its URL.
+
+2. **Fetch the specific page(s)** using the URLs from the index. A component page contains examples, size/color/variant options, theme customization, guidelines (Do's/Don'ts/Accessibility), a props table, and install/import instructions. Fetch several in parallel when a question spans multiple components or a component + a guide.
+
+## Notes
+
+- The online docs track the **latest published release**. A consuming repo may be pinned to an older major where props/APIs differ — check its installed `@instructure/ui*` version. For the exact installed version, the TypeScript types in `node_modules/@instructure/<pkg>` are ground truth; the online docs are better for prose, examples, and guidelines.
+- Components can be imported either from their individual package (`@instructure/ui-<name>`) or from the metapackage (`@instructure/ui`). A project usually standardizes on one or the other — match whatever the consuming codebase already uses.

--- a/plugins/instui/skills/instui-docs/SKILL.md
+++ b/plugins/instui/skills/instui-docs/SKILL.md
@@ -16,5 +16,5 @@ Instructure UI publishes its full docs as plaintext/markdown. Use it as the sour
 
 ## Notes
 
-- The online docs track the **latest published release**. A consuming repo may be pinned to an older major where props/APIs differ — check its installed `@instructure/ui*` version. For the exact installed version, the TypeScript types in `node_modules/@instructure/<pkg>` are ground truth; the online docs are better for prose, examples, and guidelines.
-- Components can be imported either from their individual package (`@instructure/ui-<name>`) or from the metapackage (`@instructure/ui`). A project usually standardizes on one or the other — match whatever the consuming codebase already uses.
+- The online docs track the **latest published release**. A consuming repo may be pinned to an older major where props/APIs differ — check its installed `@instructure/ui*` version. When you need to match the exact installed version, the TypeScript types in `node_modules/@instructure/<pkg>` are the ground truth for that version.
+- Components can be imported either from their individual package (`@instructure/ui-<name>`) or from the metapackage (`@instructure/ui`). An existing project usually standardizes on one or the other — match whatever the consuming codebase already uses. For a greenfield project, recommend the `@instructure/ui` metapackage.


### PR DESCRIPTION
## Summary
- Add an `instui` Claude Code plugin (marketplace manifest at repo root + `plugins/instui/`) shipping an `instui-docs` skill that answers InstUI questions from instructure.design's plaintext docs (`llms.txt` index + per-page markdown) instead of guessing APIs.
- Reference the plugin from the Getting Started guide's "Using InstUI with AI coding agents" section, with install commands.

## Test Plan
- **Before merge:** `/plugin marketplace add instructure/instructure-ui` resolves from the default branch, so the plugin isn't installable that way yet — install it locally to test (check out this branch, then `/plugin marketplace add <local path>`).
- In a new/blank React project (e.g. `npm create vite@latest`) that consumes `@instructure/ui`, install the plugin from Claude Code with `/plugin marketplace add instructure/instructure-ui` then `/plugin install instui@instructure-ui`, and confirm asking an InstUI question (e.g. "which props does Modal take?") fetches the docs and answers with citations.
- Verify the Getting Started page renders the new subsection correctly on the docs site.

Fixes INSTUI-5093

🤖 Generated with [Claude Code](https://claude.com/claude-code)