### PR TITLE
chore: add /release-notify skill to credit reporters after a release

### DIFF
--- a/.claude/commands/release-notify.md
+++ b/.claude/commands/release-notify.md
@@ -1,0 +1,96 @@
+---
+description: Draft a Slack message that credits the people whose reported issues got fixed in the latest release — gathers the release's Jira tickets and the channel's threads, works out who reported what, and hands you a copy-pasteable block
+---
+
+Work out who reported the issues fixed in the **latest release**, and produce a **copy-pasteable Slack message** that credits them by name.
+
+Usage: `/release-notify` — no arguments. The range is always the two most recent `v*` tags.
+
+## Behavior contract (do not deviate)
+
+- **Never post anything to Slack.** You produce a draft; the user posts it. The token is read-only by design — don't look for a post tool.
+- **The reporter is the author of the thread's root message.** Whoever pasted the Jira link into the thread is the _developer_. Tagging them instead is this skill's worst failure mode: it credits our own team and misses the actual reporter.
+- **Read the threads, don't just count the fields.** The JSON gives you every message. A root author discussing their own PR or gerrit CL is a contributor, not a reporter — no metadata reveals that, only the text does.
+- **Never invent a person, thread or link.** Everything in the draft comes from the gathered JSON. Unsure means unresolved, not guessed.
+- **A commit with no Jira key is internal work.** Nobody to notify; don't speculate.
+- **Don't decide a genuine ambiguity.** Show the options and ask.
+
+## Config
+
+- Jira project: **`INSTUI`**. The script normalizes typo'd prefixes (`ISTUI`, `INSUTI`) and drops keys Jira 404s.
+- Channel: `#instui` (`C0JCJ63TR`), both the release-notes channel and where reports land.
+- Credentials in the root `.env`: `SLACK_BOT_TOKEN` (read-only, bot must be a channel member) and `JIRA_BASE_URL` / `JIRA_EMAIL` / `JIRA_API_TOKEN`. Missing or broken → tell the user to run `/slack-setup`.
+- Private channels are out of scope (no `groups:history`).
+
+## Step 1 — Gather
+
+```sh
+node scripts/release-notify/gather.mjs
+```
+
+**Takes about 2.5 minutes** — every thread in the window is fetched, throttled for the rate limit. That's not a hang. Progress goes to stderr, the JSON to stdout; write it to a temp file if you want to re-read it.
+
+It gathers and narrows but never judges:
+
+- `range` — tags plus the release URL for the draft's header
+- `tickets[]` — `key`, `summary`, `slackLinks` (permalinks found in the Jira description), `prUrls`
+- `threads[]` — `channel`, `threadTs`, `keys` (issue keys quoted anywhere in the thread), `linkedFromTicket`, and every `messages[]` entry with `author`, `bot`, `isRoot`, `text`
+- `users` — author id → display name
+- `commitsWithoutKey`, `unknownKeys`
+
+Report the shape in one line before going on: _"22 tickets, 35 relevant threads, 9 commits with no key."_
+
+## Step 2 — Pair each ticket with its threads
+
+Two directions, both of which matter because either can be missing:
+
+- **From Jira:** the ticket's `slackLinks` → the thread whose `threadTs` matches. Reply links carry `thread_ts` in the query and the script already resolved them to the root, so match `threadTs` directly.
+- **From Slack:** any thread whose `keys` contain the ticket's key.
+
+Both pointing at the same thread is the strongest signal. Measured on a recent release: 6 of 22 tickets had a Jira link, and the scan found others independently — neither direction substitutes for the other.
+
+## Step 3 — Decide who gets credited
+
+For each paired thread the root message's author is the _candidate_. Rule these out:
+
+- **`bot: true` on the root** — in practice the release-notes thread: the GitHub app posts it and developers reply with issue keys, so it looks like it reported everything. Measured live: one such thread quoted five different keys.
+- **The key appears in the root message** — the developer opened the thread about their own work.
+- **The root author also wrote the message carrying the key** — internal work.
+- **The thread reads as developer discussion** — the root author shares their own CL/PR and later says the fix is up. Real case: two tickets both linked one thread whose root author was a contributor discussing his own PRs. Only the text shows this, so read it.
+
+Then weigh what's left:
+
+- **Three or more keys in the thread** → status/catch-all thread; ask rather than credit. **Two is normal** — a report often spawns a follow-up ticket and the root author reported both.
+- **One thread linked from several tickets** → usually a developer thread pasted into each; ask.
+- **Two or more plausible reporter threads for one ticket** → ask, don't pick.
+
+Group by person: one line per human even with several issues.
+
+## Step 4 — The draft
+
+One fenced block, Slack mrkdwn, no user IDs and no internal paths — the user pastes it verbatim:
+
+```
+*InstUI 11.7.5* — <https://github.com/instructure/instructure-ui/releases/tag/v11.7.5|release notes>
+
+@panna.kristof: the Checkbox toggle accessibility issue you raised <https://instructure.slack.com/…|here> is fixed — <https://github.com/…/pull/2673|#2673>
+@tamas.laszlo: the Checkbox hint alignment issue you raised <https://instructure.slack.com/…|here> is fixed — <https://github.com/…/pull/2674|#2674>
+```
+
+- One sentence per person, written from the Jira `summary` in words the reporter would recognize — not the ticket title verbatim, not the commit subject. Strip boilerplate like `Fix: [Checkbox]`.
+- `<url|text>` links so it isn't a wall of URLs. Several issues for one person: one line, links comma-separated.
+- No emojis.
+
+**Tell the user plainly:** Slack does not turn pasted text into real mentions. They must retype each `@` in the composer and pick from the autocomplete, or nobody is notified.
+
+## Step 5 — Under the block, in chat (not in it)
+
+- **Name → user ID** table, so two people with the same display name can be told apart.
+- **Which direction** resolved each person, one line.
+- **Needs a decision** — every "ask" case from Step 3, with its threads, as an explicit question. Don't bury these; a wrong guess tags the wrong person.
+- **Unresolved** — keys where neither direction found a report thread. A ticket with no Slack link and no key quoted in the channel is invisible here, so a real reporter may be hiding. Some are unreachable in principle: if the report thread never quoted the key and the ticket never linked the thread, no automation can connect them.
+- **Skipped** — count and reason, so a wrongly-skipped person can be caught.
+
+## Step 6 — Summarize
+
+Range, how many people to credit, how many unresolved, and that the draft is ready. If the unresolved list is long, say so — it means the Slack-link step of `/slack-triage` is being skipped upstream, and that's worth fixing at the source.

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,15 @@
 INSTUI_PRIVATE_REGISTRY=https://<host>/<path>/
 INSTUI_PRIVATE_REGISTRY_TOKEN=
 
