### PR TITLE
fix(ui-table): don't describe a sort state on unsorted v1 tables

### DIFF
--- a/packages/ui-table/src/Table/v1/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/v1/__tests__/Table.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT).
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { MockInstance, vi } from 'vitest'
+// v1 accepts a plain ReactNode caption, in addition to the caption function
+// that v2 requires
+import { Table } from '../index.js'
+import type { TableColHeaderProps } from '../ColHeader/props'
+import '@testing-library/jest-dom'
+
+describe('<Table /> (v1)', () => {
+  let consoleErrorMock: MockInstance<typeof console.error>
+
+  beforeEach(() => {
+    // Mocking console to prevent test output pollution
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+  })
+
+  const renderTable = (colHeaderProps?: TableColHeaderProps) =>
+    render(
+      <Table caption="Movies">
+        <Table.Head>
+          <Table.Row>
+            <Table.ColHeader id="foo" {...colHeaderProps}>
+              Foo
+            </Table.ColHeader>
+            <Table.ColHeader id="bar">Bar</Table.ColHeader>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row></Table.Row>
+        </Table.Body>
+      </Table>
+    )
+
+  describe('with a string caption', () => {
+    it('uses the caption verbatim when no column is sorted', async () => {
+      const { container } = renderTable()
+
+      expect(container.querySelector('caption')).toHaveTextContent(/^Movies$/)
+      expect(screen.getByRole('table', { name: 'Movies' })).toBeInTheDocument()
+    })
+
+    it('does not describe a sort state that does not exist', async () => {
+      const { container } = renderTable()
+
+      expect(container.querySelector('caption')).not.toHaveTextContent(
+        'Sorted by'
+      )
+      expect(container.querySelector('caption')).not.toHaveTextContent(
+        'undefined'
+      )
+    })
+
+    it('appends the sort state when a column is sorted', async () => {
+      const { container } = renderTable({
+        id: 'foo',
+        sortDirection: 'ascending'
+      })
+
+      expect(container.querySelector('caption')).toHaveTextContent(
+        'Movies Sorted by Foo (ascending)'
+      )
+    })
+  })
+})

--- a/packages/ui-table/src/Table/v1/index.tsx
+++ b/packages/ui-table/src/Table/v1/index.tsx
@@ -161,7 +161,7 @@ class Table extends Component<TableProps> {
         const headerText =
           typeof colHeader.props.children === 'string'
             ? colHeader.props.children
-            : (colHeader.props.children?.props?.children ?? '')
+            : colHeader.props.children?.props?.children ?? ''
         return { header: headerText, direction: colHeader.props.sortDirection }
       }
     }
@@ -174,7 +174,13 @@ class Table extends Component<TableProps> {
     if (typeof caption === 'function') {
       return caption(sortInfo?.header ?? '', sortInfo?.direction ?? 'none')
     }
-    const sortText = ` Sorted by ${sortInfo?.header} (${sortInfo?.direction})`
+    // An unsorted table has no sort state to describe, so use the caption as
+    // given. Falling through would append ' Sorted by undefined (undefined)'
+    // to the accessible name of every unsorted table.
+    if (!sortInfo) {
+      return caption as string
+    }
+    const sortText = ` Sorted by ${sortInfo.header} (${sortInfo.direction})`
 
     return caption ? caption + sortText : sortText.trim()
   }


### PR DESCRIPTION
✨ _Authored with AI assistance._

## Summary

A v1 `Table` given a plain string caption appends `" Sorted by undefined (undefined)"` to both its `<caption>` and its accessible name whenever **no** column is sorted:

```
aria-label="Movies Sorted by undefined (undefined)"
<caption>Movies Sorted by undefined (undefined)</caption>
```

`getCaptionText` lost its early return for the unsorted case between `11.7.4-SECURITY.3` and `11.7.4`:

```js
// 11.7.4-SECURITY.3
const caption = props.caption as string
if (!sortInfo) return caption
const sortText = ` Sorted by ${sortInfo.header} (${sortInfo.direction})`

// 11.7.4 — early return gone, so sortInfo is always interpolated
const sortText = ` Sorted by ${sortInfo?.header} (${sortInfo?.direction})`
return caption ? caption + sortText : sortText.trim()
```

This is user-facing for screen reader users, not only a test problem. It still reproduces on `11.7.5-snapshot-14`.

## Changes

- Restore the early return so an unsorted table uses its caption as given. The `caption`-as-function path is untouched, and the cast matches what SECURITY.3 did (`props.caption as string`).
- Add `packages/ui-table/src/Table/v1/__tests__/Table.test.tsx`. The existing `Table` tests import `@instructure/ui-table/latest` and only ever pass a caption *function*, so the v1 string-caption path had no coverage — which is how this shipped. The new tests import relatively so they exercise source rather than built output.

## Verification

- New tests fail on unpatched source (2 of 3, printing the literal `Movies Sorted by undefined (undefined)`) and pass with the fix. The third covers the sorted case and passes either way, guarding against over-correcting.
- `pnpm run test:vitest ui-table` — 25 passed.
- `pnpm run bootstrap` clean, including `build:types` (the first draft of this fix failed type-checking; `aria-label` needs a `string`).

## Context

Found upgrading canvas-lms off the Artifactory-only `11.7.4-SECURITY.3` onto public `11.7.4`, where it broke 10 vitest files and 6 Selenium specs that locate tables by accessible name. Reported in #instui. Canvas is carrying a `patch-package` patch for this that we'll drop once a fixed release ships.

## One question for reviewers

`componentDidUpdate` still has a commented-out condition:

```js
if (
  sortingChanged &&
  currentSortInfo &&
  // typeof this.props.caption === 'function' &&
  this._liveRegionRef
) {
```

That looks like this change was mid-flight, and the accompanying comment says sort changes should only be announced for function captions. I've left it exactly as-is because I don't know the intent — if the live-region announcement is also meant to be gated, that's a follow-up (or tell me and I'll fold it in here).
