### PR TITLE
fix(ui-table): don't append a sort state to unsorted v1 captions

### DIFF
--- a/packages/ui-table/src/Table/v1/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/Table/v1/__tests__/Table.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+import { Table } from '../index.js'
+import type { TableColHeaderProps } from '../ColHeader/props'
+
+describe('<Table /> (v1)', () => {
+  let consoleErrorMock: MockInstance<typeof console.error>
+
+  beforeEach(() => {
+    // Mocking console to prevent test output pollution
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorMock.mockRestore()
+  })
+
+  const renderTable = (colHeaderProps?: Partial<TableColHeaderProps>) =>
+    render(
+      <Table caption="Movies">
+        <Table.Head>
+          <Table.Row>
+            <Table.ColHeader id="foo" {...colHeaderProps}>
+              Foo
+            </Table.ColHeader>
+            <Table.ColHeader id="bar">Bar</Table.ColHeader>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Cell</Table.Cell>
+            <Table.Cell>Cell</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    )
+
+  describe('with a string caption', () => {
+    it('uses the caption verbatim when no column is sorted', async () => {
+      const { container } = await renderTable()
+
+      expect(container.querySelector('caption')).toHaveTextContent(/^Movies$/)
+      await expect
+        .element(page.getByRole('table', { name: 'Movies' }))
+        .toBeInTheDocument()
+    })
+
+    it('does not describe a sort state that does not exist', async () => {
+      const { container } = await renderTable()
+      const caption = container.querySelector('caption')
+
+      expect(caption).not.toHaveTextContent('Sorted by')
+      expect(caption).not.toHaveTextContent('undefined')
+    })
+
+    it('appends the sort state when a column is sorted', async () => {
+      const { container } = await renderTable({
+        id: 'foo',
+        sortDirection: 'ascending'
+      })
+
+      expect(container.querySelector('caption')).toHaveTextContent(
+        'Movies Sorted by Foo (ascending)'
+      )
+    })
+  })
+})

--- a/packages/ui-table/src/Table/v1/index.tsx
+++ b/packages/ui-table/src/Table/v1/index.tsx
@@ -161,7 +161,7 @@ class Table extends Component<TableProps> {
         const headerText =
           typeof colHeader.props.children === 'string'
             ? colHeader.props.children
-            : (colHeader.props.children?.props?.children ?? '')
+            : colHeader.props.children?.props?.children ?? ''
         return { header: headerText, direction: colHeader.props.sortDirection }
       }
     }
@@ -174,7 +174,13 @@ class Table extends Component<TableProps> {
     if (typeof caption === 'function') {
       return caption(sortInfo?.header ?? '', sortInfo?.direction ?? 'none')
     }
-    const sortText = ` Sorted by ${sortInfo?.header} (${sortInfo?.direction})`
+    // An unsorted table has no sort state to describe. Falling through would
+    // put ' Sorted by undefined (undefined)' into the accessible name of every
+    // unsorted table.
+    if (!sortInfo) {
+      return caption as string
+    }
+    const sortText = ` Sorted by ${sortInfo.header} (${sortInfo.direction})`
 
     return caption ? caption + sortText : sortText.trim()
   }


### PR DESCRIPTION
## Summary
An unsorted v1 `Table` with a plain string `caption` renders ` Sorted by undefined (undefined)` into both its `<caption>` and its accessible name:

```
aria-label="Movies Sorted by undefined (undefined)"
```

`getCaptionText` lost its `if (!sortInfo) return caption` guard in aac2b1790f (#2574), which restructured it around the new `TableCaption` function form. Shipped in v11.7.4. v2 is unaffected — `caption` must be a function there.

Our own docs site is affected too: the `__docs__` Properties, Params, Returns and ComponentTheme tables all use v1 with string captions.

## Changes
- Restore the early return in `Table/v1/index.tsx`. The function-caption branch is untouched, and the `as string` cast matches SECURITY.3 — the value feeds `aria-label`, which needs a string.
- Add `Table/v1/__tests__/Table.test.tsx`. v1 had no test coverage at all, which is why this shipped: the existing suite imports `/latest` (v2), and #2574 converted its last string captions to functions.

## Test Plan
- The two unsorted tests fail on unpatched source and pass with the fix. The sorted test passes either way, guarding against over-correcting.
- `pnpm run test:vitest ui-table` — 25 passed. Full unit suite — 2218 passed. `build:types` clean.
- Docs app: Properties and Component-theme captions render clean with matching `aria-label`s, and the function-caption sort form still works.

Worth knowing for future tests: the new file imports relatively on purpose. `getWorkspaceAliases()` in `vitest.config.mts` is only wired into the browser project, so a `@instructure/ui-table/*` import in the `web` project resolves to built `es/` output rather than source.

Fixes INSTUI-5138

Reported by @drakeaharper in [#instui](https://instructure.slack.com/archives/C0JCJ63TR/p1785354459934709) while upgrading canvas-lms onto public 11.7.4, where it broke 10 vitest files and 6 Selenium specs. Supersedes #2666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)