-# Slack MCP server, sourced by `.mcp.json` for the `/slack-triage` skill (read-only bot).
+# Slack, read-only bot. Sourced by `.mcp.json` for the `/slack-triage` skill, and read
+# directly from this file by the `/release-notify` skill.
 # SLACK_BOT_TOKEN: Bot User OAuth Token (xoxb-…) from your Slack app's OAuth & Permissions page.
 # SLACK_TEAM_ID:   workspace id (T…), e.g. from the URL app.slack.com/client/T0XXXXXX/…
 SLACK_BOT_TOKEN=xoxb-
 SLACK_TEAM_ID=T
+
+# Jira, read-only, for the `/release-notify` skill.
+# JIRA_API_TOKEN: from your Atlassian account's Security → API tokens page.
+JIRA_BASE_URL=https://instructure.atlassian.net
+JIRA_EMAIL=
+JIRA_API_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ CLAUDE.local.md
 !.claude/commands/slack-setup.md
 !.claude/commands/implement.md
 !.claude/commands/ticket.md
+!.claude/commands/release-notify.md
 
 # Playwright MCP
 .playwright-mcp

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -82,6 +82,12 @@ git push origin release
 
 - Add a new release to GitHub. This will display the newly released version as the latest and automatically triggers a Slack notification.
 
+##### 11. Notify the People Whose Issues Got Fixed
+
+- Run `/release-notify` in Claude Code. It reads the Jira issue keys out of the release's commits (or the pull requests behind them), then finds who originally reported each one from two directions — the Slack link in the Jira ticket, and the channel threads that quote the issue key — and hands you a ready-made message that credits them by name.
+- Post the resulting block in the `#instui` channel, in the thread under the release notes message. **Retype each `@` in the Slack composer** and pick the person from the autocomplete: Slack does not turn pasted text into a real mention, so without this nobody gets notified.
+- The skill never posts anything itself. It needs two read-only credentials in the root `.env` — the Slack bot token (and the bot must be a member of the channel) plus a Jira API token — a one-time setup, see `/slack-setup`.
+
 ## Release Process for Legacy Versions
 
 This document describes the steps to follow when releasing updates to legacy versions. The example given is for v7:

--- a/scripts/release-notify/gather.mjs
+++ b/scripts/release-notify/gather.mjs
@@ -1,0 +1,364 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - present Instructure, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Collects everything `/release-notify` needs to work out who reported the
+ * issues fixed in the latest release, and prints it as JSON on stdout.
+ *
+ * It gathers and narrows, but never judges: deciding who the reporter is, and
+ * whether a thread is a report at all, is left to the skill reading this JSON.
+ *
+ * Needs SLACK_BOT_TOKEN, JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN in ./.env,
+ * an authenticated `gh`, and the bot to be a member of the channel.
+ *
+ * Options: --channel=<id> --months=<n> --from=<tag> --to=<tag>
+ */
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+
+const DEFAULT_CHANNEL = 'C0JCJ63TR'
+const DEFAULT_MONTHS = 6
+const REPLIES_THROTTLE_MS = 1200
+const FIELD = '\x1f'
+const RECORD = '\x1e'
+
+const ISSUE_KEY = /(?<![A-Za-z0-9])([A-Za-z]{4,7})-(\d{3,5})(?!\d)/g
+const PROJECT_KEY = 'INSTUI'
+
+// Accepts typo'd prefixes (ISTUI, INSUTI) but not lookalikes such as the design
+// token `gray-700`, which Jira would happily resolve to a real old ticket.
+const isProjectPrefix = (prefix) =>
+  [...new Set(prefix.toUpperCase())].every((letter) =>
+    PROJECT_KEY.includes(letter)
+  )
+
+export const SLACK_PERMALINK =
+  /https?:\/\/[a-z0-9-]+\.slack\.com\/archives\/([a-z0-9]+)\/p(\d{10,})(\?[^\s"'<>|)\]]*)?/gi
+
+const option = (name, fallback) => {
+  const found = process.argv
+    .slice(2)
+    .find((arg) => arg.startsWith(`--${name}=`))
+  return found ? found.slice(name.length + 3) : fallback
+}
+
+const env = (() => {
+  const file = Object.fromEntries(
+    (fs.existsSync('./.env') ? fs.readFileSync('./.env', 'utf8') : '')
+      .split('\n')
+      .map((line) => line.match(/^\s*([A-Z_]+)\s*=\s*(.*?)\s*$/))
+      .filter(Boolean)
+      .map(([, key, value]) => [key, value.replace(/^["']|["']$/g, '')])
+  )
+  return (name) => process.env[name] || file[name] || null
+})()
+
+const sh = (command, args) =>
+  execFileSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim()
+
+const shOrNull = (command, args) => {
+  try {
+    return sh(command, args) || null
+  } catch {
+    return null
+  }
+}
+
+export const issueKeysIn = (text) => [
+  ...new Set(
+    [...String(text ?? '').matchAll(ISSUE_KEY)]
+      .filter(([, prefix]) => isProjectPrefix(prefix))
+      .map(([, , number]) => `${PROJECT_KEY}-${number}`)
+  )
+]
+
+export const permalinksIn = (value) => [
+  ...new Set(
+    (typeof value === 'string' ? value : JSON.stringify(value ?? '')).match(
+      SLACK_PERMALINK
+    ) ?? []
+  )
+]
+
+/** `/archives/C123/p1712345678123456` carries the ts without its decimal point. */
+export const threadRefOf = (permalink) => {
+  const match = new RegExp(SLACK_PERMALINK.source, 'i').exec(permalink ?? '')
+  if (!match) return null
+  const [, channel, digits, query = ''] = match
+  const messageTs = `${digits.slice(0, -6)}.${digits.slice(-6)}`
+  const threadTs = new URLSearchParams(query.replace(/^\?/, '')).get('thread_ts')
+  return { channel: channel.toUpperCase(), threadTs: threadTs || messageTs }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const slack = async (method, params, attempt = 0) => {
+  const url = new URL(`https://slack.com/api/${method}`)
+  for (const [name, value] of Object.entries(params)) {
+    if (value != null) url.searchParams.set(name, String(value))
+  }
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${env('SLACK_BOT_TOKEN')}` }
+  })
+  if (response.status === 429 && attempt < 3) {
+    await sleep((Number(response.headers.get('retry-after')) || 5) * 1000 + 1000)
+    return slack(method, params, attempt + 1)
+  }
+  const body = await response.json()
+  if (!body.ok) throw new Error(`slack ${method}: ${body.error}`)
+  return body
+}
+
+const releaseRange = () => {
+  const tags = (shOrNull('git', ['tag', '--list', 'v*', '--sort=-v:refname']) ?? '')
+    .split('\n')
+    .filter(Boolean)
+  const to = option('to', tags[0])
+  const from = option('from', tags[tags.indexOf(to) + 1])
+  if (!from || !to) {
+    throw new Error('cannot resolve the tag range — pass --from= and --to=')
+  }
+  const slug = shOrNull('gh', [
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner'
+  ])
+  return {
+    from,
+    to,
+    slug,
+    releaseUrl:
+      shOrNull('gh', ['release', 'view', to, '--json', 'url', '--jq', '.url']) ??
+      (slug ? `https://github.com/${slug}/releases/tag/${to}` : null)
+  }
+}
+
+/** Squash merges drop the branch name, so the PR is the only place to find it. */
+const commitsWithPullRequests = ({ from, to, slug }) =>
+  sh('git', [
+    'log',
+    '--no-merges',
+    `--format=%H${FIELD}%s${FIELD}%b${RECORD}`,
+    `${from}..${to}`
+  ])
+    .split(RECORD)
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha, subject, body = ''] = record.split(FIELD)
+      return { sha: sha.trim(), subject: subject.trim(), body: body.trim() }
+    })
+    .filter(({ subject }) => !subject.startsWith('chore(release)'))
+    .map((commit) => {
+      const pr = slug
+        ? shOrNull('gh', [
+            'api',
+            `repos/${slug}/commits/${commit.sha}/pulls`,
+            '--jq',
+            '.[0] | select(. != null) | {number, url: .html_url, branch: .head.ref, title, body}'
+          ])
+        : null
+      const pullRequest = pr ? JSON.parse(pr) : null
+      return {
+        ...commit,
+        prNumber: pullRequest?.number ?? null,
+        prUrl: pullRequest?.url ?? null,
+        keys: issueKeysIn(
+          [
+            commit.subject,
+            commit.body,
+            pullRequest?.branch,
+            pullRequest?.title,
+            pullRequest?.body
+          ].join('\n')
+        )
+      }
+    })
+
+const jiraTickets = async (keys) => {
+  const authorization = `Basic ${Buffer.from(
+    `${env('JIRA_EMAIL')}:${env('JIRA_API_TOKEN')}`
+  ).toString('base64')}`
+  const tickets = []
+  const unknownKeys = []
+  for (const key of keys) {
+    const response = await fetch(
+      `${env('JIRA_BASE_URL')}/rest/api/3/issue/${key}?fields=summary,description`,
+      { headers: { Authorization: authorization, Accept: 'application/json' } }
+    )
+    if (response.status === 404) {
+      unknownKeys.push(key)
+      continue
+    }
+    if (!response.ok) throw new Error(`jira ${key}: HTTP ${response.status}`)
+    const { fields } = await response.json()
+    tickets.push({
+      key,
+      summary: fields?.summary ?? null,
+      slackLinks: permalinksIn(fields?.description)
+    })
+  }
+  return { tickets, unknownKeys }
+}
+
+/**
+ * Keeps only threads that quote an issue key or that a ticket links to; keys
+ * live in replies, so every thread has to be fetched before it can be filtered.
+ */
+const relevantThreads = async ({ channel, months, linkedRefs, log }) => {
+  const oldest = Math.floor(Date.now() / 1000) - months * 30 * 24 * 60 * 60
+  const roots = []
+  let cursor
+  do {
+    const page = await slack('conversations.history', {
+      channel,
+      limit: 200,
+      oldest,
+      cursor
+    })
+    roots.push(...(page.messages ?? []))
+    cursor = page.response_metadata?.next_cursor || null
+  } while (cursor)
+
+  const linked = new Set(
+    linkedRefs.filter((ref) => ref.channel === channel).map((ref) => ref.threadTs)
+  )
+  const candidates = roots.filter(
+    (message) => message.reply_count || linked.has(message.ts)
+  )
+  log(`fetching ${candidates.length} of ${roots.length} threads`)
+
+  const threads = []
+  for (const [index, root] of candidates.entries()) {
+    if (index > 0) await sleep(REPLIES_THROTTLE_MS)
+    const { messages = [] } = await slack('conversations.replies', {
+      channel,
+      ts: root.ts,
+      limit: 200,
+      inclusive: true
+    })
+    const texts = messages.map((message) => message.text ?? '').join('\n')
+    if (!linked.has(root.ts) && issueKeysIn(texts).length === 0) continue
+    threads.push({
+      channel,
+      threadTs: root.ts,
+      keys: issueKeysIn(texts),
+      linkedFromTicket: linked.has(root.ts),
+      messages: messages.map((message) => ({
+        author: message.user ?? null,
+        bot: Boolean(message.bot_id) && !message.user,
+        isRoot: message.ts === root.ts,
+        text: message.text ?? ''
+      }))
+    })
+  }
+  return threads
+}
+
+const withDisplayNames = async (threads) => {
+  const names = new Map()
+  for (const thread of threads) {
+    for (const message of thread.messages) {
+      if (!message.author || names.has(message.author)) continue
+      const { user } = await slack('users.info', { user: message.author })
+      names.set(message.author, {
+        name:
+          user?.profile?.display_name?.trim() ||
+          user?.profile?.real_name?.trim() ||
+          message.author,
+        isBot: Boolean(user?.is_bot)
+      })
+    }
+  }
+  return Object.fromEntries(names)
+}
+
+const main = async () => {
+  const missing = [
+    'SLACK_BOT_TOKEN',
+    'JIRA_BASE_URL',
+    'JIRA_EMAIL',
+    'JIRA_API_TOKEN'
+  ].filter((name) => !env(name))
+  if (missing.length) {
+    throw new Error(`missing in ./.env: ${missing.join(', ')} — see /slack-setup`)
+  }
+  const log = (message) => process.stderr.write(`release-notify: ${message}\n`)
+  const channel = option('channel', DEFAULT_CHANNEL)
+  const months = Number(option('months', DEFAULT_MONTHS))
+
+  const range = releaseRange()
+  log(`range ${range.from}..${range.to}`)
+  const commits = commitsWithPullRequests(range)
+  const keys = [...new Set(commits.flatMap((commit) => commit.keys))]
+  log(`${commits.length} commits, ${keys.length} issue keys`)
+
+  const { tickets, unknownKeys } = await jiraTickets(keys)
+  const linkedRefs = tickets
+    .flatMap((ticket) => ticket.slackLinks.map(threadRefOf))
+    .filter(Boolean)
+  log(`${tickets.length} tickets, ${linkedRefs.length} linked from Jira`)
+
+  const threads = await relevantThreads({ channel, months, linkedRefs, log })
+  log(`${threads.length} relevant threads`)
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        range: { from: range.from, to: range.to, releaseUrl: range.releaseUrl },
+        commitsWithoutKey: commits.filter((commit) => !commit.keys.length).length,
+        unknownKeys,
+        tickets: tickets.map((ticket) => ({
+          ...ticket,
+          prUrls: [
+            ...new Set(
+              commits
+                .filter((commit) => commit.keys.includes(ticket.key))
+                .map((commit) => commit.prUrl)
+                .filter(Boolean)
+            )
+          ]
+        })),
+        threads,
+        users: await withDisplayNames(threads)
+      },
+      null,
+      2
+    )}\n`
+  )
+}
+
+if (process.argv[1]?.endsWith('gather.mjs')) {
+  main().catch((error) => {
+    process.stderr.write(`release-notify: ${error.message}\n`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- New `/release-notify` command: works out who reported the issues fixed in a release and drafts a Slack message crediting them by name. **Nothing is posted automatically** — the block is copy-pasted by a human.
- One `gather.mjs` script collects the release's Jira tickets and the `#instui` threads and narrows them down; the command itself decides who the reporter is.
- Reporters are found from two directions, because either can be missing: the Slack link in a Jira description, and channel threads quoting the issue key.
- Adds step 11 to the release process and documents the two read-only credentials (Slack bot token, Jira API token).

## Test Plan
- Run `/release-notify` after a release and check the draft credits the right people. The key thing to eyeball: the reporter must be the **thread's root author**, not the developer who pasted the Jira link into the thread.
- Needs `SLACK_BOT_TOKEN` and the three `JIRA_*` keys in the root `.env`, and the bot must be a member of `#instui` — see `/slack-setup`.
- Already verified against `v11.7.4..v11.7.5`: of a hand-written reporter list, 4 of 6 matched with no false positives. The other two are unreachable in principle — their report thread never quoted the issue key and their ticket never linked the thread, so nothing connects them.

Fixes INSTUI-5133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
