### PR TITLE
perf(ui-scripts,ui-icons): generate tree-shakeable named imports for lucide icons

### DIFF
--- a/packages/ui-scripts/lib/__node_tests__/generate-lucide-index.test.ts
+++ b/packages/ui-scripts/lib/__node_tests__/generate-lucide-index.test.ts
@@ -52,9 +52,9 @@ describe('generateLucideIndex', () => {
     const content = readFileSync(dir + 'src/generated/lucide/index.ts', 'utf-8')
     const exportCount = (content.match(/^export const /gm) || []).length
     expect(exportCount).toBeGreaterThan(0)
-    // Every exported icon should follow the wrapLucideIcon pattern
+    // Every exported icon should follow the wrapLucideIcon pattern, annotated
     expect(content).toMatch(
-      /export const \w+InstUIIcon = wrapLucideIcon\(Lucide\.\w+\)/
+      /export const \w+InstUIIcon = \/\*#__PURE__\*\/ wrapLucideIcon\(\w+\)/
     )
   })
 
@@ -74,6 +74,8 @@ describe('generateLucideIndex', () => {
     expect(content).toContain(
       "import { wrapLucideIcon } from '../../lucide/wrapLucideIcon'"
     )
-    expect(content).toContain("import * as Lucide from 'lucide-react'")
+
+    expect(content).not.toContain("import * as Lucide from 'lucide-react'")
+    expect(content).toMatch(/^import \{ \w+(, \w+)* \} from 'lucide-react'$/m)
   })
 })

--- a/packages/ui-scripts/lib/icons/generate-custom-index.ts
+++ b/packages/ui-scripts/lib/icons/generate-custom-index.ts
@@ -114,7 +114,7 @@ export default function generateCustomIndex() {
           `    ${jsxContent}\n` +
           `  </>\n` +
           `)\n` +
-          `export const ${iconName}InstUIIcon = wrapCustomIcon(${iconName}Paths, '${iconName}', ${viewBoxArg})`
+          `export const ${iconName}InstUIIcon = /*#__PURE__*/ wrapCustomIcon(${iconName}Paths, '${iconName}', ${viewBoxArg})`
       )
     } catch (err) {
       throw new Error(`Error processing ${fileName}: ${err}`)

--- a/packages/ui-scripts/lib/icons/generate-lucide-index.ts
+++ b/packages/ui-scripts/lib/icons/generate-lucide-index.ts
@@ -89,14 +89,17 @@ export default function generateLucideIndex() {
   const iconExports = allLucideIcons
     .map(
       (iconName) =>
-        `export const ${iconName}InstUIIcon = wrapLucideIcon(Lucide.${iconName})`
+        `export const ${iconName}InstUIIcon = /*#__PURE__*/ wrapLucideIcon(${iconName})`
     )
     .join('\n')
 
+  // Named imports (rather than `import * as Lucide`) let bundlers tree-shake
+  // lucide-react itself, and the /*#__PURE__*/ annotation above lets minifiers
+  // drop unused wrapLucideIcon(...) calls.
   // Output goes to src/generated/lucide/ so the import is relative to that:
   // ../../lucide/wrapLucideIcon resolves to src/lucide/wrapLucideIcon
   const content = `${HEADER}
-import * as Lucide from 'lucide-react'
+import { ${allLucideIcons.join(', ')} } from 'lucide-react'
 import { wrapLucideIcon } from '../../lucide/wrapLucideIcon'
 
 ${iconExports}


### PR DESCRIPTION
## Summary
- Generate the lucide icon barrel with named imports from `lucide-react` instead of a namespace
  import (`import * as Lucide from 'lucide-react'`)
- Annotate each generated `wrapLucideIcon(...)` call with `/*#__PURE__*/` so minifiers can drop
  unused icons
- Update the generator's unit tests to match the new output shape

## Test plan
- Create an isolated mini project and add v2 Button to it with a renderIcon prop. The prop should pick up a Lucide icon. Check if the final bundle contains other icons.


Fixes INSTUI-5171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
