### PR TITLE
feat(many): add margin prop to FormFieldGroup, CheckboxGroup, RadioInputGroup, Checkbox, RadioInput, RangeInput, Text, and ToggleButton

### DIFF
--- a/packages/ui-buttons/src/ToggleButton/__tests__/ToggleButton.test.tsx
+++ b/packages/ui-buttons/src/ToggleButton/__tests__/ToggleButton.test.tsx
@@ -243,4 +243,20 @@ describe('<ToggleButton />', () => {
     await expect.element(tooltip).toBeVisible()
     await expect.element(tooltip).toHaveTextContent('Tooltip content')
   })
+
+  it('forwards the margin prop to the button', async () => {
+    const { container } = await render(
+      <ToggleButton
+        screenReaderLabel="Toggle"
+        renderIcon={icon}
+        renderTooltipContent="Toggle"
+        status="unpressed"
+        margin="general.spaceMd"
+      />
+    )
+    const button = container.querySelector('button')
+
+    // general.spaceMd (0.75rem) resolves to 12px
+    expect(getComputedStyle(button!).marginLeft).toBe('12px')
+  })
 })

--- a/packages/ui-buttons/src/ToggleButton/v2/index.tsx
+++ b/packages/ui-buttons/src/ToggleButton/v2/index.tsx
@@ -91,6 +91,7 @@ class ToggleButton extends Component<ToggleButtonProps, ToggleButtonState> {
       status,
       placement,
       onClick,
+      margin,
       ...props
     } = this.props
 
@@ -124,6 +125,7 @@ class ToggleButton extends Component<ToggleButtonProps, ToggleButtonState> {
           aria-pressed={status === 'pressed'}
           data-cid="ToggleButton"
           renderIcon={renderIcon}
+          margin={margin}
         />
       </Tooltip>
     )

--- a/packages/ui-buttons/src/ToggleButton/v2/props.ts
+++ b/packages/ui-buttons/src/ToggleButton/v2/props.ts
@@ -35,6 +35,7 @@ import type {
 } from '@instructure/ui-position'
 import type { ViewProps } from '@instructure/ui-view/latest'
 import { Renderable } from '@instructure/shared-types'
+import type { Spacing } from '@instructure/emotion'
 
 type ToggleButtonOwnProps = {
   /**
@@ -110,6 +111,13 @@ type ToggleButtonOwnProps = {
    * or a function returning an element.
    */
   constrain?: PositionConstraint
+
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
 }
 
 type PropKeys = keyof ToggleButtonOwnProps
@@ -129,6 +137,7 @@ const allowedProps: AllowedPropKeys = [
   'elementRef',
   'interaction',
   'isShowingTooltip',
+  'margin',
   'mountNode',
   'onClick',
   'placement',

--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -352,4 +352,20 @@ describe('<Checkbox />', () => {
       expect(input).not.toHaveAttribute('aria-labelledby')
     })
   })
+
+  describe('margin prop', () => {
+    it('resolves spacing tokens and custom CSS values', async () => {
+      const { container } = await render(
+        <div>
+          <Checkbox label="A" value="a" margin="general.spaceMd" />
+          <Checkbox label="B" value="b" margin="30px" />
+        </div>
+      )
+      const boxes = container.querySelectorAll("[class$='-checkbox']")
+
+      // general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(boxes[0]!).marginLeft).toBe('12px')
+      expect(getComputedStyle(boxes[1]!).marginLeft).toBe('30px')
+    })
+  })
 })

