### PR TITLE
chore: replace TypeScript compiler API with jscodeshift in generateVersionedExports

### DIFF
--- a/packages/ui-codemods/lib/__node_tests__/updateInstUIImportVersions.test.ts
+++ b/packages/ui-codemods/lib/__node_tests__/updateInstUIImportVersions.test.ts
@@ -54,6 +54,15 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
+  it('rewrites an import that @instructure/ui re-exports under an alias', () => {
+    runInlineTest(
+      updateInstUIImportVersions,
+      { versionTo: 'v11.7' },
+      makeFileInfo(`import { TreeBrowserCollection } from '@instructure/ui'`),
+      `import { TreeBrowserCollection } from '@instructure/ui/v11_7'`
+    )
+  })
+
   it('rewrites versioned import from versionFrom to versionTo', () => {
     runInlineTest(
       updateInstUIImportVersions,

--- a/packages/ui-codemods/scripts/generateVersionedExports.ts
+++ b/packages/ui-codemods/scripts/generateVersionedExports.ts
@@ -30,7 +30,7 @@
 
 import { resolve } from 'node:path'
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import ts from 'typescript'
+import jscodeshift from 'jscodeshift'
 
 // '@instructure/ui-button/v8_0' → matches; '@instructure/ui-button' or 'react' → no match
 const VERSIONED_INSTUI = /^@instructure\/[^/]+\/v\d+_\d+$/
@@ -62,33 +62,34 @@ function findLatestVersionFile(dir: string): string {
   return resolve(dir, latest)
 }
 
-function isVersionedInstUIExport(node: ts.ExportDeclaration): boolean {
-  const { moduleSpecifier } = node
-  return (
-    moduleSpecifier !== undefined &&
-    ts.isStringLiteral(moduleSpecifier) &&
-    VERSIONED_INSTUI.test(moduleSpecifier.text)
-  )
-}
-
-function getExportedNames(node: ts.ExportDeclaration): string[] {
-  const { exportClause } = node
-  if (!exportClause || !ts.isNamedExports(exportClause)) return []
-  return exportClause.elements.map((el) => el.name.text)
-}
-
 function parseVersionedComponents(filePath: string): string[] {
   const source = readFileSync(filePath, 'utf-8')
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    source,
-    ts.ScriptTarget.Latest
-  )
+  const j = jscodeshift.withParser('ts')
+  const root = j(source)
+  const components: string[] = []
 
-  return sourceFile.statements
-    .filter(ts.isExportDeclaration)
-    .filter(isVersionedInstUIExport)
-    .flatMap(getExportedNames)
+  root.find(j.ExportNamedDeclaration).forEach((path: any) => {
+    const node = path.value
+    const source = node.source
+
+    // Check if this is a versioned @instructure/ui import
+    if (
+      source &&
+      source.type === 'StringLiteral' &&
+      VERSIONED_INSTUI.test(source.value)
+    ) {
+      // Extract exported names
+      if (node.specifiers && node.specifiers.length > 0) {
+        node.specifiers.forEach((spec: any) => {
+          if (spec.local && spec.local.name) {
+            components.push(spec.local.name)
+          }
+        })
+      }
+    }
+  })
+
+  return components
 }
 
 function generateFileContent(components: string[]): string {

--- a/packages/ui-codemods/scripts/generateVersionedExports.ts
+++ b/packages/ui-codemods/scripts/generateVersionedExports.ts
@@ -81,8 +81,8 @@ function parseVersionedComponents(filePath: string): string[] {
       // Extract exported names
       if (node.specifiers && node.specifiers.length > 0) {
         node.specifiers.forEach((spec: any) => {
-          if (spec.local && spec.local.name) {
-            components.push(spec.local.name)
+          if (spec.exported && spec.exported.name) {
+            components.push(spec.exported.name)
           }
         })
       }


### PR DESCRIPTION
## Summary
- Replace TypeScript compiler API with jscodeshift for parsing versioned exports
- Removes dependency on `ts.ScriptTarget`, `ts.isExportDeclaration`, `ts.isNamedExports`
- Generates byte-identical output; jscodeshift is stable across TypeScript versions
- Preparation for TypeScript 7 upgrade (TS 7 breaks compiler API surface)

## Test Plan
- Verify `node scripts/generateVersionedExports.ts` produces identical `versionedExports.ts` output
- Run `pnpm run bootstrap` to confirm codemod generation works in the full build pipeline

Fixes INSTUI-5144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
