### PR TITLE
fix(ui-flex): flex does not resolve spacing tokens

### DIFF
--- a/packages/ui-flex/src/Flex/v2/styles.ts
+++ b/packages/ui-flex/src/Flex/v2/styles.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { getShorthandPropValue, makeThemeVars } from '@instructure/emotion'
+import { calcSpacingFromShorthand } from '@instructure/emotion'
 import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
 import type { FlexProps, FlexStyle } from './props'
 
@@ -87,14 +87,6 @@ const generateStyle = (
     'row-reverse': 'row-reverse'
   }
 
-  // gap css prop
-  const gapValues = makeThemeVars('gap', {
-    ...sharedTokens.spacing,
-    ...sharedTokens.legacy.spacing
-  })
-  const getGapValue = (gap: FlexProps['gap'], values: Record<string, string>) =>
-    getShorthandPropValue('Flex', values, gap, 'gap')
-
   return {
     flex: {
       label: 'flex',
@@ -104,7 +96,10 @@ const generateStyle = (
       justifyContent: justifyItemsValues[justifyItems!],
       flexWrap: wrapValues[wrap!],
       flexDirection: flexDirectionValues[direction!],
-      gap: getGapValue(gap!, gapValues)
+      gap: calcSpacingFromShorthand(gap, {
+        ...sharedTokens.spacing,
+        ...sharedTokens.legacy.spacing
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary
Flex v2 resolved the `gap` prop with `getShorthandPropValue`, which only handles
the flat legacy keyword scale. The current `general.*` tokens are nested, so
`gap="general.spaceXl"` was not found and silently fell back to `0` (no gap).
Resolve `gap` with `calcSpacingFromShorthand` (the same helper View uses for
`margin`/`padding`), which supports both the `general.*` dot-path and the legacy
keywords.

## Notes
- Flex `margin`/`padding` and `Flex.Item` already worked (both delegate to View).
- Only Flex's own `gap` was affected — the sole remaining `getShorthandPropValue`
  spacing usage across v2.

## Test plan
````
<div>
  <Flex withVisualDebug margin="none none general.space2xl" gap="general.spaceMd">
    <Flex.Item><Text>One</Text></Flex.Item>
    <Flex.Item><Text>Two</Text></Flex.Item>
    <Flex.Item><Text>Three</Text></Flex.Item>
    <Flex.Item><Text>Four</Text></Flex.Item>
  </Flex>
  <Flex withVisualDebug direction="column" margin="none none general.space2xl" gap="general.spaceXl">
    <Flex.Item><Text>One</Text></Flex.Item>
    <Flex.Item><Text>Two</Text></Flex.Item>
    <Flex.Item><Text>Three</Text></Flex.Item>
    <Flex.Item><Text>Four</Text></Flex.Item>
  </Flex>
</div>
````

- Flex doc page section: Gap between Flex.Items 
 renders the expected `general.space2xl` gap 
- Legacy `gap="small"` still resolves.
- No "invalid 'gap' value" console error.

INSTUI-5125

🤖 Generated with [Claude Code](https://claude.com/claude-code)