### PR TITLE
chore: ask user to confirm commit type before committing in /commit skill

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -30,7 +30,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
    - **Never commit on `master`/`main`.** If you're on it, stop and **offer to create a feature branch** from the current HEAD — `git switch -c <type>/<short-desc>` carries the uncommitted changes onto the new branch — then commit there. Don't proceed on `master` even if the user didn't mention branching; confirm first.
    - If you're on a feature branch, glance at its name. If it looks **unrelated** to the change you're about to commit, flag it and offer to branch off (so you don't pile an unrelated commit onto someone else's WIP); otherwise proceed.
 2. Stage the files that belong in this commit — be specific, don't `git add -A`.
-3. Commit normally — let the git hooks run. The interactive Commitizen prompt is **no longer** a hook (it now lives behind `pnpm run commit` for humans), so a non-interactive `-m` commit works while `pre-commit` (lint-staged + TS references check) and `commit-msg` (commitlint) still fire:
+3. Propose a type(scope) and subject based on the diff, then **ask the user to confirm or override the commit type** before writing the message — don't assume `fix`/`feat` silently; **`feat`/`fix` types are used for non-test/tooling code in our public packages.**
+4. Commit normally — let the git hooks run. The interactive Commitizen prompt is **no longer** a hook (it now lives behind `pnpm run commit` for humans), so a non-interactive `-m` commit works while `pre-commit` (lint-staged + TS references check) and `commit-msg` (commitlint) still fire:
 
    ```bash
    git commit -m "$(cat <<'EOF'
@@ -39,6 +40,6 @@ Co-Authored-By: Claude <noreply@anthropic.com>
    )"
    ```
 
-4. `git status` to confirm.
+5. `git status` to confirm.
 
 If the `pre-commit` hook reformats files (lint-staged runs prettier/eslint), they're restaged into the same commit — that's expected. If a hook **fails** (TS references check, commitlint), fix the underlying issue and create a **new** commit — never `--amend` after a failed hook. Don't reach for `HUSKY=0` to bypass a failing hook; fix the cause.


### PR DESCRIPTION
Adds a step to the /commit skill that proposes a type(scope) and subject from the diff, then asks the user to confirm or override it before the commit message is written, instead of assuming the type silently.

Test: 
Create a commit and observe if Claude provides an interactive selector for commit type.