### PR TITLE
feat(ui-card): add Card component with base and nested variants

### DIFF
--- a/packages/__docs__/package.json
+++ b/packages/__docs__/package.json
@@ -46,6 +46,7 @@
     "@instructure/ui-buttons": "workspace:*",
     "@instructure/ui-byline": "workspace:*",
     "@instructure/ui-calendar": "workspace:*",
+    "@instructure/ui-card": "workspace:*",
     "@instructure/ui-checkbox": "workspace:*",
     "@instructure/ui-color-picker": "workspace:*",
     "@instructure/ui-color-utils": "workspace:*",

--- a/packages/__docs__/tsconfig.build.json
+++ b/packages/__docs__/tsconfig.build.json
@@ -69,6 +69,9 @@
       "path": "../ui-calendar/tsconfig.build.json"
     },
     {
+      "path": "../ui-card/tsconfig.build.json"
+    },
+    {
       "path": "../ui-checkbox/tsconfig.build.json"
     },
     {

--- a/packages/ui-card/.gitignore
+++ b/packages/ui-card/.gitignore
@@ -1,0 +1,4 @@
+lib/
+.babel-cache/
+es/
+types/

--- a/packages/ui-card/.npmignore
+++ b/packages/ui-card/.npmignore
@@ -1,0 +1,5 @@
+**/.*
+**/__tests__
+**/__testfixtures__
+*.config.js
+*.conf.js

--- a/packages/ui-card/CHANGELOG.md
+++ b/packages/ui-card/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/ui-card/README.md
+++ b/packages/ui-card/README.md
@@ -1,0 +1,24 @@
+## ui-card
+
+[![npm][npm]][npm-url]
+[![MIT License][license-badge]][license]
+[![Code of Conduct][coc-badge]][coc]
+
+### Components
+
+The `ui-card` package contains the following:
+
+- Card
+
+### Installation
+
+```sh
+npm install @instructure/ui-card
+```
+
+[npm]: https://img.shields.io/npm/v/@instructure/ui-card.svg
+[npm-url]: https://npmjs.com/package/@instructure/ui-card
+[license-badge]: https://img.shields.io/npm/l/instructure-ui.svg?style=flat-square
+[license]: https://github.com/instructure/instructure-ui/blob/master/LICENSE.md
+[coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
+[coc]: https://github.com/instructure/instructure-ui/blob/master/CODE_OF_CONDUCT.md

--- a/packages/ui-card/babel.config.js
+++ b/packages/ui-card/babel.config.js
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+module.exports = {
+  presets: [
+    [
+      require('@instructure/ui-babel-preset'),
+      {
+        esModules: Boolean(process.env.ES_MODULES),
+        removeConsole: process.env.NODE_ENV === 'production',
+        transformImports: Boolean(process.env.TRANSFORM_IMPORTS)
+      }
+    ]
+  ]
+}

--- a/packages/ui-card/package.json
+++ b/packages/ui-card/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@instructure/ui-card",
+  "version": "11.7.4",
+  "description": "A basic wrapper component for grouping content with padding, border radius, shadow, and background.",
+  "author": "Instructure, Inc. Engineering and Product Design",
+  "module": "./es/index.js",
+  "main": "./lib/index.js",
+  "types": "./types/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/instructure/instructure-ui.git"
+  },
+  "homepage": "https://instructure.github.io/instructure-ui/",
+  "bugs": "https://github.com/instructure/instructure-ui/issues",
+  "scripts": {
+    "lint": "ui-scripts lint",
+    "lint:fix": "ui-scripts lint --fix",
+    "clean": "ui-scripts clean",
+    "build": "ui-scripts build --modules es,cjs",
+    "build:watch": "pnpm run ts:check -- --watch & ui-scripts build --watch",
+    "build:types": "tsc -p tsconfig.build.json",
+    "ts:check": "tsc -p tsconfig.build.json --noEmit --emitDeclarationOnly false"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.29.7",
+    "@instructure/emotion": "workspace:*",
+    "@instructure/shared-types": "workspace:*",
+    "@instructure/ui-react-utils": "workspace:*",
+    "@instructure/ui-themes": "workspace:*"
+  },
+  "devDependencies": {
+    "@instructure/ui-axe-check": "workspace:*",
+    "@instructure/ui-babel-preset": "workspace:*",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "16.3.2",
+    "vitest": "^4.1.9"
+  },
+  "peerDependencies": {
+    "react": ">=18 <=19"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "exports": {
+    "./lib/*": "./lib/*",
+    "./es/*": "./es/*",
+    "./types/*": "./types/*",
+    "./package.json": "./package.json",
+    "./src/*": "./src/*",
+    ".": {
+      "src": "./src/exports/a.ts",
+      "types": "./types/exports/a.d.ts",
+      "import": "./es/exports/a.js",
+      "require": "./lib/exports/a.js",
+      "default": "./es/exports/a.js"
+    },
+    "./v11_7": {
+      "src": "./src/exports/a.ts",
+      "types": "./types/exports/a.d.ts",
+      "import": "./es/exports/a.js",
+      "require": "./lib/exports/a.js",
+      "default": "./es/exports/a.js"
+    },
+    "./latest": {
+      "src": "./src/exports/a.ts",
+      "types": "./types/exports/a.d.ts",
+      "import": "./es/exports/a.js",
+      "require": "./lib/exports/a.js",
+      "default": "./es/exports/a.js"
+    }
+  }
+}

--- a/packages/ui-card/src/Card/__tests__/Card.test.tsx
+++ b/packages/ui-card/src/Card/__tests__/Card.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { runAxeCheck } from '@instructure/ui-axe-check'
+
+import '@testing-library/jest-dom'
+import { Card } from '@instructure/ui-card/latest'
+
+// Values come from the generated Card theme tokens, see
+// packages/ui-themes/src/themes/newThemeTokens/<theme>/components/card.ts
+const BREAKPOINT_MD = '20rem'
+const BREAKPOINT_LG = '40rem'
+
+const renderCard = (props = {}) => {
+  const { container } = render(<Card {...props}>content</Card>)
+  const card = container.querySelector('div')!
+  return { card, style: getComputedStyle(card) }
+}
+
+describe('<Card />', () => {
+  describe('for a11y', () => {
+    it('should be accessible', async () => {
+      const { container } = render(<Card>content</Card>)
+      const axeCheck = await runAxeCheck(container)
+      expect(axeCheck).toBe(true)
+    })
+  })
+
+  it('should render children', () => {
+    render(<Card>Hello world</Card>)
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+  })
+
+  it('should render a div', () => {
+    const { card } = renderCard()
+    expect(card.tagName).toBe('DIV')
+  })
+
+  it('should pass through arbitrary HTML attributes', () => {
+    render(<Card id="my-card">content</Card>)
+    expect(document.getElementById('my-card')).toBeInTheDocument()
+  })
+
+  it('should not leak component props onto the DOM node', () => {
+    const { card } = renderCard({ variant: 'nested', size: 'lg' })
+    expect(card).not.toHaveAttribute('variant')
+    expect(card).not.toHaveAttribute('size')
+  })
+
+  describe('variant', () => {
+    it('base should render a background and a box-shadow', () => {
+      const { style } = renderCard({ variant: 'base' })
+      // an opaque surface colour, not the transparent jsdom default
+      expect(style.backgroundColor).not.toBe('')
+      expect(style.backgroundColor).not.toBe('rgba(0, 0, 0, 0)')
+      expect(style.boxShadow).toContain('rgba')
+    })
+
+    it('nested should render a border instead of a background and shadow', () => {
+      const { style } = renderCard({ variant: 'nested' })
+      // positively assert the border the nested variant *does* apply
+      expect(style.borderStyle).toBe('solid')
+      expect(style.borderWidth).toBe('1px')
+      expect(style.borderColor).not.toBe('')
+      // and that it opts out of the base surface treatment
+      expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)')
+      expect(style.boxShadow).toBe('')
+    })
+
+    it('should apply a smaller padding for nested than for base at the same size', () => {
+      const base = renderCard({ variant: 'base', size: 'md' })
+      const nested = renderCard({ variant: 'nested', size: 'md' })
+      expect(base.style.padding).not.toBe(nested.style.padding)
+      expect(parseFloat(nested.style.padding)).toBeLessThan(
+        parseFloat(base.style.padding)
+      )
+    })
+  })
+
+  describe('size', () => {
+    it('sm should cap width at the md breakpoint with no min-width', () => {
+      const { style } = renderCard({ size: 'sm' })
+      expect(style.maxWidth).toBe(BREAKPOINT_MD)
+      expect(style.minWidth).toBe('auto')
+    })
+
+    it('md should span the md and lg breakpoints', () => {
+      const { style } = renderCard({ size: 'md' })
+      expect(style.minWidth).toBe(BREAKPOINT_MD)
+      expect(style.maxWidth).toBe(BREAKPOINT_LG)
+    })
+
+    it('lg should start at the lg breakpoint with no max-width', () => {
+      const { style } = renderCard({ size: 'lg' })
+      expect(style.minWidth).toBe(BREAKPOINT_LG)
+      expect(style.maxWidth).toBe('none')
+    })
+
+    it('should grow padding from sm through lg', () => {
+      const sm = parseFloat(renderCard({ size: 'sm' }).style.padding)
+      const md = parseFloat(renderCard({ size: 'md' }).style.padding)
+      const lg = parseFloat(renderCard({ size: 'lg' }).style.padding)
+      expect(sm).toBeLessThan(md)
+      expect(md).toBeLessThan(lg)
+    })
+
+    // The documented contract is that `nested` uses a smaller radius than
+    // `base`. Absolute radii are deliberately not asserted: the legacy Canvas
+    // themes flatten every radius token to the same value, so only the
+    // relationship between the two variants holds across all four themes.
+    it.each(['sm', 'md', 'lg'] as const)(
+      'nested should not have a larger border-radius than base at size %s',
+      (size) => {
+        const base = parseFloat(
+          renderCard({ variant: 'base', size }).style.borderRadius
+        )
+        const nested = parseFloat(
+          renderCard({ variant: 'nested', size }).style.borderRadius
+        )
+        expect(nested).toBeLessThanOrEqual(base)
+      }
+    )
+  })
+
+  describe('defaults', () => {
+    it('should default to the base variant at the md size', () => {
+      const bare = renderCard()
+      const explicit = renderCard({ variant: 'base', size: 'md' })
+      expect(bare.style.padding).toBe(explicit.style.padding)
+      expect(bare.style.minWidth).toBe(BREAKPOINT_MD)
+      expect(bare.style.maxWidth).toBe(BREAKPOINT_LG)
+      expect(bare.style.boxShadow).toContain('rgba')
+    })
+  })
+})

