### PR TITLE
fix(ui-motion): only pass elementRef to children that accept it

### DIFF
--- a/packages/ui-motion/src/Transition/BaseTransition/index.ts
+++ b/packages/ui-motion/src/Transition/BaseTransition/index.ts
@@ -347,26 +347,39 @@ class BaseTransition extends Component<
       }
     }
 
-    // `typeof type === 'object'` => forwardRef wrapper (withStyle-decorated InstUI components)
-    const refProps =
-      typeof child.type === 'object'
-        ? {
-            // chain so the child's own elementRef still fires instead of being overwritten
-            elementRef: createChainedFunction(
-              (child.props as { elementRef?: (el: Element | null) => void })
-                ?.elementRef,
-              this.handleRef
-            ),
-            // fallback for forwardRef children that expose their node via `ref`, not elementRef
-            ref: elementOnlyRef
-          }
-        : {
-            // for host el / plain class|fn: findDOMNode is the fallback
-            ref: (el: ReactInstance | Element | null) =>
-              this.handleRef(
-                el instanceof Element ? el : (findDOMNode(el) as Element) ?? null
-              )
-          }
+    // `typeof type === 'object'` covers every forwardRef wrapper, not just
+    // withStyle-decorated InstUI components. `@emotion/react`'s wrapper matches
+    // too, and it forwards unknown props straight to the DOM node, so passing
+    // `elementRef` to it makes React warn about an unrecognized prop. Require
+    // the child to declare `elementRef` before handing it one; anything else
+    // gets a plain `ref`.
+    const acceptsElementRef =
+      typeof child.type === 'object' &&
+      Array.isArray(
+        (child.type as { allowedProps?: readonly string[] }).allowedProps
+      ) &&
+      (child.type as { allowedProps: readonly string[] }).allowedProps.includes(
+        'elementRef'
+      )
+
+    const refProps = acceptsElementRef
+      ? {
+          // chain so the child's own elementRef still fires instead of being overwritten
+          elementRef: createChainedFunction(
+            (child.props as { elementRef?: (el: Element | null) => void })
+              ?.elementRef,
+            this.handleRef
+          ),
+          // fallback for forwardRef children that expose their node via `ref`, not elementRef
+          ref: elementOnlyRef
+        }
+      : {
+          // for host el / plain class|fn: findDOMNode is the fallback
+          ref: (el: ReactInstance | Element | null) =>
+            this.handleRef(
+              el instanceof Element ? el : (findDOMNode(el) as Element) ?? null
+            )
+        }
 
     return safeCloneElement(child, {
       'aria-hidden': !this.props.in ? true : undefined,

--- a/packages/ui-motion/src/Transition/__tests__/Transition.test.tsx
+++ b/packages/ui-motion/src/Transition/__tests__/Transition.test.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import { Component, createRef, RefObject } from 'react'
+import { Component, createRef, forwardRef, RefObject } from 'react'
 import {
   render,
   waitFor,
@@ -273,6 +273,79 @@ describe('<Transition />', () => {
       expect(onExit).toHaveBeenCalled()
       expect(onExiting).toHaveBeenCalled()
       expect(onExited).toHaveBeenCalled()
+    })
+  })
+
+  describe('ref forwarding to the child', () => {
+    // mirrors `@emotion/react`'s wrapper: a forwardRef component (so
+    // `typeof type === 'object'`) that spreads whatever it is given onto a
+    // host element
+    const SpreadingChild = forwardRef<HTMLDivElement, any>((props, ref) => (
+      <div ref={ref} {...props}>
+        {COMPONENT_TEXT}
+      </div>
+    ))
+    SpreadingChild.displayName = 'SpreadingChild'
+
+    const elementRefWarnings = (mock: ReturnType<typeof vi.spyOn>) =>
+      mock.mock.calls.filter((args: unknown[]) =>
+        args.join(' ').includes('elementRef')
+      )
+
+    it('does not pass elementRef to a child that does not accept it', async () => {
+      const { getByText } = render(
+        <Transition type="fade" in={true}>
+          <SpreadingChild />
+        </Transition>
+      )
+      const child = getByText(COMPONENT_TEXT)
+
+      expect(child).not.toHaveAttribute('elementref')
+      expect(elementRefWarnings(consoleErrorMock)).toHaveLength(0)
+    })
+
+    it('still finds the child node when elementRef is withheld', async () => {
+      const elementRef = vi.fn()
+      render(
+        <Transition type="fade" in={true} elementRef={elementRef}>
+          <SpreadingChild />
+        </Transition>
+      )
+
+      await waitFor(() => {
+        expect(elementRef).toHaveBeenCalledWith(expect.any(Element))
+      })
+    })
+
+    it('passes elementRef to a child that declares it in allowedProps', async () => {
+      const childElementRef = vi.fn()
+      const AcceptingChild = forwardRef<HTMLDivElement, any>(
+        ({ elementRef, ...rest }, ref) => (
+          <div
+            ref={(el) => {
+              elementRef?.(el)
+              if (typeof ref === 'function') ref(el)
+            }}
+            {...rest}
+          >
+            {COMPONENT_TEXT}
+          </div>
+        )
+      ) as any
+      AcceptingChild.displayName = 'AcceptingChild'
+      AcceptingChild.allowedProps = ['elementRef']
+
+      const { getByText } = render(
+        <Transition type="fade" in={true}>
+          <AcceptingChild elementRef={childElementRef} />
+        </Transition>
+      )
+
+      // the child's own elementRef is chained, not overwritten
+      await waitFor(() => {
+        expect(childElementRef).toHaveBeenCalledWith(expect.any(Element))
+      })
+      expect(getByText(COMPONENT_TEXT)).not.toHaveAttribute('elementref')
     })
   })
 })


