### PR TITLE
fix(ui-dialog): cancel the pending focus region activation on close

### DIFF
--- a/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
+++ b/packages/ui-dialog/src/Dialog/__tests__/Dialog.test.tsx
@@ -272,6 +272,53 @@ describe('<Dialog />', () => {
       })
     })
 
+    it('should not leak a focus region when it is closed before its activation frame runs', async () => {
+      // The Dialog activates its FocusRegion in a requestAnimationFrame
+      // callback. On a busy machine that callback can land after the Dialog
+      // has already been closed. Activating a region for a closed Dialog
+      // leaked it: nothing blurred it afterwards, so its document `keydown`
+      // listener kept scoping every later tab press to an element that is not
+      // rendered anymore.
+      const realRequestAnimationFrame = window.requestAnimationFrame
+      const realCancelAnimationFrame = window.cancelAnimationFrame
+      const frames = new Map<number, FrameRequestCallback>()
+      let nextFrameId = 0
+      try {
+        window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+          frames.set(++nextFrameId, callback)
+          return nextFrameId
+        }) as typeof window.requestAnimationFrame
+        window.cancelAnimationFrame = ((id: number) => {
+          frames.delete(id)
+        }) as typeof window.cancelAnimationFrame
+
+        const Example = ({ open }: { open: boolean }) => (
+          <div>
+            <button data-testid="outside-one">one</button>
+            <button data-testid="outside-two">two</button>
+            <Dialog open={open} shouldContainFocus label={TEST_LABEL}>
+              <button>{TEST_TEXT}</button>
+            </Dialog>
+          </div>
+        )
+        const { rerender } = await render(<Example open />)
+        await rerender(<Example open={false} />)
+        // the frames queued while the Dialog was open only run now
+        frames.forEach((callback) => callback(0))
+      } finally {
+        window.requestAnimationFrame = realRequestAnimationFrame
+        window.cancelAnimationFrame = realCancelAnimationFrame
+      }
+
+      const outsideOne = page.getByTestId('outside-one')
+      ;(outsideOne.element() as HTMLElement).focus()
+      await expect.element(outsideOne).toHaveFocus()
+
+      await userEvent.tab()
+
+      await expect.element(page.getByTestId('outside-two')).toHaveFocus()
+    })
+
     it('should return focus', async () => {
       const { rerender } = await render(<DialogExample open={false} />)
       await expect.element(page.getByTestId('input-trigger')).toHaveFocus()

--- a/packages/ui-dialog/src/Dialog/index.tsx
+++ b/packages/ui-dialog/src/Dialog/index.tsx
@@ -108,9 +108,11 @@ class Dialog extends Component<DialogProps> {
 
   close() {
     const { _focusRegion, contentElement } = this
-    // setTimeout is used here to delay the blur after the mousedown event in FocusRegion for correct execution order
+    this._raf.forEach((request) => request.cancel())
+    this._raf = []
     if (_focusRegion) {
       FocusRegionManager.blurRegion(contentElement, _focusRegion.id)
+      this._focusRegion = null
     }
   }
 


### PR DESCRIPTION
## Summary
- `Dialog.close()` cancels any still-scheduled `requestAnimationFrame` region activation and clears
  `_focusRegion` after blurring. Without it, a Dialog closed before that frame ran (e.g. a Tray
  opened and closed within one frame, which happens when rAF callbacks land late under load)
  activated a region nothing ever blurred — its document `keydown` listener then ran `scopeTab` on
  an unrendered element, `preventDefault`ing every later Tab press.
- Adds a Dialog regression test that flushes the activation frame manually after the close and
  asserts Tab still moves focus outside the Dialog.

## Test Plan
- This was the cause of the flaky Tray `should handle focus properly in complex cases` browser
  test. To reproduce the old failure, stub `window.requestAnimationFrame` to fire ~150ms late and
  run `packages/ui-tray/src/Tray/__tests__/Tray.test.tsx` — it fails on the first `userEvent.tab()`
  without this fix and passes with it.
- Worth a manual keyboard pass on Modal/Popover/Tray/Menu: open, close, then Tab around to confirm
  focus return and tab order are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
