### PR TITLE
fix(emotion): only warn about a missing theme when the fallback is actually used

### DIFF
--- a/packages/emotion/src/getTheme.ts
+++ b/packages/emotion/src/getTheme.ts
@@ -31,7 +31,7 @@ import type {
   ThemeOrLegacyOverride,
   SpecificThemeOverride
 } from './EmotionTypes'
-import { InstUIProviderProps } from './InstUISettingsProvider/index.js'
+import type { InstUIProviderProps } from './InstUISettingsProvider'
 declare const process: Record<string, any> | undefined
 
 /**
@@ -61,21 +61,8 @@ const getTheme =
   ) =>
   (ancestorTheme = {} as Theme) => {
     // we need to clone the ancestor theme not to override it
-    let currentTheme
-    if (Object.keys(ancestorTheme).length === 0) {
-      if (
-        typeof process !== 'undefined' &&
-        (process?.env?.NODE_ENV !== 'production' ||
-          process?.env?.GITHUB_PULL_REQUEST_PREVIEW === 'true')
-      ) {
-        console.warn(
-          'No theme provided for [InstUISettingsProvider], using default `canvas` theme.'
-        )
-      }
-      currentTheme = canvas
-    } else {
-      currentTheme = ancestorTheme
-    }
+    const hasAncestorTheme = Object.keys(ancestorTheme).length > 0
+    const currentTheme = hasAncestorTheme ? ancestorTheme : canvas
 
     const resolvedThemeOverride =
       typeof themeOverride === 'function'
@@ -113,6 +100,19 @@ const getTheme =
         )
       }
       resolvedLegacyThemeOrOverride = {}
+    }
+
+    // We only get here if no full theme was given, so the overrides are merged
+    // into the implicit `canvas` fallback instead of a theme the consumer chose.
+    if (
+      !hasAncestorTheme &&
+      typeof process !== 'undefined' &&
+      (process?.env?.NODE_ENV !== 'production' ||
+        process?.env?.GITHUB_PULL_REQUEST_PREVIEW === 'true')
+    ) {
+      console.warn(
+        'No theme provided for [InstUISettingsProvider], using default `canvas` theme.'
+      )
     }
 
     const themeName = currentTheme.key


### PR DESCRIPTION
## Summary
- Move the "No theme provided for [InstUISettingsProvider], using default `canvas` theme." warning below the `isBaseTheme` early return so it only fires when the `canvas` fallback is actually used — previously it was a false positive whenever a valid theme was passed via the `theme` prop with no ancestor theme.
- Collapse the `currentTheme` if/else into a `hasAncestorTheme` flag; make the `InstUIProviderProps` import type-only.

## Test Plan
- Render `<InstUISettingsProvider theme={canvas}>` (no ancestor provider) and confirm no console warning appears.
- Render `<InstUISettingsProvider themeOverride={{...}}>` with no `theme` and confirm the warning still appears.

Fixes INSTUI-5142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