--- a/packages/ui-checkbox/src/Checkbox/v2/props.ts
+++ b/packages/ui-checkbox/src/Checkbox/v2/props.ts
@@ -24,7 +24,11 @@
 
 import type { FormMessage } from '@instructure/ui-form-field/latest'
 import type { OtherHTMLAttributes } from '@instructure/shared-types'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import type {
+  WithStyleProps,
+  ComponentStyle,
+  Spacing
+} from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 
@@ -72,6 +76,12 @@ type CheckboxOwnProps = {
   labelPlacement?: 'top' | 'start' | 'end'
   isRequired?: boolean
   /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
+  /**
    * A function that provides a reference to the actual underlying input element
    */
   inputRef?: (inputElement: HTMLInputElement | null) => void
@@ -116,6 +126,7 @@ const allowedProps: AllowedPropKeys = [
   'inline',
   'labelPlacement',
   'isRequired',
+  'margin',
   'inputRef'
 ]
 

--- a/packages/ui-checkbox/src/Checkbox/v2/styles.ts
+++ b/packages/ui-checkbox/src/Checkbox/v2/styles.ts
@@ -23,7 +23,8 @@
  */
 
 import type { CheckboxProps, CheckboxStyle } from './props'
-import type { NewComponentTypes } from '@instructure/ui-themes'
+import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
+import { calcSpacingFromShorthand } from '@instructure/emotion'
 
 /**
  * ---
@@ -38,9 +39,10 @@ import type { NewComponentTypes } from '@instructure/ui-themes'
  */
 const generateStyle = (
   componentTheme: ReturnType<NewComponentTypes['Checkbox']>,
-  props: CheckboxProps
+  props: CheckboxProps,
+  sharedTokens: SharedTokens
 ): CheckboxStyle => {
-  const { inline, size, variant } = props
+  const { inline, size, variant, margin } = props
 
   // toggleFullWidth calculation based on Toggle facade width (1.625rem * 1.5) and the marginInlineEnd (0.75rem)
   const toggleFullWidth = `calc(1.625rem * 1.5 + 0.75rem)`
@@ -82,6 +84,11 @@ const generateStyle = (
       label: 'checkbox',
       position: 'relative',
       width: '100%',
+      // Resolves spacing tokens (or custom CSS values) into a margin shorthand.
+      margin: calcSpacingFromShorthand(margin, {
+        ...sharedTokens.spacing,
+        ...sharedTokens.legacy.spacing
+      }),
       ...(inline && {
         display: 'inline-block',
         verticalAlign: 'middle',

--- a/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.tsx
+++ b/packages/ui-checkbox/src/CheckboxGroup/__tests__/CheckboxGroup.test.tsx
@@ -233,4 +233,16 @@ describe('<CheckboxGroup />', () => {
       expect(group).not.toHaveAttribute('aria-invalid')
     })
   })
+
+  describe('margin prop', () => {
+    it('forwards margin to the field layout, resolving spacing tokens', async () => {
+      const { container } = await renderCheckboxGroup({
+        margin: 'general.spaceMd'
+      })
+      const layout = container.querySelector("[class$='-formFieldLayout']")
+
+      // general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(layout!).marginLeft).toBe('12px')
+    })
+  })
 })

--- a/packages/ui-checkbox/src/CheckboxGroup/v2/README.md
+++ b/packages/ui-checkbox/src/CheckboxGroup/v2/README.md
@@ -12,6 +12,7 @@ type: example
 ---
 <FormFieldGroup description={<ScreenReaderContent>CheckboxGroup examples</ScreenReaderContent>}>
   <CheckboxGroup name="sports"
+    margin="general.spaceMd 0"
     onChange={function (value) { console.log(value) }}
     defaultValue={['football', 'volleyball']}
     description="Select your favorite sports"

--- a/packages/ui-checkbox/src/CheckboxGroup/v2/props.ts
+++ b/packages/ui-checkbox/src/CheckboxGroup/v2/props.ts
@@ -26,6 +26,7 @@ import { type InputHTMLAttributes } from 'react'
 import type { FormMessage } from '@instructure/ui-form-field/latest'
 import type { OtherHTMLAttributes } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type { Spacing } from '@instructure/emotion'
 
 import { Checkbox } from '../../Checkbox/v2/index.js'
 import type { CheckboxProps } from '../../Checkbox/v2/props'
@@ -44,6 +45,12 @@ type CheckboxGroupOwnProps = {
   messages?: FormMessage[]
   size?: 'small' | 'medium' | 'large'
   layout?: 'stacked' | 'columns' | 'inline'
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
 }
 
 type PropKeys = keyof CheckboxGroupOwnProps
@@ -67,7 +74,8 @@ const allowedProps: AllowedPropKeys = [
   'messages',
   'children',
   'size',
-  'layout'
+  'layout',
+  'margin'
 ]
 
 type CheckboxGroupState = {

--- a/packages/ui-form-field/src/FormFieldGroup/__tests__/FormFieldGroup.test.tsx
+++ b/packages/ui-form-field/src/FormFieldGroup/__tests__/FormFieldGroup.test.tsx
@@ -225,4 +225,20 @@ describe('<FormFieldGroup />', () => {
 
     expect(axeCheck).toBe(true)
   })
+
+  describe('margin prop', () => {
+    it('forwards margin to the field layout, resolving spacing tokens', async () => {
+      const { container } = await render(
+        <FormFieldGroup description="Name" margin="general.spaceMd">
+          <label>
+            First: <input />
+          </label>
+        </FormFieldGroup>
+      )
+      const layout = container.querySelector("[class$='-formFieldLayout']")
+
+      // general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(layout!).marginLeft).toBe('12px')
+    })
+  })
 })

