### PR TITLE
fix(ui-billboard): point icons doc links at valid icons pages

### DIFF
--- a/packages/__docs__/src/Icons/index.tsx
+++ b/packages/__docs__/src/Icons/index.tsx
@@ -49,8 +49,7 @@ const IconsPage = () => {
         }
       >
         <Alert variant="info" margin="0 0 medium">
-          The version selector does not affect this page. For icons compatible
-          with older versions, use{' '}
+          For icons compatible with older versions, use{' '}
           <Link
             href="legacy-icons"
             onClick={(e) => {

--- a/packages/ui-billboard/src/Billboard/v1/README.md
+++ b/packages/ui-billboard/src/Billboard/v1/README.md
@@ -26,7 +26,7 @@ type: example
   don't pass interactive content to the `message` prop if you have set the `href`
   or `onClick` props).
 - Use the `size` prop to adjust the size of the icon and text.
-- Pass [Instructure icons](icons-react) to the `hero` property via a function
+- Pass [Instructure icons](legacy-icons) to the `hero` property via a function
   _(see examples)_, and they will be sized correctly based on the Billboard's
   `size`.
 

--- a/packages/ui-billboard/src/Billboard/v2/README.md
+++ b/packages/ui-billboard/src/Billboard/v2/README.md
@@ -26,7 +26,7 @@ type: example
   don't pass interactive content to the `message` prop if you have set the `href`
   or `onClick` props).
 - Use the `size` prop to adjust the size of the icon and text.
-- Pass [Instructure icons](icons-react) to the `hero` property via a function
+- Pass [Instructure icons](icons) to the `hero` property via a function
   _(see examples)_, and they will be sized correctly based on the Billboard's
   `size`.
 


### PR DESCRIPTION
## Summary
The Billboard READMEs linked the `hero` icon docs to `icons-react`, which is not a
route in the docs app (dead link). Points each version at its correct icons page and
removes a now-inaccurate note from the Icons page.

## Changes
- `Billboard/v2/README.md`: `icons-react` → `icons` (current icons page)
- `Billboard/v1/README.md`: `icons-react` → `legacy-icons` (legacy icons page)
- `docs-app` Icons page: remove "The version selector does not affect this page." part of the alert.

## Test plan
- No `icons-react` reference remains in the repo.
- v2 Billboard link resolves to the `icons` route; v1 to `legacy-icons` (both valid App routes).

INSTUI-5121

🤖 Generated with [Claude Code](https://claude.com/claude-code)