### PR TITLE
fix(ui-options,ui-select): stop VoiceOver re-announcing Select option

### DIFF
--- a/packages/ui-options/src/Options/__tests__/Item.test.tsx
+++ b/packages/ui-options/src/Options/__tests__/Item.test.tsx
@@ -208,4 +208,48 @@ describe('<Item />', () => {
     expect(link).toHaveAttribute('href', '/helloWorld')
     expect(link?.tagName).toBe('A')
   })
+
+  // VoiceOver double-announces options because the highlight used to
+  // be a variant-dependent Emotion class. The variant is now expressed
+  // through a stable `data-variant` attribute + static CSS, so the class must NOT
+  // change when the variant does.
+  describe('variant applied via a stable data-variant attribute', () => {
+    it('exposes the variant through a data-variant attribute on the outer element', async () => {
+      const { container } = render(
+        <Item as="li" role="option" variant="highlighted">
+          Hello World
+        </Item>
+      )
+      const item = container.querySelector('[class$="-optionItem"]')
+
+      expect(item).toHaveAttribute('data-variant', 'highlighted')
+    })
+
+    it('does not swap the outer element class when the variant changes', async () => {
+      const { container, rerender } = render(
+        <Item as="li" role="option" variant="default">
+          Hello World
+        </Item>
+      )
+      const item = container.querySelector('[class$="-optionItem"]')!
+      const classBeforeHighlight = item.getAttribute('class')
+
+      expect(item).toHaveAttribute('data-variant', 'default')
+
+      rerender(
+        <Item as="li" role="option" variant="highlighted">
+          Hello World
+        </Item>
+      )
+      const itemAfterHighlight = container.querySelector(
+        '[class$="-optionItem"]'
+      )!
+
+      expect(itemAfterHighlight).toHaveAttribute('data-variant', 'highlighted')
+      // class hash is stable -> no ancestor mutation for VoiceOver to re-announce
+      expect(itemAfterHighlight.getAttribute('class')).toBe(
+        classBeforeHighlight
+      )
+    })
+  })
 })

