### PR TITLE
fix(ui-motion): stop leaking elementRef onto emotion-wrapped DOM children

### DIFF
--- a/packages/ui-motion/src/Transition/BaseTransition/index.ts
+++ b/packages/ui-motion/src/Transition/BaseTransition/index.ts
@@ -341,32 +341,35 @@ class BaseTransition extends Component<
 
     const child = ensureSingleChild(this.props.children) as ReactElement
 
-    const elementOnlyRef = (el: ReactInstance | Element | null) => {
-      if (el instanceof Element) {
-        this.handleRef(el)
-      }
-    }
+    // Pass elementRef only to children that declare it. Emotion's wrapper
+    // around `<div css={...}>` accepts any prop and forwards it to the DOM
+    // node, so it must take the plain `ref` path.
+    const acceptsElementRef = (
+      child.type as { allowedProps?: readonly string[] }
+    )?.allowedProps?.includes('elementRef')
 
-    // `typeof type === 'object'` => forwardRef wrapper (withStyle-decorated InstUI components)
-    const refProps =
-      typeof child.type === 'object'
-        ? {
-            // chain so the child's own elementRef still fires instead of being overwritten
-            elementRef: createChainedFunction(
-              (child.props as { elementRef?: (el: Element | null) => void })
-                ?.elementRef,
-              this.handleRef
-            ),
-            // fallback for forwardRef children that expose their node via `ref`, not elementRef
-            ref: elementOnlyRef
+    const refProps = acceptsElementRef
+      ? {
+          // chain so the child's own elementRef still fires instead of being overwritten
+          elementRef: createChainedFunction(
+            (child.props as { elementRef?: (el: Element | null) => void })
+              ?.elementRef,
+            this.handleRef
+          ),
+          // fallback for forwardRef children that expose their node via `ref`, not elementRef
+          ref: (el: ReactInstance | Element | null) => {
+            if (el instanceof Element) {
+              this.handleRef(el)
+            }
           }
-        : {
-            // for host el / plain class|fn: findDOMNode is the fallback
-            ref: (el: ReactInstance | Element | null) =>
-              this.handleRef(
-                el instanceof Element ? el : (findDOMNode(el) as Element) ?? null
-              )
-          }
+        }
+      : {
+          // host el / plain class|fn: findDOMNode is the fallback
+          ref: (el: ReactInstance | Element | null) =>
+            this.handleRef(
+              el instanceof Element ? el : (findDOMNode(el) as Element) ?? null
+            )
+        }
 
     return safeCloneElement(child, {
       'aria-hidden': !this.props.in ? true : undefined,

--- a/packages/ui-motion/src/Transition/__tests__/Transition.test.tsx
+++ b/packages/ui-motion/src/Transition/__tests__/Transition.test.tsx
@@ -23,10 +23,13 @@
  */
 
 import { Component, createRef, RefObject } from 'react'
+import type { ComponentType } from 'react'
 import { render } from 'vitest-browser-react'
 import { page } from 'vitest/browser'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { MockInstance } from 'vitest'
+
+import { withStyle } from '@instructure/emotion'
 
 import { Transition } from '../index.js'
 import { getClassNames } from '../styles.js'
@@ -54,6 +57,22 @@ class ExampleComponent extends Component<any, any> {
     return <div ref={this.ref}>{COMPONENT_TEXT}</div>
   }
 }
+
+// stands in for a real InstUI component, which ui-motion can't import (they
+// depend on it)
+type StyledChildProps = { elementRef?: (el: Element | null) => void }
+
+class StyledChildBase extends Component<StyledChildProps> {
+  static allowedProps = ['elementRef']
+  render() {
+    return <div ref={this.props.elementRef}>{COMPONENT_TEXT}</div>
+  }
+}
+
+const StyledChild = withStyle(
+  () => ({}),
+  () => ({})
+)(StyledChildBase) as unknown as ComponentType<StyledChildProps>
 
 describe('<Transition />', () => {
   let consoleWarningMock: ReturnType<typeof vi.spyOn>
@@ -269,6 +288,74 @@ describe('<Transition />', () => {
       expect(onExit).toHaveBeenCalled()
       expect(onExiting).toHaveBeenCalled()
       expect(onExited).toHaveBeenCalled()
+    })
+  })
+
+  describe('capturing the child node', () => {
+    const warningsMatching = (mock: MockInstance, pattern: RegExp) =>
+      mock.mock.calls.filter((args: unknown[]) => pattern.test(args.join(' ')))
+
+    const elementRefWarnings = (mock: MockInstance) =>
+      warningsMatching(mock, /elementRef/)
+
+    const refIsNotAPropWarnings = (mock: MockInstance) =>
+      warningsMatching(mock, /`?ref`? is not a prop/)
+
+    it('does not leak elementRef onto an emotion-wrapped host element', async () => {
+      await render(
+        <Transition type="fade" in={true}>
+          <div css={{ color: 'red' }}>hello</div>
+        </Transition>
+      )
+      const element = page.getByText('hello').element()
+
+      expect(element).not.toHaveAttribute('elementref')
+      expect(elementRefWarnings(consoleErrorMock)).toHaveLength(0)
+    })
+
+    it('still captures an emotion-wrapped host element', async () => {
+      const elementRef = vi.fn()
+      await render(
+        <Transition type="fade" in={true} elementRef={elementRef}>
+          <div css={{ color: 'red' }}>hello</div>
+        </Transition>
+      )
+
+      // the node reached handleRef, so the transition classes could be applied
+      expect(page.getByText('hello').element()).toHaveClass(
+        getClass('fade', 'entered')
+      )
+      await vi.waitFor(() => {
+        expect(elementRef).toHaveBeenCalledWith(expect.any(Element))
+      })
+    })
+
+    // a withStyle child plus a running transition made React read `ref` off the
+    // element; both conditions are needed to reproduce it
+    it('does not read `ref` off a withStyle child mid-transition', async () => {
+      const childElementRef = vi.fn()
+      const transitionElementRef = vi.fn()
+
+      await render(
+        <Transition
+          type="fade"
+          in={false}
+          transitionOnMount
+          elementRef={transitionElementRef}
+        >
+          <StyledChild elementRef={childElementRef} />
+        </Transition>
+      )
+
+      await vi.waitFor(() => {
+        // the child's own elementRef is chained, not overwritten, and
+        // Transition still captured the node
+        expect(childElementRef).toHaveBeenCalledWith(expect.any(Element))
+        expect(transitionElementRef).toHaveBeenCalledWith(expect.any(Element))
+      })
+      await expect.element(page.getByText(COMPONENT_TEXT)).toBeInTheDocument()
+      expect(refIsNotAPropWarnings(consoleErrorMock)).toHaveLength(0)
+      expect(elementRefWarnings(consoleErrorMock)).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

Any `<Transition>` child written with a `css` prop logs:

```
Warning: React does not recognize the `elementRef` prop on a DOM element.
    at span
    at BaseTransition
    at Transition -> DrawerTray -> DrawerLayout
```

`BaseTransition` treated `typeof child.type === 'object'` as "withStyle-decorated InstUI component". That's true of every forwardRef wrapper, including the one emotion's jsx runtime puts around any element carrying a `css` prop — and emotion forwards unknown props straight to the DOM node. `Tray`, `DrawerTray`, `RatingIcon` v2 and `Modal` (`constrain="parent"`) each render such a child.

## Changes

Narrow the check to children that actually declare `elementRef` in `allowedProps`. Emotion's wrapper doesn't, so `<div css={...}>` takes the plain `ref` path; a withStyle child keeps the chained `elementRef`.

This is deliberately **not** a revert of #2618 — reverting `renderChildren` brings back the `ref is not a prop` warning that PR fixed, verified by trying it rather than assuming. Two tests bracket the fix so neither behaviour can regress into the other.

## Test Plan

- `ui-motion` passes, as do `ui-tray ui-drawer-layout ui-modal ui-rating ui-overlays ui-toggle-details ui-tabs ui-popover` and the browser project. `build:types` clean.
- Both failure modes checked by temporarily swapping the implementation back.
- Docs app with devtools open: Alert dismiss/re-add and all three DrawerLayout trays — clean console, no `elementref` attributes in the DOM.

Fixes INSTUI-5139

Supersedes #2667, which proposed the same `allowedProps` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