--- a/packages/ui-form-field/src/FormFieldGroup/v2/README.md
+++ b/packages/ui-form-field/src/FormFieldGroup/v2/README.md
@@ -17,6 +17,7 @@ type: example
     rowSpacing="small"
     layout="inline"
     vAlign="middle"
+    margin="general.spaceMd 0"
   >
     <TextInput renderLabel="Favorite Breakfast Eatery"
       messages={[

--- a/packages/ui-form-field/src/FormFieldGroup/v2/props.ts
+++ b/packages/ui-form-field/src/FormFieldGroup/v2/props.ts
@@ -26,7 +26,11 @@ import type {
   AsElementType,
   OtherHTMLAttributes
 } from '@instructure/shared-types'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import type {
+  WithStyleProps,
+  ComponentStyle,
+  Spacing
+} from '@instructure/emotion'
 import type { FormFieldLayoutOwnProps } from '../../FormFieldLayout/v2/props'
 import type { FormMessage } from '../../utils/v1/FormPropTypes'
 
@@ -63,6 +67,12 @@ type FormFieldGroupOwnProps = {
   vAlign?: 'top' | 'middle' | 'bottom'
   startAt?: 'small' | 'medium' | 'large' | 'x-large' | null
   /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
+  /**
    * provides a reference to the underlying html root element
    */
   elementRef?: (element: Element | null) => void
@@ -96,6 +106,7 @@ const allowedProps: AllowedPropKeys = [
   'colSpacing',
   'vAlign',
   'startAt',
+  'margin',
   'elementRef'
 ]
 

--- a/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.tsx
+++ b/packages/ui-radio-input/src/RadioInput/__tests__/RadioInput.test.tsx
@@ -305,4 +305,20 @@ describe('<RadioInput />', () => {
       expect(axeCheck).toBe(true)
     })
   })
+
+  describe('margin prop', () => {
+    it('resolves spacing tokens and custom CSS values', async () => {
+      const { container } = await render(
+        <div>
+          <RadioInput label="A" value="a" name="n" margin="general.spaceMd" />
+          <RadioInput label="B" value="b" name="n" margin="30px" />
+        </div>
+      )
+      const inputs = container.querySelectorAll("[class$='-radioInput']")
+
+      // general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(inputs[0]!).marginLeft).toBe('12px')
+      expect(getComputedStyle(inputs[1]!).marginLeft).toBe('30px')
+    })
+  })
 })