### PR DESCRIPTION
## Summary

`BaseTransition.renderChildren()` treats `typeof child.type === 'object'` as "this is a `withStyle`-decorated InstUI component":

```js
// `typeof type === 'object'` => forwardRef wrapper (withStyle-decorated InstUI components)
const refProps =
  typeof child.type === 'object'
    ? { elementRef: createChainedFunction(...), ref: elementOnlyRef }
    : { ref: (el) => this.handleRef(...) }
```

But that's true of **every** `forwardRef` wrapper. `@emotion/react`'s wrapper matches it and forwards unknown props straight to the DOM node, so any emotion element wrapped in a `Transition` warns:

```
Warning: React does not recognize the `elementRef` prop on a DOM element.
    at span
    at @emotion/react/dist/emotion-element…
    at BaseTransition (@instructure/ui-motion/es/Transition/BaseTransition/index.js:52)
    at Transition → DrawerTray → DrawerLayout
```

`DrawerLayout.Tray` renders an emotion element inside a `Transition`, so every tray and dialog built on it logs this. `11.7.4-SECURITY.3` used `ref` + `findDOMNode` and never passed `elementRef`, so this appeared in `11.7.4`. Still present on `11.7.5-snapshot-14`.

## Changes

- Gate the `elementRef` branch on the child actually declaring `elementRef` in `allowedProps`. InstUI components decorated with `withStyle` expose it; emotion's wrapper doesn't, so it falls back to the plain `ref` path — the behaviour that shipped before this check existed.
- Keep the chaining for children that do accept it, so a child's own `elementRef` still fires rather than being overwritten.
- Add three tests under `<Transition />` covering ref forwarding.

## Verification

- The first new test fails on unpatched source and passes with the fix. The other two are guards: one proves the child node is still found via the fallback `ref`, and one proves an `allowedProps`-declaring child still receives a chained `elementRef` — that pair would catch over-correcting by dropping the `elementRef` branch entirely.
- `pnpm run test:vitest ui-motion` — 21 passed.
- `pnpm run bootstrap` clean, including `build:types`.

## Context

Found upgrading canvas-lms off the Artifactory-only `11.7.4-SECURITY.3` onto public `11.7.4`. canvas-rce's vitest setup escalates `console.error` to a failure, so this alone failed **380 tests across 23 files**, all Tray/Dialog specs. Reported in #instui. Canvas is carrying a `patch-package` patch for this that we'll drop once a fixed release ships.

## Alternative worth considering

Gating on `allowedProps` is the narrowest fix that keeps your new chaining behaviour. If you'd rather not rely on that static, the other options are an explicit opt-in prop on the child, or reverting to the pre-11.7.4 `ref` + `findDOMNode` approach and solving the overwrite problem differently. Happy to reshape this if you prefer one of those.