### PR TITLE
chore(ui-scripts,regression-test): ignore whole-pixel shifts in visual regression diffs

### DIFF
--- a/packages/ui-scripts/lib/__node_tests__/visual-diff.test.ts
+++ b/packages/ui-scripts/lib/__node_tests__/visual-diff.test.ts
@@ -23,6 +23,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { PNG } from 'pngjs'
 import {
   badgeFor,
   thumb,
@@ -30,6 +31,7 @@ import {
   sourceLinkFor,
   appUrlFor,
   dilateMask,
+  matchesWhenShifted,
   esc,
   normalizeA11y,
   normalizeImpact,
@@ -269,6 +271,82 @@ describe('dilateMask', () => {
     const src = mask(16, 16, [{ x: 3, y: 3, w: 2, h: 2 }])
     const out = dilateMask(src, 16, 16, 0)
     expect(countSet(out)).toBe(countSet(src))
+  })
+})
+
+// An opaque white image with the given rectangles painted solid black. Hard
+// edges, so a one-pixel move registers as a real difference instead of being
+// written off as antialiasing by pixelmatch's `includeAA: false`.
+function image(
+  w: number,
+  h: number,
+  rects: Array<{ x: number; y: number; w: number; h: number }>
+) {
+  const png = new PNG({ width: w, height: h })
+  png.data.fill(255)
+  for (const r of rects) {
+    for (let y = r.y; y < r.y + r.h; y++) {
+      for (let x = r.x; x < r.x + r.w; x++) {
+        const i = (y * w + x) * 4
+        png.data[i] = 0
+        png.data[i + 1] = 0
+        png.data[i + 2] = 0
+      }
+    }
+  }
+  return png
+}
+
+describe('matchesWhenShifted', () => {
+  // Big enough that a 1px move is unambiguous, and far enough from the edges to
+  // shift in any direction without clipping.
+  const box = [{ x: 6, y: 6, w: 8, h: 8 }]
+  const baseline = image(24, 24, box)
+  const matches = (actual: PNG, maxShift = 1) =>
+    matchesWhenShifted(baseline, actual, 0.1, maxShift)
+
+  it('matches an identical image', () => {
+    expect(matches(image(24, 24, box))).toBe(true)
+  })
+
+  it('matches a one-pixel horizontal shift in either direction', () => {
+    expect(matches(image(24, 24, [{ x: 7, y: 6, w: 8, h: 8 }]))).toBe(true)
+    expect(matches(image(24, 24, [{ x: 5, y: 6, w: 8, h: 8 }]))).toBe(true)
+  })
+
+  it('matches a one-pixel vertical shift', () => {
+    expect(matches(image(24, 24, [{ x: 6, y: 7, w: 8, h: 8 }]))).toBe(true)
+  })
+
+  it('matches a diagonal shift', () => {
+    expect(matches(image(24, 24, [{ x: 5, y: 7, w: 8, h: 8 }]))).toBe(true)
+  })
+
+  it('matches when the actual is a pixel taller but otherwise identical', () => {
+    expect(matches(image(24, 25, box))).toBe(true)
+  })
+
+  it('rejects a shift larger than the budget', () => {
+    expect(matches(image(24, 24, [{ x: 9, y: 6, w: 8, h: 8 }]))).toBe(false)
+  })
+
+  it('matches that larger shift once the budget allows it', () => {
+    expect(matches(image(24, 24, [{ x: 9, y: 6, w: 8, h: 8 }]), 3)).toBe(true)
+  })
+
+  it('rejects a real change that no shift can explain', () => {
+    const recolored = image(24, 24, box)
+    const i = (10 * 24 + 10) * 4
+    recolored.data[i] = 255
+    recolored.data[i + 1] = 0
+    recolored.data[i + 2] = 0
+    expect(matches(recolored)).toBe(false)
+  })
+
+  it('considers only the identity offset when maxShift is 0', () => {
+    const shifted = image(24, 24, [{ x: 7, y: 6, w: 8, h: 8 }])
+    expect(matches(shifted, 0)).toBe(false)
+    expect(matches(image(24, 24, box), 0)).toBe(true)
   })
 })
 

