### PR TITLE
fix(ui-modal): avoid redundant Modal.Body re-renders from its observers

### DIFF
--- a/packages/ui-modal/src/Modal/v1/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/v1/ModalBody/index.tsx
@@ -33,7 +33,7 @@ import generateStyle from './styles.js'
 import generateComponentTheme from './theme.js'
 
 import { allowedProps } from './props.js'
-import type { ModalBodyProps } from './props'
+import type { ModalBodyProps, ModalBodyState } from './props'
 import { UIElement } from '@instructure/shared-types'
 import ModalContext from '../ModalContext.js'
 
@@ -44,7 +44,7 @@ id: Modal.Body
 ---
 **/
 @withStyle(generateStyle, generateComponentTheme)
-class ModalBody extends Component<ModalBodyProps> {
+class ModalBody extends Component<ModalBodyProps, ModalBodyState> {
   static displayName = 'ModalBody'
   static readonly componentId = 'Modal.Body'
 
@@ -54,6 +54,11 @@ class ModalBody extends Component<ModalBodyProps> {
     as: 'div',
     variant: 'default'
   }
+
+  state: ModalBodyState = { isFirefox: false, needsTabIndex: false }
+  // mirrors state.needsTabIndex, but readable synchronously in the observer
+  // callbacks below, where a pending setState would make this.state stale
+  private lastNeedsTabIndex = false
 
   ref: UIElement | null = null
   private resizeObserver?: ResizeObserver
@@ -92,9 +97,10 @@ class ModalBody extends Component<ModalBodyProps> {
 
     const finalRef = this.getFinalRef(this.ref)
     if (finalRef && typeof ResizeObserver !== 'undefined') {
-      this.resizeObserver = new ResizeObserver(() => this.forceUpdate())
+      this.syncTabIndex()
+      this.resizeObserver = new ResizeObserver(this.syncTabIndex)
       this.resizeObserver.observe(finalRef)
-      this.mutationObserver = new MutationObserver(() => this.forceUpdate())
+      this.mutationObserver = new MutationObserver(this.syncTabIndex)
       this.mutationObserver.observe(finalRef, {
         childList: true,
         subtree: true,
@@ -122,6 +128,32 @@ class ModalBody extends Component<ModalBodyProps> {
     this.mutationObserver?.disconnect()
   }
 
+  // The body is a tab stop only while it can be scrolled but holds nothing
+  // focusable. Both inputs come from the DOM, so the observers recompute them
+  // on resize and on subtree changes — which is most changes inside the body,
+  // the vast majority of them leaving the result identical. Comparing against
+  // the last computed value before calling setState keeps those callbacks from
+  // scheduling an update at all, rather than scheduling one React later
+  // discards: `setState` warns about updates outside `act()` in tests as soon
+  // as it schedules, so bailing out inside the updater would be too late.
+  syncTabIndex = () => {
+    const finalRef = this.getFinalRef(this.ref)
+    const hasScrollbar =
+      !!finalRef &&
+      Math.abs(
+        (finalRef.scrollHeight ?? 0) -
+          (finalRef.getBoundingClientRect()?.height ?? 0)
+      ) > 1
+    const needsTabIndex = hasScrollbar && findTabbable(finalRef).length === 0
+
+    if (needsTabIndex === this.lastNeedsTabIndex) return
+    this.lastNeedsTabIndex = needsTabIndex
+    this.setState({ needsTabIndex })
+  }
+
+  // this recursive function is needed because `ref` can be a React component.
+  // TODO rethink, the 'as' prop, likely its not a good idea to allow React
+  // components. See INSTUI-4674
   getFinalRef(el: UIElement): Element | undefined {
     if (!el) {
       return undefined
@@ -144,18 +176,7 @@ class ModalBody extends Component<ModalBodyProps> {
       ModalBody
     )
     const isFit = overflow === 'fit'
-    // this recursive function is needed because `ref` can be a React component.
-    // TODO rethink, the 'as' prop, likely its not a good idea to allow React
-    // components. See INSTUI-4674
-    const finalRef = this.getFinalRef(this.ref)
-    const hasScrollbar =
-      finalRef &&
-      Math.abs(
-        (finalRef.scrollHeight ?? 0) -
-          (finalRef.getBoundingClientRect()?.height ?? 0)
-      ) > 1
-    const hasTabbableChildren = !!finalRef && findTabbable(finalRef).length > 0
-    const needsTabIndex = hasScrollbar && !hasTabbableChildren
+    const { needsTabIndex } = this.state
     return (
       <ModalContext.Consumer>
         {(value) => (

--- a/packages/ui-modal/src/Modal/v1/ModalBody/props.ts
+++ b/packages/ui-modal/src/Modal/v1/ModalBody/props.ts
@@ -56,6 +56,7 @@ type ModalBodyStyle = ComponentStyle<'modalBody'>
 
 type ModalBodyState = {
   isFirefox: boolean
+  needsTabIndex: boolean
 }
 const allowedProps: AllowedPropKeys = [
   'children',

--- a/packages/ui-modal/src/Modal/v2/ModalBody/index.tsx
+++ b/packages/ui-modal/src/Modal/v2/ModalBody/index.tsx
@@ -32,7 +32,7 @@ import { withStyleNew } from '@instructure/emotion'
 import generateStyle from './styles.js'
 
 import { allowedProps } from './props.js'
-import type { ModalBodyProps } from './props'
+import type { ModalBodyProps, ModalBodyState } from './props'
 import { UIElement } from '@instructure/shared-types'
 import ModalContext from '../ModalContext.js'
 
@@ -43,7 +43,7 @@ id: Modal.Body
 ---
 **/
 @withStyleNew(generateStyle, 'ModalBody')
-class ModalBody extends Component<ModalBodyProps> {
+class ModalBody extends Component<ModalBodyProps, ModalBodyState> {
   static displayName = 'ModalBody'
   static readonly componentId = 'Modal.Body'
   static readonly themeId = 'ModalBody'
@@ -54,6 +54,11 @@ class ModalBody extends Component<ModalBodyProps> {
     as: 'div',
     variant: 'default'
   }
+
+  state: ModalBodyState = { isFirefox: false, needsTabIndex: false }
+  // mirrors state.needsTabIndex, but readable synchronously in the observer
+  // callbacks below, where a pending setState would make this.state stale
+  private lastNeedsTabIndex = false
 
   ref: UIElement | null = null
   private resizeObserver?: ResizeObserver
@@ -92,9 +97,10 @@ class ModalBody extends Component<ModalBodyProps> {
 
     const finalRef = this.getFinalRef(this.ref)
     if (finalRef && typeof ResizeObserver !== 'undefined') {
-      this.resizeObserver = new ResizeObserver(() => this.forceUpdate())
+      this.syncTabIndex()
+      this.resizeObserver = new ResizeObserver(this.syncTabIndex)
       this.resizeObserver.observe(finalRef)
-      this.mutationObserver = new MutationObserver(() => this.forceUpdate())
+      this.mutationObserver = new MutationObserver(this.syncTabIndex)
       this.mutationObserver.observe(finalRef, {
         childList: true,
         subtree: true,
@@ -122,6 +128,32 @@ class ModalBody extends Component<ModalBodyProps> {
     this.mutationObserver?.disconnect()
   }
 
+  // The body is a tab stop only while it can be scrolled but holds nothing
+  // focusable. Both inputs come from the DOM, so the observers recompute them
+  // on resize and on subtree changes — which is most changes inside the body,
+  // the vast majority of them leaving the result identical. Comparing against
+  // the last computed value before calling setState keeps those callbacks from
+  // scheduling an update at all, rather than scheduling one React later
+  // discards: `setState` warns about updates outside `act()` in tests as soon
+  // as it schedules, so bailing out inside the updater would be too late.
+  syncTabIndex = () => {
+    const finalRef = this.getFinalRef(this.ref)
+    const hasScrollbar =
+      !!finalRef &&
+      Math.abs(
+        (finalRef.scrollHeight ?? 0) -
+          (finalRef.getBoundingClientRect()?.height ?? 0)
+      ) > 1
+    const needsTabIndex = hasScrollbar && findTabbable(finalRef).length === 0
+
+    if (needsTabIndex === this.lastNeedsTabIndex) return
+    this.lastNeedsTabIndex = needsTabIndex
+    this.setState({ needsTabIndex })
+  }
+
+  // this recursive function is needed because `ref` can be a React component.
+  // TODO rethink, the 'as' prop, likely its not a good idea to allow React
+  // components. See INSTUI-4674
   getFinalRef(el: UIElement): Element | undefined {
     if (!el) {
       return undefined
@@ -152,18 +184,7 @@ class ModalBody extends Component<ModalBodyProps> {
       ModalBody
     )
     const isFit = overflow === 'fit'
-    // this recursive function is needed because `ref` can be a React component.
-    // TODO rethink, the 'as' prop, likely its not a good idea to allow React
-    // components. See INSTUI-4674
-    const finalRef = this.getFinalRef(this.ref)
-    const hasScrollbar =
-      finalRef &&
-      Math.abs(
-        (finalRef.scrollHeight ?? 0) -
-          (finalRef.getBoundingClientRect()?.height ?? 0)
-      ) > 1
-    const hasTabbableChildren = !!finalRef && findTabbable(finalRef).length > 0
-    const needsTabIndex = hasScrollbar && !hasTabbableChildren
+    const { needsTabIndex } = this.state
     return (
       <ModalContext.Consumer>
         {(value) => (

--- a/packages/ui-modal/src/Modal/v2/ModalBody/props.ts
+++ b/packages/ui-modal/src/Modal/v2/ModalBody/props.ts
@@ -62,6 +62,7 @@ type ModalBodyStyle = ComponentStyle<'modalBody'>
 
 type ModalBodyState = {
   isFirefox: boolean
+  needsTabIndex: boolean
 }
 const allowedProps: AllowedPropKeys = [
   'children',


### PR DESCRIPTION
## Summary

`Modal.Body` becomes a tab stop when it can be scrolled but has no focusable
child inside it. It read both of those from the DOM during `render()`, and its
resize and mutation observers called `forceUpdate()` on every change they saw.

So any DOM change inside the body caused a re-render, even when the tab stop
stayed the same. In jsdom tests those updates land outside `act()`, which is the
warning consumers hit on 11.7.4.

Now the value lives in state:

- `syncTabIndex()` reads the DOM, compares the result with the last value, and
  calls `setState` only if it changed. The compare has to come before
  `setState`: a class component schedules the update (and warns) before the
  updater runs, so returning early inside the updater is too late.
- `render()` reads state instead of the DOM.
- `componentDidUpdate()` calls `syncTabIndex()` too, because the observers don't
  catch every change. If only the text changes, the body can start to overflow
  without changing its own size, and neither observer fires. Thanks @matyasf for
  catching this and writing the test for it.

Same change in v1 and v2. No prop, theme, or export changes.

Measured on the branch: 20 no-op mutations inside the body went from 20
re-renders to zero in Chromium, and 10 mutations went from 10 `act()` warnings
to zero in jsdom, in both versions.

## Test Plan

- Keyboard only: open a modal with a scrollable body that has nothing focusable
  in it. Tab to the body, check that it takes focus and that Up/Down scroll it.
- With the modal open, add a focusable child to the body. The body should stop
  being a tab stop, and focus should go to the child. Remove the child and the
  body should be focusable again.
- With the modal open, make the body long enough to scroll and then short again.
  The tab stop should follow.
- Grow the body text only, so its own size doesn't change. The body should still
  become a tab stop.
- Worth a screen reader pass (VO/NVDA/JAWS) on the scrollable body's
  `aria-label`, since this touches the same code path as INSTUI-5046.

Fixes INSTUI-5166
