### PR TITLE
test(ui-checkbox): use the vitest-browser API in the toggle variant tests

### DIFF
--- a/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/ui-checkbox/src/Checkbox/__tests__/Checkbox.test.tsx
@@ -279,30 +279,28 @@ describe('<Checkbox />', () => {
   })
 
   describe('`toggle` variant', () => {
-    it('should expose a button role and pressed state', () => {
-      renderCheckbox({ variant: 'toggle', defaultChecked: true })
-      const toggle = screen.getByRole('button')
+    it('should expose a button role and pressed state', async () => {
+      await renderCheckbox({ variant: 'toggle', defaultChecked: true })
+      const toggle = page.getByRole('button').element()
 
       expect(toggle).toHaveAttribute('aria-pressed', 'true')
-      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+      expect(page.getByRole('checkbox').query()).not.toBeInTheDocument()
     })
 
     it('should update the pressed state when toggled', async () => {
-      renderCheckbox({ variant: 'toggle', defaultChecked: false })
-      const toggle = screen.getByRole('button')
+      await renderCheckbox({ variant: 'toggle', defaultChecked: false })
+      const toggle = page.getByRole('button')
 
-      expect(toggle).toHaveAttribute('aria-pressed', 'false')
+      await expect.element(toggle).toHaveAttribute('aria-pressed', 'false')
 
-      await userEvent.click(toggle)
+      await userEvent.click(toggle, { force: true })
 
-      await waitFor(() => {
-        expect(toggle).toHaveAttribute('aria-pressed', 'true')
-      })
+      await expect.element(toggle).toHaveAttribute('aria-pressed', 'true')
     })
 
-    it('should leave the `simple` variant as a checkbox', () => {
-      renderCheckbox({ variant: 'simple' })
-      const input = screen.getByRole('checkbox')
+    it('should leave the `simple` variant as a checkbox', async () => {
+      await renderCheckbox({ variant: 'simple' })
+      const input = page.getByRole('checkbox').element()
 
       expect(input).not.toHaveAttribute('role')
       expect(input).not.toHaveAttribute('aria-pressed')


### PR DESCRIPTION
## Summary
- Convert the `toggle` variant tests to the vitest-browser API — `page.getByRole().element()` / `.query()` and `expect.element` instead of `screen.*` and `waitFor`. This is what fails `build:types`: `screen` isn't imported, so it resolves to the DOM global `window.screen` and tsc reports `Property 'getByRole' does not exist on type 'Screen'`.
- `await` the `renderCheckbox` calls — `render` returns `Promise<RenderResult>`, so the queries were running before React had committed.
- Pass `{ force: true }` to the click. The `<label>` visually covers the real `<input>` and Playwright does genuine hit-testing, so the click timed out after 15s. Matches the five other click sites in this file.

Test-only; no component code touched. The `role="button"` / `aria-pressed` behaviour added in #2673 is correct and unchanged — those three assertions had simply never executed, since the job died at typecheck.

Context: #2673 opened 2026-07-31 and merged 2026-08-14, after the vitest-browser conversion landed on 2026-08-07. GitHub only re-runs PR checks when the head moves, not when the base does, so it merged on two-week-old green checks (its job list still shows `Cypress component tests`, a job that no longer exists). `master` has been red since — and so is every open PR, because PR checks build the merge ref.

## Test Plan
- No manual verification needed; the three tests now actually run in CI for the first time.
- Worth a separate look: branch protection on `master` has `strict: true` but `required_status_checks.contexts: []`, so "require branches to be up to date" never engages and this can recur.

Fixes INSTUI-5158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
