### PR TITLE
fix(ui-badge,ui-scripts): use primaryTextColor for primary badge text

### DIFF
--- a/packages/ui-badge/src/Badge/v2/styles.ts
+++ b/packages/ui-badge/src/Badge/v2/styles.ts
@@ -40,10 +40,9 @@ const pulseAnimation = keyframes`
  * private: true
  * ---
  * Generates the style object from the theme and provided additional information
- * @param  {Object} componentTheme The theme variable object.
- * @param  {Object} props the props of the component, the style is applied to
- * @param  {Object} state the state of the component, the style is applied to
- * @return {Object} The final style object, which will be used in the component
+ * @param  componentTheme The theme variable object.
+ * @param  props the props of the component, the style is applied to
+ * @return The final style object, which will be used in the component
  */
 const generateStyle = (
   componentTheme: ReturnType<NewComponentTypes['Badge']>,
@@ -78,7 +77,7 @@ const generateStyle = (
     },
     primary: {
       badge: {
-        color: componentTheme.color,
+        color: componentTheme.primaryTextColor,
         backgroundColor: componentTheme.colorPrimary
       },
       pulseBorder: {

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/cli": "^7.27.2",
     "@instructure/command-utils": "workspace:*",
-    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.4.0",
+    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.5.0",
     "dprint": "^0.55.1",
     "http-server": "^14.1.1",
     "lerna": "9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3909,8 +3909,8 @@ importers:
         specifier: workspace:*
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
-        specifier: github:instructure/instructure-design-tokens#v1.4.0
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/0db8a8645f1c483daf4fac81394cb7dbc0f3f227
+        specifier: github:instructure/instructure-design-tokens#v1.5.0
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6
       dprint:
         specifier: ^0.55.1
         version: 0.55.1
@@ -7072,8 +7072,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/0db8a8645f1c483daf4fac81394cb7dbc0f3f227':
-    resolution: {gitHosted: true, integrity: sha512-NWck8He8l+xyS9OrwbFLXD0oMZGtkFs+m2jgxNGOD5gllDFLMEOZ4KT59BPxYcY5T2dNm5Y+/SSsrzU1K7eDVw==, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/0db8a8645f1c483daf4fac81394cb7dbc0f3f227}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -15177,7 +15177,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/0db8a8645f1c483daf4fac81394cb7dbc0f3f227':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6':
     dependencies:
       glob: 13.0.6
 
@@ -20658,7 +20658,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.5.1
       minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}


### PR DESCRIPTION
## Summary
- Primary badge text now uses `componentTheme.primaryTextColor` instead of `componentTheme.color` (v2 styles).
- Bump `@instructure/instructure-design-tokens` from v1.4.0 to v1.5.0, see https://github.com/instructure/instructure-design-tokens/releases/tag/v1.5.0

Note: the design token bump also changes Badge size. This is OK for now because 11.7 is still a beta

## Test Plan
- Verify the primary Badge renders readable text against its background across canvas, rebrand, light, dark, and high-contrast themes.

Fixes INSTUI-5115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
