### PR TITLE
docs(many): update v2 spacing prop JSDoc to use the new Spacing scale

### DIFF
--- a/packages/ui-color-picker/src/ColorPicker/v2/props.ts
+++ b/packages/ui-color-picker/src/ColorPicker/v2/props.ts
@@ -226,7 +226,9 @@ type ColorPickerOwnProps = {
   withAlpha?: boolean
 
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 

--- a/packages/ui-date-input/src/DateInput/v2/props.ts
+++ b/packages/ui-date-input/src/DateInput/v2/props.ts
@@ -167,7 +167,9 @@ type DateInputOwnProps = {
   renderCalendarIcon?: Renderable
 
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /*

--- a/packages/ui-flex/src/Flex/v2/Item/props.ts
+++ b/packages/ui-flex/src/Flex/v2/Item/props.ts
@@ -50,16 +50,16 @@ type FlexItemOwnProps = {
   elementRef?: (element: Element | null) => void
 
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 
   /**
-   * Valid values are `0`, `none`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `padding="small x-large large"`.
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
 

--- a/packages/ui-flex/src/Flex/v2/props.ts
+++ b/packages/ui-flex/src/Flex/v2/props.ts
@@ -72,16 +72,16 @@ type FlexOwnProps = {
   margin?: Spacing
 
   /**
-   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * Valid values are `0`, `none`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `gap="small auto large"`.
+   * familiar CSS-like shorthand. For example, `gap="general.spaceMd general.spaceLg"`.
    */
   gap?: Spacing
 
   /**
-   * Valid values are `0`, `none`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `padding="small x-large large"`.
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
 

--- a/packages/ui-form-field/src/FormField/v2/props.ts
+++ b/packages/ui-form-field/src/FormField/v2/props.ts
@@ -63,7 +63,9 @@ type FormFieldOwnProps = {
   isRequired?: boolean
 
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**

--- a/packages/ui-list/src/InlineList/v2/InlineListItem/props.ts
+++ b/packages/ui-list/src/InlineList/v2/InlineListItem/props.ts
@@ -39,15 +39,15 @@ type InlineListItemOwnProps = {
   delimiter?: 'none' | 'pipe' | 'slash' | 'arrow'
   size?: 'small' | 'medium' | 'large'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**
-   * Valid values are `0`, `none`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `padding="small x-large large"`.
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
   /**

--- a/packages/ui-list/src/List/v2/ListItem/props.ts
+++ b/packages/ui-list/src/List/v2/ListItem/props.ts
@@ -39,15 +39,15 @@ type ListItemOwnProps = {
   delimiter?: 'none' | 'dashed' | 'solid'
   size?: 'small' | 'medium' | 'large'
   /**
-   * Valid values are `0`, `none`, `auto`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `margin="small auto large"`.
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
   /**
-   * Valid values are `0`, `none`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `padding="small x-large large"`.
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
   /**

--- a/packages/ui-modal/src/Modal/v2/ModalBody/props.ts
+++ b/packages/ui-modal/src/Modal/v2/ModalBody/props.ts
@@ -37,6 +37,11 @@ import type {
 
 type ModalBodyOwnProps = {
   children?: React.ReactNode
+  /**
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
+   */
   padding?: Spacing
   elementRef?: (element: UIElement | null) => void
   as?: AsElementType

--- a/packages/ui-number-input/src/NumberInput/v2/props.ts
+++ b/packages/ui-number-input/src/NumberInput/v2/props.ts
@@ -180,7 +180,9 @@ type NumberInputOwnProps = {
     decrease: Renderable
   }
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-tabs/src/Tabs/v2/Panel/props.ts
+++ b/packages/ui-tabs/src/Tabs/v2/Panel/props.ts
@@ -45,6 +45,11 @@ type TabsPanelOwnProps = {
   minHeight?: string | number
   id?: string
   labelledBy?: string
+  /**
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
+   */
   padding?: Spacing
   textAlign?: 'start' | 'center' | 'end'
   /**

--- a/packages/ui-tabs/src/Tabs/v2/props.ts
+++ b/packages/ui-tabs/src/Tabs/v2/props.ts
@@ -62,9 +62,9 @@ type TabsOwnProps = {
    */
   margin?: Spacing
   /**
-   * Valid values are `0`, `none`, `xxx-small`, `xx-small`, `x-small`,
-   * `small`, `medium`, `large`, `x-large`, `xx-large`. Apply these values via
-   * familiar CSS-like shorthand. For example: `padding="small x-large large"`.
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
   textAlign?: 'start' | 'center' | 'end'

--- a/packages/ui-text-area/src/TextArea/v2/props.ts
+++ b/packages/ui-text-area/src/TextArea/v2/props.ts
@@ -113,7 +113,9 @@ type TextAreaOwnProps = {
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
 
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-text-input/src/TextInput/v2/props.ts
+++ b/packages/ui-text-input/src/TextInput/v2/props.ts
@@ -174,7 +174,9 @@ type TextInputOwnProps = {
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 
   /**
-   * Margin around the component. Accepts a `Spacing` token. See token values and example usage in [this guide](https://instructure.design/#layout-spacing).
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
    */
   margin?: Spacing
 }

--- a/packages/ui-view/src/ContextView/v2/props.ts
+++ b/packages/ui-view/src/ContextView/v2/props.ts
@@ -50,7 +50,17 @@ type ContextViewOwnProps = {
   textAlign?: 'start' | 'center' | 'end'
   background?: 'default' | 'inverse'
   debug?: boolean
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
   margin?: Spacing
+  /**
+   * Valid values are `0`, `none`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
+   */
   padding?: Spacing
   shadow?: Shadow
   stacking?: Stacking

--- a/packages/ui-view/src/View/v2/props.ts
+++ b/packages/ui-view/src/View/v2/props.ts
@@ -181,9 +181,9 @@ type ViewOwnProps = {
    */
   margin?: Spacing
   /**
-   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * Valid values are `0`, `none`, and Spacing token values,
    * see https://instructure.design/layout-spacing. Apply these values via
-   * familiar CSS-like shorthand. For example, `padding="small auto large"`.
+   * familiar CSS-like shorthand. For example, `padding="general.spaceMd general.spaceLg"`.
    */
   padding?: Spacing
   /**


### PR DESCRIPTION
## Summary
Updates the `margin` / `padding` / `gap` JSDoc on the v2 component prop types to
describe the current general Spacing scale and link to the layout-spacing guide,
instead of enumerating the deprecated keyword scale.

## Changes
- Replaces the deprecated keyword enumeration (`xxx-small … xx-large`) / the old
  `#layout-spacing` anchor with a `general.*` shorthand example and the current guide link.
- Correctness fix: `auto` is documented only for `margin`, not for `padding`/`gap`.
- 15 v2 `props.ts` files updated.

## Test plan
- `react-docgen` prop tables regenerate cleanly.
- Rendered prop docs show the new descriptions; no deprecated keyword enumeration remains.

INSTUI-5119

Related: sibling of INSTUI-5118 (same spacing-token initiative, README examples side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)