--- a/packages/ui-radio-input/src/RadioInput/v2/index.tsx
+++ b/packages/ui-radio-input/src/RadioInput/v2/index.tsx
@@ -57,6 +57,7 @@ const RadioInput = forwardRef<RadioInputHandle, RadioInputProps>(
       inline = false,
       context = 'success',
       readOnly = false,
+      margin,
       id: idProp,
       label,
       value,
@@ -95,7 +96,8 @@ const RadioInput = forwardRef<RadioInputHandle, RadioInputProps>(
         hovered,
         readOnly,
         size,
-        variant
+        variant,
+        margin
       },
       componentId: 'RadioInput',
       displayName: 'RadioInput'

--- a/packages/ui-radio-input/src/RadioInput/v2/props.ts
+++ b/packages/ui-radio-input/src/RadioInput/v2/props.ts
@@ -25,7 +25,11 @@
 import React from 'react'
 import type { InputHTMLAttributes } from 'react'
 import type { OtherHTMLAttributes } from '@instructure/shared-types'
-import type { ComponentStyle, NewThemeOverrideProp } from '@instructure/emotion'
+import type {
+  ComponentStyle,
+  NewThemeOverrideProp,
+  Spacing
+} from '@instructure/emotion'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 
@@ -77,6 +81,12 @@ type RadioInputOwnProps = {
    * Sets the `display:inline-flex` in CSS
    */
   inline?: boolean
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
   onClick?: (event: React.MouseEvent<HTMLInputElement>) => void
   /**
    * Callback fired when the input fires a change event.
@@ -118,6 +128,7 @@ const allowedProps: AllowedPropKeys = [
   'size',
   'context',
   'inline',
+  'margin',
   'onClick',
   'onChange',
   'inputRef'

--- a/packages/ui-radio-input/src/RadioInput/v2/styles.ts
+++ b/packages/ui-radio-input/src/RadioInput/v2/styles.ts
@@ -25,7 +25,10 @@
 import type { RadioInputProps, RadioInputStyle } from './props'
 import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
 import { boxShadowObjectsToCSSString } from '@instructure/ui-themes'
-import { calcFocusOutlineStyles } from '@instructure/emotion'
+import {
+  calcFocusOutlineStyles,
+  calcSpacingFromShorthand
+} from '@instructure/emotion'
 
 type StyleParams = {
   disabled: RadioInputProps['disabled']
@@ -35,6 +38,7 @@ type StyleParams = {
   readOnly: RadioInputProps['readOnly']
   size: RadioInputProps['size']
   variant: RadioInputProps['variant']
+  margin: RadioInputProps['margin']
 }
 
 /**
@@ -52,7 +56,16 @@ const generateStyle = (
   params: StyleParams,
   sharedTokens: SharedTokens
 ): RadioInputStyle => {
-  const { disabled, inline, hovered, size, readOnly, variant, context } = params
+  const {
+    disabled,
+    inline,
+    hovered,
+    size,
+    readOnly,
+    variant,
+    context,
+    margin
+  } = params
 
   // 4*2 states: base, hover, disabled, readonly X none/selected
   const insetSizes = {
@@ -272,6 +285,11 @@ const generateStyle = (
       display: 'flex',
       alignItems: 'flex-start',
       width: inline ? 'auto' : '100%',
+      // Resolves spacing tokens (or custom CSS values) into a margin shorthand.
+      margin: calcSpacingFromShorthand(margin, {
+        ...sharedTokens.spacing,
+        ...sharedTokens.legacy.spacing
+      }),
       ...(inline && {
         display: 'inline-flex',
         verticalAlign: 'middle'

--- a/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/__tests__/RadioInputGroup.test.tsx
@@ -229,4 +229,23 @@ describe('<RadioInputGroup />', () => {
     expect(group).toHaveAttribute('aria-invalid', 'true')
     expect(group).toHaveAttribute('aria-errormessage', expect.anything())
   })
+
+  describe('margin prop', () => {
+    it('forwards margin to the field layout, resolving spacing tokens', async () => {
+      const { container } = await render(
+        <RadioInputGroup
+          name="fruit"
+          description="Select a fruit"
+          margin="general.spaceMd"
+        >
+          <RadioInput label="Apple" value="apple" />
+          <RadioInput label="Banana" value="banana" />
+        </RadioInputGroup>
+      )
+      const layout = container.querySelector("[class$='-formFieldLayout']")
+
+      // general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(layout!).marginLeft).toBe('12px')
+    })
+  })
 })

--- a/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
@@ -25,7 +25,7 @@ function Example () {
     console.log(value)
   }
   return (
-    <RadioInputGroup onChange={handleChange} name="example1" defaultValue="foo" description="Select something">
+    <RadioInputGroup onChange={handleChange} name="example1" defaultValue="foo" description="Select something" margin="general.spaceMd 0">
       {inputs.map(input => <RadioInput key={input.value} value={input.value} label={input.label} />)}
     </RadioInputGroup>
   )

--- a/packages/ui-radio-input/src/RadioInputGroup/v2/props.ts
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/props.ts
@@ -27,6 +27,7 @@ import React from 'react'
 import type { FormMessage } from '@instructure/ui-form-field/latest'
 import type { OtherHTMLAttributes } from '@instructure/shared-types'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
+import type { Spacing } from '@instructure/emotion'
 
 type RadioInputGroupOwnProps = {
   /**
@@ -88,6 +89,13 @@ type RadioInputGroupOwnProps = {
    * Setting this to `true` adds and asterisk after the description (group label). It does not cause any behavioural change.
    */
   isRequired?: boolean
+
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
 }
 
 type PropKeys = keyof RadioInputGroupOwnProps
@@ -115,7 +123,8 @@ const allowedProps: AllowedPropKeys = [
   'variant',
   'size',
   'layout',
-  'isRequired'
+  'isRequired',
+  'margin'
 ]
 
 export type { RadioInputGroupProps, RadioInputGroupState }

--- a/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
+++ b/packages/ui-range-input/src/RangeInput/__tests__/RangeInput.test.tsx
@@ -389,4 +389,20 @@ describe('<RangeInput />', () => {
       expect(messages).toHaveTextContent(message)
     })
   })
