### PR TITLE
fix(ui-select,ui-text-input): show messages for non-editable selects

### DIFF
--- a/packages/ui-select/src/Select/__tests__/Select.test.tsx
+++ b/packages/ui-select/src/Select/__tests__/Select.test.tsx
@@ -940,6 +940,75 @@ describe('<Select />', () => {
     })
   })
 
+  describe('messages', () => {
+    const errorMessage = 'This is an error message'
+
+    it('should render error messages when there is no onInputChange', async () => {
+      await render(
+        <Select
+          renderLabel="Choose an option"
+          messages={[{ type: 'error', text: errorMessage }]}
+        />
+      )
+
+      expect(page.getByText(errorMessage).element()).toBeInTheDocument()
+    })
+
+    it('should render error messages when there is an onInputChange', async () => {
+      await render(
+        <Select
+          renderLabel="Choose an option"
+          onInputChange={() => {}}
+          messages={[{ type: 'error', text: errorMessage }]}
+        />
+      )
+
+      expect(page.getByText(errorMessage).element()).toBeInTheDocument()
+    })
+
+    it('should describe the input with the rendered messages', async () => {
+      await render(
+        <Select
+          renderLabel="Choose an option"
+          messages={[{ type: 'error', text: errorMessage }]}
+        />
+      )
+      const input = page.getByLabelText('Choose an option').element()
+      const descriptions = input
+        .getAttribute('aria-describedby')!
+        .split(' ')
+        .map((id) => document.getElementById(id))
+
+      expect(
+        descriptions.find((element) => element?.textContent === errorMessage)
+      ).toBeInTheDocument()
+    })
+
+    it('should not render error messages when interaction="readonly"', async () => {
+      await render(
+        <Select
+          renderLabel="Choose an option"
+          interaction="readonly"
+          messages={[{ type: 'error', text: errorMessage }]}
+        />
+      )
+
+      expect(page.getByText(errorMessage).query()).toBeNull()
+    })
+
+    it('should not render error messages when interaction="disabled"', async () => {
+      await render(
+        <Select
+          renderLabel="Choose an option"
+          interaction="disabled"
+          messages={[{ type: 'error', text: errorMessage }]}
+        />
+      )
+
+      expect(page.getByText(errorMessage).query()).toBeNull()
+    })
+  })
+
   describe('list', () => {
     it('should set aria-selected on options with isSelected={true}', async () => {
       await render(

--- a/packages/ui-select/src/Select/v2/index.tsx
+++ b/packages/ui-select/src/Select/v2/index.tsx
@@ -719,6 +719,7 @@ class Select extends Component<SelectProps> {
     const passthroughProps = omitProps(rest, Select.allowedProps)
     const { ref, ...triggerProps } = getTriggerProps({ ...passthroughProps })
     const isEditable = typeof onInputChange !== 'undefined'
+    const isForcedReadOnly = interaction === 'enabled' && !isEditable
 
     // props to ensure screen readers treat uneditable selects as accessible
     // popup buttons rather than comboboxes.
@@ -762,10 +763,8 @@ class Select extends Component<SelectProps> {
       value: inputValue,
       inputRef: utils.createChainedFunction(ref, this.handleInputRef),
       inputContainerRef: this.handleInputContainerRef,
-      interaction:
-        interaction === 'enabled' && !isEditable
-          ? 'readonly' // prevent keyboard cursor
-          : interaction,
+      interaction: isForcedReadOnly ? 'readonly' : interaction, // if readonly prevent keyboard cursor
+      forceMessages: isForcedReadOnly,
       isRequired,
       shouldNotWrap,
       layout,
@@ -805,12 +804,11 @@ class Select extends Component<SelectProps> {
         {...triggerProps}
         {...getInputProps(inputProps)}
         suppressHydrationWarning
-        {...(interaction === 'enabled' &&
-          !isEditable && {
-            themeOverride: (componentTheme) => ({
-              backgroundReadonlyColor: componentTheme.backgroundColor
-            })
-          })}
+        {...(isForcedReadOnly && {
+          themeOverride: (componentTheme) => ({
+            backgroundReadonlyColor: componentTheme.backgroundColor
+          })
+        })}
       />
     )
   }

--- a/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
+++ b/packages/ui-simple-select/src/SimpleSelect/__tests__/SimpleSelect.test.tsx
@@ -239,6 +239,37 @@ describe('<SimpleSelect />', () => {
     })
   })
 
+  describe('messages', () => {
+    const errorMessage = 'This is an error message'
+
+    it('should render error messages', async () => {
+      await render(
+        <SimpleSelect
+          renderLabel="Choose an option"
+          messages={[{ type: 'error', text: errorMessage }]}
+        >
+          {getOptions()}
+        </SimpleSelect>
+      )
+
+      expect(page.getByText(errorMessage).element()).toBeInTheDocument()
+    })
+
+    it('should not render error messages when interaction="readonly"', async () => {
+      await render(
+        <SimpleSelect
+          renderLabel="Choose an option"
+          interaction="readonly"
+          messages={[{ type: 'error', text: errorMessage }]}
+        >
+          {getOptions()}
+        </SimpleSelect>
+      )
+
+      expect(page.getByText(errorMessage).query()).toBeNull()
+    })
+  })
+
   it('should render icons before option and call renderBeforeLabel callback with necessary props', async () => {
     const renderBeforeLabel = vi.fn(() => (
       <CheckInstUIIcon data-testid="option-icon" />

--- a/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
+++ b/packages/ui-text-input/src/TextInput/__tests__/TextInput.test.tsx
@@ -164,6 +164,58 @@ describe('<TextInput/>', () => {
     })
   })
 
+  describe('messages', () => {
+    const errorMessage = 'some error message'
+    const errorMessages = [{ type: 'error' as const, text: errorMessage }]
+
+    it('should render error messages', async () => {
+      await render(<TextInput renderLabel="Name" messages={errorMessages} />)
+
+      expect(page.getByText(errorMessage).element()).toBeInTheDocument()
+    })
+
+    it('should not render error messages when readonly', async () => {
+      await render(
+        <TextInput
+          renderLabel="Name"
+          interaction="readonly"
+          messages={errorMessages}
+        />
+      )
+
+      expect(page.getByText(errorMessage).query()).toBeNull()
+    })
+
+    it('should render error messages when readonly and `forceMessages` is set', async () => {
+      await render(
+        <TextInput
+          renderLabel="Name"
+          interaction="readonly"
+          messages={errorMessages}
+          forceMessages
+        />
+      )
+      const input = page.getByRole('textbox').element()
+
+      expect(page.getByText(errorMessage).element()).toBeInTheDocument()
+      expect(input).toHaveAttribute('readonly')
+      expect(input).not.toHaveAttribute('forcemessages')
+    })
+
+    it('should not render error messages when disabled and `forceMessages` is set', async () => {
+      await render(
+        <TextInput
+          renderLabel="Name"
+          interaction="disabled"
+          messages={errorMessages}
+          forceMessages
+        />
+      )
+
+      expect(page.getByText(errorMessage).query()).toBeNull()
+    })
+  })
+
   describe('for a11y', () => {
     it('should meet standards', async () => {
       const { container } = await render(<TextInput renderLabel="Name" />)

--- a/packages/ui-text-input/src/TextInput/v2/index.tsx
+++ b/packages/ui-text-input/src/TextInput/v2/index.tsx
@@ -283,6 +283,7 @@ class TextInput extends Component<TextInputProps> {
       messages,
       inputContainerRef,
       isRequired,
+      forceMessages,
       styles
     } = this.props
 
@@ -312,7 +313,7 @@ class TextInput extends Component<TextInputProps> {
         margin={this.props.margin}
         isRequired={isRequired}
         disabled={this.interaction === 'disabled'}
-        readOnly={this.interaction === 'readonly'}
+        readOnly={this.interaction === 'readonly' && !forceMessages}
         data-cid="TextInput"
       >
         <span css={styles?.facade}>

--- a/packages/ui-text-input/src/TextInput/v2/props.ts
+++ b/packages/ui-text-input/src/TextInput/v2/props.ts
@@ -75,6 +75,7 @@ type TextInputOwnProps = {
    * receive user interactions. When "readonly" the input still cannot receive
    * user interactions but it keeps the same styles as if it were enabled.
    * Note: placeholder is only displayed when interaction is enabled. You can force it with forcePlaceholder prop
+   * Note: error and success messages are hidden when interaction is not enabled. You can force them for readonly with the forceMessages prop
    */
   interaction?: InteractionType
 
@@ -144,6 +145,11 @@ type TextInputOwnProps = {
    * Always displays placeholder when textInput is empty, regardless of interaction type
    */
   forcePlaceholder?: boolean
+
+  /**
+   * Always displays `messages`, even when the interaction is `readonly`.
+   */
+  forceMessages?: boolean
 
   /**
    * provides a reference to the underlying html root element
@@ -236,6 +242,7 @@ const allowedProps: AllowedPropKeys = [
   'placeholder',
   'isRequired',
   'forcePlaceholder',
+  'forceMessages',
   'elementRef',
   'inputRef',
   'inputContainerRef',

--- a/regression-test/src/app/select/page.tsx
+++ b/regression-test/src/app/select/page.tsx
@@ -349,6 +349,37 @@ function MultipleSelectExample({ selected }: { selected: string[] }) {
   )
 }
 
+function MessagesExample() {
+  return (
+    <View display="block">
+      <Select
+        renderLabel="Select with an error message"
+        width="450px"
+        inputValue="Alaska"
+        isShowingOptions={false}
+        messages={[{ type: 'error', text: 'This is an error message' }]}
+        onRequestShowOptions={() => {}}
+        onRequestHideOptions={() => {}}
+        onRequestHighlightOption={() => {}}
+        onRequestSelectOption={() => {}}
+      >
+        <Select.Option id="msg_opt1" key="msg_opt1">
+          Alaska
+        </Select.Option>
+      </Select>
+      <SimpleSelect
+        renderLabel="SimpleSelect with an error message"
+        width="450px"
+        messages={[{ type: 'error', text: 'This is an error message' }]}
+      >
+        <SimpleSelect.Option id="msg_opt2" value="msg_opt2">
+          Alaska
+        </SimpleSelect.Option>
+      </SimpleSelect>
+    </View>
+  )
+}
+
 export default function SelectPage() {
   const basicOptions: OptionT[] = [
     { id: 'opt1', label: 'Alaska' },
@@ -394,6 +425,7 @@ export default function SelectPage() {
           'Colorado'
         ]}
       />
+      <MessagesExample />
     </main>
   )
 }


### PR DESCRIPTION
## Problem
A Select sets its TextInput to `readonly` to hide the keyboard cursor,
but the form field layer hides messages for readonly fields. Non-editable
Selects and SimpleSelects therefore rendered the error border without the message text.

## Fix
- `TextInput` v2 gets an optional `forceMessages` prop that keeps messages visible in the readonly state; `Select` v2 sets it where it forces readonly itself.

## Test Plan
- Docs app: a `SimpleSelect` with error message and no `onInputChange` should show the message text under the input.

````
<div>
  <TextInput
    renderLabel="TextInput readonly with forceMessages"
    interaction="readonly"
    defaultValue="Alaska"
    messages={[{ type: 'error', text: 'TextInput error message' }]}
    forceMessages
  />
  <SimpleSelect
    renderLabel="SimpleSelect with an error message"
    messages={[{ type: 'error', text: 'SimpleSelect error message' }]}
  >
    <SimpleSelect.Option id="opt-1" value="1">value 1</SimpleSelect.Option>
    <SimpleSelect.Option id="opt-2" value="2">value 2</SimpleSelect.Option>
  </SimpleSelect>

  <Select
    renderLabel="Select with an error message"
    inputValue="Alaska"
    messages={[{ type: 'error', text: 'Select error message' }]}
  >
    <Select.Option id="opt-1">Alaska</Select.Option>
    <Select.Option id="opt-2">Arizona</Select.Option>
  </Select>
</div>
````
- Visual regression: the `select` page has a new `MessagesExample` (Select + SimpleSelect with an error message) 


Fixes INSTUI-5172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
