### PR TITLE
fix(ui-radio-input): set aria-required on RadioInputGroup when isRequired

### DIFF
--- a/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/README.md
@@ -224,6 +224,8 @@ type: example
 
 Whenever a `RadioInputGroup` contains required fields, you must include a note explaining what the asterisk means — typically "Fields marked with an asterisk (\*) are required."
 
+`isRequired` adds the asterisk and sets `aria-required` on the group, so screen readers announce it as required. It does not block form submission. To let the browser enforce a choice, pass `required` to every `RadioInput` in the group.
+
 ```js
 ---
 type: example

--- a/packages/ui-radio-input/src/RadioInputGroup/v2/index.tsx
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/index.tsx
@@ -167,6 +167,7 @@ class RadioInputGroup extends Component<
         elementRef={this.handleRef}
         role="radiogroup"
         isRequired={isRequired}
+        aria-required={isRequired ? true : undefined}
         data-cid="RadioInputGroup"
       >
         {this.renderChildren()}

--- a/packages/ui-radio-input/src/RadioInputGroup/v2/props.ts
+++ b/packages/ui-radio-input/src/RadioInputGroup/v2/props.ts
@@ -86,7 +86,9 @@ type RadioInputGroupOwnProps = {
   children?: React.ReactNode
 
   /**
-   * Setting this to `true` adds and asterisk after the description (group label). It does not cause any behavioural change.
+   * Setting this to `true` adds an asterisk after the description (group label) and
+   * sets `aria-required` on the group, so screen readers announce it as required.
+   * It does not turn on native form validation.
    */
   isRequired?: boolean
 


### PR DESCRIPTION
## Summary
- `RadioInputGroup` v2 sets `aria-required` on the `role="radiogroup"` element when `isRequired` is true, so screen readers announce the group as required.
- Updated the `isRequired` prop doc and the README "Required Fields" section.
- v2 only. Setting the native `required` attribute is not part of this change, it is tracked in INSTUI-5187.

## Test Plan
- With a screen reader, move focus into a `RadioInputGroup` that has `isRequired` and confirm the group is announced as required.
- Confirm form submission is still not blocked when no option is selected.

Fixes INSTUI-5186