--- a/packages/ui-scripts/lib/commands/visual-diff.ts
+++ b/packages/ui-scripts/lib/commands/visual-diff.ts
@@ -48,6 +48,7 @@ type Args = {
   baselineDir: string
   outputDir: string
   threshold: number
+  maxShift: number
   failOnMissingBaseline: boolean
   prNumber?: string
   prUrl?: string
@@ -223,6 +224,64 @@ function diffMask(baseline: PNG, actual: PNG, threshold: number) {
     sizeMismatch: bw !== aw || bh !== ah,
     actual: a
   }
+}
+
+// Copy a w*h window out of `src` starting at (sx, sy). Callers clamp the window
+// to the source bounds first.
+function crop(src: PNG, sx: number, sy: number, w: number, h: number): PNG {
+  const out = new PNG({ width: w, height: h })
+  PNG.bitblt(src, out, sx, sy, w, h, 0, 0)
+  return out
+}
+
+// Is `actual` pixel-identical to `baseline` once shifted by up to `maxShift`?
+//
+// When a layout box rounds one device pixel differently, the whole painted
+// subtree moves — glyphs, borders, all of it. The image is unchanged, just
+// translated, but a direct comparison lights up every edge in it: a one-pixel
+// shift routinely produces several thousand differing pixels. A component that
+// moved a pixel and is otherwise identical is not a visual regression, so this
+// is the check that says so.
+//
+// A pixel-count tolerance cannot do this job. The shift above and a genuine
+// 40x40 recolor land in the same order of magnitude, so any threshold loose
+// enough to absorb the first also hides the second.
+//
+// Each offset is scored over the region the two images share, so the band that
+// shifts in from outside is never counted. (0, 0) is included deliberately: the
+// caller's comparison *pads* mismatched sizes, while this one *crops* to the
+// overlap, which is what lets "one pixel taller, same content" pass.
+/** @internal — exported only for tests; not part of the package's public API. */
+export function matchesWhenShifted(
+  baseline: PNG,
+  actual: PNG,
+  threshold: number,
+  maxShift: number
+): boolean {
+  for (let dy = -maxShift; dy <= maxShift; dy++) {
+    for (let dx = -maxShift; dx <= maxShift; dx++) {
+      // A positive dx means the content sits that many pixels further right
+      // than in the baseline, so actual (x, y) lines up with baseline
+      // (x - dx, y - dy).
+      const x0 = Math.max(0, dx)
+      const y0 = Math.max(0, dy)
+      const w = Math.min(actual.width, baseline.width + dx) - x0
+      const h = Math.min(actual.height, baseline.height + dy) - y0
+      if (w <= 0 || h <= 0) continue
+
+      // No output buffer — only the count matters here.
+      const numDiff = pixelmatch(
+        crop(actual, x0, y0, w, h).data,
+        crop(baseline, x0 - dx, y0 - dy, w, h).data,
+        undefined,
+        w,
+        h,
+        { threshold, includeAA: false }
+      )
+      if (numDiff === 0) return true
+    }
+  }
+  return false
 }
 
 // How much unchanged pixels are dimmed in the diff image so the changed pixels
@@ -1431,6 +1490,7 @@ function run(args: Args): number {
     baselineDir,
     outputDir,
     threshold,
+    maxShift,
     failOnMissingBaseline
   } = args
 
@@ -1471,8 +1531,21 @@ function run(args: Args): number {
       actual: padded
     } = diffMask(baseline, actual, threshold)
 
-    const status: Status =
+    // Straight comparison first, so identical screenshots cost nothing extra;
+    // the realignment check below only runs on one that already failed it. The
+    // size guard keeps a real layout change from being shifted away — only a
+    // delta within the shift budget is a rounding artifact.
+    let status: Status =
       numDiff === 0 && !sizeMismatch ? 'unchanged' : 'changed'
+    if (
+      status === 'changed' &&
+      maxShift > 0 &&
+      Math.abs(baseline.width - actual.width) <= maxShift &&
+      Math.abs(baseline.height - actual.height) <= maxShift &&
+      matchesWhenShifted(baseline, actual, threshold, maxShift)
+    ) {
+      status = 'unchanged'
+    }
 
     if (status === 'changed') {
       const highlight = highlightImage(padded, changed, width, height)
@@ -1579,6 +1652,12 @@ export default {
       type: 'number',
       describe: 'pixelmatch color threshold (0-1)',
       default: 0.1
+    },
+    'max-shift': {
+      type: 'number',
+      describe:
+        'Treat a screenshot as unchanged when it matches its baseline exactly after being shifted by up to this many pixels. Absorbs whole-pixel layout rounding, which moves a component without altering it. 0 requires an exact match.',
+      default: 1
     },
     'fail-on-missing-baseline': {
       type: 'boolean',

--- a/regression-test/cypress.config.ts
+++ b/regression-test/cypress.config.ts
@@ -40,7 +40,14 @@ export default defineConfig({
   screenshotOnRunFailure: false,
   e2e: {
     viewportWidth: 1280,
-    viewportHeight: 800,
+    // Deliberately taller than a real browser window. `capture: 'fullPage'`
+    // scrolls the viewport down the document and stitches the slices together,
+    // and the stitch is the least reproducible part of the capture. Measured
+    // against the baselines on the `visual-baselines` branch, raising this from
+    // 800 takes the suite from 58 stitch operations to 37, and from 17 of 32
+    // pages captured in one pass to 28. Only `min-height: 100vh` on the body
+    // depends on this value.
+    viewportHeight: 2000,
     setupNodeEvents(on, config) {
       on('before:run', () => {
         writeFileSync(META_FILE, '{}')


### PR DESCRIPTION
## Summary
- `visual-diff` retries the comparison at small integer offsets before calling a screenshot changed, behind `--max-shift` (default 1, `0` restores exact matching). Scoring over the shared region also covers a screenshot one pixel taller with identical content.
- `viewportHeight` 800 → 2000, cutting the `fullPage` stitching that produces those shifts: 58 stitch operations → 37, and 17/32 → 28/32 pages captured in a single pass (measured against the `visual-baselines` branch).

A pixel-count tolerance can't do this job. On a real baseline a 1px translation produces **2825** differing pixels and a genuine 40×40 recolour produces **1479** — less than a factor of two apart, so any threshold loose enough to absorb the first would hide the second.

Verified against four real CI baselines — identical, shifted 1px, 1px taller, and a genuine recolour:

| | `--max-shift 0` (current) | default |
|---|---|---|
| identical | ok | ok |
| shifted 1px | **changed** (2825 px) | ok |
| 1px taller | **changed** (1280 px) | ok |
| real recolour | changed (1479 px) | **changed** |

## Test Plan
- **Expect a cascade of `changed` rows on this PR** — the viewport change alters layout, so it can't demonstrate its own success. Merging refreshes the baselines.
- Spot-check a few `changed` rows in the report to confirm they're the viewport reflow and not something unexpected.

Fixes INSTUI-5180

🤖 Generated with [Claude Code](https://claude.com/claude-code)