### PR TITLE
fix: lint:changes command to only lint changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:vitest-watch": "playwright install chromium && vitest --project browser --project node",
     "test:vitest-browser-ui": "playwright install chromium && vitest --project browser --browser.headless=false --ui",
     "lint": "pnpm -r --stream lint",
-    "lint:changes": "pnpm run lint -- --since HEAD^",
+    "lint:changes": "git diff --name-only $(git merge-base HEAD origin/master)..HEAD | xargs -r oxlint --format=unix",
     "lint:fix": "pnpm -r --stream lint:fix",
     "lint:commits": "commitlint --from=HEAD^1",
     "bootstrap": "node scripts/bootstrap.mjs",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:vitest-watch": "playwright install chromium && vitest --project browser --project node",
     "test:vitest-browser-ui": "playwright install chromium && vitest --project browser --browser.headless=false --ui",
     "lint": "pnpm -r --stream lint",
-    "lint:changes": "git diff --name-only $(git merge-base HEAD origin/master)..HEAD | xargs -r oxlint --format=unix",
+    "lint:changes": "git diff --diff-filter=ACMR --name-only $(git merge-base HEAD origin/master)..HEAD | { grep -E '\\.(js|jsx|ts|tsx|mjs|cjs)$' || true; } | xargs -r oxlint --format=unix",
     "lint:fix": "pnpm -r --stream lint:fix",
     "lint:commits": "commitlint --from=HEAD^1",
     "bootstrap": "node scripts/bootstrap.mjs",


### PR DESCRIPTION
## Summary
- Replace broken `--since HEAD^` flag with `git merge-base` to properly target changed files
- Pass changed files directly to oxlint instead of routing through workspace runner
- Fixes lint:changes to skip unchanged portions of the codebase

## Test Plan
- `pnpm run lint:changes` now only lints files in the diff since merge-base

Fixes INSTUI-5090
