### PR TITLE
docs: remove inline code comments from prop type documentation

### DIFF
--- a/packages/ui-avatar/src/Avatar/v1/props.ts
+++ b/packages/ui-avatar/src/Avatar/v1/props.ts
@@ -59,7 +59,7 @@ type AvatarOwnProps = {
     | 'x-large'
     | 'xx-large'
   color?:
-    | 'default' // = brand
+    | 'default'
     | 'shamrock'
     | 'barney'
     | 'crimson'

--- a/packages/ui-date-input/src/DateInput2/v1/props.ts
+++ b/packages/ui-date-input/src/DateInput2/v1/props.ts
@@ -39,7 +39,6 @@ type DateInput2OwnProps = {
     calendarIcon: string
     prevMonthButton: string
     nextMonthButton: string
-    // TODO: Make this field required in the next version. Currently optional to avoid breaking change.
     datePickerDialog?: string
     selectedLabel?: string
   }

--- a/packages/ui-range-input/src/RangeInput/v1/props.ts
+++ b/packages/ui-range-input/src/RangeInput/v1/props.ts
@@ -29,7 +29,10 @@ import type {
   RangeInputTheme,
   PickPropsWithExceptions
 } from '@instructure/shared-types'
-import type { FormFieldOwnProps, FormMessage } from '@instructure/ui-form-field/v11_6'
+import type {
+  FormFieldOwnProps,
+  FormMessage
+} from '@instructure/ui-form-field/v11_6'
 import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
 import type { InputHTMLAttributes } from 'react'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
@@ -89,9 +92,7 @@ type RangeInputOwnProps = {
    * The "deprecated" variant has an outer shadow on focus.
    * The "accessible" variant has better color contrast, border and inset focus ring for better accessibility.
    */
-  thumbVariant?:
-    | 'deprecated' // TODO: deprecated, remove in V9.
-    | 'accessible'
+  thumbVariant?: 'deprecated' | 'accessible'
 
   /**
    * A function that provides a reference to the actual underlying input element

--- a/packages/ui-text/src/Text/v2/props.ts
+++ b/packages/ui-text/src/Text/v2/props.ts
@@ -36,7 +36,10 @@ type TextOwnProps = {
    */
   as?: AsElementType
   /**
-   * Color of the text
+   * Color of the text.
+   *
+   * `primary-on` and `secondary-on` are meant for use on colored surfaces
+   * (like `warning`) and keep the same color in dark and light themes.
    */
   color?:
     | 'inherit'
@@ -48,8 +51,8 @@ type TextOwnProps = {
     | 'warning'
     | 'primary-inverse'
     | 'secondary-inverse'
-    | 'primary-on' // used on colored surfaces like warning, same color in dark and light themes
-    | 'secondary-on' // used on colored surfaces like warning, same color in dark and light themes
+    | 'primary-on'
+    | 'secondary-on'
     | 'ai-highlight'
   /**
    * Provides a reference to the underlying HTML element

--- a/packages/ui-view/src/View/v1/props.ts
+++ b/packages/ui-view/src/View/v1/props.ts
@@ -62,6 +62,10 @@ type ViewOwnProps = {
   /**
    * By default the display prop is 'auto', meaning it takes on the
    * display rules of the html element it's rendered as (see `as` prop).
+   *
+   * `inherit`, `initial`, `revert`, `revert-layer` and `unset` are the global
+   * CSS values (see the
+   * [MDN `display` reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/display)).
    */
   display?:
     | 'auto'
@@ -71,12 +75,11 @@ type ViewOwnProps = {
     | 'flex'
     | 'inline-flex'
     | 'contents'
-    // these are global CSS values
-    | 'inherit' // inherit the parent's display value
-    | 'initial' // reset the property back to the spec default
-    | 'revert' // reset to user agent stylesheet
+    | 'inherit'
+    | 'initial'
+    | 'revert'
     | 'revert-layer'
-    | 'unset' // same as initial
+    | 'unset'
   overflowX?: 'auto' | 'hidden' | 'visible'
   overflowY?: 'auto' | 'hidden' | 'visible'
   height?: string | number

--- a/packages/ui-view/src/View/v2/props.ts
+++ b/packages/ui-view/src/View/v2/props.ts
@@ -78,6 +78,10 @@ type ViewOwnProps = {
   /**
    * By default the display prop is 'auto', meaning it takes on the
    * display rules of the html element it's rendered as (see `as` prop).
+   *
+   * `inherit`, `initial`, `revert`, `revert-layer` and `unset` are the global
+   * CSS values (see the
+   * [MDN `display` reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/display)).
    */
   display?:
     | 'auto'
@@ -87,12 +91,11 @@ type ViewOwnProps = {
     | 'flex'
     | 'inline-flex'
     | 'contents'
-    // these are global CSS values
-    | 'inherit' // inherit the parent's display value
-    | 'initial' // reset the property back to the spec default
-    | 'revert' // reset to user agent stylesheet
+    | 'inherit'
+    | 'initial'
+    | 'revert'
     | 'revert-layer'
-    | 'unset' // same as initial
+    | 'unset'
   overflowX?: 'auto' | 'hidden' | 'visible'
   overflowY?: 'auto' | 'hidden' | 'visible'
   height?: string | number


### PR DESCRIPTION
INSTUI-5129

**ISSUE:**
- prop documentation table was showing inline source-code comments as if they were part of the type (e.g. the display prop of View) making them hard to read
- GitHub issue https://github.com/instructure/instructure-ui/issues/2622

**TEST PLAN:**
- no props table should display inline comments