### PR TITLE
feat(ui-checkbox): add aria-invalid attribute to Checkbox

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -259,6 +259,22 @@ describe('<Checkbox />', () => {
     expect(input).toHaveAttribute('data-checked', 'mixed')
   })
 
+  it('should set aria-invalid when errors prop is set', () => {
+    renderCheckbox({
+      messages: [{ type: 'error', text: 'This field is required' }]
+    })
+    const input = screen.getByRole('checkbox')
+
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('should not set aria-invalid when there are no error messages', () => {
+    renderCheckbox({ messages: [{ type: 'hint', text: 'This is a hint' }] })
+    const input = screen.getByRole('checkbox')
+
+    expect(input).not.toHaveAttribute('aria-invalid')
+  })
+
   describe('for a11y', () => {
     it('`simple` variant should meet standards', async () => {
       const { container } = renderCheckbox({ variant: 'simple' })

--- a/packages/ui-checkbox/src/Checkbox/v1/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v1/index.tsx
@@ -333,6 +333,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             required={isRequired}
             disabled={disabled || readOnly}
             aria-checked={indeterminate ? 'mixed' : undefined}
+            aria-invalid={this.invalid ? 'true' : undefined}
             css={styles?.input}
             onChange={this.handleChange}
             onKeyDown={createChainedFunction(onKeyDown, this.handleKeyDown)}

--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -337,6 +337,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             readOnly={readOnly}
             aria-readonly={readOnly ? true : undefined}
             aria-checked={indeterminate ? 'mixed' : undefined}
+            aria-invalid={this.invalid ? 'true' : undefined}
             css={styles?.input}
             onClickCapture={(e) => {
               if (readOnly) {


### PR DESCRIPTION
## Summary
- Add `aria-invalid="true"` attribute to Checkbox input when error messages are present
- Applies to both v1 and v2 components
- Added unit tests to verify behavior

## Test Plan
- Manual verification in the docs app: Navigate to Checkbox component, add error messages via props, verify `aria-invalid` attribute is present in the DOM
- Check that `aria-invalid` is not set when there are no error messages (or only hint/success messages)

Relates to INSTUI-5102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