--- a/packages/ui-card/src/Card/__tests__/Card.test.tsx
+++ b/packages/ui-card/src/Card/__tests__/Card.test.tsx
@@ -126,6 +126,18 @@ describe('<Card />', () => {
       expect(md).toBeLessThan(lg)
     })
 
+    // `nested` must never enforce a width: it lives inside a `base` Card's
+    // padded content box, so its available width is already smaller than
+    // the breakpoint tokens it would otherwise share with `base`.
+    it.each(['sm', 'md', 'lg'] as const)(
+      'nested should apply no width constraint at size %s',
+      (size) => {
+        const { style } = renderCard({ variant: 'nested', size })
+        expect(style.minWidth).toBe('auto')
+        expect(style.maxWidth).toBe('none')
+      }
+    )
+
     // The documented contract is that `nested` uses a smaller radius than
     // `base`. Absolute radii are deliberately not asserted: the legacy Canvas
     // themes flatten every radius token to the same value, so only the

--- a/packages/ui-card/src/Card/__tests__/Card.test.tsx
+++ b/packages/ui-card/src/Card/__tests__/Card.test.tsx
@@ -168,4 +168,84 @@ describe('<Card />', () => {
       expect(bare.style.boxShadow).toContain('rgba')
     })
   })
+
+  describe('size="auto"', () => {
+    // "auto" measures its own rendered width via a CSS container query, so
+    // it needs a real ancestor width to react to — render it inside a fixed-
+    // width wrapper rather than using renderCard's bare, unconstrained render.
+    const renderAutoCard = (widthPx: number, props = {}) => {
+      const { container } = render(
+        <div style={{ width: `${widthPx}px` }}>
+          <Card size="auto" {...props}>
+            content
+          </Card>
+        </div>
+      )
+      const widthDiv = container.firstElementChild as HTMLElement
+      const cardContainer = widthDiv.firstElementChild as HTMLElement
+      const card = cardContainer.firstElementChild as HTMLElement
+      return { widthDiv, cardContainer, card, style: getComputedStyle(card) }
+    }
+
+    it('should render an extra wrapper element with containerType set', () => {
+      const { cardContainer } = renderAutoCard(400)
+      expect(getComputedStyle(cardContainer).containerType).toBe('inline-size')
+    })
+
+    it('should not apply a min-/max-width to itself', () => {
+      const { style } = renderAutoCard(400)
+      expect(style.minWidth).toBe('0px')
+      expect(style.maxWidth).toBe('none')
+    })
+
+    it('should match the sm padding below the md breakpoint', () => {
+      const auto = renderAutoCard(200).style.padding
+      const sm = renderCard({ size: 'sm' }).style.padding
+      expect(auto).toBe(sm)
+    })
+
+    it('should match the md padding between the md and lg breakpoints', () => {
+      const auto = renderAutoCard(400).style.padding
+      const md = renderCard({ size: 'md' }).style.padding
+      expect(auto).toBe(md)
+    })
+
+    it('should match the lg padding at or above the lg breakpoint', () => {
+      const auto = renderAutoCard(800).style.padding
+      const lg = renderCard({ size: 'lg' }).style.padding
+      expect(auto).toBe(lg)
+    })
+
+    it('should grow padding as the container widens', () => {
+      const narrow = parseFloat(renderAutoCard(200).style.padding)
+      const medium = parseFloat(renderAutoCard(400).style.padding)
+      const wide = parseFloat(renderAutoCard(800).style.padding)
+      expect(narrow).toBeLessThan(medium)
+      expect(medium).toBeLessThan(wide)
+    })
+
+    it('is not supported for the nested variant and falls back to a normal render', () => {
+      const { container } = render(
+        <div style={{ width: '200px' }}>
+          <Card size="auto" variant="nested">
+            content
+          </Card>
+        </div>
+      )
+      const widthDiv = container.firstElementChild as HTMLElement
+      // no extra wrapper: the card is the direct (and only) child element
+      expect(widthDiv.children).toHaveLength(1)
+      expect(widthDiv.firstElementChild!.tagName).toBe('DIV')
+    })
+
+    it('should be accessible', async () => {
+      const { container } = render(
+        <div style={{ width: '400px' }}>
+          <Card size="auto">content</Card>
+        </div>
+      )
+      const axeCheck = await runAxeCheck(container)
+      expect(axeCheck).toBe(true)
+    })
+  })
 })

