### PR TITLE
docs(ui-top-nav-bar): fix TopNavBar doc example runtime crash

### DIFF
--- a/packages/ui-top-nav-bar/src/TopNavBar/v2/README.md
+++ b/packages/ui-top-nav-bar/src/TopNavBar/v2/README.md
@@ -2137,16 +2137,13 @@ class InPlaceDialogExample extends React.Component {
                   content: ({ closeInPlaceDialog }) => (
                     <View as="div" padding="x-small">
                       <InstUISettingsProvider
-                        theme={(currentTheme) => ({
-                          newTheme: {
-                            sharedTokens: {
-                              focusOutline: {
-                                ...currentTheme?.newTheme?.sharedTokens?.focusOutline,
-                                infoColor: 'white'
-                              }
+                        themeOverride={{
+                          sharedTokens: {
+                            focusOutline: {
+                              infoColor: 'white'
                             }
                           }
-                        })}
+                        }}
                       >
                         <TextInput
                           id="searchInput"


### PR DESCRIPTION
## Summary
- Fix the TopNavBar v2 README "Full width dialog on small viewports" example: pass the
  shared-token override via `themeOverride` instead of the `theme` prop. The `theme` prop
  deep-merged into the theme and replaced the `sharedTokens` function with a plain object,
  so opening the search dialog threw `theme.newTheme.sharedTokens is not a function`.

## Test Plan
- On the TopNavBar v2 docs page, open the "Full width dialog on small viewports" example,
  click the search icon, and confirm the in-place search dialog opens without a runtime error.

Fixes INSTUI-5126

🤖 Generated with [Claude Code](https://claude.com/claude-code)