### PR TITLE
fix(ui-checkbox): announce the toggle variant as a toggle button

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -275,6 +275,37 @@ describe('<Checkbox />', () => {
     expect(input).not.toHaveAttribute('aria-invalid')
   })
 
+  describe('`toggle` variant', () => {
+    it('should expose a button role and pressed state', () => {
+      renderCheckbox({ variant: 'toggle', defaultChecked: true })
+      const toggle = screen.getByRole('button')
+
+      expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    })
+
+    it('should update the pressed state when toggled', async () => {
+      renderCheckbox({ variant: 'toggle', defaultChecked: false })
+      const toggle = screen.getByRole('button')
+
+      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+      await userEvent.click(toggle)
+
+      await waitFor(() => {
+        expect(toggle).toHaveAttribute('aria-pressed', 'true')
+      })
+    })
+
+    it('should leave the `simple` variant as a checkbox', () => {
+      renderCheckbox({ variant: 'simple' })
+      const input = screen.getByRole('checkbox')
+
+      expect(input).not.toHaveAttribute('role')
+      expect(input).not.toHaveAttribute('aria-pressed')
+    })
+  })
+
   describe('for a11y', () => {
     it('`simple` variant should meet standards', async () => {
       const { container } = renderCheckbox({ variant: 'simple' })

--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -343,6 +343,8 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
             readOnly={readOnly}
             aria-readonly={readOnly ? true : undefined}
             aria-checked={indeterminate ? 'mixed' : undefined}
+            role={variant === 'toggle' ? 'button' : undefined}
+            aria-pressed={variant === 'toggle' ? this.checked : undefined}
             aria-invalid={this.invalid ? 'true' : undefined}
             // Keep messages in the description so the accessible name contains only the label.
             aria-labelledby={


### PR DESCRIPTION
INSTUI-5023

**ISSUE:**
- Checkbox toggle variant looks and behaves like a toggle button but announced as checkbox so role and state (checkbox/checked) don't match the presented control (toggle). A suggested fix is adding role=”button” and aria-pressed=”false/true” to the `<input>`, see https://instructure.atlassian.net/browse/LRN-11564

**TEST PLAN:**
- check the Checkbox toggle variant with VoiceOver and NVDA, it should be announced as a "toggle button"