+
+  it('forwards the margin prop to the field layout', async () => {
+    const { container } = await render(
+      <RangeInput
+        label="Volume"
+        name="volume"
+        min={0}
+        max={100}
+        margin="general.spaceMd"
+      />
+    )
+    const layout = container.querySelector("[class$='-formFieldLayout']")
+
+    // general.spaceMd (0.75rem) resolves to 12px
+    expect(getComputedStyle(layout!).marginLeft).toBe('12px')
+  })
 })

--- a/packages/ui-range-input/src/RangeInput/v2/README.md
+++ b/packages/ui-range-input/src/RangeInput/v2/README.md
@@ -24,6 +24,7 @@ const Example = () => {
           max={100}
           min={0}
           size={size}
+          margin="general.spaceMd 0"
         />
       </View>
 

--- a/packages/ui-range-input/src/RangeInput/v2/props.ts
+++ b/packages/ui-range-input/src/RangeInput/v2/props.ts
@@ -32,7 +32,11 @@ import type {
   FormFieldOwnProps,
   FormMessage
 } from '@instructure/ui-form-field/latest'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import type {
+  WithStyleProps,
+  ComponentStyle,
+  Spacing
+} from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 import type { InputHTMLAttributes } from 'react'
 import type { WithDeterministicIdProps } from '@instructure/ui-react-utils'
@@ -89,6 +93,13 @@ type RangeInputOwnProps = {
   readOnly?: boolean
 
   /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
+
+  /**
    * A function that provides a reference to the actual underlying input element
    */
   inputRef?: (inputElement: HTMLInputElement | null) => void
@@ -139,6 +150,7 @@ const allowedProps: AllowedPropKeys = [
   'inline',
   'disabled',
   'readOnly',
+  'margin',
   'inputRef'
 ]
 

--- a/packages/ui-text/src/Text/__tests__/Text.test.tsx
+++ b/packages/ui-text/src/Text/__tests__/Text.test.tsx
@@ -49,4 +49,20 @@ describe('<Text />', () => {
 
     expect(text?.tagName).toBe('LI')
   })
+
+  describe('margin prop', () => {
+    it('resolves spacing tokens and custom CSS values', async () => {
+      const { container } = await render(
+        <div>
+          <Text margin="general.spaceMd">A</Text>
+          <Text margin="30px">B</Text>
+        </div>
+      )
+      const texts = container.querySelectorAll("[class$='-text']")
+
+      // Text renders inline, so horizontal margins apply; general.spaceMd = 0.75rem = 12px
+      expect(getComputedStyle(texts[0]!).marginLeft).toBe('12px')
+      expect(getComputedStyle(texts[1]!).marginLeft).toBe('30px')
+    })
+  })
 })