--- a/packages/ui-options/src/Options/v2/Item/index.tsx
+++ b/packages/ui-options/src/Options/v2/Item/index.tsx
@@ -117,6 +117,7 @@ class Item extends Component<OptionsItemProps> {
       href,
       role,
       styles,
+      variant,
       description,
       descriptionRole,
       renderBeforeLabel,
@@ -142,6 +143,7 @@ class Item extends Component<OptionsItemProps> {
       <ElementType
         role={voiceoverRoleBugWorkaround ? role : 'none'}
         data-cid="Options.Item"
+        data-variant={variant}
         css={styles?.item}
         ref={(element: Element | null) => {
           this.ref = element
@@ -169,6 +171,7 @@ class Item extends Component<OptionsItemProps> {
               css={styles?.description}
               role={descriptionRole}
               id={this._descriptionId}
+              data-variant={variant}
             >
               {descriptionContent}
             </span>

--- a/packages/ui-options/src/Options/v2/Item/styles.ts
+++ b/packages/ui-options/src/Options/v2/Item/styles.ts
@@ -43,7 +43,6 @@ const generateStyle = (
   props: OptionsItemProps
 ): OptionsItemStyle => {
   const {
-    variant,
     children,
     renderBeforeLabel: hasContentBeforeLabel,
     renderAfterLabel: hasContentAfterLabel,
@@ -106,6 +105,20 @@ const generateStyle = (
 
   const linkStyles = { textDecoration: 'none', color: 'currentColor' }
 
+  // Apply the variant-dependent styles through a static `data-variant` attribute
+  // selector. This keeps the generated Emotion class STABLE across variant changes,
+  // no longer triggers a re-render (swap the highlight class)
+  // which made VoiceOver restart the option announcement. See INSTUI-5082.
+  const dataVariantSelectors = (extra: Record<string, unknown> = {}) =>
+    Object.fromEntries(
+      (Object.keys(variantVariants) as (keyof typeof variantVariants)[]).map(
+        (key): [string, object] => [
+          `&[data-variant="${key}"]`,
+          { ...variantVariants[key], ...extra }
+        ]
+      )
+    )
+
   return {
     item: {
       label: 'optionItem',
@@ -122,7 +135,7 @@ const generateStyle = (
       outline: 'none',
       position: 'relative',
       userSelect: 'none',
-      ...variantVariants[variant!],
+      ...dataVariantSelectors(),
       ...(containsList && { cursor: 'default' }),
 
       // for nested items
@@ -195,9 +208,9 @@ const generateStyle = (
       fontSize: componentTheme.descriptionFontSize,
       lineHeight: componentTheme.descriptionLineHeight,
       color: componentTheme.descriptionColor,
+      background: 'none', // needed to clear variant background
 
-      ...variantVariants[variant!],
-      background: 'none' // needed to clear variant background
+      ...dataVariantSelectors({ background: 'none' })
     }
   }
 }

--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -572,6 +572,39 @@ describe('<Select />', () => {
       expect(input).not.toHaveAttribute('aria-activedescendant')
     })
 
+    // a11y issue: When the highlight moved, the option's <li role="none"> ancestor
+    // used to swap its Emotion class, and VoiceOver restarted the announcement.
+    // Moving the highlight must change aria-activedescendant + data-variant WITHOUT
+    // swapping the class on the active option's ancestor.
+    it('does not swap the option class when the highlight moves', () => {
+      const { rerender } = render(
+        <Select renderLabel="Choose an option" isShowingOptions>
+          {getOptions(defaultOptions[0])}
+        </Select>
+      )
+      const input = screen.getByLabelText('Choose an option')
+
+      // 'bar' is not highlighted yet
+      const barItem = screen
+        .getByRole('option', { name: 'bar' })
+        .closest('[class$="-optionItem"]')!
+      expect(barItem).toHaveAttribute('role', 'none')
+      expect(barItem).toHaveAttribute('data-variant', 'default')
+      const barClassBeforeHighlight = barItem.getAttribute('class')
+
+      // move the highlight onto 'bar'
+      rerender(
+        <Select renderLabel="Choose an option" isShowingOptions>
+          {getOptions(defaultOptions[1])}
+        </Select>
+      )
+
+      expect(input).toHaveAttribute('aria-activedescendant', 'bar')
+      expect(barItem).toHaveAttribute('data-variant', 'highlighted')
+      // class hash is unchanged -> no ancestor mutation for VoiceOver to re-announce
+      expect(barItem.getAttribute('class')).toBe(barClassBeforeHighlight)
+    })
+
     it('should allow assistive text', () => {
       render(
         <Select renderLabel="Choose an option" assistiveText="hello world">


### PR DESCRIPTION
Bug: Arrowing through a SimpleSelect (single-select listbox) with VoiceOver announces each option, then appends "not selected" a beat later and restarts the announcement.

## Summary
- Express the `Options.Item` highlight variant through a stable `data-variant` attribute + static `&[data-variant="…"]` CSS instead of a variant-dependent Emotion class. The option's `<li role="none">` no longer swaps its class in a deferred second commit (via `withStyleNew`'s `makeStyles`→`setStyles`) one tick after `aria-activedescendant` moves — that ancestor mutation was what made VoiceOver restart the announcement and append "not selected".

## Test Plan
- Chrome + VoiceOver on macOS: open a v11.7 `Select`/`SimpleSelect`, open the listbox, and arrow up/down through the options. Each option should be announced once, cleanly (label + state + position), with no interrupt/restart 
````
const Example = ({ options }) => {
  const [value, setValue] = useState('all')
  
  return (
    <div style={{ padding: 40, maxWidth: 320 }}>
      <SimpleSelect
        renderLabel="Filter"
        value={value}
        onChange={(_e, { value }) => setValue(value)}
      >
        {options.map((o) => (
          <SimpleSelect.Option key={o.value} id={o.value} value={o.value}>
            {o.label}
          </SimpleSelect.Option>
        ))}
      </SimpleSelect>
    </div>
  )
}
render(
  <Example
    options={[
  { label: 'All notes', value: 'all' },
  { label: 'Important', value: 'important' },
  { label: 'Unclear', value: 'unclear' },
]}
  />
)
````

Fixes INSTUI-5082

🤖 Generated with [Claude Code](https://claude.com/claude-code)