### PR TITLE
chore: fix small issues in docs app and documentation

### DIFF
--- a/docs/theming/new-theme-overrides.md
+++ b/docs/theming/new-theme-overrides.md
@@ -541,7 +541,7 @@ type: example
       }
     }}
   >
-    <Table caption="Independent overrides: ColHeader purple, RowHeader deeppink">
+    <Table caption={() => 'Independent overrides: ColHeader purple, RowHeader deeppink'}>
       <Table.Head>
         <Table.Row>
           <Table.ColHeader id="row-headers">Row headers column - purple</Table.ColHeader>

--- a/packages/__docs__/src/Document/index.tsx
+++ b/packages/__docs__/src/Document/index.tsx
@@ -24,10 +24,10 @@
 
 import React, { Component } from 'react'
 
-import { Link } from '@instructure/ui-link/latest'
-import { View } from '@instructure/ui-view/latest'
-import { Tabs } from '@instructure/ui-tabs/latest'
-import type { TabsProps } from '@instructure/ui-tabs/latest'
+import { Link } from '@instructure/ui-link'
+import { View } from '@instructure/ui-view'
+import { Tabs } from '@instructure/ui-tabs'
+import type { TabsProps } from '@instructure/ui-tabs'
 import type { NewBaseTheme } from '@instructure/ui-themes'
 import type { ComponentTheme as ComponentThemeData } from '@instructure/shared-types'
 import { SourceCodeEditor } from '@instructure/ui-source-code-editor/latest'
@@ -324,25 +324,38 @@ class Document extends Component<DocumentProps, DocumentState> {
     const importName = displayName || id
 
     // For versioned components, show the version-specific import path
-    // e.g. '@instructure/ui-avatar/v11_6' instead of '@instructure/ui-avatar'
+    // e.g. '@instructure/ui-avatar/v11_6'.
+    // For non-versioned ones just the import path e.g. '@instructure/emotion'
     const versionedPackageName =
       packageName && componentVersion && selectedMinorVersion
         ? `${packageName}/${selectedMinorVersion}`
         : packageName
-
     if (!versionedPackageName) return
+    const importHelp = componentVersion ? (
+      <>
+        This import shows how to use a specific component version. For other
+        import styles, see the{' '}
+        <Link
+          href="component-versioning"
+          onClick={(e) => {
+            e.preventDefault()
+            navigateTo('component-versioning')
+          }}
+        >
+          Component versioning
+        </Link>{' '}
+        guide.
+      </>
+    ) : (
+      ``
+    )
 
     const example = `\
 import { ${importName} } from '${versionedPackageName}'`
 
     return (
       <View margin="general.space2xl 0" display="block">
-        <Heading
-          level="h2"
-          as="h3"
-          id={`${id}Usage`}
-          margin="0 0 general.spaceMd 0"
-        >
+        <Heading level="h2" as="h3" id={`${id}Usage`} margin="0 0 general.spaceMd 0">
           Usage
         </Heading>
         <SourceCodeEditor
@@ -352,18 +365,7 @@ import { ${importName} } from '${versionedPackageName}'`
           readOnly
         />
         <View as="div" margin="general.spaceMd 0 0 0">
-          This import is pinned to the selected component version; future
-          breaking changes land at new paths. For other import styles, see the{' '}
-          <Link
-            href="component-versioning"
-            onClick={(e) => {
-              e.preventDefault()
-              navigateTo('component-versioning')
-            }}
-          >
-            Component versioning
-          </Link>{' '}
-          guide.
+          {importHelp}
         </View>
       </View>
     )

--- a/packages/__docs__/src/TableOfContents/index.tsx
+++ b/packages/__docs__/src/TableOfContents/index.tsx
@@ -80,24 +80,16 @@ class TableOfContents extends Component<
   }
 
   componentDidMount() {
-    const { doc, pageElement } = this.props
+    const { pageElement } = this.props
 
     const headings = pageElement?.querySelectorAll<HTMLHeadingElement>(
       'h1, h2, h3, h4, h5, h6'
     )
     const TOCData: TableOfContentsState['TOCData'] = []
-    let hasLinkToTitle = false
-
     headings?.forEach((h) => {
       const { id, innerText, tagName } = h
-      const level = tagName[1]
       const text = innerText.toLowerCase()
       const charCount = innerText.length
-
-      if (['1', '2'].includes(level) || doc.id === id) {
-        // already has a page title
-        hasLinkToTitle = true
-      }
 
       // if header is a note or warning, leave it out
       // (e.g.: "Note", "Notes:", "Warning!", etc.)
@@ -116,21 +108,10 @@ class TableOfContents extends Component<
       TOCData.push(data)
     })
 
-    if (!hasLinkToTitle) {
-      // if there is no link to the main title,
-      // add at the beginning of the list
-      TOCData.unshift({
-        id: doc.id,
-        innerText: doc.id,
-        level: '1'
-      })
-    }
-
+    // if there is only 1 item, clear TOC, no need for list
     if (TOCData.length === 1) {
-      // if there is only 1 item, clear TOC, no need for list
       TOCData.pop()
     }
-
     this.setState({ TOCData })
   }
 

--- a/packages/emotion/src/useComputedTheme.ts
+++ b/packages/emotion/src/useComputedTheme.ts
@@ -29,14 +29,9 @@ import { applyColorModifiers } from './styleUtils/applyColorModifiers.js'
  * ---
  * category: utilities/themes
  * ---
- * A hook that returns the fully resolved theme object from the context, with all token layers evaluated.
+ * A hook that returns the fully resolved v11.7+ theme object from the context.
  *
- * The raw `newTheme` stored on the context exposes its layers as functions
- * that depend on the previous layer (`semantics` takes `primitives`,
- * `components` and `sharedTokens` take `semantics`). This hook runs those
- * functions for you and returns the computed values, so you can read
- * tokens directly without having to know the evaluation order.
- *
+ * @module useComputedTheme
  * @returns An object containing the computed `primitives`, `semantics`,
  *          `components` and `sharedTokens` of the current theme.
  */


### PR DESCRIPTION
- Fix a new theme override example
- Only show the "This import is pinned to the selected component version.." message when the component has multiple versions
 - Do not show the component's own name in its Table of Contents
 - `useComputedTheme` show up now in the docs and has a better description