### PR TITLE
INSTUI-5173: Document the new codemods in the upgrade guide; allow both Prettier 2 and 3 to run in the codemods

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 # Ignore all ejs files:
 *.ejs
-# Ignore codemod test files
-*.input.js
-*.output.js
+# Ignore codemod test fixtures. They must stay exactly as the codemod emits
+# them, which is with the consumer's Prettier (v2 or v3), not this repo's.
+packages/ui-codemods/lib/__node_tests__/__testfixtures__/

--- a/docs/contributing/codemods.md
+++ b/docs/contributing/codemods.md
@@ -28,11 +28,11 @@ import type { Transform } from 'jscodeshift'
  * @param options.usePrettier if `true` the transformed code will be run through
  * [Prettier](https://prettier.io/). You can customize this through a [Prettier
  * config file](https://prettier.io/docs/configuration.html)
- * @returns the modified file as `string` or `null`
+ * @returns a promise resolving to the modified file as `string` or to `null`
  */
-const myCodemod: Transform = (file, api,
+const myCodemod: Transform = async (file, api,
                               options?: { fileName?: string; usePrettier?: boolean }) => {
-    return instUICodemodExecutor([my, cool, scripts], file, api, options)
+    return await instUICodemodExecutor([my, cool, scripts], file, api, options)
 }
 export default myCodemod
 ```
@@ -44,14 +44,19 @@ export default myCodemod
 You should write unit tests for your codemods. They are tested via test fixtures (sample before transform, sample after transform). To create a unit test for say `sampleCodemod` the following steps are needed:
 
 1. Create a new test in `packages/ui-codemods/lib/__node_tests__/codemod.tests.ts`:
+
    ```ts
    ---
    type: code
    ---
-   it('tests the cool sampleCodemod', () => {
-     runTest(sampleCodemod)
+   it('tests the cool sampleCodemod', async () => {
+     await runTest(sampleCodemod)
    })
    ```
+
+   Don't forget the `await`: an un-awaited `runTest` reports a passing test
+   while its assertions land in a later one.
+
 2. Create a folder named `sampleCodemod` in `packages/ui-codemods/lib/__node_tests__/__testfixtures__`
 3. Here create sample input-output file pairs whose filename follows the following naming convention: `[fixtureName].input.[js/ts/tsx]`, `[fixtureName].output.[js/ts/tsx]`. These should be your test cases that ensure that the codemod does the transformation correctly.
 

--- a/docs/upgrading/upgrade-guide-v11.md
+++ b/docs/upgrading/upgrade-guide-v11.md
@@ -1,10 +1,10 @@
 ---
-title: Upgrade guide for v10 -> v11
+title: Upgrade guide for v10 -> 11
 category: Upgrading
 order: 1
 ---
 
-# Upgrade guide for v10 -> v11
+# Upgrade guide for v10 -> 11
 
 ## InstUI and React
 

--- a/docs/upgrading/upgrade-guide-v11.md
+++ b/docs/upgrading/upgrade-guide-v11.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade guide for v10 -> 11
+title: Upgrade guide from v10 to v11
 category: Upgrading
 order: 1
 ---

--- a/docs/upgrading/upgrade-guide.md
+++ b/docs/upgrading/upgrade-guide.md
@@ -1,10 +1,10 @@
 ---
-title: Upgrade guide for v11.x -> 11.7
+title: Upgrade guide for new theming
 category: Upgrading
 order: 2
 ---
 
-# Upgrade Guide for multi version support
+# Upgrade Guide to the /v11_7 components
 
 ## New theming system
 
@@ -145,7 +145,7 @@ npm install @instructure/ui-codemods
 npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/[codemod name].ts <path>  \
   --extensions=ts,tsx \
   --ignore-pattern="**/node_modules/**" \
-  --ignore-pattern="**/*.d.ts" \
+  --ignore-pattern="**/*.d.ts"
 ```
 
 ### updateInstUIImportVersions

--- a/docs/upgrading/upgrade-guide.md
+++ b/docs/upgrading/upgrade-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade guide for v11.7
+title: Upgrade guide for v11.x -> 11.7
 category: Upgrading
 order: 2
 ---
@@ -130,6 +130,99 @@ type: example
   />
 </InstUISettingsProvider>
 ```
+
+## Codemods
+
+How to use:
+
+It is worth adding `--extensions=ts,tsx` for TypeScript codebases. Also exclude `node_modules` and declaration files to avoid false matches:
+
+```sh
+---
+type: code
+---
+npm install @instructure/ui-codemods
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/[codemod name].ts <path>  \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" \
+  --ignore-pattern="**/*.d.ts" \
+```
+
+### updateInstUIImportVersions
+
+Rewrites `@instructure/*` import paths to a specific version subpath (e.g. `@instructure/ui-buttons/v11_7`). Only touches known versioned components — utilities and non-versioned symbols are left untouched. Imports mixing versioned components with other symbols are automatically split into two declarations.
+
+**Diagnose** — inspect which components are imported and at what version, without modifying files:
+
+```sh
+---
+type: code
+---
+# inspect all versioned imports
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
+  --diagnose=true
+
+# inspect only specific components
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
+  --diagnose=true --components=Button,Alert
+```
+
+**Update** — rewrite import paths:
+
+```sh
+---
+type: code
+---
+# all versioned components → v11.7
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
+  --versionTo=v11.7
+
+# only imports already pinned to v11.6
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
+  --versionFrom=v11.6 --versionTo=v11.7
+
+# specific components only
+npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
+  --extensions=ts,tsx \
+  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
+  --versionTo=v11.7 --components=Button,Alert
+```
+
+Options:
+
+- `versionTo`: target version, e.g. `v11.7`. Required for update mode.
+- `versionFrom`: only rewrite imports already pinned to this version.
+- `components`: comma-separated component names. Defaults to all known versioned exports.
+- `diagnose`: report matching imports without modifying files.
+- `fileName`: write parse errors and transform failures to this file.
+- `usePrettier`: run output through Prettier (default `true`).
+
+### migrateToNewIcons
+
+Migrates legacy InstUI icons (`IconXxxLine` / `IconXxxSolid`) to new `XxxInstUIIcon` components. Does the rename based on the official mapping: https://github.com/instructure/instructure-ui/blob/v11.7.5/packages/ui-icons/src/lucide/mapping.json (link just for reference, the codemod will always use the latest version).  
+Warns about legacy icons that has no mappings and have to be migrated manually.
+
+This codemod will rename icons if they are imported from:
+
+- `@instructure/ui-icons`
+- `@instructure/ui-icons/es/svg`
+- `@instructure/ui`
+
+### multiVersionThemeVariablesCodemod
+
+- Renames/removes component theme variables to their new (multi-version) names, basically it does the theme variable changes described in the "Breaking changes" section described below.
+- Migrates the legacy provider-level theme override `<InstUISettingsProvider theme={{ componentOverrides: { Comp: {...} } }} />`
+  to the new theming-system shape `<InstUISettingsProvider themeOverride={{ components: { Comp: {...} } }} />`
+
+## Breaking changes for each component
 
 ### Alert
 
@@ -1856,82 +1949,3 @@ type: embed
 />
 
 ```
-
-## Codemods
-
-### updateInstUIImportVersions
-
-Rewrites `@instructure/*` import paths to a specific version subpath (e.g. `@instructure/ui-buttons/v11_7`). Only touches known versioned components — utilities and non-versioned symbols are left untouched. Imports mixing versioned components with other symbols are automatically split into two declarations.
-
-```sh
----
-type: code
----
-npm install @instructure/ui-codemods
-```
-
-It is worth adding `--extensions=ts,tsx` for TypeScript codebases. Also exclude `node_modules` and declaration files to avoid false matches:
-
-```sh
----
-type: code
----
-npx jscodeshift@latest node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" \
-  --ignore-pattern="**/*.d.ts" \
-  --diagnose=true
-```
-
-**Diagnose** — inspect which components are imported and at what version, without modifying files:
-
-```sh
----
-type: code
----
-# inspect all versioned imports
-npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
-  --diagnose=true
-
-# inspect only specific components
-npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
-  --diagnose=true --components=Button,Alert
-```
-
-**Update** — rewrite import paths:
-
-```sh
----
-type: code
----
-# all versioned components → v11.7
-npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
-  --versionTo=v11.7
-
-# only imports already pinned to v11.6
-npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
-  --versionFrom=v11.6 --versionTo=v11.7
-
-# specific components only
-npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateInstUIImportVersions.ts <path> \
-  --extensions=ts,tsx \
-  --ignore-pattern="**/node_modules/**" --ignore-pattern="**/*.d.ts" \
-  --versionTo=v11.7 --components=Button,Alert
-```
-
-Options:
-
-- `versionTo`: target version, e.g. `v11.7`. Required for update mode.
-- `versionFrom`: only rewrite imports already pinned to this version.
-- `components`: comma-separated component names. Defaults to all known versioned exports.
-- `diagnose`: report matching imports without modifying files.
-- `fileName`: write parse errors and transform failures to this file.
-- `usePrettier`: run output through Prettier (default `true`).

--- a/packages/ui-codemods/README.md
+++ b/packages/ui-codemods/README.md
@@ -28,6 +28,13 @@ type: code
 npx jscodeshift@latest -t node_modules/@instructure/ui-codemods/lib/updateV10Breaking.ts <path>
 ```
 
+### Formatting
+
+Codemods run their output through [Prettier](https://prettier.io/) by default,
+using your project's Prettier installation and [config
+file](https://prettier.io/docs/configuration.html). Prettier is an optional peer
+dependency, both Prettier 2 and Prettier 3 work.
+
 For more information about what the codemods do, see the [major version upgrade guides](upgrade-guide)
 
 [npm]: https://img.shields.io/npm/v/@instructure/ui-codemods.svg

--- a/packages/ui-codemods/lib/__node_tests__/__testfixtures__/updateV10Breaking/colors2.output.tsx
+++ b/packages/ui-codemods/lib/__node_tests__/__testfixtures__/updateV10Breaking/colors2.output.tsx
@@ -602,8 +602,10 @@ const Header: React.FC<HeaderProps> = ({
   )
 }
 
-interface HeaderSearchProps
-  extends Omit<Partial<ComponentProps<typeof StaticSearch>>, 'styles'> {
+interface HeaderSearchProps extends Omit<
+  Partial<ComponentProps<typeof StaticSearch>>,
+  'styles'
+> {
   styles: Record<string, any>
 }
 

--- a/packages/ui-codemods/lib/__node_tests__/codemods.test.ts
+++ b/packages/ui-codemods/lib/__node_tests__/codemods.test.ts
@@ -60,38 +60,38 @@ describe('test codemods', () => {
     consoleWarningMock.mockRestore()
   })
 
-  it('test InstUI v10 color codemods', () => {
-    runTest(updateV10Breaking)
+  it('test InstUI v10 color codemods', async () => {
+    await runTest(updateV10Breaking)
   })
 
-  it('test removing "as" prop from InstUISettingsProvider', () => {
-    runTest(removeAsFromInstUISettingsProvider)
+  it('test removing "as" prop from InstUISettingsProvider', async () => {
+    await runTest(removeAsFromInstUISettingsProvider)
   })
 
-  it('test renaming Canvas themes', () => {
-    runTest(renameCanvasThemesCodemod)
+  it('test renaming Canvas themes', async () => {
+    await runTest(renameCanvasThemesCodemod)
   })
 
-  it('test renaming "getComputedStyle" to getCSSStyleDeclaration', () => {
-    runTest(renameGetComputedStyleToGetCSSStyleDeclaration)
+  it('test renaming "getComputedStyle" to getCSSStyleDeclaration', async () => {
+    await runTest(renameGetComputedStyleToGetCSSStyleDeclaration)
   })
 
   it('test Table caption prop warning', async () => {
-    runTest(warnTableCaptionMissing)
+    await runTest(warnTableCaptionMissing)
   })
 
   it('test CodeEditor removed warning', async () => {
-    runTest(warnCodeEditorRemoved)
+    await runTest(warnCodeEditorRemoved)
   })
 
-  it('test migrating legacy icons to lucide/custom icons', () => {
-    runTest(migrateToNewIcons)
+  it('test migrating legacy icons to lucide/custom icons', async () => {
+    await runTest(migrateToNewIcons)
   })
 
   // All fixtures run through the full `multiVersionThemeVariablesCodemod` (both
   // legs: token renames + provider override relocation), so every `.output` is
   // the real end-to-end result a user gets - no single-leg intermediate states.
-  it('test multi-version theme variables codemod (end-to-end)', () => {
-    runTest(multiVersionThemeVariablesCodemod)
+  it('test multi-version theme variables codemod (end-to-end)', async () => {
+    await runTest(multiVersionThemeVariablesCodemod)
   })
 })

--- a/packages/ui-codemods/lib/__node_tests__/runTest.ts
+++ b/packages/ui-codemods/lib/__node_tests__/runTest.ts
@@ -36,13 +36,13 @@ import { expect, vi } from 'vitest'
  * - Fixtures must be named `XY.input.[ts|tsx|js]` and `XY.output.[ts|tsx|js]`
  * @param codemod The codemod to run
  */
-export function runTest(codemod: Transform) {
+export async function runTest(codemod: Transform) {
   // Fixtures live in `./__testfixtures__/[codemod name]/`.
   const fixturesDir = `${__dirname}/__testfixtures__/${codemod.name}`
   const entries = fs.readdirSync(fixturesDir, { withFileTypes: true })
 
   let fixturesRun = 0
-  entries.forEach((entry) => {
+  for (const entry of entries) {
     if (entry.isFile() && entry.name.includes('input')) {
       const isWarningTest = entry.name.includes('.warning.input')
       const inputPath = path.join(entry.parentPath, entry.name)
@@ -82,7 +82,7 @@ export function runTest(codemod: Transform) {
           const options = {}
 
           // Run codemod withouth comparison
-          codemod(fileInfo, api, options)
+          await codemod(fileInfo, api, options)
 
           const expectedWarningContent = fs
             .readFileSync(expectedPath, 'utf8')
@@ -123,11 +123,16 @@ export function runTest(codemod: Transform) {
           warnSpy.mockRestore()
         }
       } else {
-        runInlineTest(codemod, {}, { path: inputPath, source: input }, expected)
+        await runInlineTest(
+          codemod,
+          {},
+          { path: inputPath, source: input },
+          expected
+        )
       }
       fixturesRun++
     }
-  })
+  }
   if (fixturesRun === 0) {
     throw new Error(
       `Test failed for codemod "${codemod.name}": No fixtures found.`

--- a/packages/ui-codemods/lib/__node_tests__/updateInstUIImportVersions.test.ts
+++ b/packages/ui-codemods/lib/__node_tests__/updateInstUIImportVersions.test.ts
@@ -45,8 +45,8 @@ function makeFileInfo(source: string) {
 }
 
 describe('updateInstUIImportVersions', () => {
-  it('rewrites unversioned @instructure import to target version', () => {
-    runInlineTest(
+  it('rewrites unversioned @instructure import to target version', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(`import { Button } from '@instructure/ui'`),
@@ -54,8 +54,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('rewrites an import that @instructure/ui re-exports under an alias', () => {
-    runInlineTest(
+  it('rewrites an import that @instructure/ui re-exports under an alias', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(`import { TreeBrowserCollection } from '@instructure/ui'`),
@@ -63,8 +63,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('rewrites versioned import from versionFrom to versionTo', () => {
-    runInlineTest(
+  it('rewrites versioned import from versionFrom to versionTo', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', versionFrom: 'v11.6' },
       makeFileInfo(`import { Button } from '@instructure/ui/v11_6'`),
@@ -72,8 +72,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('returns null when versionFrom does not match', () => {
-    const result = updateInstUIImportVersions(
+  it('returns null when versionFrom does not match', async () => {
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import { Button } from '@instructure/ui/v11_5'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       { versionTo: 'v11.7', versionFrom: 'v11.6' }
@@ -81,8 +81,8 @@ describe('updateInstUIImportVersions', () => {
     expect(result).toBeNull()
   })
 
-  it('rewrites only imports containing the specified component', () => {
-    runInlineTest(
+  it('rewrites only imports containing the specified component', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', components: 'Button' },
       makeFileInfo(
@@ -99,8 +99,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('returns null when no imports match the specified component', () => {
-    const result = updateInstUIImportVersions(
+  it('returns null when no imports match the specified component', async () => {
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import { Alert } from '@instructure/ui'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       { versionTo: 'v11.7', components: 'Button' }
@@ -108,7 +108,7 @@ describe('updateInstUIImportVersions', () => {
     expect(result).toBeNull()
   })
 
-  it('returns null for non-@instructure imports', () => {
+  it('returns null for non-@instructure imports', async () => {
     // Includes component names that are in versionedExports but come from other packages —
     // the codemod must check the package, not just the import name.
     const cases = [
@@ -118,7 +118,7 @@ describe('updateInstUIImportVersions', () => {
       `import { Alert } from 'antd'`
     ]
     for (const source of cases) {
-      const result = updateInstUIImportVersions(
+      const result = await updateInstUIImportVersions(
         makeFileInfo(source),
         makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
         { versionTo: 'v11.7' }
@@ -127,9 +127,9 @@ describe('updateInstUIImportVersions', () => {
     }
   })
 
-  it('does not rewrite non-versioned components', () => {
+  it('does not rewrite non-versioned components', async () => {
     // 'withStyleNew' is not in versionedExports, so it should be skipped
-    const result = updateInstUIImportVersions(
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import { withStyleNew } from '@instructure/ui'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       { versionTo: 'v11.7' }
@@ -137,10 +137,10 @@ describe('updateInstUIImportVersions', () => {
     expect(result).toBeNull()
   })
 
-  it('does not split mixed @instructure/ui import: moves all specifiers to versioned path', () => {
+  it('does not split mixed @instructure/ui import: moves all specifiers to versioned path', async () => {
     // @instructure/ui version files re-export everything including non-component
     // symbols (e.g. canvas), so splitting is unnecessary — rewrite the whole import.
-    runInlineTest(
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(`import {canvas, Button} from "@instructure/ui"`),
@@ -148,9 +148,9 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('splits mixed import from an individual @instructure package: non-component stays, component moves', () => {
+  it('splits mixed import from an individual @instructure package: non-component stays, component moves', async () => {
     // TestComponent is not in versionedExports, Button is → triggers a split
-    runInlineTest(
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(
@@ -161,8 +161,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('does not add semicolons to split imports when usePrettier=false and file has no semis', () => {
-    runInlineTest(
+  it('does not add semicolons to split imports when usePrettier=false and file has no semis', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', usePrettier: false },
       makeFileInfo(
@@ -172,8 +172,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('preserves semicolons in split imports when file uses semis and usePrettier=false', () => {
-    runInlineTest(
+  it('preserves semicolons in split imports when file uses semis and usePrettier=false', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', usePrettier: false },
       makeFileInfo(
@@ -183,9 +183,9 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('moves type specifier to versioned path when its name is a known component', () => {
+  it('moves type specifier to versioned path when its name is a known component', async () => {
     // 'type Alert' — inline type modifier, Alert is in versionedExports
-    runInlineTest(
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', components: 'Button,Alert' },
       makeFileInfo(`import { Button, type Alert } from '@instructure/ui'`),
@@ -193,10 +193,10 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('moves all specifiers to versioned path when source is @instructure/ui, even with --components filter', () => {
+  it('moves all specifiers to versioned path when source is @instructure/ui, even with --components filter', async () => {
     // ButtonProps is not in the components filter, but @instructure/ui
     // version files re-export everything — no split, whole import moves.
-    runInlineTest(
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7', components: 'Button' },
       makeFileInfo(
@@ -206,8 +206,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('leaves default imports and type-only named imports untouched when not in components', () => {
-    const result = updateInstUIImportVersions(
+  it('leaves default imports and type-only named imports untouched when not in components', async () => {
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import Service, { type Config } from '@instructure/ui'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       { versionTo: 'v11.7' }
@@ -216,8 +216,8 @@ describe('updateInstUIImportVersions', () => {
     expect(result).toBeNull()
   })
 
-  it('returns null when versionTo is not provided', () => {
-    const result = updateInstUIImportVersions(
+  it('returns null when versionTo is not provided', async () => {
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import { Button } from '@instructure/ui'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       {}
@@ -225,11 +225,11 @@ describe('updateInstUIImportVersions', () => {
     expect(result).toBeNull()
   })
 
-  it('diagnose mode reports matching imports', () => {
+  it('diagnose mode reports matching imports', async () => {
     const reported: string[] = []
     const api = makeApi((msg: string) => reported.push(msg))
 
-    updateInstUIImportVersions(
+    await updateInstUIImportVersions(
       makeFileInfo(`import { Button, Alert } from '@instructure/ui/v11_6'`),
       api as Parameters<typeof updateInstUIImportVersions>[1],
       { diagnose: true }
@@ -241,11 +241,11 @@ describe('updateInstUIImportVersions', () => {
     expect(reported[0]).toContain('v11_6')
   })
 
-  it('diagnose mode filters by component name', () => {
+  it('diagnose mode filters by component name', async () => {
     const reported: string[] = []
     const api = makeApi((msg: string) => reported.push(msg))
 
-    updateInstUIImportVersions(
+    await updateInstUIImportVersions(
       makeFileInfo(`import { Button, Alert } from '@instructure/ui/v11_6'`),
       api as Parameters<typeof updateInstUIImportVersions>[1],
       { diagnose: true, components: 'Button' }
@@ -256,11 +256,11 @@ describe('updateInstUIImportVersions', () => {
     expect(reported[0]).not.toContain('Alert')
   })
 
-  it('diagnose mode shows "oldest" label for unversioned imports', () => {
+  it('diagnose mode shows "oldest" label for unversioned imports', async () => {
     const reported: string[] = []
     const api = makeApi((msg: string) => reported.push(msg))
 
-    updateInstUIImportVersions(
+    await updateInstUIImportVersions(
       makeFileInfo(`import { Button } from '@instructure/ui'`),
       api as Parameters<typeof updateInstUIImportVersions>[1],
       { diagnose: true }
@@ -270,7 +270,7 @@ describe('updateInstUIImportVersions', () => {
     expect(reported[0]).toContain('oldest')
   })
 
-  it('rewrites all matching imports in a file with 10+ @instructure imports', () => {
+  it('rewrites all matching imports in a file with 10+ @instructure imports', async () => {
     const input = [
       `import React from 'react'`,
       `import { Alert } from '@instructure/ui'`,
@@ -305,7 +305,7 @@ describe('updateInstUIImportVersions', () => {
       `import type { SomeType } from 'some-lib'`
     ].join('\n')
 
-    runInlineTest(
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(input),
@@ -313,8 +313,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('rewrites named imports from individual @instructure packages', () => {
-    runInlineTest(
+  it('rewrites named imports from individual @instructure packages', async () => {
+    await runInlineTest(
       updateInstUIImportVersions,
       { versionTo: 'v11.7' },
       makeFileInfo(
@@ -332,8 +332,8 @@ describe('updateInstUIImportVersions', () => {
     )
   })
 
-  it('does not rewrite default imports from @instructure packages', () => {
-    const result = updateInstUIImportVersions(
+  it('does not rewrite default imports from @instructure packages', async () => {
+    const result = await updateInstUIImportVersions(
       makeFileInfo(`import Button from '@instructure/ui-button'`),
       makeApi() as Parameters<typeof updateInstUIImportVersions>[1],
       { versionTo: 'v11.7' }

--- a/packages/ui-codemods/lib/index.ts
+++ b/packages/ui-codemods/lib/index.ts
@@ -34,14 +34,17 @@ import updateInstUIImportVersions from './updateInstUIImportVersions'
 import multiVersionThemeVariablesCodemod from './multiVersionThemeVariablesCodemod/multiVersionThemeVariablesCodemod'
 
 export {
+  // Codemods for InstUI v9 -> v10
   updateV10Breaking,
+  // Codemods for InstUI v10 -> v11
   instUIv11Codemods,
   removeAsFromInstUISettingsProvider,
   renameCanvasThemes,
-  renameGetComputedStyleToGetCSSStyleDeclaration,
   warnTableCaptionMissing,
+  renameGetComputedStyleToGetCSSStyleDeclaration,
   warnCodeEditorRemoved,
+  // Codemods for new theming/multi version (used by InstUI v11.7.2 and above)
   migrateToNewIcons,
-  updateInstUIImportVersions,
-  multiVersionThemeVariablesCodemod
+  multiVersionThemeVariablesCodemod,
+  updateInstUIImportVersions
 }

--- a/packages/ui-codemods/lib/instUIv11Codemods.ts
+++ b/packages/ui-codemods/lib/instUIv11Codemods.ts
@@ -32,12 +32,12 @@ import { warnCodeEditorRemovedCodemod } from './warnCodeEditorRemoved'
 /**
  * Runs all InstUI v10 -> v11 upgrade codemods
  */
-const InstUIv11Codemods: Transform = (
+const InstUIv11Codemods: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(
+  return await instUICodemodExecutor(
     [
       removeAsProp,
       renameCanvasThemes,

--- a/packages/ui-codemods/lib/migrateToNewIcons.ts
+++ b/packages/ui-codemods/lib/migrateToNewIcons.ts
@@ -111,8 +111,10 @@ function migrateIcons(j: JSCodeshift, root: Collection): boolean {
 /**
  * Migrates legacy InstUI icons (`IconXxxLine` / `IconXxxSolid`) to new
  * `XxxInstUIIcon` components.
+ * Warns about legacy icons that has no mappings and have to be migrated manually.
+ * New icons were introduced in InstUI v11.7.2
  *
- * Renames specifiers in-place for imports from:
+ * This codemod will rename icons if they are imported from:
  *   - `@instructure/ui-icons`
  *   - `@instructure/ui-icons/es/svg`
  *   - `@instructure/ui`

--- a/packages/ui-codemods/lib/migrateToNewIcons.ts
+++ b/packages/ui-codemods/lib/migrateToNewIcons.ts
@@ -124,8 +124,13 @@ const migrateToNewIconsCodemod: InstUICodemod = (j, root, filePath) => {
   return migrateIcons(j, root)
 }
 
-const migrateToNewIcons: Transform = (file, api, options) => {
-  return instUICodemodExecutor(migrateToNewIconsCodemod, file, api, options)
+const migrateToNewIcons: Transform = async (file, api, options) => {
+  return await instUICodemodExecutor(
+    migrateToNewIconsCodemod,
+    file,
+    api,
+    options
+  )
 }
 
 export default migrateToNewIcons

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/migrateComponentOverridesToThemeOverride.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/migrateComponentOverridesToThemeOverride.ts
@@ -39,6 +39,7 @@ import { namedTypes } from 'ast-types'
  * channel, so every component override must move - regardless of whether its
  * tokens have changed. Token renames are handled separately by
  * `transformThemeVariables`.
+ * This change was introduced in InstUI v11.7.2
  */
 const migrateComponentOverridesToThemeOverride: Transform = (
   file,

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/migrateComponentOverridesToThemeOverride.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/migrateComponentOverridesToThemeOverride.ts
@@ -41,12 +41,12 @@ import { namedTypes } from 'ast-types'
  * `transformThemeVariables`.
  * This change was introduced in InstUI v11.7.2
  */
-const migrateComponentOverridesToThemeOverride: Transform = (
+const migrateComponentOverridesToThemeOverride: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(
+  return await instUICodemodExecutor(
     migrateComponentOverridesToThemeOverrideCodemod,
     file,
     api,

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/multiVersionThemeVariablesCodemod.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/multiVersionThemeVariablesCodemod.ts
@@ -31,12 +31,12 @@ import { migrateComponentOverridesToThemeOverrideCodemod } from './migrateCompon
  * Runs all InstUI multi-version upgrade codemods.
  * (used for multi-version introduced in InstUI v11.7.2)
  */
-const multiVersionThemeVariablesCodemod: Transform = (
+const multiVersionThemeVariablesCodemod: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(
+  return await instUICodemodExecutor(
     [
       transformThemeVariablesCodemod,
       migrateComponentOverridesToThemeOverrideCodemod

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/multiVersionThemeVariablesCodemod.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/multiVersionThemeVariablesCodemod.ts
@@ -28,7 +28,8 @@ import { transformThemeVariablesCodemod } from './transformThemeVariables'
 import { migrateComponentOverridesToThemeOverrideCodemod } from './migrateComponentOverridesToThemeOverride'
 
 /**
- * Runs all InstUI multi-version upgrade codemods
+ * Runs all InstUI multi-version upgrade codemods.
+ * (used for multi-version introduced in InstUI v11.7.2)
  */
 const multiVersionThemeVariablesCodemod: Transform = (
   file,

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/themeVariableMappings/index.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/themeVariableMappings/index.ts
@@ -159,7 +159,9 @@ export const THEME_VARIABLE_MAPPINGS: Record<string, ComponentMapping> = {
     import: '@instructure/ui-billboard',
     removed: {
       iconColor: {},
-      iconHoverColor: {}
+      iconHoverColor: {},
+      iconHoverColorInverse: {},
+      messageColorInverse: {}
     }
   },
   Spinner: {
@@ -1189,6 +1191,14 @@ export const THEME_VARIABLE_MAPPINGS: Record<string, ComponentMapping> = {
     import: '@instructure/ui-instructure',
     renamed: {
       cardBorderRadius: { to: 'borderRadius' }
+    }
+  },
+  DataPermissionLevels: {
+    import: '@instructure/ui-instructure',
+    removed: {
+      cardPadding: {},
+      cardExplainerContainerBottomMargin: {},
+      cardGap: {}
     }
   },
   Flex: {

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/transformThemeVariables.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/transformThemeVariables.ts
@@ -32,6 +32,7 @@ import type { ComponentMapping } from './themeVariableMappings'
 
 /**
  * Renames/removes component theme variables to their new (multi-version) names.
+ * This change was introduced in InstUI v11.7.2
  */
 const transformThemeVariables: Transform = (
   file,

--- a/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/transformThemeVariables.ts
+++ b/packages/ui-codemods/lib/multiVersionThemeVariablesCodemod/transformThemeVariables.ts
@@ -34,12 +34,12 @@ import type { ComponentMapping } from './themeVariableMappings'
  * Renames/removes component theme variables to their new (multi-version) names.
  * This change was introduced in InstUI v11.7.2
  */
-const transformThemeVariables: Transform = (
+const transformThemeVariables: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(
+  return await instUICodemodExecutor(
     transformThemeVariablesCodemod,
     file,
     api,

--- a/packages/ui-codemods/lib/removeAsFromInstUISettingsProvider.ts
+++ b/packages/ui-codemods/lib/removeAsFromInstUISettingsProvider.ts
@@ -30,12 +30,12 @@ import { isJSXAttribute } from './utils/codemodTypeCheckers'
 /**
  * removes the `as` prop from InstUISettingsProvider.
  */
-const removeAsFromInstUISettingsProvider: Transform = (
+const removeAsFromInstUISettingsProvider: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(removeAsProp, file, api, options)
+  return await instUICodemodExecutor(removeAsProp, file, api, options)
 }
 
 const removeAsProp = (j: JSCodeshift, root: Collection, filePath: string) => {

--- a/packages/ui-codemods/lib/renameCanvasThemesCodemod.ts
+++ b/packages/ui-codemods/lib/renameCanvasThemesCodemod.ts
@@ -32,12 +32,12 @@ import instUICodemodExecutor from './utils/instUICodemodExecutor'
  * `canvasHighContrastTheme`, warns about deleted `ThemeRegistry` imports and
  * the removed `canvas.use()`/`canvasHighContrast.use()` functions
  */
-const renameCanvasThemesCodemod: Transform = (
+const renameCanvasThemesCodemod: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(renameCanvasThemes, file, api, options)
+  return await instUICodemodExecutor(renameCanvasThemes, file, api, options)
 }
 
 const renameCanvasThemes: InstUICodemod = (j, root, filePath) => {

--- a/packages/ui-codemods/lib/renameGetComputedStyleToGetCSSStyleDeclaration.ts
+++ b/packages/ui-codemods/lib/renameGetComputedStyleToGetCSSStyleDeclaration.ts
@@ -28,12 +28,12 @@ import instUICodemodExecutor from './utils/instUICodemodExecutor'
 /**
  * renames the `getComputedStyle` utility function to `getCSSStyleDeclaration`
  */
-const renameGetComputedStyleToGetCSSStyleDeclaration: Transform = (
+const renameGetComputedStyleToGetCSSStyleDeclaration: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(renameGetComputedStyle, file, api, options)
+  return await instUICodemodExecutor(renameGetComputedStyle, file, api, options)
 }
 
 const renameGetComputedStyle = (j: JSCodeshift, root: Collection) => {

--- a/packages/ui-codemods/lib/updateInstUIImportVersions.ts
+++ b/packages/ui-codemods/lib/updateInstUIImportVersions.ts
@@ -211,7 +211,7 @@ const updateInstUIImportVersionsCodemod =
     return hasChanges
   }
 
-const updateInstUIImportVersions: Transform = (file, api, options) => {
+const updateInstUIImportVersions: Transform = async (file, api, options) => {
   // When no --components filter is given, fall back to the full list of known
   const components = parseComponents(options.components) ?? [
     ...versionedExports
@@ -245,7 +245,7 @@ const updateInstUIImportVersions: Transform = (file, api, options) => {
   const hasSemi = detectSemi(file.source)
 
   try {
-    const result = instUICodemodExecutor(
+    const result = await instUICodemodExecutor(
       updateInstUIImportVersionsCodemod(
         components,
         versionTo,

--- a/packages/ui-codemods/lib/updateV10Breaking.ts
+++ b/packages/ui-codemods/lib/updateV10Breaking.ts
@@ -29,12 +29,12 @@ import instUICodemodExecutor from './utils/instUICodemodExecutor'
 /**
  * Updates theme color syntax from InstUI v9 to v10
  */
-const updateV10Breaking: Transform = (
+const updateV10Breaking: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(updateToV10Colors, file, api, options)
+  return await instUICodemodExecutor(updateToV10Colors, file, api, options)
 }
 
 export default updateV10Breaking

--- a/packages/ui-codemods/lib/utils/formatSource.ts
+++ b/packages/ui-codemods/lib/utils/formatSource.ts
@@ -22,17 +22,87 @@
  * SOFTWARE.
  */
 
-import prettier from 'prettier'
+type PrettierOptions = Record<string, unknown>
 
-export default function formatSource(source: string, sourcePath: string) {
-  let options = null
+/**
+ * The subset of the Prettier API this module uses. Both Prettier 2 and 3 are
+ * supported: in v2 `format` is synchronous and `resolveConfig` returns a
+ * promise, in v3 both are asynchronous. Awaiting covers both shapes.
+ */
+type PrettierModule = {
+  format: (
+    source: string,
+    options?: PrettierOptions
+  ) => string | Promise<string>
+  resolveConfig: (
+    path: string
+  ) => PrettierOptions | null | Promise<PrettierOptions | null>
+}
+
+const PRETTIER = 'prettier'
+
+let prettierPromise: Promise<PrettierModule | undefined> | undefined
+let warnedAboutMissingPrettier = false
+
+/**
+ * jscodeshift registers `@babel/register` for `.mjs` and `.cjs` files too and
+ * rewrites their modules to CommonJS. That breaks Prettier 3, whose `index.cjs`
+ * loads the ESM `index.mjs` at runtime. Hiding the dynamic import in a
+ * `new Function` keeps Babel from compiling it to a `require` call, so Node
+ * loads Prettier itself.
+ */
+const importModule = new Function('specifier', 'return import(specifier)') as (
+  specifier: string
+) => Promise<Record<string, unknown>>
+
+async function importPrettier(): Promise<Record<string, unknown>> {
+  try {
+    return await importModule(PRETTIER)
+  } catch {
+    // Test runners that evaluate modules in their own context (Vitest) give
+    // `new Function` no dynamic import callback, but do handle a plain import.
+    return await import(PRETTIER)
+  }
+}
+
+/**
+ * Prettier is an optional peer dependency, so it is resolved from the
+ * consumer's `node_modules` and its version is whatever they installed.
+ */
+function loadPrettier() {
+  if (!prettierPromise) {
+    prettierPromise = importPrettier()
+      .then((namespace) => {
+        const asDefault = namespace.default as PrettierModule | undefined
+        return typeof asDefault?.format === 'function'
+          ? asDefault
+          : (namespace as unknown as PrettierModule)
+      })
+      .catch(() => undefined)
+  }
+  return prettierPromise
+}
+
+export default async function formatSource(source: string, sourcePath: string) {
+  const prettier = await loadPrettier()
+  if (!prettier) {
+    if (!warnedAboutMissingPrettier) {
+      warnedAboutMissingPrettier = true
+      console.warn(
+        'Prettier is not installed, the codemod result is not formatted. ' +
+          'Install prettier (v2 or v3) or run the codemod with --usePrettier=false'
+      )
+    }
+    return source
+  }
+  let options: PrettierOptions | null = null
   const extension = sourcePath.split('.').pop()
   let parser = 'babel'
   if (extension === 'ts' || extension === 'tsx') {
     parser = 'typescript'
   }
   try {
-    options = prettier.resolveConfig.sync(sourcePath)
+    options = await prettier.resolveConfig(sourcePath)
     if (options) {
       // Set the parser argument if the consumer did not set one to avoid a console warning
       options = {
@@ -45,7 +115,7 @@ export default function formatSource(source: string, sourcePath: string) {
   }
   let result = source
   try {
-    result = prettier.format(
+    result = await prettier.format(
       source,
       options || {
         parser: parser,

--- a/packages/ui-codemods/lib/utils/instUICodemodExecutor.ts
+++ b/packages/ui-codemods/lib/utils/instUICodemodExecutor.ts
@@ -49,10 +49,11 @@ export type InstUICodemod = (
  * written to this file.
  * @param options.usePrettier if `true` the transformed code will be run through
  * [Prettier](https://prettier.io/). You can customize this through a [Prettier
- * config file](https://prettier.io/docs/configuration.html)
- * @returns the modified file as `string` or `null`
+ * config file](https://prettier.io/docs/configuration.html). Prettier is an
+ * optional peer dependency; both Prettier 2 and 3 work.
+ * @returns a promise resolving to the modified file as `string` or to `null`
  */
-const instUICodemodExecutor = (
+const instUICodemodExecutor = async (
   instUICodemods: InstUICodemod[] | InstUICodemod,
   file: FileInfo,
   api: API,
@@ -61,7 +62,7 @@ const instUICodemodExecutor = (
     usePrettier?: boolean
     quote?: 'single' | 'double' | 'auto'
   }
-) => {
+): Promise<string | null> => {
   const j = api.jscodeshift.withParser('tsx')
   const root = j(file.source)
   let hasModifications = false
@@ -83,7 +84,7 @@ const instUICodemodExecutor = (
   if (hasModifications) {
     const shouldUsePrettier = options?.usePrettier !== false
     return shouldUsePrettier
-      ? formatSource(root.toSource(), file.path)
+      ? await formatSource(root.toSource(), file.path)
       : root.toSource({ quote: options?.quote ?? 'double' })
   } else {
     return null

--- a/packages/ui-codemods/lib/warnCodeEditorRemoved.ts
+++ b/packages/ui-codemods/lib/warnCodeEditorRemoved.ts
@@ -29,12 +29,17 @@ import type { InstUICodemod } from './utils/instUICodemodExecutor'
 /**
  * Prints a warning if a `CodeEditor` import is found
  */
-const warnCodeEditorRemoved: Transform = (
+const warnCodeEditorRemoved: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(warnCodeEditorRemovedCodemod, file, api, options)
+  return await instUICodemodExecutor(
+    warnCodeEditorRemovedCodemod,
+    file,
+    api,
+    options
+  )
 }
 
 const warnCodeEditorRemovedCodemod: InstUICodemod = (

--- a/packages/ui-codemods/lib/warnTableCaptionMissing.ts
+++ b/packages/ui-codemods/lib/warnTableCaptionMissing.ts
@@ -36,12 +36,12 @@ const TABLE_IMPORT_PATHS = ['@instructure/ui-table', '@instructure/ui']
 /**
  * Prints a warning if the `caption` prop is missing from a `<Table />`.
  */
-const warnTableCaptionMissing: Transform = (
+const warnTableCaptionMissing: Transform = async (
   file,
   api,
   options?: { fileName?: string; usePrettier?: boolean }
 ) => {
-  return instUICodemodExecutor(
+  return await instUICodemodExecutor(
     warnTableCaptionMissingCodemod,
     file,
     api,

--- a/packages/ui-codemods/package.json
+++ b/packages/ui-codemods/package.json
@@ -20,15 +20,22 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jscodeshift": "^17.3.0",
-    "prettier": "^2.8.8"
+    "jscodeshift": "^17.3.0"
+  },
+  "peerDependencies": {
+    "prettier": "^2.8.8 || ^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@instructure/ui-babel-preset": "workspace:*",
     "@types/jscodeshift": "^17.3.0",
     "@types/node": "24.1.0",
-    "@types/prettier": "^2.7.3",
     "ast-types": "^0.16.1",
+    "prettier": "3.8.1",
     "vitest": "^4.1.9"
   },
   "publishConfig": {
@@ -44,9 +51,6 @@
     "./types/*": "./types/*",
     "./package.json": "./package.json",
     "./src/*": "./src/*"
-  },
-  "//dependency-comments": {
-    "prettier": "Prettier 3 is async, https://prettier.io/blog/2023/07/05/3.0.0.html#api-1"
   },
   "type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1548,9 +1548,6 @@ importers:
       jscodeshift:
         specifier: ^17.3.0
         version: 17.3.0(@babel/preset-env@7.29.5(@babel/core@7.29.0))
-      prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
     devDependencies:
       '@instructure/ui-babel-preset':
         specifier: workspace:*
@@ -1561,12 +1558,12 @@ importers:
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
-      '@types/prettier':
-        specifier: ^2.7.3
-        version: 2.7.3
       ast-types:
         specifier: ^0.16.1
         version: 0.16.1
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@24.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(vite@7.3.1(@types/node@24.1.0)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))
@@ -8032,9 +8029,6 @@ packages:
 
   '@types/pngjs@6.0.5':
     resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
-
-  '@types/prettier@2.7.3':
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -16010,8 +16004,6 @@ snapshots:
   '@types/pngjs@6.0.5':
     dependencies:
       '@types/node': 22.19.15
-
-  '@types/prettier@2.7.3': {}
 
   '@types/prop-types@15.7.15': {}
 


### PR DESCRIPTION
## Summary
- Make Prettier a peer dependency; allow users to use both v2 and v3
- Move the codemod section to the top of the v11.7 upgrade guide and add `migrateToNewIcons` and `multiVersionThemeVariablesCodemod` docs
- Add the missing Billboard `iconHoverColorInverse` / `messageColorInverse` removals and a `DataPermissionLevels` entry to the theme variable mappings

## Test Plan
- Check the v11.7 upgrade guide in the docs app
- Run `multiVersionThemeVariablesCodemod` against a file using Billboard `iconHoverColorInverse` / `messageColorInverse` and `DataPermissionLevels` overrides to confirm they're removed.

Fixes INSTUI-5173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
