### PR TITLE
fix(ui-alerts,console): remove Alert live-region role warning

### DIFF
--- a/packages/__docs__/src/index.html
+++ b/packages/__docs__/src/index.html
@@ -131,7 +131,7 @@
     <meta name="description" content="Instructure UI" />
   </head>
   <body>
-    <div id="flash-messages" role="alert"></div>
+    <div id="flash-messages"></div>
     <div id="app">
       <div class="docsLoading">
         <span class="docsLoading__Spinner" aria-hidden="true"></span>

--- a/packages/ui-alerts/src/Alert/v2/README.md
+++ b/packages/ui-alerts/src/Alert/v2/README.md
@@ -231,7 +231,7 @@ type: embed
     <Figure.Item>Use the Error alert to notify user of an error</Figure.Item>
     <Figure.Item>Use the Warning alert to notify user of a warning</Figure.Item>
     <Figure.Item>Use the Success alert to notify user of a success event or action</Figure.Item>
-    <Figure.Item>Use the `variantScreenReaderLabel` prop to indicate the alert variant to screen reader users</Figure.Item>
+    <Figure.Item>Use the <code>variantScreenReaderLabel</code> prop to indicate the alert variant to screen reader users</Figure.Item>
   </Figure>
   <Figure recommendation="no" title="Don't">
     <Figure.Item>Have alert messaging that is more than two lines long</Figure.Item>
@@ -250,7 +250,7 @@ type: embed
     <Figure.Item>aria-live="polite" alerts will only be announced if the user is not currently doing anything. Polite should be used in most situations involving live regions that present new info to users</Figure.Item>
     <Figure.Item>aria-live="assertive" alerts will be announced to the user as soon as possible, but not necessarily immediately. Assertive should be used if there is information that a user must know about right away, for example, a warning message in a form that does validation on the fly</Figure.Item>
     <Figure.Item>The aria-atomic=BOOLEAN is used to set whether or not the screen reader should always present the live region as a whole, even if only part of the region changes. The possible settings are: false or true. The default setting is false.</Figure.Item>
-    <Figure.Item>If the `liveRegion` element has a `role`, match it to the `liveRegionPoliteness` level: use `role="status"` for `polite` and `role="alert"` for `assertive`.</Figure.Item>
+    <Figure.Item>Do not set the <code>role</code> prop on the <code>liveRegion</code> because <code>liveRegionPoliteness</code> and <code>isLiveRegionAtomic</code> override the set values.</Figure.Item>
   </Figure>
 </Guidelines>
 ```

--- a/packages/ui-alerts/src/Alert/v2/README.md
+++ b/packages/ui-alerts/src/Alert/v2/README.md
@@ -250,6 +250,7 @@ type: embed
     <Figure.Item>aria-live="polite" alerts will only be announced if the user is not currently doing anything. Polite should be used in most situations involving live regions that present new info to users</Figure.Item>
     <Figure.Item>aria-live="assertive" alerts will be announced to the user as soon as possible, but not necessarily immediately. Assertive should be used if there is information that a user must know about right away, for example, a warning message in a form that does validation on the fly</Figure.Item>
     <Figure.Item>The aria-atomic=BOOLEAN is used to set whether or not the screen reader should always present the live region as a whole, even if only part of the region changes. The possible settings are: false or true. The default setting is false.</Figure.Item>
+    <Figure.Item>If the `liveRegion` element has a `role`, match it to the `liveRegionPoliteness` level: use `role="status"` for `polite` and `role="alert"` for `assertive`.</Figure.Item>
   </Figure>
 </Guidelines>
 ```

--- a/packages/ui-alerts/src/Alert/v2/index.tsx
+++ b/packages/ui-alerts/src/Alert/v2/index.tsx
@@ -153,11 +153,6 @@ class Alert extends Component<AlertProps, AlertState> {
   }
 
   initLiveRegion(liveRegion: Element) {
-    error(
-      liveRegion.getAttribute('role') === 'alert',
-      `[Alert] live region must have role='alert' set on page load in order to announce content`
-    )
-
     if (liveRegion) {
       liveRegion.setAttribute('aria-live', this.props.liveRegionPoliteness!)
       // indicates what notifications the user agent will trigger when the

--- a/regression-test/src/app/alert/page.tsx
+++ b/regression-test/src/app/alert/page.tsx
@@ -30,7 +30,7 @@ export default function AlertPage() {
   const myElementRef = useRef(null)
   return (
     <main className="flex gap-8 p-8 flex-row items-start axe-test">
-      <div id="flash-messages" role="alert" ref={myElementRef}></div>
+      <div id="flash-messages" ref={myElementRef}></div>
       <div>
         {variants.map((variant) => (
           <Alert variant={variant} key={variant} transition="none">


### PR DESCRIPTION
INSTUI-5131

**ISSUE:** 
- Alert warns that your live region must have role="alert", but role="alert" means **assertive** per WAI-ARIA, so even when you'd set liveRegionPoliteness="polite" (**non-assertive**), you got a warning asking for role="alert". It was likely a leftover before the liveRegionPoliteness prop was added. GitHub issue: https://github.com/instructure/instructure-ui/issues/2276

> Setting role="alert" is equivalent to setting aria-live="assertive" and aria-atomic="true". [...] Dynamic changes that are less urgent should use a less aggressive method, such as including aria-live="polite" or using an other live region role like status.
> https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role

**TEST PLAN:**
- run it locally
- add this to `packages/__docs__/src/index.html` after line 4 (webpack 5 doesn't provide `process` in the browser so typeof process resolves to "undefined" in `packages/console/src/console.ts` and log messages are not emitted)
```
     window.process = window.process || { env: {} }
    </script>
    <script>
```
- test this example, it should not emit a warning

```
<div>
  <div className="alerts-container" id="live-region"></div>
  <Alert
    variant="info"
    renderCloseButtonLabel="Dismiss alert"
    liveRegion={() => document.getElementById("live-region")}
    liveRegionPoliteness="polite"
  >
    Just an alert.
  </Alert>
</div>
```
- if you revert the fix, the warning should reappear

