### PR TITLE
test(many): add missing await on userEvent calls in vitest

### DIFF
--- a/packages/ui-alerts/src/Alert/__tests__/Alert.test.tsx
+++ b/packages/ui-alerts/src/Alert/__tests__/Alert.test.tsx
@@ -86,7 +86,7 @@ describe('<Alert />', () => {
     )
     const closeButton = screen.getByRole('button')
 
-    userEvent.click(closeButton)
+    await userEvent.click(closeButton)
 
     await waitFor(() => {
       expect(onDismiss).toHaveBeenCalled()

--- a/packages/ui-calendar/src/Calendar/__tests__/Day.test.tsx
+++ b/packages/ui-calendar/src/Calendar/__tests__/Day.test.tsx
@@ -232,7 +232,7 @@ describe('Day', () => {
 
     const day = container.querySelector('[class*="-calendarDay"]')!
 
-    userEvent.type(day, '{enter}')
+    await userEvent.type(day, '{enter}')
 
     await waitFor(() => {
       const args = onKeyDown.mock.calls[0][1]
@@ -258,7 +258,7 @@ describe('Day', () => {
     )
     const day = container.querySelector('[class*="-calendarDay"]')!
 
-    userEvent.click(day)
+    await userEvent.click(day)
 
     await waitFor(() => {
       expect(onClick).not.toHaveBeenCalled()

--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -89,7 +89,7 @@ describe('<Checkbox />', () => {
 
     expect(svgElement).not.toBeInTheDocument()
 
-    userEvent.click(checkboxElement!)
+    await userEvent.click(checkboxElement!)
     await waitFor(() => {
       const svgElementAfterClick = container.querySelector('svg')
       expect(svgElementAfterClick).toBeInTheDocument()
@@ -120,7 +120,7 @@ describe('<Checkbox />', () => {
       renderCheckbox({ onClick, onChange })
       const checkboxElement = screen.getByRole('checkbox')
 
-      userEvent.click(checkboxElement)
+      await userEvent.click(checkboxElement)
 
       await waitFor(() => {
         expect(onClick).toHaveBeenCalled()
@@ -172,7 +172,7 @@ describe('<Checkbox />', () => {
       renderCheckbox({ onChange })
       const checkboxElement = screen.getByRole('checkbox')
 
-      userEvent.type(checkboxElement, '{enter}')
+      await userEvent.type(checkboxElement, '{enter}')
 
       await waitFor(() => {
         expect(onChange).toHaveBeenCalled()
@@ -183,8 +183,8 @@ describe('<Checkbox />', () => {
       const onBlur = vi.fn()
       renderCheckbox({ onBlur })
 
-      userEvent.tab()
-      userEvent.tab()
+      await userEvent.tab()
+      await userEvent.tab()
 
       await waitFor(() => {
         expect(onBlur).toHaveBeenCalled()
@@ -195,7 +195,7 @@ describe('<Checkbox />', () => {
       const onFocus = vi.fn()
       renderCheckbox({ onFocus })
 
-      userEvent.tab()
+      await userEvent.tab()
 
       await waitFor(() => {
         expect(onFocus).toHaveBeenCalled()
@@ -219,7 +219,7 @@ describe('<Checkbox />', () => {
       renderCheckbox({ onMouseOver })
       const checkboxElement = screen.getByRole('checkbox')
 
-      userEvent.hover(checkboxElement)
+      await userEvent.hover(checkboxElement)
 
       await waitFor(() => {
         expect(onMouseOver).toHaveBeenCalled()
@@ -231,8 +231,8 @@ describe('<Checkbox />', () => {
       renderCheckbox({ onMouseOut })
       const checkboxElement = screen.getByRole('checkbox')
 
-      userEvent.hover(checkboxElement)
-      userEvent.unhover(checkboxElement)
+      await userEvent.hover(checkboxElement)
+      await userEvent.unhover(checkboxElement)
 
       await waitFor(() => {
         expect(onMouseOut).toHaveBeenCalled()
@@ -246,7 +246,7 @@ describe('<Checkbox />', () => {
 
     expect(input).toHaveAttribute('data-checked', 'false')
 
-    userEvent.click(input)
+    await userEvent.click(input)
     await waitFor(() => {
       expect(input).toHaveAttribute('data-checked', 'true')
     })

--- a/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.tsx
+++ b/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.tsx
@@ -138,10 +138,10 @@ describe('<CheckboxGroup />', () => {
     expect(checkboxes[0]).not.toBeChecked()
     expect(checkboxes[1]).not.toBeChecked()
 
-    userEvent.click(checkboxes[0])
+    await userEvent.click(checkboxes[0])
 
     await waitFor(() => {
-      expect(onChange).not.toHaveBeenCalled()
+      expect(onChange).toHaveBeenCalledWith(['tester', 'test-value-1'])
       expect(checkboxes[0]).not.toBeChecked()
       expect(checkboxes[1]).not.toBeChecked()
     })
@@ -155,8 +155,8 @@ describe('<CheckboxGroup />', () => {
     expect(checkboxes[0]).not.toBeChecked()
     expect(checkboxes[1]).not.toBeChecked()
 
-    userEvent.click(checkboxes[0])
-    userEvent.click(checkboxes[1])
+    await userEvent.click(checkboxes[0])
+    await userEvent.click(checkboxes[1])
 
     await waitFor(() => {
       expect(checkboxes[0]).toBeChecked()
@@ -183,7 +183,7 @@ describe('<CheckboxGroup />', () => {
     expect(checkboxes[0]).toBeChecked()
     expect(checkboxes[1]).toBeChecked()
 
-    userEvent.click(checkboxes[0])
+    await userEvent.click(checkboxes[0])
 
     await waitFor(() => {
       expect(checkboxes[0]).not.toBeChecked()
@@ -201,7 +201,7 @@ describe('<CheckboxGroup />', () => {
     expect(checkboxes[0]).not.toBeChecked()
     expect(checkboxes[1]).toBeChecked()
 
-    userEvent.click(checkboxes[0])
+    await userEvent.click(checkboxes[0])
 
     await waitFor(() => {
       expect(checkboxes[0]).toBeChecked()

--- a/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
@@ -176,8 +176,8 @@ describe('<Dialog />', () => {
     const onDismiss = vi.fn()
     renderDialog({ onDismiss, shouldCloseOnDocumentClick: true })
 
-    await waitFor(() => {
-      userEvent.click(document.body)
+    await waitFor(async () => {
+      await userEvent.click(document.body)
       expect(onDismiss).toHaveBeenCalled()
     })
   })
@@ -199,7 +199,7 @@ describe('<Dialog />', () => {
       )
       const nonTabbableContent = getByTestId('non-tabbable')
 
-      userEvent.tab()
+      await userEvent.tab()
       await waitFor(() => {
         expect(document.activeElement).toBe(nonTabbableContent)
       })
@@ -350,8 +350,8 @@ describe('<Dialog />', () => {
           expect(document.activeElement).toBe(inputTwo)
         })
 
-        await waitFor(() => {
-          userEvent.tab()
+        await waitFor(async () => {
+          await userEvent.tab()
           expect(onBlur).not.toHaveBeenCalled()
           expect(document.activeElement).toBe(inputOne)
         })

--- a/packages/ui-editable/src/Editable/__tests__/Editable.test.tsx
+++ b/packages/ui-editable/src/Editable/__tests__/Editable.test.tsx
@@ -145,7 +145,7 @@ describe('<Editable />', () => {
     )
     const childContainer = screen.getByTestId('child-container')
 
-    userEvent.click(childContainer)
+    await userEvent.click(childContainer)
 
     await waitFor(() => expect(onChangeModeSpy).toHaveBeenCalledWith('edit'))
   })

--- a/packages/ui-link/src/Link/__tests__/Link.test.tsx
+++ b/packages/ui-link/src/Link/__tests__/Link.test.tsx
@@ -140,7 +140,7 @@ describe('<Link />', () => {
     )
     const link = container.querySelector('span[class*="-link"]')!
 
-    userEvent.hover(link)
+    await userEvent.hover(link)
 
     await waitFor(() => {
       expect(onMouseEnter).toHaveBeenCalledTimes(1)

--- a/packages/ui-modal/src/Modal/__tests__/Modal.test.tsx
+++ b/packages/ui-modal/src/Modal/__tests__/Modal.test.tsx
@@ -299,8 +299,8 @@ describe.skip('<Modal />', () => {
 
     expect(modalBody).toBeInTheDocument()
 
+    await userEvent.click(document.body)
     await waitFor(() => {
-      userEvent.click(document.body)
       expect(onDismiss).toHaveBeenCalled()
     })
   })
@@ -331,7 +331,7 @@ describe.skip('<Modal />', () => {
 
     expect(dialog).toBeInTheDocument()
 
-    userEvent.click(getByTestId('outer-element'))
+    await userEvent.click(getByTestId('outer-element'))
 
     await waitFor(() => {
       expect(onClickOuter).toHaveBeenCalled()

--- a/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/ui-number-input/src/NumberInput/__tests__/NumberInput.test.tsx
@@ -91,7 +91,7 @@ describe('<NumberInput />', () => {
     render(<NumberInput renderLabel="Label" onChange={onChange} />)
     const input = screen.getByRole('spinbutton')
 
-    userEvent.type(input, '5')
+    await userEvent.type(input, '5')
 
     await waitFor(() => {
       const event = onChange.mock.calls[0][0]
@@ -107,7 +107,7 @@ describe('<NumberInput />', () => {
     render(<NumberInput renderLabel="Label" onKeyDown={onKeyDown} />)
     const input = screen.getByRole('spinbutton')
 
-    userEvent.type(input, '5')
+    await userEvent.type(input, '5')
 
     await waitFor(() => {
       expect(onKeyDown).toHaveBeenCalledTimes(1)
@@ -118,8 +118,8 @@ describe('<NumberInput />', () => {
     const onBlur = vi.fn()
     render(<NumberInput renderLabel="Label" onBlur={onBlur} />)
 
-    userEvent.tab()
-    userEvent.tab()
+    await userEvent.tab()
+    await userEvent.tab()
 
     await waitFor(() => {
       expect(onBlur).toHaveBeenCalledTimes(1)
@@ -167,7 +167,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[0])
+    await userEvent.click(buttons[0])
 
     await waitFor(() => {
       expect(onIncrement).toHaveBeenCalledTimes(1)
@@ -187,7 +187,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[0])
+    await userEvent.click(buttons[0])
 
     await waitFor(() => {
       expect(onIncrement).toHaveBeenCalledTimes(0)
@@ -203,7 +203,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[0])
+    await userEvent.click(buttons[0])
 
     await waitFor(() => {
       expect(onIncrement).toHaveBeenCalledTimes(0)
@@ -220,7 +220,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[1])
+    await userEvent.click(buttons[1])
 
     await waitFor(() => {
       expect(onDecrement).toHaveBeenCalledTimes(1)
@@ -240,7 +240,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[1])
+    await userEvent.click(buttons[1])
 
     await waitFor(() => {
       expect(onDecrement).toHaveBeenCalledTimes(0)
@@ -256,7 +256,7 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[1])
+    await userEvent.click(buttons[1])
 
     await waitFor(() => {
       expect(onDecrement).toHaveBeenCalledTimes(0)
@@ -294,12 +294,12 @@ describe('<NumberInput />', () => {
       'button[class$="-numberInput_arrow"]'
     )
 
-    userEvent.click(buttons[0])
+    await userEvent.click(buttons[0])
     await waitFor(() => {
       expect(onIncrement).toHaveBeenCalledTimes(1)
     })
 
-    userEvent.click(buttons[1])
+    await userEvent.click(buttons[1])
     await waitFor(() => {
       expect(onDecrement).toHaveBeenCalledTimes(1)
     })

--- a/packages/ui-options/src/Options/__tests__/Item.test.tsx
+++ b/packages/ui-options/src/Options/__tests__/Item.test.tsx
@@ -137,12 +137,12 @@ describe('<Item />', () => {
       '[class$="-optionItem__container"]'
     )
 
-    userEvent.click(optionItem!)
+    await userEvent.click(optionItem!)
     await waitFor(() => {
       expect(onClick).not.toHaveBeenCalled()
     })
 
-    userEvent.click(optionItemContainer!)
+    await userEvent.click(optionItemContainer!)
     await waitFor(() => {
       expect(onClick).toHaveBeenCalledTimes(1)
     })

--- a/packages/ui-pages/src/Pages/__tests__/Pages.test.tsx
+++ b/packages/ui-pages/src/Pages/__tests__/Pages.test.tsx
@@ -132,7 +132,7 @@ describe('<Pages />', () => {
 
     const button = container.querySelector('button')!
 
-    userEvent.click(button)
+    await userEvent.click(button)
 
     await waitFor(() => {
       expect(onPageIndexChange).toHaveBeenCalledTimes(1)

--- a/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.tsx
+++ b/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.tsx
@@ -29,7 +29,10 @@ import { vi } from 'vitest'
 
 import '@testing-library/jest-dom'
 import { runAxeCheck } from '@instructure/ui-axe-check'
-import { RadioInput, type RadioInputHandle } from '@instructure/ui-radio-input/latest'
+import {
+  RadioInput,
+  type RadioInputHandle
+} from '@instructure/ui-radio-input/latest'
 
 describe('<RadioInput />', () => {
   let consoleWarningMock: ReturnType<typeof vi.spyOn>
@@ -91,7 +94,7 @@ describe('<RadioInput />', () => {
 
       const input = container.querySelector('input')
 
-      userEvent.click(input!)
+      await userEvent.click(input!)
 
       await waitFor(() => {
         expect(onClick).toHaveBeenCalled()
@@ -159,7 +162,7 @@ describe('<RadioInput />', () => {
 
       const input = container.querySelector('input')
 
-      userEvent.click(input!)
+      await userEvent.click(input!)
 
       await waitFor(() => {
         expect(onChange).toHaveBeenCalled()

--- a/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
@@ -79,7 +79,7 @@ describe('<RadioInputGroup />', () => {
     )
     const input = container.querySelector('input')
 
-    userEvent.click(input!)
+    await userEvent.click(input!)
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalled()
@@ -153,7 +153,7 @@ describe('<RadioInputGroup />', () => {
 
     expect(orange).toHaveAttribute('checked')
 
-    userEvent.click(banana!)
+    await userEvent.click(banana!)
 
     await waitFor(() => {
       expect(orange).toHaveAttribute('checked')

--- a/packages/ui-selectable/src/Selectable/__tests__/Selectable.test.tsx
+++ b/packages/ui-selectable/src/Selectable/__tests__/Selectable.test.tsx
@@ -78,7 +78,7 @@ describe('<Selectable />', () => {
 
     expect(document.activeElement).not.toBe(input)
 
-    userEvent.click(label)
+    await userEvent.click(label)
 
     await waitFor(() => {
       expect(document.activeElement).toBe(input)
@@ -117,7 +117,7 @@ describe('<Selectable />', () => {
 
     expect(document.activeElement).not.toBe(input)
 
-    userEvent.click(label)
+    await userEvent.click(label)
 
     await waitFor(() => {
       expect(onFocus).toHaveBeenCalledTimes(1)
@@ -158,7 +158,7 @@ describe('<Selectable />', () => {
     const list = screen.getByRole('listbox')
 
     input.focus()
-    userEvent.click(list)
+    await userEvent.click(list)
 
     await waitFor(() => {
       expect(document.activeElement).toBe(input)
@@ -208,7 +208,7 @@ describe('<Selectable />', () => {
     const option = screen.getByText('foo')
 
     input.focus()
-    userEvent.click(option)
+    await userEvent.click(option)
 
     await waitFor(() => {
       expect(document.activeElement).toBe(input)
@@ -253,7 +253,7 @@ describe('<Selectable />', () => {
     )
     const button = screen.getByText('Selected')
 
-    userEvent.click(button)
+    await userEvent.click(button)
     await userEvent.type(button, '{enter}')
 
     await waitFor(() => {
@@ -278,7 +278,7 @@ describe('<Selectable />', () => {
         )
         const label = screen.getByText('Selectable')
 
-        userEvent.click(label)
+        await userEvent.click(label)
 
         await waitFor(() => {
           expect(onRequestShowOptions).toHaveBeenCalledTimes(1)
@@ -294,7 +294,7 @@ describe('<Selectable />', () => {
           </Selectable>
         )
 
-        userEvent.click(label)
+        await userEvent.click(label)
 
         await waitFor(() => {
           expect(onRequestShowOptions).toHaveBeenCalledTimes(1)
@@ -314,7 +314,7 @@ describe('<Selectable />', () => {
         )
         const input = screen.getByRole('combobox')
 
-        userEvent.click(input)
+        await userEvent.click(input)
 
         await waitFor(() => {
           expect(onRequestShowOptions).toHaveBeenCalledTimes(1)
@@ -329,7 +329,7 @@ describe('<Selectable />', () => {
           </Selectable>
         )
 
-        userEvent.click(input)
+        await userEvent.click(input)
 
         await waitFor(() => {
           expect(onRequestShowOptions).toHaveBeenCalledTimes(1)
@@ -1198,8 +1198,8 @@ describe('<Selectable />', () => {
       const option_0 = screen.getByText(defaultOptions[0])
       const option_1 = screen.getByText(defaultOptions[1])
 
-      userEvent.click(option_0)
-      userEvent.click(option_1)
+      await userEvent.click(option_0)
+      await userEvent.click(option_1)
 
       await waitFor(() => {
         expect(onRequestSelectOption).toHaveBeenCalledTimes(2)

--- a/packages/ui-side-nav-bar/src/SideNavBar/__tests__/SideNavBar.test.tsx
+++ b/packages/ui-side-nav-bar/src/SideNavBar/__tests__/SideNavBar.test.tsx
@@ -188,7 +188,7 @@ describe('<SideNavBar />', () => {
     expect(nav).toHaveTextContent('Minimize SideNavBar')
     expect(toggleBtn).toHaveAttribute('aria-expanded', 'true')
 
-    userEvent.click(toggleBtn)
+    await userEvent.click(toggleBtn)
 
     await waitFor(() => {
       const updatedToggleBtn = screen.getByRole('button')

--- a/packages/ui-table/src/Table/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/__tests__/Table.test.tsx
@@ -283,7 +283,7 @@ describe('<Table />', async () => {
       )
       const button = screen.getByRole('button', { name: 'Foo' })
 
-      userEvent.click(button)
+      await userEvent.click(button)
 
       await waitFor(() => {
         expect(onRequestSort).toHaveBeenCalledTimes(1)
@@ -303,7 +303,7 @@ describe('<Table />', async () => {
       )
       const input = screen.getByRole('combobox')
 
-      userEvent.click(input)
+      await userEvent.click(input)
 
       await waitFor(async () => {
         const options = screen.getAllByRole('option')

--- a/packages/ui-tag/src/Tag/__tests__/Tag.test.tsx
+++ b/packages/ui-tag/src/Tag/__tests__/Tag.test.tsx
@@ -68,7 +68,7 @@ describe('<Tag />', async () => {
 
     const button = screen.getByTestId('summer-button')
 
-    userEvent.click(button)
+    await userEvent.click(button)
 
     await waitFor(() => {
       expect(onClick).toHaveBeenCalledTimes(1)

--- a/packages/ui-text-area/src/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/ui-text-area/src/TextArea/__tests__/TextArea.test.tsx
@@ -170,8 +170,8 @@ describe('TextArea', () => {
       const onBlur = vi.fn()
       render(<TextArea label="Name" autoGrow={false} onBlur={onBlur} />)
 
-      userEvent.tab()
-      userEvent.tab()
+      await userEvent.tab()
+      await userEvent.tab()
 
       await waitFor(() => {
         expect(onBlur).toHaveBeenCalled()

--- a/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
@@ -112,8 +112,8 @@ describe('<TextInput/>', () => {
       const onBlur = vi.fn()
       render(<TextInput renderLabel="Name" onBlur={onBlur} />)
 
-      userEvent.tab()
-      userEvent.tab()
+      await userEvent.tab()
+      await userEvent.tab()
 
       await waitFor(() => {
         expect(onBlur).toHaveBeenCalled()


### PR DESCRIPTION
INSTUI-5100

**ISSUE:**

- 63 userEvent.* calls in vitest tests were missing await. Without "wait," the test fires the click and immediately runs its check — before the click has actually done anything. So the test can say "passed" even when the feature is broken. 

**TEST PLAN:**
- confirm no userEvent action is left un-awaited anywhere