--- a/packages/ui-text/src/Text/v2/README.md
+++ b/packages/ui-text/src/Text/v2/README.md
@@ -186,6 +186,21 @@ type: example
 </Text>
 ```
 
+### Margin
+
+Use the `margin` prop to add space around the component with spacing tokens or CSS-like shorthand. On the default inline `Text` only left/right margins render, so render it as a block element (`as="p"`) when you need vertical spacing.
+
+```js
+---
+type: example
+---
+<div>
+  <Text margin="general.spaceXs general.spaceXs">text</Text>
+  <Text margin="general.spaceMd general.spaceMd">text</Text>
+  <Text as="p" margin="general.spaceXl">text</Text>
+</div>
+```
+
 ### DEPRECATED legacy values
 
 Multiple values from `size`, `weight` and `lineHeight` are deprecated, but still supported for backward compatibility reasons. Please only use the above listed, semantic values.

--- a/packages/ui-text/src/Text/v2/props.ts
+++ b/packages/ui-text/src/Text/v2/props.ts
@@ -27,7 +27,11 @@ import type {
   AsElementType,
   OtherHTMLAttributes
 } from '@instructure/shared-types'
-import type { WithStyleProps, ComponentStyle } from '@instructure/emotion'
+import type {
+  WithStyleProps,
+  ComponentStyle,
+  Spacing
+} from '@instructure/emotion'
 import type { NewComponentTypes } from '@instructure/ui-themes'
 
 type TextOwnProps = {
@@ -109,6 +113,12 @@ type TextOwnProps = {
    */
   weight?: 'normal' | 'light' | 'bold' | 'weightRegular' | 'weightImportant'
   wrap?: 'normal' | 'break-word'
+  /**
+   * Valid values are `0`, `none`, `auto`, and Spacing token values,
+   * see https://instructure.design/layout-spacing. Apply these values via
+   * familiar CSS-like shorthand. For example, `margin="general.spaceMd auto"`.
+   */
+  margin?: Spacing
   children?: React.ReactNode
 }
 
@@ -133,7 +143,8 @@ const allowedProps: AllowedPropKeys = [
   'transform',
   'variant',
   'weight',
-  'wrap'
+  'wrap',
+  'margin'
 ]
 
 export type { TextProps, TextStyle }

--- a/packages/ui-text/src/Text/v2/styles.ts
+++ b/packages/ui-text/src/Text/v2/styles.ts
@@ -23,8 +23,9 @@
  */
 
 import type { TextProps, TextStyle } from './props'
-import type { NewComponentTypes } from '@instructure/ui-themes'
+import type { NewComponentTypes, SharedTokens } from '@instructure/ui-themes'
 import type { TokenTypographyValueInst } from '@instructure/ui-themes'
+import { calcSpacingFromShorthand } from '@instructure/emotion'
 
 type StyleParams = {
   color: TextProps['color']
@@ -36,6 +37,7 @@ type StyleParams = {
   variant: TextProps['variant']
   weight: TextProps['weight']
   wrap: TextProps['wrap']
+  margin: TextProps['margin']
 }
 
 /**
@@ -45,11 +47,13 @@ type StyleParams = {
  * Generates the style object from the theme and provided additional information
  * @param componentTheme The theme variable object.
  * @param params Additional parameters to customize the style.
+ * @param sharedTokens Shared token object that stores common values for the theme.
  * @return The final style object, which will be used in the component
  */
 const generateStyle = (
   componentTheme: ReturnType<NewComponentTypes['Text']>,
-  params: StyleParams
+  params: StyleParams,
+  sharedTokens: SharedTokens
 ): TextStyle => {
   const {
     color,
@@ -60,7 +64,8 @@ const generateStyle = (
     size,
     variant,
     weight,
-    wrap
+    wrap,
+    margin
   } = params
 
   const variants: Record<
@@ -220,6 +225,11 @@ const generateStyle = (
       label: 'text',
       fontFamily: componentTheme.fontFamily,
       ...baseStyles,
+      // Resolves spacing tokens (or custom CSS values) into a margin shorthand.
+      margin: calcSpacingFromShorthand(margin, {
+        ...sharedTokens.spacing,
+        ...sharedTokens.legacy.spacing
+      }),
 
       // NOTE: needs separate groups for `:is()` and `:-webkit-any()` because
       // of css selector group validation (see https://www.w3.org/TR/selectors-3/#grouping)


### PR DESCRIPTION
INSTUI-4399

## Summary
- Add an optional `margin` prop (`Spacing`) to the **v2** versions of FormFieldGroup, CheckboxGroup, RadioInputGroup, Checkbox, RadioInput, RangeInput, Text, and ToggleButton.
- Text / Checkbox / RadioInput resolve it directly in their styles via `calcSpacingFromShorthand(margin, { ...sharedTokens.spacing, ...sharedTokens.legacy.spacing })`; the rest forward it to an already margin-capable child (ToggleButton→IconButton, RangeInput→FormField, groups→FormFieldGroup/FormFieldLayout).
- Accepts current dot-path spacing tokens (e.g. `general.spaceMd`), CSS-like 1–4 value shorthand, and raw CSS values; documented via each component's props table and, for Text, a dedicated "Margin" section.

## Test Plan
- Paste and try the snippet below into any v11_7 playground: 

````
const MarginDemo = () => {
  // Try any token from the Layout Spacing guide, a custom value, or shorthand
  const demoMargin = 'general.spaceLg'

  const icon = (
    <svg width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true">
      <circle cx="8" cy="8" r="7" fill="currentColor" />
    </svg>
  )

  // Left = default, right = same component with `margin`.
  // The border box makes the whitespace the margin adds clearly visible.
  const Compare = ({ label, build }) => (
    <View as="div" display="block" margin="0 0 general.spaceLg">
      <Text weight="bold">{label}</Text>
      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start', flexWrap: 'wrap', marginTop: '0.5rem' }}>
        <View as="div" display="flex" borderWidth="small" background="secondary">
          {build(undefined)}
        </View>
        <View as="div" display="flex" borderWidth="small" background="secondary">
          {build(demoMargin)}
        </View>
      </div>
    </View>
  )

  return (
    <div>
      <Compare label="Text" build={(m) => <Text margin={m}>Sample text</Text>} />

      <Compare label="ToggleButton" build={(m) => (
        <ToggleButton
          margin={m}
          screenReaderLabel="Toggle"
          renderTooltipContent="Toggle"
          renderIcon={icon}
          status="unpressed"
        />
      )} />

      <Compare label="Checkbox" build={(m) => (
        <Checkbox margin={m} label="Checkbox" value="c" />
      )} />

      <Compare label="RadioInput" build={(m) => (
        <RadioInput margin={m} label="RadioInput" value="r" name={m ? 'r-margin' : 'r-base'} />
      )} />

      <Compare label="RangeInput" build={(m) => (
        <RangeInput margin={m} label="RangeInput" name={m ? 'rng-margin' : 'rng-base'} min={0} max={100} defaultValue={50} />
      )} />

      <Compare label="CheckboxGroup" build={(m) => (
        <CheckboxGroup margin={m} name={m ? 'cg-margin' : 'cg-base'} description="CheckboxGroup">
          <Checkbox label="One" value="1" />
          <Checkbox label="Two" value="2" />
        </CheckboxGroup>
      )} />

      <Compare label="RadioInputGroup" build={(m) => (
        <RadioInputGroup margin={m} name={m ? 'rg-margin' : 'rg-base'} description="RadioInputGroup">
          <RadioInput label="One" value="1" />
          <RadioInput label="Two" value="2" />
        </RadioInputGroup>
      )} />

      <Compare label="FormFieldGroup" build={(m) => (
        <FormFieldGroup margin={m} description="FormFieldGroup">
          <TextInput renderLabel="Field" />
        </FormFieldGroup>
      )} />
    </div>
  )
}

render(<MarginDemo />)
````


🤖 Generated with [Claude Code](https://claude.com/claude-code)