### PR TITLE
fix(ui-checkbox): fix message indentation

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/v2/index.tsx
+++ b/packages/ui-checkbox/src/Checkbox/v2/index.tsx
@@ -286,10 +286,9 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
         display="block"
         margin="small 0 0"
         css={
-          this.isError &&
-          (variant === 'toggle'
+          variant === 'toggle'
             ? styles?.indentedToggleError
-            : styles?.indentedError)
+            : styles?.indentedError
         }
       >
         <FormFieldMessages id={this._messagesId} messages={messages} />


### PR DESCRIPTION
Fixes INSTUI-5140

**Test:**
Add a hint and error message to a Checkbox example, check if there is indentation. Remove the error message and confirm indentation remains the same.