--- a/packages/ui-card/src/Card/__tests__/Card.test.tsx
+++ b/packages/ui-card/src/Card/__tests__/Card.test.tsx
@@ -30,8 +30,10 @@ import { Card } from '@instructure/ui-card/latest'
 
 // Values come from the generated Card theme tokens, see
 // packages/ui-themes/src/themes/newThemeTokens/<theme>/components/card.ts
-const BREAKPOINT_MD = '20rem'
-const BREAKPOINT_LG = '40rem'
+// (20rem/40rem). Tests run in a real browser, whose getComputedStyle
+// resolves rem to the equivalent px at the default 16px root font size.
+const BREAKPOINT_MD = '320px'
+const BREAKPOINT_LG = '640px'
 
 const renderCard = (props = {}) => {
   const { container } = render(<Card {...props}>content</Card>)
@@ -86,7 +88,7 @@ describe('<Card />', () => {
       expect(style.borderColor).not.toBe('')
       // and that it opts out of the base surface treatment
       expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)')
-      expect(style.boxShadow).toBe('')
+      expect(style.boxShadow).toBe('none')
     })
 
     it('should apply a smaller padding for nested than for base at the same size', () => {
@@ -103,7 +105,7 @@ describe('<Card />', () => {
     it('sm should cap width at the md breakpoint with no min-width', () => {
       const { style } = renderCard({ size: 'sm' })
       expect(style.maxWidth).toBe(BREAKPOINT_MD)
-      expect(style.minWidth).toBe('auto')
+      expect(style.minWidth).toBe('0px')
     })
 
     it('md should span the md and lg breakpoints', () => {
@@ -133,7 +135,7 @@ describe('<Card />', () => {
       'nested should apply no width constraint at size %s',
       (size) => {
         const { style } = renderCard({ variant: 'nested', size })
-        expect(style.minWidth).toBe('auto')
+        expect(style.minWidth).toBe('0px')
         expect(style.maxWidth).toBe('none')
       }
     )

--- a/packages/ui-card/src/Card/v1/README.md
+++ b/packages/ui-card/src/Card/v1/README.md
@@ -40,6 +40,24 @@ type: example
 </div>
 ```
 
+### Auto sizing (prototype)
+
+For `variant="base"`, `size="auto"` measures the Card's own rendered width
+(via a CSS container query, using the same breakpoints as the explicit
+sizes) and picks `sm`/`md`/`lg` padding and border radius itself — no size
+prop needed. Resize the panel below to see it change.
+
+```js
+---
+type: example
+---
+<div style={{ resize: 'horizontal', overflow: 'auto', minWidth: '10rem', maxWidth: '100%', border: '1px dashed #999', padding: '0.5rem' }}>
+  <Card size="auto">
+    <Text variant="content">Resize this panel's right edge to see padding and border radius change.</Text>
+  </Card>
+</div>
+```
+
 ### Nested cards
 
 The `nested` variant is meant to be placed inside a `base` Card. It omits the

--- a/packages/ui-card/src/Card/v1/README.md
+++ b/packages/ui-card/src/Card/v1/README.md
@@ -105,27 +105,29 @@ type: example
   <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
     <Card variant="nested">
       <Heading level="h3" margin="0 0 x-small 0">
-        Course settings
+        Lorem ipsum
       </Heading>
       <Text variant="content">
-        Control who can see this course and when it becomes available to
-        students.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+        eiusmod tempor incididunt ut labore.
       </Text>
     </Card>
     <Card variant="nested">
       <Heading level="h3" margin="0 0 x-small 0">
-        Grading
+        Dolor sit amet
       </Heading>
       <Text variant="content">
-        Choose the grading scheme and decide how final grades are calculated.
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+        nisi ut aliquip ex ea commodo.
       </Text>
     </Card>
     <Card variant="nested">
       <Heading level="h3" margin="0 0 x-small 0">
-        Notifications
+        Consectetur adipiscing
       </Heading>
       <Text variant="content">
-        Pick which course events should send an alert to enrolled users.
+        Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla.
       </Text>
     </Card>
   </div>

--- a/packages/ui-card/src/Card/v1/README.md
+++ b/packages/ui-card/src/Card/v1/README.md
@@ -19,9 +19,9 @@ type: example
 
 ### Sizes
 
-`size` controls padding, border radius, and the card's min-/max-width
-breakpoints: `sm` applies a max-width, `md` applies a min- and max-width, and
-`lg` applies a min-width.
+`size` controls padding and border radius. For `variant="base"`, it also
+controls the card's min-/max-width breakpoints: `sm` applies a max-width,
+`md` applies a min- and max-width, and `lg` applies a min-width.
 
 ```js
 ---
@@ -43,9 +43,12 @@ type: example
 ### Nested cards
 
 The `nested` variant is meant to be placed inside a `base` Card. It omits the
-background color and shadow, and uses a smaller border radius. A nested
-Card's `size` is independent of its parent's — choose it based on the nested
-content's own needs, not to match the parent.
+background color and shadow, and uses a smaller border radius. Unlike
+`base`, `nested` doesn't apply min-/max-width breakpoints — its width comes
+from its parent and the surrounding layout, since it's already constrained
+by the `base` Card's padded content area. A nested Card's `size` still
+scales its own padding and border radius independently of its parent's —
+choose it based on the nested content's own needs, not to match the parent.
 
 ```js
 ---
@@ -155,9 +158,9 @@ type: embed
       <code>base</code> Card's <code>size</code>
     </Figure.Item>
     <Figure.Item>
-      Give a row of <code>md</code>/<code>lg</code> <code>nested</code> Cards
-      enough width to fit their minimum widths, or let them wrap, when
-      placing several side by side
+      Use a wrapping flex or grid layout when placing several{' '}
+      <code>nested</code> Cards side by side, so they can reflow to fit the
+      available width
     </Figure.Item>
   </Figure>
   <Figure recommendation="no" title="Don't">

--- a/packages/ui-card/src/Card/v1/README.md
+++ b/packages/ui-card/src/Card/v1/README.md
@@ -1,0 +1,172 @@
+---
+describes: Card
+---
+
+Use `<Card />` as a basic wrapper for grouping related content with padding,
+border radius, shadow, and background color.
+
+```js
+---
+type: example
+---
+<Card>
+  <Heading level="h3" margin="0 0 x-small 0">
+    Base card
+  </Heading>
+  <Text variant="content">Medium size, the default.</Text>
+</Card>
+```
+
+### Sizes
+
+`size` controls padding, border radius, and the card's min-/max-width
+breakpoints: `sm` applies a max-width, `md` applies a min- and max-width, and
+`lg` applies a min-width.
+
+```js
+---
+type: example
+---
+<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+  <Card size="sm">
+    <Text variant="content">Small card</Text>
+  </Card>
+  <Card size="md">
+    <Text variant="content">Medium card</Text>
+  </Card>
+  <Card size="lg">
+    <Text variant="content">Large card</Text>
+  </Card>
+</div>
+```
+
+### Nested cards
+
+The `nested` variant is meant to be placed inside a `base` Card. It omits the
+background color and shadow, and uses a smaller border radius. A nested
+Card's `size` is independent of its parent's — choose it based on the nested
+content's own needs, not to match the parent.
+
+```js
+---
+type: example
+---
+<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+  <Card variant="base" size="sm">
+    <Card variant="nested" size="sm">
+      <Text variant="content">Nested small card</Text>
+    </Card>
+  </Card>
+  <Card variant="base" size="md">
+    <Card variant="nested" size="md">
+      <Text variant="content">Nested medium card</Text>
+    </Card>
+  </Card>
+  <Card variant="base" size="lg">
+    <Card variant="nested" size="lg">
+      <Text variant="content">Nested large card</Text>
+    </Card>
+  </Card>
+</div>
+```
+
+### Mixed sizes
+
+Nested Cards don't need to match their parent's size, or each other's — you
+can place several different-sized `nested` Cards side by side inside one
+larger `base` Card.
+
+```js
+---
+type: example
+---
+<Card variant="base" size="lg">
+  <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+    <Card variant="nested" size="sm">
+      <Text variant="content">Small nested card</Text>
+    </Card>
+    <Card variant="nested" size="md">
+      <Text variant="content">Medium nested card</Text>
+    </Card>
+  </div>
+</Card>
+```
+
+### Multiple nested cards
+
+A `base` Card can hold several `nested` Cards, for example to lay out a group
+of related sub-sections inside a single container.
+
+```js
+---
+type: example
+---
+<Card variant="base" size="lg">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+    <Card variant="nested">
+      <Heading level="h3" margin="0 0 x-small 0">
+        Course settings
+      </Heading>
+      <Text variant="content">
+        Control who can see this course and when it becomes available to
+        students.
+      </Text>
+    </Card>
+    <Card variant="nested">
+      <Heading level="h3" margin="0 0 x-small 0">
+        Grading
+      </Heading>
+      <Text variant="content">
+        Choose the grading scheme and decide how final grades are calculated.
+      </Text>
+    </Card>
+    <Card variant="nested">
+      <Heading level="h3" margin="0 0 x-small 0">
+        Notifications
+      </Heading>
+      <Text variant="content">
+        Pick which course events should send an alert to enrolled users.
+      </Text>
+    </Card>
+  </div>
+</Card>
+```
+
+### Guidelines
+
+```js
+---
+type: embed
+---
+<Guidelines>
+  <Figure recommendation="yes" title="Do">
+    <Figure.Item>
+      Place a <code>nested</code> Card inside a <code>base</code> Card
+    </Figure.Item>
+    <Figure.Item>
+      Place a <code>nested</code> Card on top of another surface, such as a
+      Card, Modal, or utility panel (e.g. Tray, DrawerLayout)
+    </Figure.Item>
+    <Figure.Item>
+      Size each <code>nested</code> Card independently, based on its own
+      content — it doesn't need to match its parent{' '}
+      <code>base</code> Card's <code>size</code>
+    </Figure.Item>
+    <Figure.Item>
+      Give a row of <code>md</code>/<code>lg</code> <code>nested</code> Cards
+      enough width to fit their minimum widths, or let them wrap, when
+      placing several side by side
+    </Figure.Item>
+  </Figure>
+  <Figure recommendation="no" title="Don't">
+    <Figure.Item>
+      Place a <code>base</code> Card inside another <code>base</code> Card
+    </Figure.Item>
+    <Figure.Item>
+      Place a <code>nested</code> Card directly on the page background — it
+      relies on a surface behind it for contrast, since it has no background
+      color of its own
+    </Figure.Item>
+  </Figure>
+</Guidelines>
+```

--- a/packages/ui-card/src/Card/v1/index.tsx
+++ b/packages/ui-card/src/Card/v1/index.tsx
@@ -47,6 +47,16 @@ const Card = ({
     displayName: 'Card'
   })
 
+  if (size === 'auto' && variant === 'base') {
+    return (
+      <div css={styles?.container}>
+        <div {...passthroughProps(rest)} css={styles?.card}>
+          {children}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div {...passthroughProps(rest)} css={styles?.card}>
       {children}

--- a/packages/ui-card/src/Card/v1/index.tsx
+++ b/packages/ui-card/src/Card/v1/index.tsx
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { useStyleNew } from '@instructure/emotion'
+import { passthroughProps } from '@instructure/ui-react-utils'
+
+import type { CardProps } from './props.js'
+import generateStyle from './styles.js'
+
+/**
+---
+category: components
+---
+**/
+const Card = ({
+  children,
+  variant = 'base',
+  size = 'md',
+  themeOverride,
+  ...rest
+}: CardProps) => {
+  const styles = useStyleNew({
+    generateStyle,
+    themeOverride,
+    params: { variant, size },
+    componentId: 'Card',
+    displayName: 'Card'
+  })
+
+  return (
+    <div {...passthroughProps(rest)} css={styles?.card}>
+      {children}
+    </div>
+  )
+}
+
+export default Card
+export { Card }

--- a/packages/ui-card/src/Card/v1/props.ts
+++ b/packages/ui-card/src/Card/v1/props.ts
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { ReactNode } from 'react'
+import type { ComponentStyle, NewThemeOverrideProp } from '@instructure/emotion'
+import type { OtherHTMLAttributes } from '@instructure/shared-types'
+import type { NewComponentTypes } from '@instructure/ui-themes'
+
+type CardOwnProps = {
+  /**
+   * The content to be rendered inside the Card
+   */
+  children?: ReactNode
+  /**
+   * `base` renders a background, border color, and shadow. `nested` is
+   * meant to be placed inside a `base` Card and omits the background,
+   * border color, and shadow.
+   */
+  variant?: 'base' | 'nested'
+  /**
+   * `sm` applies a max-width, `md` applies a min- and max-width, and `lg`
+   * applies a min-width, each based on breakpoint tokens. Padding and
+   * border radius also scale per size.
+   */
+  size?: 'sm' | 'md' | 'lg'
+}
+
+type PropKeys = keyof CardOwnProps
+
+type AllowedPropKeys = Readonly<Array<PropKeys>>
+
+type CardProps = CardOwnProps &
+  NewThemeOverrideProp<ReturnType<NewComponentTypes['Card']>> &
+  OtherHTMLAttributes<CardOwnProps>
+
+type CardStyle = ComponentStyle<'card'>
+
+const allowedProps: AllowedPropKeys = ['children', 'variant', 'size']
+
+export type { CardProps, CardStyle }
+export { allowedProps }

--- a/packages/ui-card/src/Card/v1/props.ts
+++ b/packages/ui-card/src/Card/v1/props.ts
@@ -44,8 +44,15 @@ type CardOwnProps = {
    * applies a min- and max-width, and `lg` applies a min-width. `nested`
    * doesn't enforce a width — its available space is already constrained
    * by its parent `base` Card.
+   *
+   * `"auto"` is only supported for `variant="base"`. Instead of a fixed
+   * size, the Card measures its own rendered width (via a CSS container
+   * query, using the same breakpoints as the explicit sizes) and picks
+   * `sm`/`md`/`lg` accordingly. Prefer an explicit size for `nested` Cards,
+   * where size is a deliberate content choice rather than a reflection of
+   * available space.
    */
-  size?: 'sm' | 'md' | 'lg'
+  size?: 'sm' | 'md' | 'lg' | 'auto'
 }
 
 type PropKeys = keyof CardOwnProps
@@ -56,7 +63,7 @@ type CardProps = CardOwnProps &
   NewThemeOverrideProp<ReturnType<NewComponentTypes['Card']>> &
   OtherHTMLAttributes<CardOwnProps>
 
-type CardStyle = ComponentStyle<'card'>
+type CardStyle = ComponentStyle<'card'> & Partial<ComponentStyle<'container'>>
 
 const allowedProps: AllowedPropKeys = ['children', 'variant', 'size']
 

--- a/packages/ui-card/src/Card/v1/props.ts
+++ b/packages/ui-card/src/Card/v1/props.ts
@@ -39,9 +39,11 @@ type CardOwnProps = {
    */
   variant?: 'base' | 'nested'
   /**
-   * `sm` applies a max-width, `md` applies a min- and max-width, and `lg`
-   * applies a min-width, each based on breakpoint tokens. Padding and
-   * border radius also scale per size.
+   * Scales padding and border radius. For `variant="base"` only, `size`
+   * also applies min-/max-width breakpoints: `sm` applies a max-width, `md`
+   * applies a min- and max-width, and `lg` applies a min-width. `nested`
+   * doesn't enforce a width — its available space is already constrained
+   * by its parent `base` Card.
    */
   size?: 'sm' | 'md' | 'lg'
 }

--- a/packages/ui-card/src/Card/v1/styles.ts
+++ b/packages/ui-card/src/Card/v1/styles.ts
@@ -43,19 +43,33 @@ const generateStyle = (
 
   const boxShadow = boxShadowObjectsToCSSString(componentTheme.boxShadow)
 
+  // Width breakpoints only apply to `base`: a `nested` Card's available width
+  // is already constrained by its parent's padded content box, so enforcing
+  // the same breakpoints on `nested` could make it not fit inside `base`.
+  const widthVariants =
+    variant === 'base'
+      ? {
+          sm: { maxWidth: componentTheme.breakpoint.md },
+          md: {
+            minWidth: componentTheme.breakpoint.md,
+            maxWidth: componentTheme.breakpoint.lg
+          },
+          lg: { minWidth: componentTheme.breakpoint.lg }
+        }
+      : { sm: {}, md: {}, lg: {} }
+
   const sizeVariants = {
     sm: {
       padding: componentTheme.padding[variant].sm,
-      maxWidth: componentTheme.breakpoint.md
+      ...widthVariants.sm
     },
     md: {
       padding: componentTheme.padding[variant].md,
-      minWidth: componentTheme.breakpoint.md,
-      maxWidth: componentTheme.breakpoint.lg
+      ...widthVariants.md
     },
     lg: {
       padding: componentTheme.padding[variant].lg,
-      minWidth: componentTheme.breakpoint.lg
+      ...widthVariants.lg
     }
   }
 

--- a/packages/ui-card/src/Card/v1/styles.ts
+++ b/packages/ui-card/src/Card/v1/styles.ts
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { boxShadowObjectsToCSSString } from '@instructure/ui-themes'
+import type { NewComponentTypes } from '@instructure/ui-themes'
+import type { CardProps, CardStyle } from './props'
+
+/**
+ * ---
+ * private: true
+ * ---
+ * Generates the style object from the theme and provided additional information
+ * @param componentTheme The theme variable object.
+ * @param props the props of the component, the style is applied to
+ * @return The final style object, which will be used in the component
+ */
+const generateStyle = (
+  componentTheme: ReturnType<NewComponentTypes['Card']>,
+  props: CardProps
+): CardStyle => {
+  const { variant = 'base', size = 'md' } = props
+
+  const boxShadow = boxShadowObjectsToCSSString(componentTheme.boxShadow)
+
+  const sizeVariants = {
+    sm: {
+      padding: componentTheme.padding[variant].sm,
+      maxWidth: componentTheme.breakpoint.md
+    },
+    md: {
+      padding: componentTheme.padding[variant].md,
+      minWidth: componentTheme.breakpoint.md,
+      maxWidth: componentTheme.breakpoint.lg
+    },
+    lg: {
+      padding: componentTheme.padding[variant].lg,
+      minWidth: componentTheme.breakpoint.lg
+    }
+  }
+
+  const variantVariants = {
+    base: {
+      background: componentTheme.backgroundColor,
+      boxShadow
+    },
+    nested: {
+      border: `1px solid ${componentTheme.nestedBorderColor}`
+    }
+  }
+
+  return {
+    card: {
+      label: 'card',
+      boxSizing: 'border-box',
+      borderRadius: componentTheme.borderRadius[variant][size],
+      ...sizeVariants[size],
+      ...variantVariants[variant]
+    }
+  }
+}
+
+export default generateStyle

--- a/packages/ui-card/src/Card/v1/styles.ts
+++ b/packages/ui-card/src/Card/v1/styles.ts
@@ -43,32 +43,58 @@ const generateStyle = (
 
   const boxShadow = boxShadowObjectsToCSSString(componentTheme.boxShadow)
 
+  const borderRadius = {
+    base: {
+      sm: componentTheme.borderRadiusBaseSm,
+      md: componentTheme.borderRadiusBaseMd,
+      lg: componentTheme.borderRadiusBaseLg
+    },
+    nested: {
+      sm: componentTheme.borderRadiusNestedSm,
+      md: componentTheme.borderRadiusNestedMd,
+      lg: componentTheme.borderRadiusNestedLg
+    }
+  }
+
+  const padding = {
+    base: {
+      sm: componentTheme.paddingBaseSm,
+      md: componentTheme.paddingBaseMd,
+      lg: componentTheme.paddingBaseLg
+    },
+    nested: {
+      sm: componentTheme.paddingNestedSm,
+      md: componentTheme.paddingNestedMd,
+      lg: componentTheme.paddingNestedLg
+    }
+  }
+
   // Width breakpoints only apply to `base`: a `nested` Card's available width
   // is already constrained by its parent's padded content box, so enforcing
   // the same breakpoints on `nested` could make it not fit inside `base`.
   const widthVariants =
     variant === 'base'
       ? {
-          sm: { maxWidth: componentTheme.breakpoint.md },
+          sm: { maxWidth: componentTheme.breakpointMd },
           md: {
-            minWidth: componentTheme.breakpoint.md,
-            maxWidth: componentTheme.breakpoint.lg
+            minWidth: componentTheme.breakpointMd,
+            maxWidth: componentTheme.breakpointLg
           },
-          lg: { minWidth: componentTheme.breakpoint.lg }
+          lg: { minWidth: componentTheme.breakpointLg }
         }
       : { sm: {}, md: {}, lg: {} }
 
   const sizeVariants = {
     sm: {
-      padding: componentTheme.padding[variant].sm,
+      padding: padding[variant].sm,
       ...widthVariants.sm
     },
     md: {
-      padding: componentTheme.padding[variant].md,
+      padding: padding[variant].md,
       ...widthVariants.md
     },
     lg: {
-      padding: componentTheme.padding[variant].lg,
+      padding: padding[variant].lg,
       ...widthVariants.lg
     }
   }
@@ -87,7 +113,7 @@ const generateStyle = (
     card: {
       label: 'card',
       boxSizing: 'border-box',
-      borderRadius: componentTheme.borderRadius[variant][size],
+      borderRadius: borderRadius[variant][size],
       ...sizeVariants[size],
       ...variantVariants[variant]
     }

--- a/packages/ui-card/src/Card/v1/styles.ts
+++ b/packages/ui-card/src/Card/v1/styles.ts
@@ -40,6 +40,10 @@ const generateStyle = (
   props: CardProps
 ): CardStyle => {
   const { variant = 'base', size = 'md' } = props
+  const isAuto = size === 'auto' && variant === 'base'
+  // `auto` isn't supported for `nested` Cards (see props.ts) — fall back to
+  // the default size rather than indexing the size lookups with 'auto'.
+  const sizeKey = size === 'auto' ? 'md' : size
 
   const boxShadow = boxShadowObjectsToCSSString(componentTheme.boxShadow)
 
@@ -109,12 +113,42 @@ const generateStyle = (
     }
   }
 
+  // `auto` measures the Card's own rendered width via a CSS container query
+  // and picks padding/border-radius from the same breakpoints the explicit
+  // sizes use — mobile-first: `sm` values are the base, `md`/`lg` values
+  // apply once the container is wide enough. It needs a wrapping element
+  // (`container`) because a container query can't target the element that
+  // declares `containerType` itself, only its descendants.
+  if (isAuto) {
+    return {
+      container: {
+        label: 'card__container',
+        containerType: 'inline-size'
+      },
+      card: {
+        label: 'card',
+        boxSizing: 'border-box',
+        borderRadius: borderRadius.base.sm,
+        padding: padding.base.sm,
+        ...variantVariants.base,
+        [`@container (min-width: ${componentTheme.breakpointMd})`]: {
+          borderRadius: borderRadius.base.md,
+          padding: padding.base.md
+        },
+        [`@container (min-width: ${componentTheme.breakpointLg})`]: {
+          borderRadius: borderRadius.base.lg,
+          padding: padding.base.lg
+        }
+      }
+    }
+  }
+
   return {
     card: {
       label: 'card',
       boxSizing: 'border-box',
-      borderRadius: borderRadius[variant][size],
-      ...sizeVariants[size],
+      borderRadius: borderRadius[variant][sizeKey],
+      ...sizeVariants[sizeKey],
       ...variantVariants[variant]
     }
   }

--- a/packages/ui-card/src/exports/a.ts
+++ b/packages/ui-card/src/exports/a.ts
@@ -1,0 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+export { Card } from '../Card/v1/index.js'
+export type { CardProps } from '../Card/v1/props'

--- a/packages/ui-card/tsconfig.build.json
+++ b/packages/ui-card/tsconfig.build.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./types",
+    "composite": true,
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../emotion/tsconfig.build.json"
+    },
+    {
+      "path": "../shared-types/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-axe-check/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-babel-preset/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-react-utils/tsconfig.build.json"
+    },
+    {
+      "path": "../ui-themes/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/ui-card/tsconfig.json
+++ b/packages/ui-card/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {}
+}

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/cli": "^7.27.2",
     "@instructure/command-utils": "workspace:*",
-    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.5.0",
+    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.6.0",
     "dprint": "^0.55.1",
     "http-server": "^14.1.1",
     "inquirer": "^14.0.2",

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/cli": "^7.27.2",
     "@instructure/command-utils": "workspace:*",
-    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.7.0",
+    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.8.0",
     "dprint": "^0.55.1",
     "http-server": "^14.1.1",
     "inquirer": "^14.0.2",

--- a/packages/ui-scripts/package.json
+++ b/packages/ui-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@babel/cli": "^7.27.2",
     "@instructure/command-utils": "workspace:*",
-    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.6.0",
+    "@instructure/instructure-design-tokens": "github:instructure/instructure-design-tokens#v1.7.0",
     "dprint": "^0.55.1",
     "http-server": "^14.1.1",
     "inquirer": "^14.0.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "@instructure/ui-buttons": "workspace:*",
     "@instructure/ui-byline": "workspace:*",
     "@instructure/ui-calendar": "workspace:*",
+    "@instructure/ui-card": "workspace:*",
     "@instructure/ui-checkbox": "workspace:*",
     "@instructure/ui-color-picker": "workspace:*",
     "@instructure/ui-date-input": "workspace:*",

--- a/packages/ui/src/v11_7.ts
+++ b/packages/ui/src/v11_7.ts
@@ -78,6 +78,8 @@ export type {
   CalendarDayProps,
   CalendarProps
 } from '@instructure/ui-calendar/v11_7'
+export { Card } from '@instructure/ui-card/v11_7'
+export type { CardProps } from '@instructure/ui-card/v11_7'
 export {
   Checkbox,
   CheckboxGroup,

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -38,6 +38,9 @@
       "path": "../ui-calendar/tsconfig.build.json"
     },
     {
+      "path": "../ui-card/tsconfig.build.json"
+    },
+    {
       "path": "../ui-checkbox/tsconfig.build.json"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3946,8 +3946,8 @@ importers:
         specifier: workspace:*
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
-        specifier: github:instructure/instructure-design-tokens#v1.6.0
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b
+        specifier: github:instructure/instructure-design-tokens#v1.7.0
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c
       dprint:
         specifier: ^0.55.1
         version: 0.55.1
@@ -7108,8 +7108,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -14908,7 +14908,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c':
     dependencies:
       glob: 13.0.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3946,8 +3946,8 @@ importers:
         specifier: workspace:*
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
-        specifier: github:instructure/instructure-design-tokens#v1.7.0
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c
+        specifier: github:instructure/instructure-design-tokens#v1.8.0
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/b85c96436131df6a23174a54bcbd3b03a5da1b8a
       dprint:
         specifier: ^0.55.1
         version: 0.55.1
@@ -7108,8 +7108,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/b85c96436131df6a23174a54bcbd3b03a5da1b8a':
+    resolution: {gitHosted: true, integrity: sha512-hat5oOsuifuMyzM5Usgnvbc7ApL/bQACEhYMq/JC/w1R+xsuQQAfb1sYe/F1Gs0VoZwx08OD1MHhAZfucNsTlA==, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/b85c96436131df6a23174a54bcbd3b03a5da1b8a}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -14908,7 +14908,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/1200a1bdbcf1b05ad9ebe0fd466fe645e6b2156c':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/b85c96436131df6a23174a54bcbd3b03a5da1b8a':
     dependencies:
       glob: 13.0.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@instructure/ui-calendar':
         specifier: workspace:*
         version: link:../ui-calendar
+      '@instructure/ui-card':
+        specifier: workspace:*
+        version: link:../ui-card
       '@instructure/ui-checkbox':
         specifier: workspace:*
         version: link:../ui-checkbox
@@ -677,6 +680,9 @@ importers:
       '@instructure/ui-calendar':
         specifier: workspace:*
         version: link:../ui-calendar
+      '@instructure/ui-card':
+        specifier: workspace:*
+        version: link:../ui-card
       '@instructure/ui-checkbox':
         specifier: workspace:*
         version: link:../ui-checkbox
@@ -1466,6 +1472,43 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@22.19.15)(@vitest/browser-playwright@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@7.3.1(@types/node@24.1.0)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))
+
+  packages/ui-card:
+    dependencies:
+      '@babel/runtime':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@instructure/emotion':
+        specifier: workspace:*
+        version: link:../emotion
+      '@instructure/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
+      '@instructure/ui-react-utils':
+        specifier: workspace:*
+        version: link:../ui-react-utils
+      '@instructure/ui-themes':
+        specifier: workspace:*
+        version: link:../ui-themes
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@instructure/ui-axe-check':
+        specifier: workspace:*
+        version: link:../ui-axe-check
+      '@instructure/ui-babel-preset':
+        specifier: workspace:*
+        version: link:../ui-babel-preset
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@7.3.1(@types/node@24.1.0)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ui-checkbox:
     dependencies:
@@ -3903,8 +3946,8 @@ importers:
         specifier: workspace:*
         version: link:../command-utils
       '@instructure/instructure-design-tokens':
-        specifier: github:instructure/instructure-design-tokens#v1.5.0
-        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6
+        specifier: github:instructure/instructure-design-tokens#v1.6.0
+        version: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b
       dprint:
         specifier: ^0.55.1
         version: 0.55.1
@@ -7065,8 +7108,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6}
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b}
     version: 1.0.0
 
   '@isaacs/cliui@8.0.2':
@@ -14865,7 +14908,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
-  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/ae8f600e8ad4cbadddbaad857f0b6477c4a1e1d6':
+  '@instructure/instructure-design-tokens@https://codeload.github.com/instructure/instructure-design-tokens/tar.gz/4828298799329c972e8515ed959a789e8757906b':
     dependencies:
       glob: 13.0.6
 

--- a/regression-test/cypress/e2e/spec.cy.ts
+++ b/regression-test/cypress/e2e/spec.cy.ts
@@ -124,6 +124,7 @@ const PAGES: PageSpec[] = [
   { slug: 'button', title: 'Button and derivatives', wait: 100 },
   { slug: 'byline', title: 'Byline' },
   { slug: 'calendar', title: 'Calendar' },
+  { slug: 'card', title: 'Card' },
   { slug: 'checkbox', title: 'Checkbox', wait: 100 },
   { slug: 'checkboxgroup', title: 'Checkboxgroup', wait: 300 },
   {

--- a/regression-test/src/app/card/page.tsx
+++ b/regression-test/src/app/card/page.tsx
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use client'
+import React from 'react'
+import { Card as c, Text as t } from '@instructure/ui/latest'
+
+// alias to avoid TS/SSR friction like other pages
+const Card = c as any
+const Text = t as any
+
+export default function CardPage() {
+  return (
+    <main className="flex gap-8 p-8 flex-col items-start axe-test">
+      {/* Sizes */}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Card size="sm">
+          <Text variant="content">Small base card</Text>
+        </Card>
+        <Card size="md">
+          <Text variant="content">Medium base card</Text>
+        </Card>
+        <Card size="lg">
+          <Text variant="content">Large base card</Text>
+        </Card>
+      </div>
+
+      {/* Nested cards */}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Card variant="base" size="sm">
+          <Card variant="nested" size="sm">
+            <Text variant="content">Nested small card</Text>
+          </Card>
+        </Card>
+        <Card variant="base" size="md">
+          <Card variant="nested" size="md">
+            <Text variant="content">Nested medium card</Text>
+          </Card>
+        </Card>
+        <Card variant="base" size="lg">
+          <Card variant="nested" size="lg">
+            <Text variant="content">Nested large card</Text>
+          </Card>
+        </Card>
+      </div>
+    </main>
+  )
+}

--- a/regression-test/src/app/card/page.tsx
+++ b/regression-test/src/app/card/page.tsx
@@ -63,6 +63,25 @@ export default function CardPage() {
           </Card>
         </Card>
       </div>
+
+      {/* Auto sizing: each wrapper's fixed width pins it to one breakpoint */}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ width: '200px' }} data-testid="auto-card-sm-wrapper">
+          <Card size="auto">
+            <Text variant="content">Auto card, sm width</Text>
+          </Card>
+        </div>
+        <div style={{ width: '400px' }} data-testid="auto-card-md-wrapper">
+          <Card size="auto">
+            <Text variant="content">Auto card, md width</Text>
+          </Card>
+        </div>
+        <div style={{ width: '800px' }} data-testid="auto-card-lg-wrapper">
+          <Card size="auto">
+            <Text variant="content">Auto card, lg width</Text>
+          </Card>
+        </div>
+      </div>
     </main>
   )
 }

--- a/regression-test/src/app/page.tsx
+++ b/regression-test/src/app/page.tsx
@@ -37,6 +37,7 @@ const components = [
   'tooltip',
   'byline',
   'calendar',
+  'card',
   'checkbox',
   'checkboxgroup',
   'colorpicker',


### PR DESCRIPTION
## Summary
- Add `@instructure/ui-card`: a wrapper with `variant` (`base` | `nested`) and `size` (`sm` | `md` | `lg` | `auto`), built on the v11.7 token system (`useStyleNew` + generated Card tokens) and exported from `@instructure/ui/v11_7`
- Bump `instructure-design-tokens` to `v1.8.0` (the Card token set first landed in `v1.7.0`; `v1.8.0` flattens Card's token structure)
- Add `size="auto"` for `variant="base"`: measures the Card's own rendered width via a CSS container query and picks `sm`/`md`/`lg` padding and border radius itself, using the same breakpoint tokens as the explicit sizes. Not supported for `nested`, where size is a deliberate content choice rather than a reflection of available width — falls back to a normal render.
- Document Card with per-size nested examples, mixed sizes inside one base Card, do/don't composition guidelines, and a live auto-sizing example
- Add unit tests asserting concrete token values (including `size="auto"` at fixed container widths, its extra wrapper element, and its `nested` fallback), plus the `/card` visual regression page (now including `size="auto"` cases) and its axe check

## Test Plan
- Docs → Card: switch the Theme selector to a dark theme and confirm example copy stays legible (examples use `Heading`/`Text` so they inherit token-driven colours rather than a browser default)
- Docs → Card → "Mixed sizes": confirm differently-sized `nested` Cards sit side by side cleanly inside one `lg` `base` Card
- Docs → Card → "Auto sizing (prototype)": resize the example panel and confirm padding/border-radius shift at the `md`/`lg` breakpoints without a `size` prop
- Under the `canvas (legacy)` theme, compare `base` Card corner radii across `sm`/`md`/`lg` — see the token note below
- Visual regression: review the new `/card` baseline

## Notes
- `pnpm-lock.yaml` carries 4 lines of drift unrelated to Card: vitest re-resolved `es-module-lexer` `2.1.0` → `2.2.0` within its pre-existing `^2.0.0` range, which also cleared a now-stale `optional: true` flag on the 2.2.0 entry. No `package.json` range was changed and webpack still resolves 2.1.0.
- `size="auto"` renders an extra wrapper `div` around the styled Card (a CSS container query can't target the element that declares `containerType` itself, only its descendants) — every other mode keeps the existing single-`div` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)